### PR TITLE
fix(ci): keep nightly verify smoke test green

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
             'type: concept' \
             'updated: 2026-01-01' \
             'verify_by: Is this fixture still accurate?' \
-            'verify_by_date: 2026-01-01' \
+            'verify_by_date: 2099-12-31' \
             '---' \
             '# Verify Fixture' \
             'A synthetic fixture used by nightly verify-pages CI.' \


### PR DESCRIPTION
Follow-up to #11. After fixing the `--wiki-dir`/`--hypo-dir` flag, nightly still failed because the fixture's `verify_by_date: 2026-01-01` was already in the past, so `verify.mjs` exited 1 with the page in the `overdue` bucket. The step is meant to be a smoke test confirming verify.mjs runs cleanly on a wiki with verify_by content, not an alert about the fixture itself.

Bumping the date to 2099-12-31 puts the fixture into the `ok` bucket; verify exits 0. Tested locally — `verify.mjs --json` returns ok with the fixture and exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)