### PR TITLE
feat: 9-6 commands/scripts + 9-8 Privacy Onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# Hypomnema
+
+LLM-native personal wiki system for Claude Code.
+
+Hypomnema turns Claude Code into a compounding knowledge base. Instead of chunking sources as-is, an LLM reads each source, synthesizes it, and updates existing pages — so new sources update knowledge more than they create it.
+
+---
+
+## Quick start
+
+```bash
+npm install -g hypomnema   # or: npx hypomnema
+```
+
+In Claude Code, run:
+
+```
+/hypo:init
+```
+
+This sets up your wiki directory, installs hooks, and merges them into `~/.claude/settings.json`.
+
+---
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/hypo:init` | Set up a new wiki |
+| `/hypo:doctor` | Health check |
+| `/hypo:upgrade` | Upgrade hooks to latest version |
+| `/hypo:uninstall` | Remove hooks and registrations |
+| `/hypo:ingest` | Ingest an external source into the wiki |
+| `/hypo:query` | Search and synthesize an answer from wiki pages |
+| `/hypo:crystallize` | Consolidate drafts and related pages into stable knowledge |
+| `/hypo:resume` | Resume the most recent session for an active project |
+| `/hypo:feedback` | Record an AI behavior correction |
+| `/hypo:verify` | Audit pages for overdue or missing `verify_by` fields |
+| `/hypo:stats` | Show wiki statistics |
+| `/hypo:graph` | Generate a wikilink dependency graph |
+| `/hypo:lint` | Validate frontmatter and wikilinks |
+
+---
+
+## How it works
+
+1. **Ingest** — drop a document, URL, or paste text into `/hypo:ingest`. Claude saves the raw source and synthesizes it into a structured page.
+2. **Query** — ask `/hypo:query` anything. Claude searches your pages and synthesizes a grounded answer with `[[wikilink]]` citations.
+3. **Session close** — on session end, Claude updates `session-state.md` (next tasks) and `hot.md` (what was done) so the next session resumes seamlessly.
+4. **Compound value** — over time, new sources update existing pages rather than creating new ones. The wiki gets denser and more useful.
+
+---
+
+## Directory layout
+
+```
+<wiki-root>/
+├── hypo-config.md      ← root marker + settings
+├── index.md            ← searchable page catalog
+├── hot.md              ← active project pointers
+├── log.md              ← append-only activity log
+├── SCHEMA.md           ← type system reference
+├── wiki-guide.md       ← operations guide
+├── .wikiignore         ← privacy/exclusion patterns
+├── pages/              ← permanent knowledge pages
+├── projects/           ← project artifacts and session logs
+└── sources/            ← raw ingested sources (never edit)
+```
+
+---
+
+## Privacy
+
+All wiki data is stored locally. No content is sent to external services by Hypomnema itself.
+
+Three privacy modes are available: `personal` (default), `shared`, and `public`. A `.wikiignore` file controls which files hooks scan and include in context.
+
+See [docs/PRIVACY.md](docs/PRIVACY.md) for the full privacy guide, including what each hook reads, how to exclude sensitive content, and how to delete your wiki completely.
+
+---
+
+## Requirements
+
+- Node.js ≥ 18
+- Claude Code CLI
+
+---
+
+## License
+
+MIT

--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -1,0 +1,84 @@
+---
+description: Crystallize draft notes and related pages into stable wiki knowledge
+---
+
+You are running `/hypo:crystallize`. Identify and consolidate draft or scattered knowledge into stable, well-linked pages.
+
+## What this does
+
+- Scans `pages/` for draft pages, unlinked pages, and tag clusters
+- Synthesizes related pages into a `synthesis` page (or upgrades a draft to stable)
+- Adds cross-links between related pages
+
+---
+
+## Step 1 — Surface candidates
+
+Locate the Hypomnema package root (the directory containing this file's parent `commands/`).
+
+```bash
+node <package-root>/scripts/crystallize.mjs [--wiki-dir="<path>"] [--min-group=2]
+```
+
+Show the output to the user. If no candidates are found, tell them the wiki looks well-connected and no crystallization is needed.
+
+---
+
+## Step 2 — Choose what to crystallize
+
+If candidates exist, ask:
+
+> "Which would you like to crystallize?
+> 1. A tag cluster (synthesize related pages into one synthesis page)
+> 2. A draft page (upgrade to stable)
+> 3. Unlinked pages (add cross-links)"
+
+---
+
+## Step 3a — Tag cluster synthesis
+
+For a tag cluster:
+
+1. Read all pages in the cluster
+2. Create `pages/syntheses/<topic>.md` with `type: synthesis`
+3. Frontmatter:
+   ```yaml
+   ---
+   title: "<synthesis title>"
+   type: synthesis
+   updated: YYYY-MM-DD
+   tags: [<shared tags>]
+   confidence: high
+   ---
+   ```
+4. Body: synthesize key insights across the cluster, cite each source page with `[[slug]]`
+5. Add back-links: add `[[syntheses/<topic>]]` to each constituent page's "See also" section
+6. Update `index.md`
+
+---
+
+## Step 3b — Draft upgrade
+
+For a draft page:
+
+1. Read the draft
+2. Fill in any missing sections, improve clarity, add cross-links
+3. Change `tags: [draft]` → remove `draft` tag, set `confidence: high`
+4. Update `updated:` to today
+
+---
+
+## Step 3c — Cross-link unlinked pages
+
+For unlinked pages:
+
+1. Read each unlinked page
+2. Search the wiki for related pages (run `/hypo:query` mentally on the page title/tags)
+3. Add a `## See also` section with `[[slug]]` links to 2–3 related pages
+4. Reciprocally add links back where natural
+
+---
+
+## Step 4 — Report
+
+Show what was created or modified, and offer to run `/hypo:lint` to verify all new links resolve.

--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -1,0 +1,67 @@
+---
+description: Record an AI behavior correction or preference into the wiki
+---
+
+You are running `/hypo:feedback`. Capture a behavior correction or preference into `pages/feedback/` for future sessions.
+
+## What this does
+
+- Creates or updates `pages/feedback/<topic>.md` with a dated entry
+- Appends a reference to `log.md`
+- Ensures the feedback is findable in future sessions
+
+---
+
+## Step 1 — Gather feedback details
+
+If the user did not provide them, ask:
+
+1. **Topic** (slug): "What topic does this feedback apply to? (e.g. `response-length`, `commit-style`, `code-comments`)"
+2. **Rule**: "State the rule or correction in one or two sentences."
+3. **Why** (optional): "What was the reason or incident that prompted this?"
+
+---
+
+## Step 2 — List existing feedback (optional)
+
+To check for an existing topic, locate the Hypomnema package root and run:
+
+```bash
+node <package-root>/scripts/feedback.mjs --list [--wiki-dir="<path>"]
+```
+
+If a matching topic exists, confirm with the user whether to append to it or create a new one.
+
+---
+
+## Step 3 — Write the feedback entry
+
+Compose the entry text. Format:
+
+```
+**Rule**: <one-line rule>
+
+**Why**: <reason or incident>
+
+**How to apply**: <when this kicks in>
+```
+
+Then run:
+
+```bash
+node <package-root>/scripts/feedback.mjs \
+  --topic="<slug>" \
+  --entry="<formatted entry text>" \
+  [--wiki-dir="<path>"] \
+  [--dry-run]
+```
+
+Run with `--dry-run` first to preview, then without it to write.
+
+---
+
+## Step 4 — Confirm and cross-reference
+
+After writing:
+- Tell the user: "Saved to `pages/feedback/<topic>.md`."
+- If this feedback should also update the project's `session-state.md` or the user's CLAUDE.md `<learned_behaviors>`, ask: "Should I also add this to your CLAUDE.md learned behaviors?"

--- a/commands/graph.md
+++ b/commands/graph.md
@@ -1,0 +1,54 @@
+---
+description: Generate a wikilink dependency graph for the wiki
+---
+
+You are running `/hypo:graph`. Generate a link dependency graph from wiki pages.
+
+## What this does
+
+- Scans `pages/` and `projects/` for all `.md` files
+- Extracts `[[wikilink]]` references between pages
+- Outputs an adjacency graph in JSON, Mermaid, or DOT format
+
+---
+
+## Step 1 — Locate package root
+
+Locate the Hypomnema package root (the directory containing this file's parent `commands/`).
+
+If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag.
+
+---
+
+## Step 2 — Run the graph script
+
+```bash
+node <package-root>/scripts/graph.mjs \
+  [--wiki-dir="<path>"] \
+  [--format=json|mermaid|dot] \
+  [--min-edges=<n>]
+```
+
+Options:
+- `--format=json` (default) — adjacency list with in/out degree counts
+- `--format=mermaid` — Mermaid `graph TD` diagram (paste into a Markdown code block)
+- `--format=dot` — Graphviz DOT format
+- `--min-edges=<n>` — only include nodes with at least N total edges
+
+---
+
+## Step 3 — Present results
+
+- For **JSON**: summarise the top 10 most-connected nodes (highest in+out degree), then offer to show the full output.
+- For **Mermaid**: wrap the output in a `\`\`\`mermaid` code block so it renders in the chat.
+- For **DOT**: show the raw output and suggest pasting it into a Graphviz renderer.
+
+If `--min-edges` was not specified and there are more than 50 nodes, suggest re-running with `--min-edges=2` to focus on well-connected pages.
+
+---
+
+## Step 4 — Insights
+
+After displaying results, offer one or two observations:
+- Pages with high in-degree are hub pages — consider linking to them from new pages.
+- Pages with zero edges are isolated — suggest adding cross-links or running `/hypo:crystallize`.

--- a/commands/ingest.md
+++ b/commands/ingest.md
@@ -1,0 +1,85 @@
+---
+description: Ingest an external source into the wiki
+---
+
+You are running `/hypo:ingest`. Save a raw source and synthesize it into wiki pages.
+
+## What this does
+
+- Saves raw source content to `sources/<slug>.<ext>` (never edited after)
+- Synthesizes the source into one or more pages in `pages/`
+- Updates `index.md` with new or updated pages
+- Appends an entry to `log.md`
+
+---
+
+## Step 1 — Collect source details
+
+Ask the user:
+
+1. **Source**: "What is the source? (paste text, provide a file path, or give a URL)"
+2. **Slug**: "What slug should this source have? (e.g. `openai-swarm-paper`, `team-retro-2026-04`)"
+   - Default: derive from title or filename
+
+If a URL is provided, fetch the content. If a file path is provided, read it.
+
+---
+
+## Step 2 — Check for orphaned sources
+
+Locate the Hypomnema package root. Run the ingest helper to surface existing orphaned sources:
+
+```bash
+node <package-root>/scripts/ingest.mjs [--wiki-dir="<path>"]
+```
+
+If there are orphaned sources already in `sources/`, ask: "There are N unprocessed sources — do you want to ingest one of those instead?"
+
+---
+
+## Step 3 — Save raw source
+
+Save the raw content to `sources/<slug>.<ext>` (use `.md` for text, `.txt` for plain text, `.pdf` or original extension for documents).
+
+Do **not** modify or summarize in the sources file — save it as-is.
+
+---
+
+## Step 4 — Synthesize
+
+Read and synthesize the source:
+
+1. **Check index.md** — does a page on this topic already exist?
+   - If yes: update the existing page (merge new information, mark `updated:` today)
+   - If no: create a new page in `pages/` with `type: source-summary` and `source: <slug>`
+
+2. **Frontmatter** for new pages:
+   ```yaml
+   ---
+   title: "<descriptive title>"
+   type: source-summary
+   updated: YYYY-MM-DD
+   tags: [<relevant tags>]
+   source: <slug>
+   confidence: high | medium | low
+   evidence_strength: direct
+   ---
+   ```
+
+3. **Content**: synthesis in your own words — not a copy of the source. Include key insights, quotes as blockquotes, and cross-links to related pages.
+
+---
+
+## Step 5 — Update index.md and log.md
+
+- Append a line to `index.md`: `- [[pages/<slug>]] — <one-line description>`
+- Append to `log.md`: `- YYYY-MM-DD ingest: [[pages/<slug>]] from sources/<slug>.<ext>`
+
+---
+
+## Step 6 — Report
+
+Show:
+- ✓ Saved source: `sources/<slug>.<ext>`
+- ✓ Created/Updated: `pages/<slug>.md`
+- ↪ Updated: `index.md`, `log.md`

--- a/commands/query.md
+++ b/commands/query.md
@@ -1,0 +1,55 @@
+---
+description: Query the wiki and synthesize an answer from relevant pages
+---
+
+You are running `/hypo:query`. Answer a question by searching the wiki and synthesizing from relevant pages.
+
+## What this does
+
+- Searches `pages/` and `projects/` for pages relevant to the query
+- Reads and cross-references the top matches
+- Synthesizes a grounded answer citing `[[page-slug]]` links
+
+---
+
+## Step 1 — Understand the query
+
+Ask the user what they want to know if it was not provided in the command invocation.
+
+---
+
+## Step 2 — Locate package root and search
+
+Locate the Hypomnema package root (the directory containing this file's parent `commands/`).
+
+Run full-text search:
+
+```bash
+node <package-root>/scripts/query.mjs \
+  --q="<query terms>" \
+  [--wiki-dir="<path>"] \
+  [--limit=10]
+```
+
+---
+
+## Step 3 — Read relevant pages
+
+Read `index.md` first to understand the page catalog, then read the top-scoring pages returned by the search script (up to 5).
+
+---
+
+## Step 4 — Synthesize answer
+
+Write a clear, concise answer that:
+- Cites source pages as `[[slug]]` links
+- Notes confidence level if any source is speculative
+- Flags if no relevant pages were found ("The wiki does not currently have a page on this topic.")
+
+If the query surfaces a gap, offer to create a new page or run `/hypo:ingest` on a relevant source.
+
+---
+
+## Step 5 — Offer follow-ups
+
+After answering, suggest 1–2 related pages the user might want to read next.

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -1,0 +1,48 @@
+---
+description: Resume the most recent session for an active project
+---
+
+You are running `/hypo:resume`. Load the session state for an active project and pick up where you left off.
+
+## What this does
+
+- Reads `projects/<name>/session-state.md` (next tasks)
+- Reads `projects/<name>/hot.md` (what was done last session)
+- Offers to continue from the last stopping point
+
+---
+
+## Step 1 — Resolve project
+
+If the user named a project in the command invocation, use that. Otherwise, locate the Hypomnema package root and run:
+
+```bash
+node <package-root>/scripts/resume.mjs [--wiki-dir="<path>"] [--project=<name>]
+```
+
+The script will resolve the most recently active project from `hot.md` if `--project` is omitted.
+
+---
+
+## Step 2 — Present session state
+
+Show the output from the script:
+- **Project** name
+- **Next tasks** from `session-state.md`
+- **Background** from `hot.md` (what was done last session, condensed)
+
+---
+
+## Step 3 — Offer to continue
+
+After presenting the state, ask:
+
+> "Ready to pick up from here? Which task should we start with?"
+
+If the session-state lists numbered tasks, offer them as options. Start immediately once the user selects one.
+
+---
+
+## Step 4 — On completion of a task
+
+When a task is marked done, offer to update `session-state.md` to reflect the new state before closing.

--- a/commands/stats.md
+++ b/commands/stats.md
@@ -1,0 +1,39 @@
+---
+description: Show statistics about the wiki
+---
+
+You are running `/hypo:stats`. Display a summary of wiki health and activity.
+
+## What this shows
+
+- Total page count, broken down by type
+- Number of projects and sources
+- ADR count
+- Date of last recorded activity
+
+---
+
+## Step 1 — Locate package root
+
+Locate the Hypomnema package root (the directory containing this file's parent `commands/`).
+
+If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag.
+
+---
+
+## Step 2 — Run the stats script
+
+```bash
+node <package-root>/scripts/stats.mjs [--wiki-dir="<path>"] [--json]
+```
+
+---
+
+## Step 3 — Report results
+
+Show the output verbatim. Then add a brief health commentary:
+
+- If `sources` is 0: "No external sources yet — consider running `/hypo:ingest` with a document or URL."
+- If `missingFrontmatter` > 0: "N page(s) missing frontmatter — run `/hypo:lint` to identify them."
+- If `lastActivity` is more than 14 days ago: "Last activity was over 2 weeks ago — consider a `/hypo:crystallize` pass."
+- Otherwise: "Wiki looks active and healthy."

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -1,0 +1,52 @@
+---
+description: Remove Hypomnema hooks and clean up settings.json
+---
+
+You are running `/hypo:uninstall`. Remove Hypomnema from this machine.
+
+## What this does
+
+- Removes Hypomnema hook files from `~/.claude/hooks/` (and optionally `~/.codex/hooks/`)
+- Strips Hypomnema entries from `~/.claude/settings.json`, leaving all other hooks untouched
+- **Dry-run by default** — shows what would be removed without making any changes
+
+---
+
+## Step 1 — Confirm intent
+
+Say:
+> "This will remove Hypomnema hooks from your system. Your wiki files are NOT deleted.
+> Run in dry-run mode first to preview changes? [yes]"
+
+Default: yes (dry-run first)
+
+---
+
+## Step 2 — Dry run
+
+Run:
+```
+node scripts/uninstall.mjs
+```
+
+Show the output to the user. Ask:
+> "Proceed with removal? (yes / no)"
+
+If no → abort and confirm nothing was changed.
+
+---
+
+## Step 3 — Apply (if confirmed)
+
+```
+node scripts/uninstall.mjs --apply
+```
+
+If the user also wants Codex hooks removed, append `--codex`.
+
+---
+
+## Notes
+
+- Wiki content (`~/wiki/`) is never touched — only hook files and settings.json entries
+- To reinstall, run `/hypo:init`

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -1,0 +1,60 @@
+---
+description: Check verify_by fields and surface overdue or missing verifications
+---
+
+You are running `/hypo:verify`. Audit wiki pages for overdue or missing `verify_by` fields.
+
+## What this does
+
+- Scans `pages/` and `projects/` for pages of types `adr`, `page`, `learning`, `concept`, `playbook`, `tool-eval`
+- Reports overdue pages (past `verify_by_date`), upcoming (within 14 days), and pages missing a `verify_by` question
+
+---
+
+## Step 1 — Locate package root and run
+
+Locate the Hypomnema package root (the directory containing this file's parent `commands/`).
+
+```bash
+node <package-root>/scripts/verify.mjs [--wiki-dir="<path>"] [--file=<path>]
+```
+
+Options:
+- `--file=<path>` — check a single page only (useful after editing a page)
+
+---
+
+## Step 2 — Report results
+
+Show the script output verbatim:
+- `✗ Overdue` — page is past its `verify_by_date`; requires immediate review
+- `⚠ Due soon` — within 14 days
+- `⚠ Missing verify_by` — tracked page has no verification question set
+- `✓` — all pages up to date
+
+---
+
+## Step 3 — Offer to review overdue pages
+
+For each overdue page, ask:
+
+> "[[<slug>]] is overdue for verification. The question was: '<verify_by>'. Is this still accurate?"
+
+If the user confirms it is still accurate:
+- Update `verify_by_date` to a new future date (suggest 90 days from today)
+
+If the user says it is outdated:
+- Help update the page content
+- Reset `verify_by_date` and optionally revise `verify_by`
+
+---
+
+## Step 4 — Add missing verify_by fields
+
+For pages missing `verify_by`, suggest a verification question based on the page type:
+- `concept` / `learning`: "Is this still the recommended approach?"
+- `playbook`: "Has this procedure been tested recently?"
+- `tool-eval`: "Is this evaluation still current? Check for a newer version."
+- `adr`: "Is this decision still in effect, or has it been superseded?"
+
+Ask the user to confirm the question, then add it to the frontmatter.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,100 @@
+# Privacy Guide
+
+Hypomnema stores all wiki data **locally on your machine**. No content is sent to any external service by the package itself.
+
+---
+
+## What is stored and where
+
+| Location | Contents | Notes |
+|----------|----------|-------|
+| `<wiki-dir>/pages/` | Synthesized knowledge pages | Written by Claude during ingest/crystallize |
+| `<wiki-dir>/projects/` | Project artifacts, session logs, ADRs | Written by Claude during session close |
+| `<wiki-dir>/sources/` | Raw ingested source documents | Saved as-is; never edited |
+| `<wiki-dir>/log.md` | Append-only activity log | Dates, page slugs, brief descriptions |
+| `<wiki-dir>/hot.md` | Active project pointer table | Project names and dates only |
+| `<wiki-dir>/hypo-config.md` | Wiki root marker + user settings | Includes privacy mode |
+| `~/.claude/hooks/` | Hook scripts | JavaScript files; run locally by Claude Code |
+| `~/.claude/settings.json` | Hook registrations | Command strings pointing to local hook files |
+
+---
+
+## Privacy modes
+
+Set via `/hypo:init` or by editing `privacy:` in `hypo-config.md`.
+
+### `personal` (default)
+Standard mode for private local use. No restrictions beyond `.wikiignore`.
+
+### `shared`
+Adds ignore patterns for personal identifiers: `*personal*`, `*private*`, `journal/`.
+Suitable for wikis that may be viewed by teammates, but where personal notes should be excluded.
+
+### `public`
+Maximum redaction. Blocks `journal/`, personal identifiers, and applies stricter `.wikiignore` rules.
+Suitable for wikis synced to a public git remote.
+
+---
+
+## `.wikiignore` — excluding content from hooks
+
+The `.wikiignore` file in your wiki root controls which files the hooks scan (context injection, hot.md rebuild, etc.).
+
+Syntax: one glob pattern per line. Lines starting with `#` are comments.
+
+```
+# Example .wikiignore
+journal/
+*private*
+sources/*.pdf
+```
+
+Files matched by `.wikiignore` are never read by hooks or included in index lookups. They remain on disk but are invisible to the Hypomnema tooling.
+
+---
+
+## What the hooks do
+
+Hypomnema installs Claude Code hooks that run locally. They do **not** make network requests.
+
+| Hook | Event | What it reads |
+|------|-------|---------------|
+| `wiki-session-start.mjs` | Session start | `hot.md`, `session-state.md` |
+| `wiki-first-prompt.mjs` | First user prompt | `hot.md` |
+| `wiki-file-watch.mjs` | File save | Changed wiki files (for auto-stage) |
+| `wiki-auto-stage.mjs` | File save | Git status in wiki dir |
+| `wiki-auto-commit.mjs` | Session stop | Git status in wiki dir |
+| `wiki-compact-guard.mjs` | Pre-compact | `session-log/` (checks for missing entries) |
+| `wiki-hot-rebuild.mjs` | Post-tool | `projects/*/hot.md` |
+| `wiki-lookup.mjs` | Tool use | Wiki pages (for context injection) |
+| `personal-wiki-check.mjs` | Pre-tool | Settings and config validation |
+
+---
+
+## Git sync and remote remotes
+
+If you configure a git remote during `/hypo:init`, your wiki content will be pushed to that remote on session close (via `wiki-auto-commit.mjs`).
+
+**Before adding a remote**, verify your `.wikiignore` excludes any content you do not want to publish. The auto-commit hook does not filter content — it commits everything not in `.gitignore`.
+
+---
+
+## Deleting your wiki
+
+To remove Hypomnema completely:
+
+1. **Delete the wiki directory**: `rm -rf <wiki-dir>`
+2. **Remove hook files**: `rm ~/.claude/hooks/wiki-*.mjs ~/.claude/hooks/personal-wiki-check.mjs`
+3. **Remove hook registrations** from `~/.claude/settings.json` (the `hooks` object entries added by Hypomnema)
+4. Optionally run `/hypo:uninstall` which automates steps 2–3.
+
+---
+
+## Data sent to Claude
+
+When Claude Code reads wiki pages (via hooks or commands), that content is sent to Anthropic's API as part of the conversation context, subject to [Anthropic's privacy policy](https://www.anthropic.com/privacy).
+
+To exclude sensitive content from Claude's context:
+- Add the relevant paths to `.wikiignore`
+- Use `privacy: public` mode to apply maximum redaction
+- Store sensitive raw documents in `sources/` and only keep the synthesized summary (which you control) in `pages/`

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema crystallize script
+ *
+ * Finds synthesis candidates: pages that share tags, unlinked pages,
+ * and draft pages that could be crystallized into stable knowledge.
+ * Used by /hypo:crystallize to surface what Claude should synthesize.
+ *
+ * Usage:
+ *   node scripts/crystallize.mjs [options]
+ *
+ * Options:
+ *   --wiki-dir=<path>   Wiki root (default: resolved via HYPO_DIR / hypo-config.md / ~/wiki)
+ *   --min-group=<n>     Min pages per tag group to report (default: 2)
+ *   --json              Output as JSON
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, extname } from 'path';
+import { resolveWikiRoot, expandHome } from './lib/wiki-root.mjs';
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { wikiDir: null, minGroup: 2, json: false };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--wiki-dir='))    args.wikiDir  = expandHome(arg.slice(11));
+    else if (arg.startsWith('--min-group=')) args.minGroup = parseInt(arg.slice(12), 10) || 2;
+    else if (arg === '--json')             args.json     = true;
+  }
+  if (!args.wikiDir) args.wikiDir = resolveWikiRoot();
+  return args;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function collectPages(dir, root, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) collectPages(full, root, acc);
+    else if (extname(entry) === '.md') {
+      acc.push({ path: full, rel: relative(root, full) });
+    }
+  }
+  return acc;
+}
+
+function parseFrontmatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+  }
+  return fm;
+}
+
+function parseTags(fm) {
+  if (!fm.tags) return [];
+  const raw = fm.tags.trim().replace(/^\[|\]$/g, '');
+  return raw.split(',').map(t => t.trim()).filter(Boolean);
+}
+
+function extractWikilinks(content) {
+  return [...content.matchAll(/\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]/g)].map(m => m[1].trim());
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args = parseArgs(process.argv);
+
+const pagesDir = join(args.wikiDir, 'pages');
+const pages = collectPages(pagesDir, args.wikiDir);
+
+const tagGroups  = {};  // tag → [{ slug, title }]
+const unlinked   = [];  // pages with no outbound wikilinks
+const drafts     = [];  // pages tagged draft
+
+for (const { path, rel } of pages) {
+  let content;
+  try { content = readFileSync(path, 'utf-8'); } catch { continue; }
+  const fm = parseFrontmatter(content);
+  if (!fm) continue;
+
+  const slug  = rel.replace(/\.md$/, '');
+  const title = fm.title || slug;
+  const tags  = parseTags(fm);
+
+  // tag groups
+  for (const tag of tags) {
+    if (!tagGroups[tag]) tagGroups[tag] = [];
+    tagGroups[tag].push({ slug, title });
+  }
+
+  // draft detection
+  if (tags.includes('draft') || fm.confidence === 'speculative') {
+    drafts.push({ slug, title, confidence: fm.confidence });
+  }
+
+  // unlinked (no outbound wikilinks in body)
+  const body  = content.replace(/^---[\s\S]*?---/, '');
+  const links = extractWikilinks(body);
+  if (links.length === 0) unlinked.push({ slug, title });
+}
+
+// filter tag groups by min-group
+const synthesisGroups = Object.entries(tagGroups)
+  .filter(([, pages]) => pages.length >= args.minGroup)
+  .sort((a, b) => b[1].length - a[1].length)
+  .map(([tag, pages]) => ({ tag, pages }));
+
+if (args.json) {
+  console.log(JSON.stringify({ synthesisGroups, unlinked, drafts }, null, 2));
+  process.exit(0);
+}
+
+let found = false;
+
+if (synthesisGroups.length > 0) {
+  found = true;
+  console.log(`Synthesis candidates by tag (${synthesisGroups.length} group(s)):\n`);
+  for (const { tag, pages: grp } of synthesisGroups) {
+    console.log(`  [${tag}] (${grp.length} pages):`);
+    for (const p of grp) console.log(`    [[${p.slug}]] — ${p.title}`);
+  }
+  console.log('');
+}
+
+if (unlinked.length > 0) {
+  found = true;
+  console.log(`Unlinked pages (no outbound [[wikilinks]]) — ${unlinked.length}:`);
+  for (const p of unlinked) console.log(`  [[${p.slug}]] — ${p.title}`);
+  console.log('');
+}
+
+if (drafts.length > 0) {
+  found = true;
+  console.log(`Draft/speculative pages ready to crystallize — ${drafts.length}:`);
+  for (const p of drafts) console.log(`  [[${p.slug}]] — ${p.title}`);
+  console.log('');
+}
+
+if (!found) {
+  console.log('✓ No crystallization candidates found — wiki looks well-connected.');
+}

--- a/scripts/feedback.mjs
+++ b/scripts/feedback.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema feedback script
+ *
+ * Creates or appends to pages/feedback/<topic>.md with a feedback entry.
+ * Also appends a log entry to log.md.
+ * Used by /hypo:feedback after Claude drafts the feedback content.
+ *
+ * Usage:
+ *   node scripts/feedback.mjs --topic=<slug> --entry=<text> [options]
+ *
+ * Options:
+ *   --wiki-dir=<path>   Wiki root (default: resolved via HYPO_DIR / hypo-config.md / ~/wiki)
+ *   --topic=<slug>      Feedback topic slug (e.g. "response-length", "code-style")
+ *   --entry=<text>      Feedback entry text (one-line rule or short paragraph)
+ *   --dry-run           Preview without writing
+ *   --list              List existing feedback topics
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { resolveWikiRoot, expandHome } from './lib/wiki-root.mjs';
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { wikiDir: null, topic: null, entry: null, dryRun: false, list: false };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--wiki-dir=')) args.wikiDir = expandHome(arg.slice(11));
+    else if (arg.startsWith('--topic='))   args.topic  = arg.slice(8);
+    else if (arg.startsWith('--entry='))   args.entry  = arg.slice(8);
+    else if (arg === '--dry-run')          args.dryRun = true;
+    else if (arg === '--list')             args.list   = true;
+  }
+  if (!args.wikiDir) args.wikiDir = resolveWikiRoot();
+  return args;
+}
+
+// ── list mode ────────────────────────────────────────────────────────────────
+
+function listTopics(wikiDir) {
+  const feedbackDir = join(wikiDir, 'pages', 'feedback');
+  if (!existsSync(feedbackDir)) {
+    console.log('No feedback pages found.');
+    return;
+  }
+  const files = readdirSync(feedbackDir).filter(f => f.endsWith('.md'));
+  if (files.length === 0) {
+    console.log('No feedback pages found.');
+    return;
+  }
+  console.log(`Feedback topics (${files.length}):`);
+  for (const f of files) console.log(`  ${f.replace(/\.md$/, '')}`);
+}
+
+// ── write feedback entry ──────────────────────────────────────────────────────
+
+function writeFeedback(wikiDir, topic, entry, dryRun) {
+  const feedbackDir = join(wikiDir, 'pages', 'feedback');
+  const filePath    = join(feedbackDir, `${topic}.md`);
+  const today       = new Date().toISOString().slice(0, 10);
+
+  let content;
+
+  if (existsSync(filePath)) {
+    content = readFileSync(filePath, 'utf-8');
+    const newEntry = `\n## ${today}\n\n${entry}\n`;
+    content = content.trimEnd() + '\n' + newEntry;
+  } else {
+    content = `---
+title: "Feedback: ${topic}"
+type: feedback
+updated: ${today}
+tags: [feedback]
+---
+
+# Feedback: ${topic}
+
+## ${today}
+
+${entry}
+`;
+  }
+
+  if (dryRun) {
+    console.log('[DRY RUN — no changes made]\n');
+    console.log(`Would write to: ${filePath}\n`);
+    console.log(content);
+    return;
+  }
+
+  if (!existsSync(feedbackDir)) mkdirSync(feedbackDir, { recursive: true });
+  writeFileSync(filePath, content);
+  console.log(`✓ Written: ${filePath}`);
+
+  // append to log.md
+  const logPath = join(wikiDir, 'log.md');
+  const logEntry = `\n- ${today} feedback: [[pages/feedback/${topic}]] — ${entry.split('\n')[0].slice(0, 80)}\n`;
+  if (existsSync(logPath)) {
+    const log = readFileSync(logPath, 'utf-8');
+    writeFileSync(logPath, log.trimEnd() + logEntry);
+    console.log(`↪ Appended to log.md`);
+  }
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args = parseArgs(process.argv);
+
+if (args.list) {
+  listTopics(args.wikiDir);
+  process.exit(0);
+}
+
+if (!args.topic) {
+  console.error('Error: --topic=<slug> is required (or use --list)');
+  process.exit(1);
+}
+
+if (!args.entry) {
+  console.error('Error: --entry=<text> is required');
+  process.exit(1);
+}
+
+writeFeedback(args.wikiDir, args.topic, args.entry, args.dryRun);

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema ingest helper script
+ *
+ * Lists files in sources/ that have no corresponding source-summary page,
+ * and reports pages that reference missing source files.
+ * Used by /hypo:ingest to surface what needs ingestion before Claude synthesizes.
+ *
+ * Usage:
+ *   node scripts/ingest.mjs [options]
+ *
+ * Options:
+ *   --wiki-dir=<path>   Wiki root (default: resolved via HYPO_DIR / hypo-config.md / ~/wiki)
+ *   --json              Output as JSON
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join, extname, basename } from 'path';
+import { resolveWikiRoot, expandHome } from './lib/wiki-root.mjs';
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { wikiDir: null, json: false };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--wiki-dir=')) args.wikiDir = expandHome(arg.slice(11));
+    else if (arg === '--json')         args.json = true;
+  }
+  if (!args.wikiDir) args.wikiDir = resolveWikiRoot();
+  return args;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function collectMdFiles(dir, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) collectMdFiles(full, acc);
+    else if (extname(entry) === '.md') acc.push(full);
+  }
+  return acc;
+}
+
+function parseFrontmatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return {};
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+  }
+  return fm;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args = parseArgs(process.argv);
+
+const sourcesDir = join(args.wikiDir, 'sources');
+const allSources = existsSync(sourcesDir)
+  ? readdirSync(sourcesDir).filter(e => !e.startsWith('.') && !statSync(join(sourcesDir, e)).isDirectory())
+  : [];
+
+// collect all source: references in wiki pages
+const pageFiles = collectMdFiles(join(args.wikiDir, 'pages'));
+const referencedSources = new Set();
+
+for (const f of pageFiles) {
+  let content;
+  try { content = readFileSync(f, 'utf-8'); } catch { continue; }
+  const fm = parseFrontmatter(content);
+  if (fm.source && !fm.source.startsWith('session:')) {
+    referencedSources.add(fm.source);
+  }
+}
+
+// sources with no summary page
+const orphaned = allSources.filter(s => {
+  const slug = basename(s, extname(s));
+  return !referencedSources.has(s) && !referencedSources.has(slug);
+});
+
+// pages referencing sources that don't exist on disk
+const missingSource = [];
+for (const f of pageFiles) {
+  let content;
+  try { content = readFileSync(f, 'utf-8'); } catch { continue; }
+  const fm = parseFrontmatter(content);
+  if (!fm.source || fm.source.startsWith('session:')) continue;
+  const sourceFile = join(sourcesDir, fm.source);
+  const sourceFileWithExt = allSources.find(s => s === fm.source || basename(s, extname(s)) === fm.source);
+  if (!sourceFileWithExt && !existsSync(sourceFile)) {
+    missingSource.push({ page: f, source: fm.source });
+  }
+}
+
+if (args.json) {
+  console.log(JSON.stringify({
+    totalSources: allSources.length,
+    orphaned,
+    missingSource,
+  }, null, 2));
+} else {
+  console.log(`Sources: ${allSources.length} total`);
+
+  if (orphaned.length === 0) {
+    console.log('✓ All sources have a corresponding source-summary page');
+  } else {
+    console.log(`\n⊘ ${orphaned.length} source(s) not yet ingested:`);
+    for (const s of orphaned) console.log(`  sources/${s}`);
+  }
+
+  if (missingSource.length > 0) {
+    console.log(`\n⚠ ${missingSource.length} page(s) reference a missing source file:`);
+    for (const { page, source } of missingSource) {
+      console.log(`  ${page}  →  source: ${source}`);
+    }
+  }
+
+  if (orphaned.length > 0) {
+    console.log('\nRun /hypo:ingest to synthesize the listed sources into wiki pages.');
+  }
+}

--- a/scripts/query.mjs
+++ b/scripts/query.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema query script
+ *
+ * Full-text search across wiki pages and projects.
+ * Returns matching files with a context excerpt and frontmatter summary.
+ * Used by /hypo:query to surface relevant pages before Claude synthesizes.
+ *
+ * Usage:
+ *   node scripts/query.mjs --q="<search terms>" [options]
+ *
+ * Options:
+ *   --wiki-dir=<path>   Wiki root (default: resolved via HYPO_DIR / hypo-config.md / ~/wiki)
+ *   --q=<query>         Search query (required)
+ *   --limit=<n>         Max results (default: 10)
+ *   --json              Output as JSON
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, extname } from 'path';
+import { resolveWikiRoot, expandHome } from './lib/wiki-root.mjs';
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { wikiDir: null, query: null, limit: 10, json: false };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--wiki-dir=')) args.wikiDir = expandHome(arg.slice(11));
+    else if (arg.startsWith('--q='))     args.query  = arg.slice(4);
+    else if (arg.startsWith('--limit=')) args.limit  = parseInt(arg.slice(8), 10) || 10;
+    else if (arg === '--json')           args.json   = true;
+  }
+  if (!args.wikiDir) args.wikiDir = resolveWikiRoot();
+  return args;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function collectMdFiles(dir, root, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) collectMdFiles(full, root, acc);
+    else if (extname(entry) === '.md') acc.push({ path: full, rel: relative(root, full) });
+  }
+  return acc;
+}
+
+function parseFrontmatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return {};
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+  }
+  return fm;
+}
+
+function scoreAndExcerpt(content, terms) {
+  const lower = content.toLowerCase();
+  let score = 0;
+  for (const t of terms) score += (lower.match(new RegExp(t, 'g')) || []).length;
+
+  // find first matching line for excerpt
+  const lines = content.split('\n');
+  let excerpt = '';
+  for (const line of lines) {
+    if (terms.some(t => line.toLowerCase().includes(t))) {
+      excerpt = line.trim().slice(0, 120);
+      break;
+    }
+  }
+  return { score, excerpt };
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args = parseArgs(process.argv);
+
+if (!args.query) {
+  console.error('Error: --q=<query> is required');
+  process.exit(1);
+}
+
+const terms = args.query.toLowerCase().split(/\s+/).filter(Boolean);
+const scanDirs = ['pages', 'projects'].map(d => join(args.wikiDir, d));
+const files = scanDirs.flatMap(d => collectMdFiles(d, args.wikiDir));
+
+const results = [];
+
+for (const { path, rel } of files) {
+  let content;
+  try { content = readFileSync(path, 'utf-8'); } catch { continue; }
+  const { score, excerpt } = scoreAndExcerpt(content, terms);
+  if (score === 0) continue;
+  const fm = parseFrontmatter(content);
+  results.push({ slug: rel.replace(/\.md$/, ''), title: fm.title || rel, type: fm.type || '', score, excerpt });
+}
+
+results.sort((a, b) => b.score - a.score);
+const top = results.slice(0, args.limit);
+
+if (args.json) {
+  console.log(JSON.stringify(top, null, 2));
+} else {
+  if (top.length === 0) {
+    console.log(`No results for: ${args.query}`);
+  } else {
+    console.log(`Found ${results.length} result(s) for "${args.query}" (showing ${top.length}):\n`);
+    for (const r of top) {
+      console.log(`[[${r.slug}]] — ${r.title}${r.type ? ` (${r.type})` : ''} [score: ${r.score}]`);
+      if (r.excerpt) console.log(`  ${r.excerpt}`);
+    }
+  }
+}

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema resume script
+ *
+ * Reads the session-state.md for a project and outputs the next-tasks section.
+ * Used by /hypo:resume to surface what was left off before Claude continues.
+ *
+ * Usage:
+ *   node scripts/resume.mjs [options]
+ *
+ * Options:
+ *   --wiki-dir=<path>     Wiki root (default: resolved via HYPO_DIR / hypo-config.md / ~/wiki)
+ *   --project=<name>      Project name (default: most recently active from hot.md)
+ *   --json                Output as JSON
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { resolveWikiRoot, expandHome } from './lib/wiki-root.mjs';
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { wikiDir: null, project: null, json: false };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--wiki-dir='))  args.wikiDir = expandHome(arg.slice(11));
+    else if (arg.startsWith('--project=')) args.project = arg.slice(10);
+    else if (arg === '--json')           args.json    = true;
+  }
+  if (!args.wikiDir) args.wikiDir = resolveWikiRoot();
+  return args;
+}
+
+// ── active project from hot.md ───────────────────────────────────────────────
+
+function resolveActiveProject(wikiDir) {
+  const hotPath = join(wikiDir, 'hot.md');
+  if (!existsSync(hotPath)) return null;
+
+  const content = readFileSync(hotPath, 'utf-8');
+  // look for table rows with project links: | [name](projects/name/...) | ...
+  const tableRow = content.match(/\|\s*\[([^\]]+)\]\(projects\/([^/)]+)/);
+  if (tableRow) return tableRow[2];
+
+  // fallback: most recently modified project with a session-state.md
+  const projectsDir = join(wikiDir, 'projects');
+  if (!existsSync(projectsDir)) return null;
+
+  let latest = null;
+  let latestMtime = 0;
+  for (const p of readdirSync(projectsDir)) {
+    const ssPath = join(projectsDir, p, 'session-state.md');
+    if (!existsSync(ssPath)) continue;
+    const mtime = statSync(ssPath).mtimeMs;
+    if (mtime > latestMtime) { latestMtime = mtime; latest = p; }
+  }
+  return latest;
+}
+
+// ── read session state ────────────────────────────────────────────────────────
+
+function readSessionState(wikiDir, project) {
+  const ssPath = join(wikiDir, 'projects', project, 'session-state.md');
+  if (!existsSync(ssPath)) return null;
+  return readFileSync(ssPath, 'utf-8');
+}
+
+function readHot(wikiDir, project) {
+  const hotPath = join(wikiDir, 'projects', project, 'hot.md');
+  if (!existsSync(hotPath)) return null;
+  return readFileSync(hotPath, 'utf-8');
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args = parseArgs(process.argv);
+
+const project = args.project || resolveActiveProject(args.wikiDir);
+
+if (!project) {
+  console.error('Error: no active project found. Use --project=<name> or create a hot.md entry.');
+  process.exit(1);
+}
+
+const sessionState = readSessionState(args.wikiDir, project);
+if (!sessionState) {
+  console.error(`Error: no session-state.md found for project "${project}"`);
+  process.exit(1);
+}
+
+const hotContent = readHot(args.wikiDir, project);
+
+if (args.json) {
+  console.log(JSON.stringify({ project, sessionState, hot: hotContent }, null, 2));
+  process.exit(0);
+}
+
+console.log(`Project: ${project}`);
+console.log(`State: projects/${project}/session-state.md\n`);
+console.log('─'.repeat(60));
+console.log(sessionState.trim());
+
+if (hotContent) {
+  console.log('\n' + '─'.repeat(60));
+  console.log('Background (hot.md):');
+  console.log(hotContent.trim());
+}

--- a/scripts/stats.mjs
+++ b/scripts/stats.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema stats script
+ *
+ * Reports statistics about the wiki: page counts by type, project count,
+ * source count, ADR count, and last activity date.
+ *
+ * Usage:
+ *   node scripts/stats.mjs [options]
+ *
+ * Options:
+ *   --wiki-dir=<path>   Wiki root (default: resolved via HYPO_DIR / hypo-config.md / ~/wiki)
+ *   --json              Output as JSON
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join, extname } from 'path';
+import { resolveWikiRoot, expandHome } from './lib/wiki-root.mjs';
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { wikiDir: null, json: false };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--wiki-dir=')) args.wikiDir = expandHome(arg.slice(11));
+    else if (arg === '--json')         args.json = true;
+  }
+  if (!args.wikiDir) args.wikiDir = resolveWikiRoot();
+  return args;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function collectMdFiles(dir, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) collectMdFiles(full, acc);
+    else if (extname(entry) === '.md') acc.push(full);
+  }
+  return acc;
+}
+
+function parseFrontmatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+  }
+  return fm;
+}
+
+function listDirs(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter(e => {
+    if (e.startsWith('.')) return false;
+    return statSync(join(dir, e)).isDirectory();
+  });
+}
+
+function getLastActivity(wikiDir) {
+  const logPath = join(wikiDir, 'log.md');
+  if (!existsSync(logPath)) return null;
+  const content = readFileSync(logPath, 'utf-8');
+  const dates = [...content.matchAll(/\b(\d{4}-\d{2}-\d{2})\b/g)].map(m => m[1]);
+  return dates.length ? dates[dates.length - 1] : null;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args = parseArgs(process.argv);
+
+const pageFiles = collectMdFiles(join(args.wikiDir, 'pages'));
+const projects  = listDirs(join(args.wikiDir, 'projects'));
+const sources   = existsSync(join(args.wikiDir, 'sources'))
+  ? readdirSync(join(args.wikiDir, 'sources')).filter(e => !e.startsWith('.'))
+  : [];
+
+const typeCounts = {};
+let missingFrontmatter = 0;
+
+for (const f of pageFiles) {
+  let content;
+  try { content = readFileSync(f, 'utf-8'); } catch { continue; }
+  const fm = parseFrontmatter(content);
+  if (!fm) { missingFrontmatter++; continue; }
+  const t = fm.type || 'unknown';
+  typeCounts[t] = (typeCounts[t] || 0) + 1;
+}
+
+let adrCount = 0;
+for (const p of projects) {
+  const decisionsDir = join(args.wikiDir, 'projects', p, 'decisions');
+  if (existsSync(decisionsDir)) {
+    adrCount += readdirSync(decisionsDir).filter(f => f.endsWith('.md')).length;
+  }
+}
+
+const lastActivity = getLastActivity(args.wikiDir);
+
+const stats = {
+  pages: { total: pageFiles.length, byType: typeCounts, missingFrontmatter },
+  projects: projects.length,
+  sources: sources.length,
+  adrs: adrCount,
+  lastActivity,
+};
+
+if (args.json) {
+  console.log(JSON.stringify(stats, null, 2));
+} else {
+  console.log(`Pages:    ${pageFiles.length} total`);
+  const typeEntries = Object.entries(typeCounts).sort((a, b) => b[1] - a[1]);
+  if (typeEntries.length) {
+    console.log(`  by type: ${typeEntries.map(([t, n]) => `${t} (${n})`).join(', ')}`);
+  }
+  if (missingFrontmatter) {
+    console.log(`  missing frontmatter: ${missingFrontmatter}`);
+  }
+  console.log(`Projects: ${projects.length}`);
+  console.log(`Sources:  ${sources.length}`);
+  console.log(`ADRs:     ${adrCount}`);
+  if (lastActivity) console.log(`Last activity: ${lastActivity}`);
+}

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema uninstall script
+ *
+ * Removes hook files installed by Hypomnema and strips wiki entries from
+ * settings.json, leaving all other user hooks untouched.
+ *
+ * Usage:
+ *   node scripts/uninstall.mjs [options]
+ *
+ * Options:
+ *   --apply              Actually remove files / edit settings.json (default: dry-run)
+ *   --codex              Also remove Codex hooks (~/.codex/hooks/)
+ *   --hooks-dir=<path>   Override Claude hooks directory (default: ~/.claude/hooks)
+ */
+
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+
+const HOME       = homedir();
+const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
+const PKG_ROOT   = join(SCRIPT_DIR, '..');
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { apply: false, codex: false, hooksDir: null };
+  for (const arg of argv.slice(2)) {
+    if (arg === '--apply')                 args.apply    = true;
+    else if (arg === '--codex')            args.codex    = true;
+    else if (arg.startsWith('--hooks-dir=')) args.hooksDir = arg.slice(12);
+  }
+  return args;
+}
+
+// ── hook map (single source of truth) ───────────────────────────────────────
+
+function loadHookFiles() {
+  let cfg;
+  try {
+    cfg = JSON.parse(readFileSync(join(PKG_ROOT, 'hooks', 'hooks.json'), 'utf-8'));
+  } catch {
+    console.error('Error: cannot read hooks/hooks.json');
+    process.exit(1);
+  }
+  if (!cfg?.hooks || typeof cfg.hooks !== 'object' || Array.isArray(cfg.hooks)) {
+    console.error('Error: hooks/hooks.json must contain a "hooks" object');
+    process.exit(1);
+  }
+
+  const hookFiles = new Set();
+  for (const files of Object.values(cfg.hooks)) {
+    for (const f of files) hookFiles.add(f);
+  }
+  if (Array.isArray(cfg.shared)) {
+    for (const f of cfg.shared) hookFiles.add(f);
+  }
+  return { hookMap: cfg.hooks, hookFiles };
+}
+
+// ── hook file removal ────────────────────────────────────────────────────────
+
+function removeHookFiles(hooksDir, hookFiles, apply) {
+  const removed = [], missing = [];
+  for (const file of hookFiles) {
+    const p = join(hooksDir, file);
+    if (existsSync(p)) {
+      if (apply) rmSync(p);
+      removed.push(p);
+    } else {
+      missing.push(p);
+    }
+  }
+  return { removed, missing };
+}
+
+// ── settings.json cleanup ────────────────────────────────────────────────────
+
+function stripSettingsJson(settingsPath, hooksDir, hookMap, apply) {
+  if (!existsSync(settingsPath)) return { stripped: [], kept: 0 };
+
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    return { stripped: [], kept: 0, error: `${settingsPath} is not valid JSON — skipping` };
+  }
+
+  if (!settings.hooks || typeof settings.hooks !== 'object') return { stripped: [], kept: 0 };
+
+  const stripped = [];
+  let changed = false;
+
+  for (const [event, groups] of Object.entries(settings.hooks)) {
+    if (!Array.isArray(groups)) continue;
+
+    const filtered = groups.filter(group => {
+      if (!Array.isArray(group.hooks)) return true;
+      // Check if every hook in this group is a Hypomnema-managed command
+      const allHypo = group.hooks.every(h => {
+        if (h.type !== 'command' || typeof h.command !== 'string') return false;
+        const hookFiles = hookMap[event] ?? [];
+        return hookFiles.some(file => {
+          const cmd = `node ${hooksDir.replace(HOME, '$HOME')}/${file}`;
+          return h.command === cmd;
+        });
+      });
+      if (allHypo) {
+        for (const h of group.hooks) stripped.push(`${event}: ${h.command}`);
+        return false; // remove this group
+      }
+      return true; // keep non-Hypomnema groups
+    });
+
+    if (filtered.length !== groups.length) {
+      settings.hooks[event] = filtered;
+      changed = true;
+    }
+  }
+
+  if (changed && apply) {
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  }
+
+  return { stripped, kept: 0 };
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args   = parseArgs(process.argv);
+const dryRun = !args.apply;
+
+const { hookMap, hookFiles } = loadHookFiles();
+
+const claudeHooksDir  = args.hooksDir ?? join(HOME, '.claude', 'hooks');
+const claudeSettings  = join(HOME, '.claude', 'settings.json');
+
+const hookResult     = removeHookFiles(claudeHooksDir, hookFiles, args.apply);
+const settingsResult = stripSettingsJson(claudeSettings, claudeHooksDir, hookMap, args.apply);
+
+let codexHookResult     = { removed: [], missing: [] };
+let codexSettingsResult = { stripped: [] };
+
+if (args.codex) {
+  const codexHooksDir = join(HOME, '.codex', 'hooks');
+  const codexSettings = join(HOME, '.codex', 'settings.json');
+  codexHookResult     = removeHookFiles(codexHooksDir, hookFiles, args.apply);
+  codexSettingsResult = stripSettingsJson(codexSettings, codexHooksDir, hookMap, args.apply);
+}
+
+// ── report ───────────────────────────────────────────────────────────────────
+
+const lines = [];
+if (dryRun) lines.push('[DRY RUN — pass --apply to make changes]');
+
+const allRemoved = [...hookResult.removed, ...codexHookResult.removed];
+const allStripped = [...settingsResult.stripped, ...codexSettingsResult.stripped];
+
+if (allRemoved.length)  lines.push(`✓ Hook files ${dryRun ? 'to remove' : 'removed'} (${allRemoved.length}):\n${allRemoved.map(p => `  ${p}`).join('\n')}`);
+if (allStripped.length) lines.push(`✓ settings.json entries ${dryRun ? 'to remove' : 'removed'} (${allStripped.length}):\n${allStripped.map(p => `  ${p}`).join('\n')}`);
+if (hookResult.missing.length) lines.push(`⊘ Already absent (${hookResult.missing.length}):\n${hookResult.missing.map(p => `  ${p}`).join('\n')}`);
+if (settingsResult.error) lines.push(`⚠ ${settingsResult.error}`);
+
+if (!allRemoved.length && !allStripped.length && !hookResult.missing.length) {
+  lines.push('Nothing to uninstall — Hypomnema does not appear to be installed.');
+}
+
+console.log(lines.join('\n\n'));

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Hypomnema verify script
+ *
+ * Checks verify_by and verify_by_date fields across wiki pages.
+ * More detailed than the doctor check: shows the actual verify_by questions
+ * and groups results by status.
+ *
+ * Usage:
+ *   node scripts/verify.mjs [options]
+ *
+ * Options:
+ *   --wiki-dir=<path>   Wiki root (default: resolved via HYPO_DIR / hypo-config.md / ~/wiki)
+ *   --file=<path>       Check a single file only
+ *   --json              Output as JSON
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, extname } from 'path';
+import { resolveWikiRoot, expandHome } from './lib/wiki-root.mjs';
+
+// ── arg parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { wikiDir: null, file: null, json: false };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--wiki-dir=')) args.wikiDir = expandHome(arg.slice(11));
+    else if (arg.startsWith('--file='))    args.file   = expandHome(arg.slice(7));
+    else if (arg === '--json')             args.json   = true;
+  }
+  if (!args.wikiDir) args.wikiDir = resolveWikiRoot();
+  return args;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function collectMdFiles(dir, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) collectMdFiles(full, acc);
+    else if (extname(entry) === '.md') acc.push(full);
+  }
+  return acc;
+}
+
+function parseFrontmatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim().replace(/\s*#.*$/, '').replace(/^["']|["']$/g, '');
+  }
+  return fm;
+}
+
+const VERIFIED_TYPES = new Set(['adr', 'page', 'learning', 'concept', 'playbook', 'tool-eval']);
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const args = parseArgs(process.argv);
+const today = new Date().toISOString().slice(0, 10);
+
+let files;
+if (args.file) {
+  files = [args.file];
+} else {
+  const scanDirs = ['pages', 'projects'].map(d => join(args.wikiDir, d));
+  files = scanDirs.flatMap(d => collectMdFiles(d));
+}
+
+const overdue  = [];
+const upcoming = [];
+const missing  = [];
+const ok       = [];
+
+for (const file of files) {
+  let content;
+  try { content = readFileSync(file, 'utf-8'); } catch { continue; }
+  const fm = parseFrontmatter(content);
+  if (!fm) continue;
+
+  const type = fm.type || '';
+  if (!VERIFIED_TYPES.has(type)) continue;
+
+  const rel = args.wikiDir ? relative(args.wikiDir, file) : file;
+  const entry = {
+    file: rel,
+    title: fm.title || rel,
+    type,
+    verify_by: fm.verify_by || null,
+    verify_by_date: fm.verify_by_date || null,
+  };
+
+  if (!fm.verify_by) {
+    missing.push(entry);
+  } else if (fm.verify_by_date && /^\d{4}-\d{2}-\d{2}$/.test(fm.verify_by_date)) {
+    const daysUntil = Math.ceil((new Date(fm.verify_by_date) - new Date(today)) / 86400000);
+    if (fm.verify_by_date < today) {
+      overdue.push({ ...entry, daysOverdue: -daysUntil });
+    } else if (daysUntil <= 14) {
+      upcoming.push({ ...entry, daysUntil });
+    } else {
+      ok.push(entry);
+    }
+  } else {
+    ok.push(entry);
+  }
+}
+
+if (args.json) {
+  console.log(JSON.stringify({ overdue, upcoming, missing, ok }, null, 2));
+  process.exit(overdue.length > 0 ? 1 : 0);
+}
+
+const total = overdue.length + upcoming.length + missing.length + ok.length;
+console.log(`Scanned ${total} tracked page(s)\n`);
+
+if (overdue.length > 0) {
+  console.log(`✗ Overdue (${overdue.length}):`);
+  for (const p of overdue) {
+    console.log(`  ${p.file}  [${p.daysOverdue}d overdue]`);
+    console.log(`    verify_by: ${p.verify_by}`);
+  }
+  console.log('');
+}
+
+if (upcoming.length > 0) {
+  console.log(`⚠ Due soon (${upcoming.length}):`);
+  for (const p of upcoming) {
+    console.log(`  ${p.file}  [in ${p.daysUntil}d, ${p.verify_by_date}]`);
+    console.log(`    verify_by: ${p.verify_by}`);
+  }
+  console.log('');
+}
+
+if (missing.length > 0) {
+  console.log(`⚠ Missing verify_by (${missing.length}):`);
+  for (const p of missing) console.log(`  ${p.file}`);
+  console.log('');
+}
+
+if (ok.length > 0 && overdue.length === 0 && upcoming.length === 0) {
+  console.log(`✓ All ${ok.length} page(s) verified and up to date`);
+}
+
+const summary = [
+  overdue.length  ? `${overdue.length} overdue`  : '',
+  upcoming.length ? `${upcoming.length} due soon` : '',
+  missing.length  ? `${missing.length} missing verify_by` : '',
+  ok.length       ? `${ok.length} ok` : '',
+].filter(Boolean).join(', ');
+
+console.log(`Result: ${summary || 'nothing to verify'}`);
+
+if (overdue.length > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- **9-6** 나머지 commands 8개 추가: `crystallize`, `resume`, `feedback`, `ingest`, `query`, `verify`, `stats`, `graph`
- **9-6** 대응 scripts 7개 추가: 각 command의 데이터 수집/검색/파일 I/O 담당
- **9-5** 잔여: `uninstall` command + script 추가
- **9-8** Privacy Onboarding: `docs/PRIVACY.md` (스토리지, 훅 동작, privacy 모드, 삭제 방법), `README.md` (프로젝트 개요)

## Test plan

- [x] 신규 스크립트 7개 `node --check` 문법 검사 통과
- [x] `stats`, `ingest`, `verify`, `query`, `crystallize`, `resume` 실제 wiki(`~/wiki`)로 동작 확인
- [x] 기존 테스트 51/51 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)