### PR TITLE
fix(#6/#7/#8/#11): doctor Foundation 검사 4개 추가

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -407,6 +407,61 @@ function checkVerifyBy(hypoDir, ignorePatterns = []) {
   }
 }
 
+function checkCodexPaths() {
+  const codexHooks = join(HOME, '.codex', 'hooks');
+  const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
+
+  let missing = 0;
+  for (const file of allFiles) {
+    if (!existsSync(join(codexHooks, file))) missing++;
+  }
+
+  if (missing === 0) {
+    pass('Codex hook files installed', codexHooks);
+  } else if (missing < allFiles.length) {
+    warn('Codex hook files installed', `${missing}/${allFiles.length} missing in ${codexHooks} — run /hypo:init --codex`);
+  } else {
+    fail('Codex hook files installed', `No hook files found in ${codexHooks} — run /hypo:init --codex`);
+  }
+
+  const settingsPath = join(HOME, '.codex', 'settings.json');
+  if (!existsSync(settingsPath)) {
+    warn('Codex settings.json hook registrations', 'settings.json not found — run /hypo:init --codex');
+    return;
+  }
+
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    fail('Codex settings.json hook registrations', 'settings.json is not valid JSON');
+    return;
+  }
+
+  const hooksDir = codexHooks;
+  let registered = 0;
+  let total = 0;
+
+  for (const [event, files] of Object.entries(HOOK_MAP)) {
+    for (const file of files) {
+      total++;
+      const cmd = `node ${hooksDir.replace(HOME, '$HOME')}/${file}`;
+      const found = (Array.isArray(settings.hooks?.[event]) ? settings.hooks[event] : [])
+        .flatMap(g => g.hooks || [])
+        .some(h => h.command === cmd);
+      if (found) registered++;
+    }
+  }
+
+  if (registered === total) {
+    pass('Codex settings.json hook registrations', `${registered}/${total} registered`);
+  } else if (registered > 0) {
+    warn('Codex settings.json hook registrations', `${registered}/${total} registered — run /hypo:init --codex`);
+  } else {
+    fail('Codex settings.json hook registrations', `0/${total} registered — run /hypo:init --codex`);
+  }
+}
+
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
@@ -422,6 +477,7 @@ if (rootOk) {
 }
 checkHooks();
 checkSettingsJson();
+if (args.codex) checkCodexPaths();
 checkGit(args.hypoDir);
 
 // ── report ───────────────────────────────────────────────────────────────────

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -263,6 +263,7 @@ function checkSettingsJson() {
   for (const [, groups] of Object.entries(settings.hooks || {})) {
     if (!Array.isArray(groups)) continue;
     for (const g of groups) {
+      if (!g || typeof g !== 'object') continue;
       for (const h of (g.hooks || [])) {
         if (typeof h.command === 'string' && /hypo-[^/]+\.mjs/.test(h.command) && !expectedCmds.has(h.command)) {
           stale.push(h.command);
@@ -282,6 +283,7 @@ function checkSettingsJson() {
     if (!Array.isArray(groups)) continue;
     const seen = new Set();
     for (const g of groups) {
+      if (!g || typeof g !== 'object') continue;
       for (const h of (g.hooks || [])) {
         if (typeof h.command !== 'string' || !/hypo-[^/]+\.mjs/.test(h.command)) continue;
         if (seen.has(h.command)) dupes.push(`${event}:${h.command}`);
@@ -428,7 +430,7 @@ function checkSyncState(hypoDir) {
     pass('Sync state', 'No unresolved sync failures');
   } else {
     const last = entries[entries.length - 1];
-    warn('Sync state', `${entries.length} unresolved failure(s) — last: ${last.op || '?'} at ${last.timestamp || '?'}. Run /hypo:resume to review.`);
+    warn('Sync state', `${entries.length} unresolved failure(s) — last: ${last.op || '?'} at ${last.timestamp || '?'}. Inspect .cache/sync-state.json or push/pull manually to clear.`);
   }
 }
 

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -407,6 +407,31 @@ function checkVerifyBy(hypoDir, ignorePatterns = []) {
   }
 }
 
+function checkSyncState(hypoDir) {
+  // "open" = file exists with ≥1 entries; session-start (fix #10) clears after user resolves
+  const syncStatePath = join(hypoDir, '.cache', 'sync-state.json');
+  if (!existsSync(syncStatePath)) {
+    pass('Sync state', 'No unresolved sync failures');
+    return;
+  }
+
+  let entries;
+  try {
+    const lines = readFileSync(syncStatePath, 'utf-8').split('\n').filter(l => l.trim());
+    entries = lines.map(l => JSON.parse(l));
+  } catch {
+    warn('Sync state', 'Cannot parse .cache/sync-state.json — inspect manually');
+    return;
+  }
+
+  if (entries.length === 0) {
+    pass('Sync state', 'No unresolved sync failures');
+  } else {
+    const last = entries[entries.length - 1];
+    warn('Sync state', `${entries.length} unresolved failure(s) — last: ${last.op || '?'} at ${last.timestamp || '?'}. Run /hypo:resume to review.`);
+  }
+}
+
 function checkCodexPaths() {
   const codexHooks = join(HOME, '.codex', 'hooks');
   const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
@@ -478,6 +503,7 @@ if (rootOk) {
 checkHooks();
 checkSettingsJson();
 if (args.codex) checkCodexPaths();
+if (rootOk) checkSyncState(args.hypoDir);
 checkGit(args.hypoDir);
 
 // ── report ───────────────────────────────────────────────────────────────────

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -252,6 +252,48 @@ function checkSettingsJson() {
   } else {
     fail('settings.json hook registrations', `0/${total} registered — run /hypo:init`);
   }
+
+  // fix #7: stale hypo-* entries (uninstall remnants)
+  const expectedCmds = new Set(
+    Object.entries(HOOK_MAP).flatMap(([, files]) =>
+      files.map(f => `node ${hooksDir.replace(HOME, '$HOME')}/${f}`)
+    )
+  );
+  const stale = [];
+  for (const [, groups] of Object.entries(settings.hooks || {})) {
+    if (!Array.isArray(groups)) continue;
+    for (const g of groups) {
+      for (const h of (g.hooks || [])) {
+        if (typeof h.command === 'string' && /hypo-[^/]+\.mjs/.test(h.command) && !expectedCmds.has(h.command)) {
+          stale.push(h.command);
+        }
+      }
+    }
+  }
+  if (stale.length > 0) {
+    warn('settings.json stale hypo-* entries', `${stale.length} unrecognised hypo-* command(s) — run /hypo:uninstall then /hypo:init: ${stale.slice(0, 3).join(', ')}`);
+  } else {
+    pass('settings.json stale hypo-* entries', 'None');
+  }
+
+  // fix #7: duplicate hypo-* entries per event
+  const dupes = [];
+  for (const [event, groups] of Object.entries(settings.hooks || {})) {
+    if (!Array.isArray(groups)) continue;
+    const seen = new Set();
+    for (const g of groups) {
+      for (const h of (g.hooks || [])) {
+        if (typeof h.command !== 'string' || !/hypo-[^/]+\.mjs/.test(h.command)) continue;
+        if (seen.has(h.command)) dupes.push(`${event}:${h.command}`);
+        else seen.add(h.command);
+      }
+    }
+  }
+  if (dupes.length > 0) {
+    warn('settings.json duplicate hypo-* entries', `${dupes.length} duplicate(s) — run /hypo:init to repair: ${dupes.slice(0, 2).join(', ')}`);
+  } else {
+    pass('settings.json duplicate hypo-* entries', 'None');
+  }
 }
 
 function checkGit(hypoDir) {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -33,10 +33,11 @@ const PKG_INTEGRITY_HINT = '→ This indicates a corrupt or incomplete install. 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, json: false };
+  const args = { hypoDir: null, json: false, codex: false };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--json')         args.json = true;
+    else if (arg === '--codex')        args.codex = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;
@@ -126,6 +127,38 @@ const HOOK_MAP     = Object.fromEntries(Object.entries(_hookConfig.hooks).map(([
 const SHARED_FILES = _hookConfig.shared ?? [];
 
 // ── checks ───────────────────────────────────────────────────────────────────
+
+function checkExternalDeps() {
+  const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
+  if (nodeMajor >= 18) {
+    pass('Node.js ≥ 18', `v${process.versions.node}`);
+  } else {
+    fail('Node.js ≥ 18', `v${process.versions.node} — upgrade to Node.js 18+`);
+  }
+
+  const npm = spawnSync('npm', ['--version'], { encoding: 'utf-8' });
+  if (npm.status === 0) {
+    pass('npm', `v${npm.stdout.trim()}`);
+  } else {
+    fail('npm', 'Not found — install npm');
+  }
+
+  const git = spawnSync('git', ['--version'], { encoding: 'utf-8' });
+  if (git.status === 0) {
+    pass('git', git.stdout.trim().replace('git version ', 'v'));
+  } else {
+    fail('git', 'Not found — install git');
+  }
+
+  const shell = process.env.SHELL || '';
+  if (shell.endsWith('zsh') || shell.endsWith('bash')) {
+    pass('Shell (zsh/bash)', shell);
+  } else if (!shell) {
+    warn('Shell (zsh/bash)', '$SHELL not set');
+  } else {
+    warn('Shell (zsh/bash)', `${shell} — zsh or bash recommended`);
+  }
+}
 
 function checkHypoRoot(hypoDir) {
   if (!existsSync(hypoDir)) {
@@ -336,6 +369,7 @@ function checkVerifyBy(hypoDir, ignorePatterns = []) {
 
 const args = parseArgs(process.argv);
 
+checkExternalDeps();
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const rootOk = checkHypoRoot(args.hypoDir);
 if (rootOk) {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -263,6 +263,60 @@ test('doctor-checks-node-git-shell-npm: shell check present', () => {
   assert.ok(['pass', 'warn', 'fail'].includes(shellCheck.status), `unexpected status: ${shellCheck.status}`);
 });
 
+// fix #7: doctor-settings-integrity
+suite('doctor.mjs — fix #7: settings integrity');
+
+test('doctor-settings-integrity: no stale entries → pass', () => {
+  withTmpHome(home => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify({ hooks: {} }));
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const staleCheck = out.find(c => c.label === 'settings.json stale hypo-* entries');
+    assert.ok(staleCheck, 'stale check not found');
+    assert.equal(staleCheck.status, 'pass', `expected pass: ${staleCheck.detail}`);
+  });
+});
+
+test('doctor-settings-integrity: stale hypo-* entry → warn', () => {
+  withTmpHome(home => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    const staleSetting = {
+      hooks: {
+        PostToolUse: [{
+          hooks: [{ type: 'command', command: `node $HOME/.claude/hooks/hypo-old-removed.mjs` }],
+        }],
+      },
+    };
+    writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify(staleSetting));
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const staleCheck = out.find(c => c.label === 'settings.json stale hypo-* entries');
+    assert.ok(staleCheck, 'stale check not found');
+    assert.equal(staleCheck.status, 'warn', `expected warn: ${staleCheck.detail}`);
+  });
+});
+
+test('doctor-settings-integrity: duplicate hypo-* entry → warn', () => {
+  withTmpHome(home => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    const dupeSetting = {
+      hooks: {
+        Stop: [
+          { hooks: [{ type: 'command', command: `node $HOME/.claude/hooks/hypo-auto-commit.mjs` }] },
+          { hooks: [{ type: 'command', command: `node $HOME/.claude/hooks/hypo-auto-commit.mjs` }] },
+        ],
+      },
+    };
+    writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify(dupeSetting));
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const dupeCheck = out.find(c => c.label === 'settings.json duplicate hypo-* entries');
+    assert.ok(dupeCheck, 'duplicate check not found');
+    assert.equal(dupeCheck.status, 'warn', `expected warn: ${dupeCheck.detail}`);
+  });
+});
+
 // ── hook contract tests ───────────────────────────────────────────────────────
 
 const HOOKS = join(REPO, 'hooks');

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -228,6 +228,41 @@ test('JSON output is an array of check objects', () => {
   assert.ok('label' in out[0], 'expected label field');
 });
 
+// fix #6: doctor-checks-node-git-shell-npm
+suite('doctor.mjs — fix #6: external deps');
+
+test('doctor-checks-node-git-shell-npm: Node.js check passes (running on ≥18)', () => {
+  const r = run('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json']);
+  const out = JSON.parse(r.stdout);
+  const nodeCheck = out.find(c => c.label === 'Node.js ≥ 18');
+  assert.ok(nodeCheck, 'Node.js ≥ 18 check not found');
+  assert.equal(nodeCheck.status, 'pass', `expected pass, got ${nodeCheck.status}: ${nodeCheck.detail}`);
+});
+
+test('doctor-checks-node-git-shell-npm: git check present', () => {
+  const r = run('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json']);
+  const out = JSON.parse(r.stdout);
+  const gitCheck = out.find(c => c.label === 'git');
+  assert.ok(gitCheck, 'git check not found');
+  assert.ok(['pass', 'fail'].includes(gitCheck.status), `unexpected status: ${gitCheck.status}`);
+});
+
+test('doctor-checks-node-git-shell-npm: npm check present', () => {
+  const r = run('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json']);
+  const out = JSON.parse(r.stdout);
+  const npmCheck = out.find(c => c.label === 'npm');
+  assert.ok(npmCheck, 'npm check not found');
+  assert.ok(['pass', 'fail'].includes(npmCheck.status), `unexpected status: ${npmCheck.status}`);
+});
+
+test('doctor-checks-node-git-shell-npm: shell check present', () => {
+  const r = run('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json']);
+  const out = JSON.parse(r.stdout);
+  const shellCheck = out.find(c => c.label === 'Shell (zsh/bash)');
+  assert.ok(shellCheck, 'Shell check not found');
+  assert.ok(['pass', 'warn', 'fail'].includes(shellCheck.status), `unexpected status: ${shellCheck.status}`);
+});
+
 // ── hook contract tests ───────────────────────────────────────────────────────
 
 const HOOKS = join(REPO, 'hooks');

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -317,6 +317,42 @@ test('doctor-settings-integrity: duplicate hypo-* entry → warn', () => {
   });
 });
 
+// fix #11: doctor-sync-state-warn
+suite('doctor.mjs — fix #11: sync-state warn');
+
+test('doctor-sync-state-warn: no .cache/sync-state.json → pass', () => {
+  withTmpDir(dir => {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'projects'), { recursive: true });
+    mkdirSync(join(dir, 'sources'), { recursive: true });
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find(c => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'pass', `expected pass: ${check.detail}`);
+  });
+});
+
+test('doctor-sync-state-warn: open sync-state.json entries → warn', () => {
+  withTmpDir(dir => {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'projects'), { recursive: true });
+    mkdirSync(join(dir, 'sources'), { recursive: true });
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({ timestamp: '2026-05-14T00:00:00Z', op: 'push', error: 'network timeout', host: 'test' }) + '\n'
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find(c => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+  });
+});
+
 // fix #8: doctor-codex-paths
 suite('doctor.mjs — fix #8: codex paths');
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -317,6 +317,35 @@ test('doctor-settings-integrity: duplicate hypo-* entry → warn', () => {
   });
 });
 
+// fix #8: doctor-codex-paths
+suite('doctor.mjs — fix #8: codex paths');
+
+test('doctor-codex-paths: no codex checks without --codex flag', () => {
+  const r = run('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json']);
+  const out = JSON.parse(r.stdout);
+  const codexChecks = out.filter(c => c.label.includes('Codex'));
+  assert.equal(codexChecks.length, 0, 'expected no Codex checks without --codex flag');
+});
+
+test('doctor-codex-paths: --codex flag triggers codex hook file check', () => {
+  withTmpHome(home => {
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--codex', '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const hookCheck = out.find(c => c.label === 'Codex hook files installed');
+    assert.ok(hookCheck, 'Codex hook files check not found');
+    assert.equal(hookCheck.status, 'fail', `expected fail when ~/.codex/hooks is empty: ${hookCheck.detail}`);
+  });
+});
+
+test('doctor-codex-paths: --codex flag triggers codex settings.json check', () => {
+  withTmpHome(home => {
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--codex', '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const settingsCheck = out.find(c => c.label === 'Codex settings.json hook registrations');
+    assert.ok(settingsCheck, 'Codex settings.json check not found');
+  });
+});
+
 // ── hook contract tests ───────────────────────────────────────────────────────
 
 const HOOKS = join(REPO, 'hooks');


### PR DESCRIPTION
## Summary

- **#6** `checkExternalDeps()` 신규: Node.js ≥18, npm, git, zsh/bash 바이너리 존재 검사 (§4.2 Strict 외부 의존성 정책)
- **#7** `checkSettingsJson()` 강화: 잔여 `hypo-*` entry(uninstall 잔재) + 중복 entry 검출 (§4.4.2 불변 조건)
- **#8** `--codex` 플래그 신규: `~/.codex/hooks/` 파일 존재 + settings.json 등록 검사 (§4.4.3 Codex 1급 시민)
- **#11** `checkSyncState()` 신규: `.cache/sync-state.json` open entries warn (§7.4 Git silent+노출)

## Test plan

- [ ] `npm test` 91 passed, 0 failed 확인
- [ ] `node scripts/doctor.mjs --json` 실행 후 Node.js/npm/git/Shell 체크 pass 확인
- [ ] `node scripts/doctor.mjs --codex --json` 실행 후 Codex 체크 항목 존재 확인
- [ ] `.cache/sync-state.json` 에 entry 추가 후 doctor가 warn 반환 확인

## Notes

- Codex 검토 후 null hook group crash 방지 guard 추가 (fix: 9478293)
- sync-state warn 메시지 `/hypo:resume` → 수동 점검 안내로 교체

🤖 Generated with [Claude Code](https://claude.com/claude-code)