### PR TITLE
Enable dual install paths (plugin + npm) with safe slash-command sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace.json",
+  "name": "hypomnema",
+  "description": "LLM-native personal wiki system for Claude Code — session-aware knowledge base with hooks, slash commands, and a synthesis pipeline.",
+  "owner": {
+    "name": "sk-lim19f",
+    "email": "limsangkyu0219@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "hypomnema",
+      "source": "./",
+      "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
+      "version": "1.0.0",
+      "homepage": "https://github.com/sk-lim19f/Hypomnema"
+    }
+  ]
+}

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -11,6 +11,8 @@
  * Options:
  *   --hypo-dir=<path>      Hypomnema root directory (default: resolves via HYPO_DIR env / hypo-config.md scan / ~/hypomnema)
  *   --no-hooks             Skip hook installation
+ *   --no-commands          Skip slash command installation to ~/.claude/commands/hypo/
+ *   --force-commands       Overwrite user-modified slash command files (creates .bak)
  *   --codex                Also install Codex hooks (~/.codex/hooks/)
  *   --git-remote=<url>     Git remote URL
  *   --no-git-init          Skip git initialization
@@ -19,18 +21,27 @@
  *   --help, -h             Show this help message
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, readdirSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, readdirSync, renameSync, unlinkSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
 import { expandHome, resolveHypoRoot } from './lib/hypo-root.mjs';
+import { readPkgJson as readPkgJsonSafe, writePkgJsonAtomic, sha256 as sha256Buf, isRegularFile, readFileIfRegular } from './lib/pkg-json.mjs';
 
-const HOME     = homedir();
+const HOME       = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
 const PKG_ROOT   = join(SCRIPT_DIR, '..');
-const HOOKS_SRC  = join(PKG_ROOT, 'hooks');
-const TEMPLATES  = join(PKG_ROOT, 'templates');
+const HOOKS_SRC    = join(PKG_ROOT, 'hooks');
+const COMMANDS_SRC = join(PKG_ROOT, 'commands');
+const TEMPLATES    = join(PKG_ROOT, 'templates');
+const PKG_VERSION  = (() => {
+  try { return JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf-8')).version; }
+  catch { return null; }
+})();
+
+function sha256(buf) { return sha256Buf(buf); }
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -38,6 +49,8 @@ function parseArgs(argv) {
   const args = {
     hypoDir:     resolveHypoRoot(),
     hooks:       true,
+    commands:    true,
+    forceCommands: false,
     codex:       false,
     gitRemote:   null,
     gitInit:     true,
@@ -53,6 +66,8 @@ function parseArgs(argv) {
 Options:
   --hypo-dir=<path>      Hypomnema root directory (default: resolves via HYPO_DIR env / hypo-config.md scan / ~/hypomnema)
   --no-hooks             Skip hook installation
+  --no-commands          Skip slash command installation to ~/.claude/commands/hypo/
+  --force-commands       Overwrite user-modified slash command files (creates .bak)
   --codex                Also install Codex hooks (~/.codex/hooks/)
   --git-remote=<url>     Git remote URL
   --no-git-init          Skip git initialization
@@ -65,6 +80,8 @@ Options:
     }
     else if (arg.startsWith('--hypo-dir='))      args.hypoDir    = expandHome(arg.slice(11));
     else if (arg === '--no-hooks')                args.hooks      = false;
+    else if (arg === '--no-commands')             args.commands   = false;
+    else if (arg === '--force-commands')          args.forceCommands = true;
     else if (arg === '--codex')                   args.codex      = true;
     else if (arg.startsWith('--git-remote='))     args.gitRemote  = arg.slice(13);
     else if (arg === '--no-git-init')             args.gitInit    = false;
@@ -261,13 +278,129 @@ echo "[post-commit] hooks/ changed — syncing to ~/.claude/hooks/ ..."
 node "$REPO_ROOT/scripts/upgrade.mjs" --apply
 `;
 
-function writePkgJson(dryRun) {
-  const dest = join(HOME, '.claude', 'hypo-pkg.json');
+function pkgJsonPath() { return join(HOME, '.claude', 'hypo-pkg.json'); }
+
+function writePkgJson(dryRun, extraFields = {}) {
+  const dest     = pkgJsonPath();
+  const existing = readPkgJsonSafe(dest);
+  const merged   = {
+    ...existing,
+    pkgRoot:       PKG_ROOT,
+    pkgVersion:    PKG_VERSION,
+    schemaVersion: '1.0',
+    ...extraFields,
+  };
   if (!dryRun) {
-    mkdirSync(join(HOME, '.claude'), { recursive: true });
-    writeFileSync(dest, JSON.stringify({ pkgRoot: PKG_ROOT }, null, 2) + '\n');
+    writePkgJsonAtomic(dest, merged);
     log('created', dest);
   }
+  return merged;
+}
+
+// ── slash command installation ───────────────────────────────────────────────
+//
+// Sync `commands/*.md` to `~/.claude/commands/hypo/<name>.md` with 3-way SHA tracking.
+// Decision matrix (per file):
+//   on-disk SHA == recorded SHA && on-disk SHA == packaged SHA  → no-op (up to date)
+//   on-disk SHA == recorded SHA && on-disk SHA != packaged SHA  → overwrite (user untouched)
+//   on-disk SHA != recorded SHA                                 → skip + warn (user modified)
+//     (force=true overrides, writing <name>.md.bak first)
+//   file missing                                                → install fresh
+// Recorded SHAs are kept in ~/.claude/hypo-pkg.json under `commands: { "<name>.md": "<sha>" }`.
+
+function installCommands(targetDir, dryRun, force) {
+  if (!existsSync(COMMANDS_SRC)) { log('errors', `commands source missing: ${COMMANDS_SRC}`); return null; }
+  if (!dryRun) mkdirSync(targetDir, { recursive: true });
+
+  const prevPkg  = readPkgJsonSafe(pkgJsonPath());
+  const prevSHAs = (prevPkg.commands && typeof prevPkg.commands === 'object') ? prevPkg.commands : {};
+  const newSHAs  = {};
+
+  function writeFresh(dest, srcContent) {
+    if (dryRun) return;
+    const tmp = `${dest}.tmp.${process.pid}.${Date.now()}`;
+    writeFileSync(tmp, srcContent);
+    try { renameSync(tmp, dest); }
+    catch (err) { try { unlinkSync(tmp); } catch {} throw err; }
+  }
+
+  for (const file of readdirSync(COMMANDS_SRC)) {
+    if (!file.endsWith('.md')) continue;
+    const srcPath    = join(COMMANDS_SRC, file);
+    const dest       = join(targetDir, file);
+    const srcContent = readFileSync(srcPath);
+    const srcSHA     = sha256(srcContent);
+
+    // Fresh install
+    if (!existsSync(dest)) {
+      writeFresh(dest, srcContent);
+      newSHAs[file] = srcSHA;
+      log('created', dest);
+      continue;
+    }
+
+    // Refuse to operate on non-regular files (symlinks, sockets, etc.)
+    if (!isRegularFile(dest)) {
+      log('skipped', `${dest} (not a regular file — refusing to overwrite)`);
+      // Do NOT record ownership for paths we didn't write
+      if (prevSHAs[file]) newSHAs[file] = prevSHAs[file];
+      continue;
+    }
+
+    const onDiskContent = readFileIfRegular(dest);
+    if (onDiskContent === null) {
+      log('skipped', `${dest} (could not read — refusing to overwrite)`);
+      if (prevSHAs[file]) newSHAs[file] = prevSHAs[file];
+      continue;
+    }
+    const onDiskSHA = sha256(onDiskContent);
+    const recordedSHA = prevSHAs[file];
+
+    if (onDiskSHA === srcSHA) {
+      newSHAs[file] = srcSHA;
+      log('skipped', `${dest} (up to date)`);
+      continue;
+    }
+
+    if (recordedSHA && onDiskSHA === recordedSHA) {
+      // Compare-and-swap: re-verify just before write.
+      if (!dryRun) {
+        const verifyContent = readFileIfRegular(dest);
+        const verifySHA = verifyContent ? sha256(verifyContent) : null;
+        if (verifySHA !== recordedSHA) {
+          log('skipped', `${dest} (changed since check — skipping for safety)`);
+          newSHAs[file] = recordedSHA;
+          continue;
+        }
+        writeFresh(dest, srcContent);
+      }
+      newSHAs[file] = srcSHA;
+      log('merged', `${dest} (updated to package version)`);
+      continue;
+    }
+
+    // User-modified path
+    if (force) {
+      if (!dryRun) {
+        writeFresh(dest + '.bak', onDiskContent);
+        writeFresh(dest, srcContent);
+      }
+      newSHAs[file] = srcSHA;
+      log('merged', `${dest} (force-overwritten, backup at ${file}.bak)`);
+      continue;
+    }
+
+    // Preserve user changes. Only claim ownership if we already had a recorded
+    // SHA for this file — never invent ownership for files we didn't install.
+    if (recordedSHA) {
+      newSHAs[file] = recordedSHA;
+      log('skipped', `${dest} (user-modified — re-run with --force-commands to overwrite)`);
+    } else {
+      log('skipped', `${dest} (file exists but Hypomnema does not own it — re-run with --force-commands to take ownership)`);
+    }
+  }
+
+  return newSHAs;
 }
 
 function installPkgGitHook(dryRun) {
@@ -466,11 +599,20 @@ if (args.fromRemote) {
 
 // 4. hooks
 
+let commandSHAs = null;
+if (args.commands) {
+  const claudeCommands = join(HOME, '.claude', 'commands', 'hypo');
+  commandSHAs = installCommands(claudeCommands, args.dryRun, args.forceCommands);
+}
+
 if (args.hooks) {
   const claudeHooks = join(HOME, '.claude', 'hooks');
   installHooks(claudeHooks, args.dryRun);
   mergeSettingsJson(join(HOME, '.claude', 'settings.json'), claudeHooks, args.dryRun, HOOK_MAP);
-  writePkgJson(args.dryRun);
+}
+
+if (args.hooks || args.commands) {
+  writePkgJson(args.dryRun, commandSHAs ? { commands: commandSHAs } : {});
 }
 
 // 5. shell function (claude wrapper)

--- a/scripts/lib/pkg-json.mjs
+++ b/scripts/lib/pkg-json.mjs
@@ -1,0 +1,59 @@
+/**
+ * Shared helpers for reading/writing ~/.claude/hypo-pkg.json safely.
+ *
+ * - `readPkgJson` returns `{}` on missing/corrupt files but logs a warning so
+ *   callers can decide whether to surface it.
+ * - `writePkgJsonAtomic` writes via a sibling temp file + rename so a crash
+ *   mid-write cannot leave a truncated JSON file behind.
+ * - `sha256FileSafe` reads a regular file and returns its hex SHA. Returns
+ *   `null` if the path is a symlink or non-regular file — callers must treat
+ *   that as a refusal to operate on the destination.
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync, lstatSync, mkdirSync, unlinkSync } from 'fs';
+import { join, dirname } from 'path';
+import { createHash } from 'crypto';
+
+export function sha256(buf) {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+export function isRegularFile(path) {
+  if (!existsSync(path)) return false;
+  try { return lstatSync(path).isFile(); } catch { return false; }
+}
+
+export function readFileIfRegular(path) {
+  if (!isRegularFile(path)) return null;
+  try { return readFileSync(path); } catch { return null; }
+}
+
+export function readPkgJson(pkgJsonPath) {
+  if (!existsSync(pkgJsonPath)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (err) {
+    // Preserve corrupt file as <name>.corrupt-<ts>.json so the user can recover.
+    try {
+      const ts  = new Date().toISOString().replace(/[:.]/g, '-');
+      const bak = `${pkgJsonPath}.corrupt-${ts}.json`;
+      renameSync(pkgJsonPath, bak);
+      console.error(`[hypomnema] WARN: ${pkgJsonPath} was not valid JSON. Preserved as ${bak}.`);
+    } catch {}
+    return {};
+  }
+}
+
+export function writePkgJsonAtomic(pkgJsonPath, data) {
+  const dir = dirname(pkgJsonPath);
+  mkdirSync(dir, { recursive: true });
+  const tmp = `${pkgJsonPath}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
+  try {
+    renameSync(tmp, pkgJsonPath);
+  } catch (err) {
+    try { unlinkSync(tmp); } catch {}
+    throw err;
+  }
+}

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -14,22 +14,67 @@
  *   --hooks-dir=<path>   Override Claude hooks directory (default: ~/.claude/hooks)
  */
 
-import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, rmSync, rmdirSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+import { readPkgJson as readPkgJsonSafe, sha256, isRegularFile, readFileIfRegular } from './lib/pkg-json.mjs';
 
 const HOME       = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
 const PKG_ROOT   = join(SCRIPT_DIR, '..');
 
+function removeCommands(apply, force) {
+  const targetDir = join(HOME, '.claude', 'commands', 'hypo');
+  const pkgPath   = join(HOME, '.claude', 'hypo-pkg.json');
+  if (!existsSync(targetDir)) return { removed: [], skippedUserModified: [], skippedNonRegular: [] };
+
+  const recorded = readPkgJsonSafe(pkgPath).commands || {};
+  const removed = [];
+  const skippedUserModified = [];
+  const skippedNonRegular = [];
+
+  for (const file of readdirSync(targetDir)) {
+    if (!file.endsWith('.md')) continue;
+    const fullPath = join(targetDir, file);
+    const recordedSHA = recorded[file];
+    if (!recordedSHA) continue; // wasn't installed by us — leave alone
+
+    if (!isRegularFile(fullPath)) {
+      // Refuse to follow symlinks during destructive ops.
+      skippedNonRegular.push(fullPath);
+      continue;
+    }
+    const buf = readFileIfRegular(fullPath);
+    const sha = buf ? sha256(buf) : null;
+
+    if (sha === recordedSHA || force) {
+      if (apply) rmSync(fullPath);
+      removed.push(fullPath);
+    } else {
+      // User-modified tracked command — preserve unless --force.
+      skippedUserModified.push(fullPath);
+    }
+  }
+
+  // Remove the hypo/ dir only if it ends up empty.
+  if (apply && existsSync(targetDir)) {
+    try {
+      const remaining = readdirSync(targetDir);
+      if (remaining.length === 0) rmdirSync(targetDir);
+    } catch {}
+  }
+  return { removed, skippedUserModified, skippedNonRegular };
+}
+
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { apply: false, codex: false, hooksDir: null };
+  const args = { apply: false, codex: false, hooksDir: null, forceCommands: false };
   for (const arg of argv.slice(2)) {
     if (arg === '--apply')                 args.apply    = true;
     else if (arg === '--codex')            args.codex    = true;
+    else if (arg === '--force-commands')   args.forceCommands = true;
     else if (arg.startsWith('--hooks-dir=')) args.hooksDir = arg.slice(12);
   }
   return args;
@@ -157,6 +202,16 @@ const claudeSettings  = join(HOME, '.claude', 'settings.json');
 
 const hookResult     = removeHookFiles(claudeHooksDir, hookFiles, args.apply);
 const settingsResult = stripSettingsJson(claudeSettings, claudeHooksDir, hookMap, args.apply);
+const commandResult  = removeCommands(args.apply, args.forceCommands);
+
+// pkg.json metadata file removal — only when no user-modified commands remain on disk.
+const pkgJsonPath = join(HOME, '.claude', 'hypo-pkg.json');
+let pkgJsonRemoved = null;
+const keepPkgJson = commandResult.skippedUserModified.length > 0 || commandResult.skippedNonRegular.length > 0;
+if (existsSync(pkgJsonPath) && !keepPkgJson) {
+  if (args.apply) rmSync(pkgJsonPath);
+  pkgJsonRemoved = pkgJsonPath;
+}
 
 let codexHookResult     = { removed: [], missing: [] };
 let codexSettingsResult = { stripped: [] };
@@ -177,11 +232,16 @@ const allRemoved = [...hookResult.removed, ...codexHookResult.removed];
 const allStripped = [...settingsResult.stripped, ...codexSettingsResult.stripped];
 
 if (allRemoved.length)  lines.push(`✓ Hook files ${dryRun ? 'to remove' : 'removed'} (${allRemoved.length}):\n${allRemoved.map(p => `  ${p}`).join('\n')}`);
+if (commandResult.removed.length) lines.push(`✓ Slash commands ${dryRun ? 'to remove' : 'removed'} (${commandResult.removed.length}):\n${commandResult.removed.map(p => `  ${p}`).join('\n')}`);
+if (commandResult.skippedUserModified.length) lines.push(`⊘ Slash commands preserved (user-modified, ${commandResult.skippedUserModified.length}) — pass --force-commands to remove anyway:\n${commandResult.skippedUserModified.map(p => `  ${p}`).join('\n')}`);
+if (commandResult.skippedNonRegular.length) lines.push(`⊘ Slash commands skipped (non-regular file, ${commandResult.skippedNonRegular.length}) — refusing to follow symlinks:\n${commandResult.skippedNonRegular.map(p => `  ${p}`).join('\n')}`);
 if (allStripped.length) lines.push(`✓ settings.json entries ${dryRun ? 'to remove' : 'removed'} (${allStripped.length}):\n${allStripped.map(p => `  ${p}`).join('\n')}`);
+if (pkgJsonRemoved)     lines.push(`✓ Package metadata ${dryRun ? 'to remove' : 'removed'}: ${pkgJsonRemoved}`);
+if (keepPkgJson && !pkgJsonRemoved && existsSync(pkgJsonPath)) lines.push(`⊘ Package metadata preserved (${pkgJsonPath}) — user-modified or non-regular commands still tracked`);
 if (hookResult.missing.length) lines.push(`⊘ Already absent (${hookResult.missing.length}):\n${hookResult.missing.map(p => `  ${p}`).join('\n')}`);
 if (settingsResult.error) lines.push(`⚠ ${settingsResult.error}`);
 
-if (!allRemoved.length && !allStripped.length && !hookResult.missing.length) {
+if (!allRemoved.length && !allStripped.length && !hookResult.missing.length && !commandResult.removed.length && !pkgJsonRemoved && !commandResult.skippedUserModified.length) {
   lines.push('Nothing to uninstall — Hypomnema does not appear to be installed.');
 }
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -15,27 +15,34 @@
  *   --json              Output results as JSON
  */
 
-import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync, readdirSync, renameSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
+import { readPkgJson as readPkgJsonSafe, writePkgJsonAtomic, sha256 as sha256Buf, isRegularFile, readFileIfRegular } from './lib/pkg-json.mjs';
 
-const HOME       = homedir();
-const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
-const PKG_ROOT   = join(SCRIPT_DIR, '..');
-const HOOKS_SRC  = join(PKG_ROOT, 'hooks');
-const TEMPLATES  = join(PKG_ROOT, 'templates');
+const HOME         = homedir();
+const SCRIPT_DIR   = fileURLToPath(new URL('.', import.meta.url));
+const PKG_ROOT     = join(SCRIPT_DIR, '..');
+const HOOKS_SRC    = join(PKG_ROOT, 'hooks');
+const COMMANDS_SRC = join(PKG_ROOT, 'commands');
+const TEMPLATES    = join(PKG_ROOT, 'templates');
+
+function sha256(buf) { return sha256Buf(buf); }
+function pkgJsonPath() { return join(HOME, '.claude', 'hypo-pkg.json'); }
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, apply: false, json: false };
+  const args = { hypoDir: null, apply: false, json: false, forceCommands: false };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
-    else if (arg === '--apply')        args.apply = true;
-    else if (arg === '--json')         args.json  = true;
+    else if (arg === '--apply')              args.apply = true;
+    else if (arg === '--force-commands')     args.forceCommands = true;
+    else if (arg === '--json')               args.json  = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;
@@ -370,6 +377,159 @@ function checkPkgJson() {
   }
 }
 
+// ── slash command sync (mirrors init.mjs:installCommands logic) ─────────────
+
+function readPkgRecordedCommands() {
+  const pkg = readPkgJsonSafe(pkgJsonPath());
+  return (pkg && pkg.commands && typeof pkg.commands === 'object') ? pkg.commands : {};
+}
+
+function checkCommands() {
+  const targetDir = join(HOME, '.claude', 'commands', 'hypo');
+  const results = [];
+  if (!existsSync(COMMANDS_SRC)) return results;
+
+  const recorded = readPkgRecordedCommands();
+  const packagedFiles = new Set();
+
+  for (const file of readdirSync(COMMANDS_SRC)) {
+    if (!file.endsWith('.md')) continue;
+    packagedFiles.add(file);
+    const srcPath = join(COMMANDS_SRC, file);
+    const dest    = join(targetDir, file);
+    const srcSHA  = sha256(readFileSync(srcPath));
+
+    if (!existsSync(dest)) {
+      results.push({ file, status: 'missing', srcPath, dest, srcSHA });
+      continue;
+    }
+    if (!isRegularFile(dest)) {
+      results.push({ file, status: 'non-regular', srcPath, dest, srcSHA });
+      continue;
+    }
+    const onDiskBuf = readFileIfRegular(dest);
+    if (onDiskBuf === null) {
+      results.push({ file, status: 'unreadable', srcPath, dest, srcSHA });
+      continue;
+    }
+    const onDiskSHA = sha256(onDiskBuf);
+    if (onDiskSHA === srcSHA) {
+      results.push({ file, status: 'up-to-date', srcPath, dest, srcSHA });
+      continue;
+    }
+    const recordedSHA = recorded[file];
+    if (recordedSHA && onDiskSHA === recordedSHA) {
+      results.push({ file, status: 'stale', srcPath, dest, srcSHA, recordedSHA });
+    } else {
+      results.push({ file, status: 'user-modified', srcPath, dest, srcSHA, onDiskSHA });
+    }
+  }
+
+  // Reconcile orphaned recorded entries (packages removed a command we previously installed)
+  for (const file of Object.keys(recorded)) {
+    if (packagedFiles.has(file)) continue;
+    const dest = join(targetDir, file);
+    results.push({ file, status: 'orphaned', dest, recordedSHA: recorded[file] });
+  }
+  return results;
+}
+
+function writeFreshAtomic(dest, content) {
+  const tmp = `${dest}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, content);
+  try { renameSync(tmp, dest); }
+  catch (err) { try { unlinkSync(tmp); } catch {} throw err; }
+}
+
+function applyCommands(commandResults, force) {
+  const targetDir = join(HOME, '.claude', 'commands', 'hypo');
+  mkdirSync(targetDir, { recursive: true });
+
+  const applied = [];
+  const newSHAs = {};
+
+  for (const c of commandResults) {
+    if (c.status === 'up-to-date') {
+      newSHAs[c.file] = c.srcSHA;
+      continue;
+    }
+    if (c.status === 'missing') {
+      writeFreshAtomic(c.dest, readFileSync(c.srcPath));
+      newSHAs[c.file] = c.srcSHA;
+      applied.push(c.file);
+      continue;
+    }
+    if (c.status === 'stale') {
+      // Compare-and-swap: re-verify just before write to avoid TOCTOU.
+      const verifyBuf = readFileIfRegular(c.dest);
+      const verifySHA = verifyBuf ? sha256(verifyBuf) : null;
+      if (verifySHA !== c.recordedSHA) {
+        // Something changed between check and apply — keep recorded SHA, skip.
+        newSHAs[c.file] = c.recordedSHA;
+        applied.push(`${c.file} (skipped — changed since check)`);
+        continue;
+      }
+      writeFreshAtomic(c.dest, readFileSync(c.srcPath));
+      newSHAs[c.file] = c.srcSHA;
+      applied.push(c.file);
+      continue;
+    }
+    if (c.status === 'user-modified') {
+      if (force) {
+        const buf = readFileIfRegular(c.dest);
+        if (buf) writeFreshAtomic(c.dest + '.bak', buf);
+        writeFreshAtomic(c.dest, readFileSync(c.srcPath));
+        newSHAs[c.file] = c.srcSHA;
+        applied.push(`${c.file} (force-overwritten, backup at ${c.file}.bak)`);
+      } else {
+        // Preserve user changes — only claim ownership if we already had it.
+        // (user-modified is only reported when on-disk SHA != src SHA; the
+        //  pre-existing ownership comes from the recorded map.)
+        const recorded = readPkgRecordedCommands();
+        if (recorded[c.file]) newSHAs[c.file] = recorded[c.file];
+      }
+      continue;
+    }
+    if (c.status === 'non-regular' || c.status === 'unreadable') {
+      // Refuse silently — keep prior recorded SHA if any.
+      const recorded = readPkgRecordedCommands();
+      if (recorded[c.file]) newSHAs[c.file] = recorded[c.file];
+      continue;
+    }
+    if (c.status === 'orphaned') {
+      // Package no longer ships this command. Drop from recorded map; only
+      // delete on-disk file if it still matches our recorded SHA (unmodified).
+      if (existsSync(c.dest) && isRegularFile(c.dest)) {
+        const buf = readFileIfRegular(c.dest);
+        const sha = buf ? sha256(buf) : null;
+        if (sha === c.recordedSHA) {
+          unlinkSync(c.dest);
+          applied.push(`${c.file} (orphaned — removed)`);
+        } else {
+          // Leave user-modified orphaned file alone.
+          applied.push(`${c.file} (orphaned — user-modified, kept on disk)`);
+        }
+      }
+      // Either way, drop the recorded entry.
+      continue;
+    }
+  }
+
+  // Persist atomically — single write per upgrade run.
+  const path = pkgJsonPath();
+  const existing = readPkgJsonSafe(path);
+  let pkgVersion = null;
+  try { pkgVersion = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf-8')).version; } catch {}
+  writePkgJsonAtomic(path, {
+    ...existing,
+    pkgRoot:       PKG_ROOT,
+    pkgVersion,
+    schemaVersion: '1.0',
+    commands:      newSHAs,
+  });
+  return applied;
+}
+
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
@@ -378,6 +538,7 @@ const schema   = checkSchemaVersion(args.hypoDir);
 const hooks    = checkHookFiles();
 const settings = checkSettingsJson();
 const pkgJson  = checkPkgJson();
+const commands = checkCommands();
 const oldHookRefs = checkOldHookNames();
 
 const staleHooks      = hooks.filter(h => h.status === 'stale' || h.status === 'missing' || h.status === 'src-missing');
@@ -385,12 +546,17 @@ const missingSettings = settings.filter(s => s.status === 'missing');
 const invalidSettings = settings.some(s => s.status === 'invalid-json');
 const schemaDrift     = schema.bump !== 'none' && schema.bump !== 'unknown' && schema.bump !== 'ahead';
 const pkgJsonDrift    = pkgJson.status !== 'up-to-date';
+const staleCommands        = commands.filter(c => c.status === 'stale' || c.status === 'missing');
+const userModifiedCommands = commands.filter(c => c.status === 'user-modified');
+const orphanedCommands     = commands.filter(c => c.status === 'orphaned');
+const nonRegularCommands   = commands.filter(c => c.status === 'non-regular' || c.status === 'unreadable');
 
 let migrationPath        = null;
 let appliedHooks         = [];
 let appliedSettings      = [];
 let appliedPkgJson       = false;
 let appliedHookNameRenames = [];
+let appliedCommands      = [];
 
 if (args.apply) {
   if (oldHookRefs.length > 0) {
@@ -401,14 +567,14 @@ if (args.apply) {
   }
   appliedHooks    = applyHookFiles(hooks);
   appliedSettings = applySettingsJson(settings);
-  const pkgJsonPath = join(HOME, '.claude', 'hypo-pkg.json');
-  writeFileSync(pkgJsonPath, JSON.stringify({ pkgRoot: PKG_ROOT }, null, 2) + '\n');
+  // applyCommands handles the single atomic hypo-pkg.json write (pkgRoot, version, schema, commands map)
+  appliedCommands = applyCommands(commands, args.forceCommands);
   appliedPkgJson = true;
 }
 
 // ── output ───────────────────────────────────────────────────────────────────
 
-const hasDrift = staleHooks.length > 0 || missingSettings.length > 0 || schemaDrift || invalidSettings || pkgJsonDrift || oldHookRefs.length > 0;
+const hasDrift = staleHooks.length > 0 || missingSettings.length > 0 || schemaDrift || invalidSettings || pkgJsonDrift || oldHookRefs.length > 0 || staleCommands.length > 0 || userModifiedCommands.length > 0 || orphanedCommands.length > 0 || nonRegularCommands.length > 0;
 
 if (args.json) {
   console.log(JSON.stringify({
@@ -416,8 +582,9 @@ if (args.json) {
     hooks,
     settings,
     pkgJson,
+    commands,
     oldHookRefs,
-    applied: { hooks: appliedHooks, settings: appliedSettings, pkgJson: appliedPkgJson, hookNameRenames: appliedHookNameRenames },
+    applied: { hooks: appliedHooks, settings: appliedSettings, pkgJson: appliedPkgJson, hookNameRenames: appliedHookNameRenames, commands: appliedCommands },
     migrationReport: migrationPath,
   }, null, 2));
   process.exit(hasDrift && !args.apply ? 1 : 0);
@@ -486,6 +653,30 @@ if (pkgJson.status === 'up-to-date') {
   lines.push(`✗ Package metadata  hypo-pkg.json missing — run --apply to install`);
 }
 
+// Slash commands
+const cmdUpToDate    = commands.filter(c => c.status === 'up-to-date').length;
+const cmdStaleCount  = commands.filter(c => c.status === 'stale').length;
+const cmdMissCount   = commands.filter(c => c.status === 'missing').length;
+const cmdUserCount   = userModifiedCommands.length;
+const cmdOrphanCount = orphanedCommands.length;
+const cmdNonRegCount = nonRegularCommands.length;
+if (commands.length === 0) {
+  lines.push(`⚠ Slash commands    package commands/ is empty`);
+} else if (cmdStaleCount === 0 && cmdMissCount === 0 && cmdUserCount === 0 && cmdOrphanCount === 0 && cmdNonRegCount === 0) {
+  lines.push(`✓ Slash commands    ${cmdUpToDate}/${commands.length} up to date in ~/.claude/commands/hypo/`);
+} else {
+  lines.push(`⚠ Slash commands    ${cmdUpToDate} up to date, ${cmdStaleCount} stale, ${cmdMissCount} missing, ${cmdUserCount} user-modified, ${cmdOrphanCount} orphaned, ${cmdNonRegCount} non-regular:`);
+  for (const c of commands) {
+    if (c.status === 'up-to-date')         lines.push(`    ✓ ${c.file}`);
+    else if (c.status === 'stale')         lines.push(`    ⚠ ${c.file}  [stale — package has newer version]`);
+    else if (c.status === 'missing')       lines.push(`    ✗ ${c.file}  [not installed]`);
+    else if (c.status === 'user-modified') lines.push(`    ⚠ ${c.file}  [user-modified — use --apply --force-commands to overwrite]`);
+    else if (c.status === 'orphaned')      lines.push(`    ⊘ ${c.file}  [orphaned — no longer shipped by package; --apply will reconcile]`);
+    else if (c.status === 'non-regular')   lines.push(`    ✗ ${c.file}  [not a regular file (symlink?) — refusing to touch]`);
+    else if (c.status === 'unreadable')    lines.push(`    ✗ ${c.file}  [unreadable — refusing to touch]`);
+  }
+}
+
 // Old hook names (wiki-*.mjs → hypo-*.mjs rename migration)
 if (oldHookRefs.length > 0) {
   lines.push(`⚠ Hook name migration  ${oldHookRefs.length} old wiki-*.mjs reference(s) in settings.json — run --apply to rename:`);
@@ -502,7 +693,7 @@ if (migrationPath) {
 }
 
 // Applied actions
-if (appliedHooks.length > 0 || appliedSettings.length > 0 || appliedPkgJson || appliedHookNameRenames.length > 0) {
+if (appliedHooks.length > 0 || appliedSettings.length > 0 || appliedPkgJson || appliedHookNameRenames.length > 0 || appliedCommands.length > 0) {
   lines.push('');
   if (appliedHookNameRenames.length > 0) {
     lines.push(`✓ Renamed legacy hook references (${appliedHookNameRenames.length}):`);
@@ -511,6 +702,10 @@ if (appliedHooks.length > 0 || appliedSettings.length > 0 || appliedPkgJson || a
   if (appliedHooks.length > 0) {
     lines.push(`✓ Updated hook files (${appliedHooks.length}):`);
     for (const f of appliedHooks) lines.push(`    → ${f}`);
+  }
+  if (appliedCommands.length > 0) {
+    lines.push(`✓ Updated slash commands (${appliedCommands.length}):`);
+    for (const f of appliedCommands) lines.push(`    → ${f}`);
   }
   if (appliedSettings.length > 0) {
     lines.push(`✓ Merged settings.json entries (${appliedSettings.length}):`);
@@ -523,7 +718,7 @@ if (appliedHooks.length > 0 || appliedSettings.length > 0 || appliedPkgJson || a
 
 // Summary
 lines.push('');
-const totalDrift = staleHooks.length + missingSettings.length + (schemaDrift ? 1 : 0) + (invalidSettings ? 1 : 0) + (pkgJsonDrift ? 1 : 0) + oldHookRefs.length;
+const totalDrift = staleHooks.length + missingSettings.length + (schemaDrift ? 1 : 0) + (invalidSettings ? 1 : 0) + (pkgJsonDrift ? 1 : 0) + oldHookRefs.length + staleCommands.length + userModifiedCommands.length + orphanedCommands.length + nonRegularCommands.length;
 if (totalDrift === 0) {
   lines.push('Result: Hypomnema is up to date');
 } else if (args.apply) {


### PR DESCRIPTION
## Summary

- README v1.0.0 ships a quickstart that runs `npm install -g hypomnema` and then expects `/hypo:init` to exist, but neither the npm install nor `init.mjs` ever registered slash commands with Claude Code. This PR fixes that by enabling **both** install paths simultaneously.
- **Plugin path**: adds `.claude-plugin/marketplace.json` so `/plugin marketplace add sk-lim19f/Hypomnema` followed by `/plugin install hypomnema@hypomnema` registers the slash commands.
- **npm path**: `init.mjs` now copies `commands/*.md` into `~/.claude/commands/hypo/` and tracks per-file SHAs in `~/.claude/hypo-pkg.json` so upgrades and uninstalls can distinguish package content from user edits.

## What changed (5 atomic commits)

1. `feat(plugin)` — marketplace manifest, validated by `claude plugin validate .`.
2. `feat(lib)` — `scripts/lib/pkg-json.mjs`: atomic temp-file + rename writes, corrupt-file recovery, symlink-aware SHA helpers.
3. `feat(init)` — installCommands() with SHA tracking, compare-and-swap before overwrite, symlink refusal, `--force-commands`, `--no-commands`.
4. `feat(upgrade)` — checkCommands/applyCommands with TOCTOU guard, orphan reconciliation, single-writer atomic pkg.json.
5. `fix(uninstall)` — SHA gate that preserves user-modified slash commands; pkg.json is preserved when tracked content remains.

## Cross-reviewed by Codex (omc-teams:2)

All 7 findings were applied:
- BLOCKER: `marketplace.json` `source: "."` was rejected by validator → `source: "./"`.
- HIGH: phantom ownership when a pre-existing file had no recorded SHA.
- HIGH: TOCTOU between check and write.
- HIGH: symlink destinations were followed.
- MED: removed commands left ghost entries in pkg.json.
- HIGH: pkg.json writes were non-atomic.
- HIGH: uninstall deleted user-modified slash commands.

## Test plan

- [x] `claude plugin validate .` passes
- [x] Sandboxed `init.mjs` installs all 13 commands and records SHAs
- [x] Re-run init is idempotent (`up to date`)
- [x] User-modified file is preserved (skipped + warned)
- [x] `--force-commands` overwrites with `.bak`
- [x] Pre-existing untracked file is NOT claimed in pkg.json
- [x] Symlink destination is refused; target file remains untouched
- [x] `upgrade --apply` restores stale file via compare-and-swap
- [x] Orphaned recorded entry is reconciled; user-modified orphan kept on disk
- [x] `uninstall --apply` removes only matching SHA; user edits preserved
- [x] No `.tmp` residue after atomic writes
- [x] `node --check` passes for all three scripts

## Follow-ups (separate branches)

- `fix/template-and-clarity` — lint should skip wikilinks inside HTML comments and inline code (currently emits 11 false-positive warnings on a fresh wiki); `scripts/ingest.mjs` docstring should clarify it lists pending sources but doesn't synthesize.
- `docs/readme-rewrite` — README quickstart in both languages to surface both install paths, env var precedence, and the accurate ingest workflow description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)