### PR TITLE
fix(ci): use --hypo-dir flag in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Init wiki
         run: |
           node scripts/init.mjs \
-            --wiki-dir=/tmp/wiki-nightly \
+            --hypo-dir=/tmp/wiki-nightly \
             --no-hooks --no-git-init
       - name: Seed verify fixture
         run: |
@@ -38,5 +38,5 @@ jobs:
       - name: Verify all pages
         run: |
           node scripts/verify.mjs \
-            --wiki-dir=/tmp/wiki-nightly \
+            --hypo-dir=/tmp/wiki-nightly \
             --json


### PR DESCRIPTION
Nightly CI has been failing every night because nightly.yml passed `--wiki-dir` to `scripts/init.mjs`, which does not recognise that flag. Init silently fell back to the default home path, leaving `/tmp/wiki-nightly/pages` non-existent, and the next step failed to write the verify fixture.

`--hypo-dir` is the actual flag — same name as the rest of the CLI. Verified locally: `init.mjs --hypo-dir=/tmp/X` creates `/tmp/X/pages/`, seed writes succeed, `verify.mjs --hypo-dir=/tmp/X --json` returns the expected output.

This is unrelated to v1.0.1 — the same failure shows up on May 11 nightly run (before any of the v1.0.1 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)