### PR TITLE
feat: 9-10 Agent Skills — hypo-ingest, hypo-query, hypo-crystallize, hypo-verify

### DIFF
--- a/skills/crystallize.md
+++ b/skills/crystallize.md
@@ -1,0 +1,83 @@
+---
+description: Surface synthesis candidates and consolidate scattered wiki knowledge into stable pages
+---
+
+You are running `/hypo:crystallize`. Find pages that are ready to be consolidated into stable, cross-linked knowledge — then guide the synthesis.
+
+## What this does
+
+- Finds tag groups with ≥ N pages sharing the same tag (synthesis candidates)
+- Lists orphan pages (no inbound `[[wikilinks]]`)
+- Lists draft / stub pages that could be fleshed out
+- After the script runs, you help the user pick what to crystallize and do it
+
+---
+
+## Step 1 — Locate package root
+
+Locate the Hypomnema package root (the directory containing this file's parent `skills/`).
+
+If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/wiki`.
+
+---
+
+## Step 2 — Run crystallize scan
+
+```bash
+node <package-root>/scripts/crystallize.mjs \
+  [--wiki-dir="<path>"] \
+  [--min-group=<n>] \
+  [--json]
+```
+
+Options:
+- `--min-group=<n>` — minimum pages per tag group to report (default: 2)
+- `--json` — output results as JSON
+
+Show the output verbatim.
+
+---
+
+## Step 3 — Session-close checklist (if triggered at session end)
+
+If `/hypo:crystallize` was invoked as a session-close action, run through this checklist before synthesizing:
+
+1. **hot.md** — update `projects/<name>/hot.md` with a snapshot of this session (what changed, decisions made, next steps). Keep under 500 words.
+2. **session-log** — append a session entry to `projects/<name>/session-log/` (or `session-log.md`).
+3. **open-questions** — move any resolved questions out of `pages/open-questions.md`; add new ones.
+4. **log.md** — append a `session` entry to `<wiki-root>/log.md`.
+
+Ask the user to confirm each section before writing, or proceed automatically if they said "auto".
+
+---
+
+## Step 4 — Pick a synthesis target
+
+Present the top candidates from the script output:
+- Tag clusters with the most pages
+- Long-standing orphans
+- Pages marked `status: draft`
+
+Ask: "Which of these would you like to crystallize now? (or 'all' / 'skip')"
+
+---
+
+## Step 5 — Synthesize
+
+For the chosen target:
+
+1. Read all pages in the cluster.
+2. Write a new synthesis page at `pages/syntheses/<slug>.md` with:
+
+```yaml
+---
+title: <synthesis title>
+type: synthesis
+tags: [<shared tags>]
+updated: <today YYYY-MM-DD>
+evidence_strength: inferred
+---
+```
+
+3. Cross-link all source pages back to the synthesis with `[[wikilink]]`.
+4. Add the synthesis to `index.md` under `## Pages — Syntheses`.

--- a/skills/ingest.md
+++ b/skills/ingest.md
@@ -1,0 +1,83 @@
+---
+description: Add a source document to the wiki and synthesize a source-summary page
+---
+
+You are running `/hypo:ingest`. Add a new source document to `sources/` and create (or update) its corresponding `source-summary` page under `pages/`.
+
+## What this does
+
+- Checks which files in `sources/` are missing a `source-summary` page
+- Reports pages that reference a source file that does not exist in `sources/`
+- After the script runs, guides you to synthesize a summary for any un-ingested source
+
+---
+
+## Step 1 — Locate package root
+
+Locate the Hypomnema package root (the directory containing this file's parent `skills/`).
+
+If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/wiki`.
+
+---
+
+## Step 2 — Run ingest status check
+
+```bash
+node <package-root>/scripts/ingest.mjs [--wiki-dir="<path>"] [--json]
+```
+
+Options:
+- `--json` — output results as JSON (useful for tooling)
+
+Show the output verbatim.
+
+---
+
+## Step 3 — Handle the source file
+
+**If the user provided a file or URL to ingest:**
+
+1. Copy or download the source into `<wiki-root>/sources/<slug>.<ext>` (e.g., `sources/2026-05-07-article-title.md`).
+2. Confirm the file is now present.
+
+**If no file was provided:**
+
+List un-ingested sources from the script output and ask which one to process now.
+
+---
+
+## Step 4 — Synthesize a source-summary page
+
+For the chosen source, read its content and create `pages/<slug>.md` with the following frontmatter:
+
+```yaml
+---
+title: <descriptive title>
+type: source-summary
+source: sources/<filename>
+tags: [<relevant tags>]
+updated: <today YYYY-MM-DD>
+evidence_strength: direct   # or inferred
+---
+```
+
+Then write a concise summary:
+- Key ideas (bullet list)
+- Why this source matters to the wiki
+- Any open questions or follow-up items
+
+Cross-reference existing pages with `[[wikilink]]` syntax where relevant.
+
+---
+
+## Step 5 — Update log.md
+
+Append an ingest entry to `<wiki-root>/log.md`:
+
+```
+## <YYYY-MM-DD> ingest — <slug>
+
+- source: sources/<filename>
+- summary: pages/<slug>.md
+- tags: <tags>
+```

--- a/skills/query.md
+++ b/skills/query.md
@@ -1,0 +1,58 @@
+---
+description: Search wiki pages by keyword and retrieve relevant knowledge
+---
+
+You are running `/hypo:query`. Full-text search across all wiki pages and projects, then synthesize an answer from the matching pages.
+
+## What this does
+
+- Searches `pages/` and `projects/` for the given query terms
+- Returns matching files with a context excerpt and frontmatter summary
+- You then read the top results and synthesize an answer
+
+---
+
+## Step 1 — Locate package root
+
+Locate the Hypomnema package root (the directory containing this file's parent `skills/`).
+
+If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/wiki`.
+
+---
+
+## Step 2 — Extract the query
+
+Use the search terms from the user's message. If no query was provided, ask:
+
+> "What would you like to search for in your wiki?"
+
+---
+
+## Step 3 — Run query
+
+```bash
+node <package-root>/scripts/query.mjs \
+  --q="<search terms>" \
+  [--wiki-dir="<path>"] \
+  [--limit=<n>] \
+  [--json]
+```
+
+Options:
+- `--q=<query>` — search query (required)
+- `--limit=<n>` — max results (default: 10)
+- `--json` — output results as JSON
+
+Show the output verbatim.
+
+---
+
+## Step 4 — Synthesize an answer
+
+Read the top matching pages (up to 5) and produce a synthesized response:
+
+1. **Direct answer** — if the query has a clear answer from the wiki, state it first.
+2. **Supporting pages** — list the relevant pages with one-line descriptions and `[[wikilink]]` references.
+3. **Gaps** — if the wiki lacks coverage on the topic, note what is missing and suggest an ingest target.
+
+If zero results are returned, say so and offer to broaden the search or suggest using `/hypo:ingest` to add relevant sources.

--- a/skills/verify.md
+++ b/skills/verify.md
@@ -1,0 +1,66 @@
+---
+description: Check wiki pages for stale or unverified knowledge and prompt review
+---
+
+You are running `/hypo:verify`. Check all wiki pages for `verify_by` and `verify_by_date` fields, surface overdue pages, and guide a review pass.
+
+## What this does
+
+- Scans all pages for `verify_by` (a question to re-check) and `verify_by_date` (deadline)
+- Groups results: **overdue**, **due soon** (within 30 days), and **ok**
+- After the script runs, you help the user review and update each overdue page
+
+---
+
+## Step 1 — Locate package root
+
+Locate the Hypomnema package root (the directory containing this file's parent `skills/`).
+
+If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/wiki`.
+
+---
+
+## Step 2 — Run verify
+
+```bash
+node <package-root>/scripts/verify.mjs \
+  [--wiki-dir="<path>"] \
+  [--file="<path>"] \
+  [--json]
+```
+
+Options:
+- `--file=<path>` — check a single file only
+- `--json` — output results as JSON
+
+Show the output verbatim.
+
+---
+
+## Step 3 — Interpret results
+
+- **overdue** — `verify_by_date` is in the past; the page needs immediate review
+- **due soon** — `verify_by_date` is within 30 days; worth reviewing this session
+- **ok** — no verify fields, or deadline is far enough out
+
+A page with `verify_by` but no `verify_by_date` is treated as **due soon** (undated verification intent).
+
+---
+
+## Step 4 — Review overdue pages
+
+For each overdue page, in priority order:
+
+1. Read the page content.
+2. Show the `verify_by` question to the user.
+3. Ask: "Is this still accurate? (yes / no / partially)"
+4. Based on the answer:
+   - **yes** — update `last_reviewed: <today>` and push `verify_by_date` forward by 90 days.
+   - **no / partially** — help the user edit the page to correct the outdated content, then update `last_reviewed` and `verify_by_date`.
+5. Offer to move to the next overdue page.
+
+---
+
+## Step 5 — Update frontmatter
+
+After each review, apply the updated `last_reviewed` and `verify_by_date` fields to the page frontmatter. Do not change any other fields unless the user approves.

--- a/templates/.wikiignore
+++ b/templates/.wikiignore
@@ -1,0 +1,18 @@
+# .wikiignore — patterns excluded from Hypomnema hooks
+# One glob per line. Lines starting with # are comments.
+# Matched files are not read by hooks or included in index lookups.
+# Syntax follows .gitignore glob rules.
+
+# Large binaries
+*.pdf
+*.zip
+*.tar.gz
+
+# Credentials and secrets
+*.pem
+*.key
+*.env
+
+# Draft / scratch (uncomment to hide from hooks)
+# drafts/
+# scratch/

--- a/templates/Home.md
+++ b/templates/Home.md
@@ -1,0 +1,34 @@
+---
+title: Home
+type: reference
+updated: YYYY-MM-DD
+tags: [wiki, home]
+---
+
+# Wiki
+
+> Personal knowledge base powered by [Hypomnema](https://github.com/sk-lim19f/Hypomnema).
+
+---
+
+## Quick Start
+
+- [[index]] — full page catalog
+- [[hot]] — active projects and last session context
+- [[log]] — chronological activity log
+- [[SCHEMA]] — type system reference
+- [[wiki-guide]] — operations guide
+
+---
+
+## Active Projects
+
+<!-- Links to your active project indexes -->
+<!-- [[projects/my-project/index|my-project]] -->
+
+---
+
+## Recent Pages
+
+<!-- Update after each significant ingest or writing session -->
+<!-- [[learnings/topic]] — date -->

--- a/templates/Overview.md
+++ b/templates/Overview.md
@@ -1,0 +1,50 @@
+---
+title: Wiki Overview
+type: reference
+updated: YYYY-MM-DD
+tags: [wiki, overview]
+---
+
+# Wiki Overview
+
+> A high-level map of this knowledge base. For the full page catalog see [[index]].
+
+---
+
+## Knowledge Areas
+
+<!-- Group your pages by domain/topic area -->
+<!-- Add sections as your wiki grows -->
+
+### Concepts
+
+<!-- [[concepts/topic]] — brief description -->
+
+### Playbooks
+
+<!-- [[playbooks/topic]] — how to do X -->
+
+### Learnings
+
+<!-- [[learnings/topic]] — what was learned and when -->
+
+### Tool Evaluations
+
+<!-- [[tool-evaluations/tool-name]] — adopt / hold / reject -->
+
+---
+
+## Projects
+
+<!-- Links to active and archived project indexes -->
+
+| Project | Status | Last Session |
+|---------|--------|-------------|
+| <!-- [[projects/name/index\|name]] --> | active | YYYY-MM-DD |
+
+---
+
+## Sources
+
+<!-- Key external sources ingested into this wiki -->
+<!-- [[sources/slug]] — title (YYYY-MM-DD) -->

--- a/templates/hypo-help.md
+++ b/templates/hypo-help.md
@@ -1,0 +1,53 @@
+---
+title: Hypomnema — Command Reference
+type: reference
+updated: YYYY-MM-DD
+tags: [hypo, commands, reference]
+---
+
+# Hypomnema Command Reference
+
+Quick reference for all `/hypo:*` commands.
+
+---
+
+## Setup & Maintenance
+
+| Command | Description |
+|---------|-------------|
+| `/hypo:init` | Initialize a new wiki (first-time setup) |
+| `/hypo:doctor` | Health check — verifies dirs, hooks, settings |
+| `/hypo:upgrade` | Update hooks and settings to latest version |
+| `/hypo:uninstall` | Remove hooks and deregister from settings.json |
+
+---
+
+## Daily Operations
+
+| Command | Description |
+|---------|-------------|
+| `/hypo:resume` | Show next tasks from session-state.md |
+| `/hypo:query <terms>` | Full-text search + synthesis across all pages |
+| `/hypo:ingest <url/text>` | Add external knowledge to sources/ and synthesize |
+| `/hypo:feedback <topic>` | Record AI behavior correction for a topic |
+| `/hypo:stats` | Wiki health summary — page counts, ADRs, last activity |
+
+---
+
+## Knowledge Curation
+
+| Command | Description |
+|---------|-------------|
+| `/hypo:crystallize` | Find synthesis candidates — tag clusters, unlinked pages, drafts |
+| `/hypo:verify` | Review overdue verify_by deadlines |
+| `/hypo:lint` | Validate frontmatter and [[wikilinks]] |
+| `/hypo:graph` | Generate link graph (json / mermaid / dot) |
+
+---
+
+## Tips
+
+- **Session start**: `hot.md` → `session-state.md` → begin work
+- **Session end**: run `/session-compact` (if available) or update session-state.md manually
+- **Privacy**: edit `.wikiignore` to exclude sensitive paths from hooks
+- **Verify schedule**: add `verify_by:` and `verify_by_date:` to pages you want to review periodically

--- a/templates/pages/_index.md
+++ b/templates/pages/_index.md
@@ -1,0 +1,61 @@
+---
+title: Pages Index
+type: reference
+updated: YYYY-MM-DD
+tags: [wiki, index, pages]
+---
+
+# Pages
+
+> All permanent knowledge pages, grouped by type.
+> Format: `[[slug]] — one-line description`
+> Keep entries alphabetical within each section.
+
+---
+
+## Concepts
+
+<!-- Principles, theories, design ideas -->
+<!-- [[concepts/topic]] — description -->
+
+---
+
+## Learnings
+
+<!-- Discoveries, gotchas, lessons learned (append-only) -->
+<!-- [[learnings/topic]] — description -->
+
+---
+
+## Playbooks
+
+<!-- Repeatable how-to procedures -->
+<!-- [[playbooks/topic]] — how to do X -->
+
+---
+
+## Tool Evaluations
+
+<!-- Tool adopt / hold / reject records -->
+<!-- [[tool-evaluations/tool-name]] — evaluation summary -->
+
+---
+
+## Prompt Patterns
+
+<!-- Verified prompt patterns for LLM interactions -->
+<!-- [[prompt-patterns/pattern-name]] — description -->
+
+---
+
+## Syntheses
+
+<!-- Cross-page synthesis (3+ pages analyzed) -->
+<!-- [[syntheses/topic]] — synthesis summary -->
+
+---
+
+## Feedback
+
+<!-- AI behavior correction records -->
+<!-- [[feedback/topic]] — correction description -->

--- a/templates/projects/_template/hot.md
+++ b/templates/projects/_template/hot.md
@@ -1,0 +1,28 @@
+---
+title: <project-name> — Hot Cache
+type: reference
+updated: YYYY-MM-DD
+tags: [hot-cache, project]
+---
+
+# <project-name> — Hot Cache
+
+> Project-scoped session snapshot. Updated at session close.
+> Root `hot.md` holds the pointer table; this file holds the detail.
+
+## Background
+
+(1-3 sentences on what this project is and where it stands.)
+
+## Current Focus
+
+(What's being actively worked on right now.)
+
+## Key Decisions
+
+<!-- Brief pointers to important ADRs or design choices -->
+<!-- [[decisions/0001-topic]] — decision summary -->
+
+## Blockers / Open Questions
+
+<!-- (none) -->

--- a/templates/projects/_template/index.md
+++ b/templates/projects/_template/index.md
@@ -1,0 +1,39 @@
+---
+title: <project-name> — Index
+type: project-index
+status: active
+started: YYYY-MM-DD
+updated: YYYY-MM-DD
+working_dir: ~/path/to/project
+tags: [project]
+---
+
+# <project-name>
+
+> One-line description of the project.
+
+---
+
+## Progress
+
+- [ ] Phase 1 — Description
+- [ ] Phase 2 — Description
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `prd.md` | Purpose and success criteria |
+| `hot.md` | Session snapshot and background |
+| `session-state.md` | Next-session handoff |
+| `session-log/` | Monthly work narrative |
+| `decisions/` | Architecture decision records |
+
+---
+
+## Links
+
+- [[projects/<project-name>/prd|PRD]]
+- [[projects/<project-name>/hot|Hot Cache]]

--- a/templates/projects/_template/prd.md
+++ b/templates/projects/_template/prd.md
@@ -1,0 +1,29 @@
+---
+title: <project-name> — PRD
+type: prd
+status: active
+started: YYYY-MM-DD
+updated: YYYY-MM-DD
+tags: [project, prd]
+---
+
+# PRD: <project-name>
+
+## 목적
+
+(Why does this project exist? What problem does it solve?)
+
+## 성공 기준
+
+1. (Measurable outcome 1)
+2. (Measurable outcome 2)
+
+## 제약
+
+- (Constraint or non-goal 1)
+- (Constraint or non-goal 2)
+
+## 범위
+
+- In scope: ...
+- Out of scope: ...

--- a/templates/projects/_template/session-state.md
+++ b/templates/projects/_template/session-state.md
@@ -1,0 +1,9 @@
+---
+title: <project-name> — Session State
+type: session-state
+updated: YYYY-MM-DD
+---
+
+## 다음 이어받기
+
+- (session close 시 기록)

--- a/templates/wiki-automation.md
+++ b/templates/wiki-automation.md
@@ -1,0 +1,69 @@
+---
+title: Wiki Automation
+type: reference
+updated: YYYY-MM-DD
+tags: [wiki, automation, hooks]
+---
+
+# Wiki Automation
+
+How Hypomnema's Claude Code hooks work together to automate context injection,
+session continuity, and git sync.
+
+---
+
+## Hook Overview
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| `wiki-session-start.mjs` | Session start | Injects `hot.md` and `session-state.md` into context |
+| `wiki-first-prompt.mjs` | First user prompt | Injects active project context on first message |
+| `wiki-auto-stage.mjs` | File save | Auto-stages changed wiki files |
+| `wiki-auto-commit.mjs` | Session stop | Commits and pushes staged wiki changes |
+| `wiki-compact-guard.mjs` | Pre-compact | Blocks `/compact` if session-log entry is missing |
+| `wiki-hot-rebuild.mjs` | Post-tool | Rebuilds `hot.md` from project hot caches |
+| `personal-wiki-check.mjs` | Pre-tool | Validates config and blocks on lint errors |
+
+All hooks run **locally** — no network requests.
+
+---
+
+## Session Flow
+
+```
+Session start
+  └─ wiki-session-start.mjs → reads hot.md + session-state.md → injects context
+
+During session
+  └─ wiki-auto-stage.mjs → auto-stages .md edits in wiki dir
+  └─ wiki-hot-rebuild.mjs → refreshes hot.md after project hot.md changes
+
+Session end
+  └─ /session-compact → writes session-log, session-state, ADRs
+  └─ wiki-auto-commit.mjs → git commit + push
+```
+
+---
+
+## `.wikiignore`
+
+Files matching patterns in `.wikiignore` are excluded from hook reads and index lookups.
+They remain on disk but are invisible to all Hypomnema tooling.
+
+```
+# Example .wikiignore
+journal/
+*private*
+sources/*.pdf
+```
+
+See [[docs/PRIVACY]] for full privacy documentation.
+
+---
+
+## Lint Gate
+
+`personal-wiki-check.mjs` runs `lint.mjs` before destructive operations.
+If **blocker** errors are found, the operation is blocked until errors are resolved.
+
+Run `/hypo:lint` to check and fix issues.


### PR DESCRIPTION
## Summary

- `skills/ingest.md` — `/hypo:ingest`: sources/ 추가 + source-summary 합성 + log.md 기록
- `skills/query.md` — `/hypo:query`: 전문 검색 + 지식 합성 답변
- `skills/crystallize.md` — `/hypo:crystallize`: 합성 후보 탐색 + session-close 체크리스트 내장
- `skills/verify.md` — `/hypo:verify`: verify_by/verify_by_date 만료 페이지 리뷰

기존 `skills/lint.md`, `skills/graph.md` 패턴을 따름.

## Test plan

- [ ] plugin.json `"skills": "./skills/"` 디렉토리 스캔으로 자동 등록 확인
- [ ] 각 skill 파일 description frontmatter 정상 파싱 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)