### PR TITLE
Fix lint template noise and clarify ingest CLI scope

### DIFF
--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 /**
- * Hypomnema ingest helper script
+ * Hypomnema ingest *listing* helper
  *
- * Lists files in sources/ that have no corresponding source-summary page,
- * and reports pages that reference missing source files.
- * Used by /hypo:ingest to surface what needs ingestion before Claude synthesizes.
+ * This script does NOT synthesize wiki pages — that step is LLM-driven by
+ * `/hypo:ingest` inside Claude Code. The CLI helper only inspects the wiki
+ * filesystem and reports:
+ *   - files under `sources/` that have no matching `source-summary` page
+ *   - pages whose `source:` frontmatter points at a missing `sources/` file
+ *
+ * Calling it from the shell will never modify the wiki; it is read-only.
  *
  * Usage:
  *   node scripts/ingest.mjs [options]
@@ -108,6 +112,7 @@ if (args.json) {
     missingSource,
   }, null, 2));
 } else {
+  console.log('[hypomnema] Listing pending ingest targets — synthesis is performed by /hypo:ingest inside Claude Code.');
   console.log(`Sources: ${allSources.length} total`);
 
   if (orphaned.length === 0) {

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -76,9 +76,29 @@ function buildSlugMap(pages) {
 
 // ── wikilink extractor ────────────────────────────────────────────────────────
 
+// Strip regions where wikilinks are not real references:
+//   - fenced code blocks (``` or ~~~ anchored to line start; markdown allows
+//     up to 3 spaces of indent and pairs the same fence character)
+//   - inline code spans (``...`` then `...`, so double-tick spans aren't split)
+//   - HTML comments (<!-- ... -->)
+// Replacement preserves newline positions so future line-aware checks still
+// line up. Fences are anchored to line starts because the previous version
+// matched any two backtick triples in prose, which could silently hide real
+// wikilinks between them.
+function stripNonWikilinkRegions(content) {
+  let out = content;
+  out = out.replace(/^[ \t]{0,3}```[\s\S]*?^[ \t]{0,3}```/gm, m => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/^[ \t]{0,3}~~~[\s\S]*?^[ \t]{0,3}~~~/gm, m => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/<!--[\s\S]*?-->/g, m => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/``[^`\n]*``/g, m => ' '.repeat(m.length));
+  out = out.replace(/`[^`\n]*`/g, m => ' '.repeat(m.length));
+  return out;
+}
+
 function extractWikilinks(content) {
+  const stripped = stripNonWikilinkRegions(content);
   const links = [];
-  for (const m of content.matchAll(/\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]/g)) {
+  for (const m of stripped.matchAll(/\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]/g)) {
     links.push(m[1].trim());
   }
   return links;

--- a/templates/projects/_template/index.md
+++ b/templates/projects/_template/index.md
@@ -35,5 +35,8 @@ tags: [project]
 
 ## Links
 
+<!-- Replace `<project-name>` with the project slug and uncomment.
 - [[projects/<project-name>/prd|PRD]]
 - [[projects/<project-name>/hot|Hot Cache]]
+-->
+


### PR DESCRIPTION
## Summary

- A fresh wiki right after `init` emitted 11 lint warnings against the package's own templates. All of them were false positives — placeholder wikilinks inside HTML comments, code fences, and inline code spans.
- `scripts/lint.mjs` now strips fenced code blocks (\`\`\`/~~~ anchored to line start), HTML comments, double/single backtick spans, and other code regions before running the wikilink regex. Real broken wikilinks still get caught.
- `templates/projects/_template/index.md` wraps its `<project-name>` placeholders in an HTML comment so they document the format without being treated as live links.
- `scripts/ingest.mjs` docstring + first banner line now make explicit that the CLI helper is read-only and only lists pending sources; the synthesis itself is performed by `/hypo:ingest` inside Claude.

## Cross-reviewed by Codex

Two findings were applied:
- MED: code-fence regex was unanchored — now line-anchored, handles ``` and ~~~.
- LOW: tilde fences and double-backtick spans now handled.

The remaining "false negative" example codex flagged (`Use \`\`\` ... [[link]] ... \`\`\` later` on a single line) is actually correct behavior under CommonMark — those triples open and close an inline code span containing the link.

## Test plan

- [x] Fresh wiki: `lint` returns 0 warnings, 0 errors
- [x] Regression: a page with a real broken wikilink alongside code-spanned / commented / fenced examples still flags only the real one
- [x] `~~~` fenced regions properly ignored
- [x] `node --check scripts/lint.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)