### PR TITLE
fix(#35): init 시 pages/observability/_index.md stub 생성

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -143,7 +143,7 @@ function log(action, path) { results[action].push(path); }
 
 // ── directory structure ──────────────────────────────────────────────────────
 
-const HYPO_DIRS = ['pages', 'projects', 'sources', 'journal/daily', 'journal/weekly', 'journal/monthly'];
+const HYPO_DIRS = ['pages', 'projects', 'sources', 'journal/daily', 'journal/weekly', 'journal/monthly', 'pages/observability'];
 
 function ensureDir(dir, dryRun) {
   if (existsSync(dir)) return;
@@ -625,6 +625,7 @@ if (args.fromRemote) {
   copyTemplate('hypo-automation.md',join(args.hypoDir, 'hypo-automation.md'),args.dryRun);
   copyTemplate('session-state.md',  join(args.hypoDir, 'session-state.md'),  args.dryRun);
   copyTemplate(join('pages', '_index.md'), join(args.hypoDir, 'pages', '_index.md'), args.dryRun);
+  copyTemplate(join('pages', 'observability', '_index.md'), join(args.hypoDir, 'pages', 'observability', '_index.md'), args.dryRun);
 
   // projects/_template structure
   ensureDir(join(args.hypoDir, 'projects', '_template'), args.dryRun);

--- a/templates/pages/observability/_index.md
+++ b/templates/pages/observability/_index.md
@@ -1,0 +1,77 @@
+---
+title: Observability Index
+type: reference
+updated: YYYY-MM-DD
+tags: [observability, autonomy, wiki-health]
+---
+
+# Observability
+
+> Tracks how often and how well the wiki is used per session. Score = proxy for autonomous wiki engagement (not ground truth).
+
+---
+
+## 1. Data flow
+
+```
+Stop hook (hypo-session-record.mjs)
+    │  appends one JSONL entry per session
+    ▼
+.cache/sessions/index.jsonl
+    │
+    ▼
+scripts/session-audit.mjs   ← per-session metrics + classification
+    │
+    ▼
+scripts/weekly-report.mjs   ← weekly autonomy score
+    │
+    ▼
+pages/observability/<YYYY-WW>.md
+```
+
+---
+
+## 2. Session classification
+
+| Class | Rule |
+|---|---|
+| `staleness-skip` | `recorded_at` older than `--max-age-days` (default 30) |
+| `ingest-missed` | `urls >= 2` and `ingest_count == 0` |
+| `search-many` | `search_count >= 5` |
+| `search-0` | `search_count == 0` |
+| `normal` | otherwise |
+
+Counted tools: `Grep`, `WebSearch`, `WebFetch`. Counted commands: `/hypo:query`, `/hypo:ingest`, `/hypo:feedback`.
+
+---
+
+## 3. Autonomy score formula (heuristic v0)
+
+Score is clamped to `[0, 100]`. `staleness-skip` sessions are excluded.
+
+```
+numerator   = Σ min(search_count, 3) + ingest_count × 3 + feedback_count × 2
+denominator = Σ 1 + (urls > 0 ? min(urls, 5) × 2 : 0)
+score       = clamp(round(numerator / denominator × 100), 0, 100)
+```
+
+- Each real session contributes 1 to denominator (baseline expectation).
+- URLs raise the bar: each external URL is a missed-ingest opportunity (weight 2, capped at 5).
+- Ingest (weight 3) and feedback (weight 2) are the strongest positive signals.
+- Search (weight 1, capped at 3) is a weaker signal.
+
+---
+
+## 4. Four-week baseline plan
+
+Capture v0 scores for 4 weeks before introducing LLM-judge classification or changing formula weights. Goal: establish a baseline before tuning.
+
+| Week | Score | Notes |
+|---|---|---|
+| <!-- YYYY-WW --> | <!-- % --> | <!-- first run --> |
+
+---
+
+## 5. Privacy
+
+Weekly reports emit only `session_id` plus aggregate counts — no transcript content, no URLs, no tool inputs. Transcripts live under `~/.claude/projects/` or `.cache/sessions/`, excluded by `.hypoignore`.

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -179,9 +179,25 @@ test('actual run creates expected directories', () => {
       '--no-git-init',
     ]);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    for (const sub of ['pages', 'projects', 'sources']) {
+    for (const sub of ['pages', 'projects', 'sources', 'pages/observability']) {
       assert.ok(existsSync(join(hypoDir, sub)), `missing: ${sub}/`);
     }
+  });
+});
+
+test('init creates pages/observability/_index.md stub', () => {
+  withTmpDir(dir => {
+    const hypoDir = join(dir, 'wiki');
+    const r = run('init.mjs', [
+      `--hypo-dir=${hypoDir}`,
+      '--no-hooks',
+      '--no-git-init',
+    ]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const stubPath = join(hypoDir, 'pages', 'observability', '_index.md');
+    assert.ok(existsSync(stubPath), 'pages/observability/_index.md should be created');
+    const content = readFileSync(stubPath, 'utf8');
+    assert.ok(content.includes('autonomy score'), '_index.md should contain autonomy score section');
   });
 });
 


### PR DESCRIPTION
## Summary

- `HYPO_DIRS`에 `pages/observability` 추가 → `ensureDir` 루프가 자동으로 디렉토리 생성
- `templates/pages/observability/_index.md` 추가 (autonomy score 공식 §3, 세션 분류 기준, 4주 baseline 계획 포함)
- `init` 시 `pages/observability/_index.md` 자동 복사 (`copyTemplate` 추가)

## Changes

- `scripts/init.mjs` — HYPO_DIRS + copyTemplate
- `templates/pages/observability/_index.md` — 신규 템플릿
- `tests/runner.mjs` — 테스트 2건 추가 (dir 생성 + stub 내용 검증)

## Test plan

- [x] `npm test` — 80 passed, 0 failed
- [x] `node --check` — init/session-audit/weekly-report/runner 구문 검사 통과
- [x] `git diff --check` — 공백 이슈 없음
- [x] smoke test — `init --no-hooks --no-git-init` 실행 후 `pages/observability/_index.md` 생성 확인
- [x] Codex 검토 — Findings 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)