### PR TITLE
feat(#20): 자연어 close 패턴 감지 (Layer 1 behavioral rule)

### DIFF
--- a/hooks/hypo-lookup.mjs
+++ b/hooks/hypo-lookup.mjs
@@ -89,7 +89,6 @@ function typePrior(slug) {
   if (/\/decisions\/|^decisions\//.test(slug)) return 1.5;
   if (/\bprd\b|spec-v/.test(slug))             return 1.3;
   if (/\/session-log\/|\/session-log$/.test(slug)) return 1.2;
-  if (/^sources\//.test(slug))                  return 1.2;
   return 1.0;
 }
 

--- a/hooks/hypo-lookup.mjs
+++ b/hooks/hypo-lookup.mjs
@@ -85,6 +85,14 @@ function bm25Score(queryTerms, entries, k1 = 1.5, b = 0.75) {
   }).sort((a, c) => c.score - a.score);
 }
 
+function typePrior(slug) {
+  if (/\/decisions\/|^decisions\//.test(slug)) return 1.5;
+  if (/\bprd\b|spec-v/.test(slug))             return 1.3;
+  if (/\/session-log\/|\/session-log$/.test(slug)) return 1.2;
+  if (/^sources\//.test(slug))                  return 1.2;
+  return 1.0;
+}
+
 function parseIndexEntries(indexContent) {
   const entries = [];
   for (const line of indexContent.split('\n')) {
@@ -122,13 +130,19 @@ process.stdin.on('end', () => {
     }
 
     const entries  = parseIndexEntries(readFileSync(INDEX_PATH, 'utf-8'));
-    const scored   = bm25Score(keywords, entries).filter(e => e.score > 0);
+    const scored   = bm25Score(keywords, entries)
+      .map(e => ({ ...e, score: e.score * typePrior(e.slug) }))
+      .sort((a, c) => c.score - a.score)
+      .filter(e => e.score > 0);
     const topScore = scored[0]?.score ?? 0;
     const matched  = scored.filter(e => e.score >= topScore * 0.5);
 
     if (matched.length === 0) {
       const topic   = keywords.slice(0, 5).join(', ');
-      const closest = bm25Score(keywords, entries).slice(0, 3).map(e => `[[${e.slug}]]`).join(', ');
+      const closest = bm25Score(keywords, entries)
+        .map(e => ({ ...e, score: e.score * typePrior(e.slug) }))
+        .sort((a, c) => c.score - a.score)
+        .slice(0, 3).map(e => `[[${e.slug}]]`).join(', ');
       console.log(JSON.stringify(
         buildOutput(
           `[WIKI LOOKUP: miss] "${topic}" — no match. Closest: ${closest || 'none'}`,

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -27,6 +27,7 @@ import {
   hotMdIsClean,
   readChecklist,
   isGateSkipped,
+  isClosePattern,
 } from './hypo-shared.mjs';
 
 const CRITICAL_FILE = join(homedir(), '.claude', 'state', 'wiki-context-critical.json');
@@ -92,14 +93,16 @@ process.stdin.on('end', () => {
     return;
   }
 
-  // ── Bypass 2: env var ──
-  if (!isGateSkipped() && transcriptPath && existsSync(transcriptPath)) {
-    // Only scan user-role messages to avoid matching the block reason text
-    // which itself contains "Bypass with HYPO_SKIP_GATE=1"
+  // ── Transcript scan (Bypass 2 + #20 close-intent detection) ──
+  let hasCloseIntent = false;
+  if (transcriptPath && existsSync(transcriptPath)) {
     const userText = extractUserMessages(transcriptPath);
-    if (/HYPO_SKIP_GATE=1/.test(userText)) {
+    // Bypass 2: user-role "HYPO_SKIP_GATE=1" (scan before gate so bypass takes effect)
+    if (!isGateSkipped() && /HYPO_SKIP_GATE=1/.test(userText)) {
       process.env.HYPO_SKIP_GATE = '1';
     }
+    // #20: natural-language close-intent detection (informational — enriches block message)
+    hasCloseIntent = isClosePattern(userText);
   }
 
   // ── Heavy checks ──
@@ -179,10 +182,14 @@ process.stdin.on('end', () => {
     `  [ ] 12. git commit & push`,
   ].join('\n');
 
+  const closeIntentNote = hasCloseIntent
+    ? `[Close intent detected in recent messages — completing session close first.]\n`
+    : '';
+
   console.log(JSON.stringify({
     decision: 'block',
     reason: [
-      `[WIKI CHECK — BLOCKING] Session close incomplete. (${reasons.join(', ')})`,
+      `${closeIntentNote}[WIKI CHECK — BLOCKING] Session close incomplete. (${reasons.join(', ')})`,
       `Run the checklist below in order, then retry /compact:`,
       ``,
       checklistText,

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -153,6 +153,41 @@ export function isCompactCommand(prompt) {
 }
 
 /**
+ * Returns true if the text contains a natural-language session-close signal.
+ * Scans Korean and English close patterns. Designed for transcript user-message
+ * text — favours low false-positive rate over recall.
+ *
+ * Examples that match: "세션 마무리하자", "오늘 여기까지", "wrap up", "signing off".
+ * Examples that do NOT match: "이 함수 마무리하자", "wrap up this PR".
+ */
+export function isClosePattern(text) {
+  if (!text || typeof text !== 'string') return false;
+  const krPatterns = [
+    /세션\s*(끝|종료|마무리)/,
+    /오늘\s*은?\s*(여기|작업|세션).*(끝|마치|마무리|종료)/,
+    // 여기까지: requires no continuation action word (e.g. 여기까지 구현해줘 is not a close signal)
+    /여기(서)?까지(?!\s*(?:구현|작성|완성|수정|변경|추가|삭제|테스트|확인|검토|해줘|해야|하고|하면))/,
+    /이만\s*(마치|끝|종료|마무리)/,
+    // 작업 종료/마무리: requires verb ending, not noun modifier (e.g. 작업 종료 조건을 is not a close signal)
+    /작업\s*(?:마무리|종료)\s*(?:하자|할게|하겠|했어|임)/,
+    /오늘은?\s*여기/,
+    /그만\s*(하자|할게|하겠|합시다)/,
+    /슬슬\s*(마무리|종료)/,
+    /오늘은?\s*이만/,
+  ];
+  const enPatterns = [
+    // wrap up: requires session-level context or sentence-end, not code-level objects
+    /wrap(?:ping)?\s+up(?!\s+(?:this|the)\s+(?:pr|issue|bug|task|function|component|module|feature|code|test)\b)/i,
+    /done\s+for\s+(?:today|now|the\s+day)/i,
+    /that'?s?\s+(?:all|it)\s+for\s+(?:today|now|the\s+day)/i,
+    /signing\s+off/i,
+    /end(?:ing)?\s+(?:the|this)\s+(?:session|work|day)/i,
+    /close\s+(?:the|this)\s+session/i,
+  ];
+  return [...krPatterns, ...enPatterns].some(re => re.test(text));
+}
+
+/**
  * Build hook output for Claude Code (additionalContext channel).
  * Codex hooks write systemMessage directly in their own files.
  */

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "scripts": {
     "test": "node tests/runner.mjs",
     "lint": "node scripts/lint.mjs",
-    "graph": "node scripts/graph.mjs"
+    "graph": "node scripts/graph.mjs",
+    "smoke-pack": "node scripts/smoke-pack.mjs",
+    "prepublishOnly": "npm test && npm run lint && npm run smoke-pack"
   }
 }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -143,7 +143,7 @@ function log(action, path) { results[action].push(path); }
 
 // ── directory structure ──────────────────────────────────────────────────────
 
-const HYPO_DIRS = ['pages', 'projects', 'sources', 'journal/daily', 'journal/weekly', 'journal/monthly'];
+const HYPO_DIRS = ['pages', 'projects', 'sources', 'journal/daily', 'journal/weekly', 'journal/monthly', 'pages/observability'];
 
 function ensureDir(dir, dryRun) {
   if (existsSync(dir)) return;
@@ -625,6 +625,7 @@ if (args.fromRemote) {
   copyTemplate('hypo-automation.md',join(args.hypoDir, 'hypo-automation.md'),args.dryRun);
   copyTemplate('session-state.md',  join(args.hypoDir, 'session-state.md'),  args.dryRun);
   copyTemplate(join('pages', '_index.md'), join(args.hypoDir, 'pages', '_index.md'), args.dryRun);
+  copyTemplate(join('pages', 'observability', '_index.md'), join(args.hypoDir, 'pages', 'observability', '_index.md'), args.dryRun);
 
   // projects/_template structure
   ensureDir(join(args.hypoDir, 'projects', '_template'), args.dryRun);

--- a/scripts/query.mjs
+++ b/scripts/query.mjs
@@ -114,6 +114,7 @@ if (args.json) {
 } else {
   if (top.length === 0) {
     console.log(`No results for: ${args.query}`);
+    console.log(`→ 관련 페이지가 없습니다. 새 지식이 있다면 /hypo:ingest 로 추가해 보세요.`);
   } else {
     console.log(`Found ${results.length} result(s) for "${args.query}" (showing ${top.length}):\n`);
     for (const r of top) {

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * scripts/smoke-pack.mjs — pre-publish smoke test
+ *
+ * Runs `npm pack`, installs the resulting tarball into an isolated temp
+ * directory, and exercises the installed CLI to verify the published
+ * artifact actually works. Catches mistakes that local tests miss:
+ *   - `files:` / `.npmignore` excluding required assets
+ *   - `bin` entry pointing to a missing file
+ *   - runtime requires on paths not shipped in the tarball
+ *
+ * Usage:
+ *   node scripts/smoke-pack.mjs [--keep]
+ *
+ * --keep   Leave the temp directory in place for inspection on success.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync, renameSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const KEEP = process.argv.includes('--keep');
+
+const PKG = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf-8'));
+const PKG_NAME = PKG.name;
+
+function run(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, { stdio: 'pipe', encoding: 'utf-8', ...opts });
+  if (res.status !== 0) {
+    process.stderr.write(res.stdout || '');
+    process.stderr.write(res.stderr || '');
+    throw new Error(`${cmd} ${args.join(' ')} exited ${res.status}`);
+  }
+  return res;
+}
+
+function step(msg) { console.log(`\n▸ ${msg}`); }
+
+const work = mkdtempSync(join(tmpdir(), 'hypo-smoke-'));
+const sandboxHome = join(work, 'home');
+const installRoot = join(work, 'install');
+const wikiDir = join(work, 'wiki');
+let cleanupOk = false;
+
+try {
+  step('npm pack');
+  const pack = run('npm', ['pack', '--json'], { cwd: REPO });
+  const meta = JSON.parse(pack.stdout)[0];
+  const tarball = join(REPO, meta.filename);
+  console.log(`  → ${meta.filename} (${meta.size} bytes, ${meta.entryCount} entries)`);
+
+  step(`install into ${installRoot}`);
+  run('mkdir', ['-p', installRoot]);
+  writeFileSync(join(installRoot, 'package.json'), JSON.stringify({
+    name: 'hypo-smoke-host',
+    version: '0.0.0',
+    private: true,
+  }) + '\n');
+  run('npm', ['install', '--no-audit', '--no-fund', '--silent', tarball], { cwd: installRoot });
+
+  // Move tarball into the work dir so it's not left in the repo.
+  renameSync(tarball, join(work, meta.filename));
+
+  const cliBin = join(installRoot, 'node_modules', '.bin', 'hypomnema');
+  if (!existsSync(cliBin)) {
+    throw new Error(`bin not installed at ${cliBin}`);
+  }
+
+  step('hypomnema --help (installed)');
+  const help = run(cliBin, ['--help']);
+  if (!help.stdout.includes('Usage: hypomnema')) {
+    throw new Error('--help output did not match expected banner');
+  }
+
+  step('hypomnema init --dry-run (installed)');
+  const dryEnv = { ...process.env, HOME: sandboxHome, HYPO_DIR: wikiDir };
+  const dry = run(cliBin, [
+    'init',
+    '--dry-run',
+    `--hypo-dir=${wikiDir}`,
+    '--no-hooks',
+    '--no-commands',
+    '--no-git-init',
+    '--no-shell',
+  ], { env: dryEnv });
+  if (!/dry[\s-]?run/i.test(dry.stdout + dry.stderr)) {
+    console.log(dry.stdout);
+    throw new Error('init --dry-run did not announce dry-run mode');
+  }
+
+  step('verify shipped assets are present');
+  const required = [
+    'scripts/init.mjs',
+    'scripts/upgrade.mjs',
+    'hooks',
+    'commands',
+    'templates',
+    'README.md',
+  ];
+  const pkgRoot = join(installRoot, 'node_modules', PKG_NAME);
+  for (const rel of required) {
+    if (!existsSync(join(pkgRoot, rel))) {
+      throw new Error(`shipped tarball missing: ${rel}`);
+    }
+  }
+
+  console.log('\n✓ smoke-pack passed');
+  cleanupOk = true;
+} catch (err) {
+  console.error(`\n✗ smoke-pack failed: ${err.message}`);
+  console.error(`  work dir preserved: ${work}`);
+  process.exitCode = 1;
+} finally {
+  if (cleanupOk && !KEEP) {
+    rmSync(work, { recursive: true, force: true });
+  } else if (KEEP) {
+    console.log(`\nwork dir kept: ${work}`);
+  }
+  // Sweep any stray tarballs left in the repo root from a crashed run.
+  for (const f of readdirSync(REPO)) {
+    if (f.startsWith(`${PKG_NAME}-`) && f.endsWith('.tgz')) {
+      rmSync(join(REPO, f), { force: true });
+    }
+  }
+}

--- a/templates/Home.md
+++ b/templates/Home.md
@@ -19,6 +19,8 @@ tags: [wiki, home]
 - [[SCHEMA]] — type system reference
 - [[hypo-guide]] — operations guide
 
+> **Auto-ingest rule**: after any `WebFetch` / `WebSearch` that yields relevant knowledge, run `/hypo:ingest` immediately without waiting for an explicit request.
+
 ---
 
 ## Active Projects

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -61,7 +61,7 @@ Files responsible for session continuity — separate from the type taxonomy abo
 - Session start: root `hot.md` → project `hot.md` → `session-state.md`
 - Session close: update project `hot.md` (what was done) + `session-state.md` (what to do next) + root `hot.md`
 
-**Pointer table row format** (`hypo-hot-rebuild.mjs` parses this with a fixed regex — any deviation causes silent row drop):
+**Pointer table row format** (`hypo-hot-rebuild.mjs` parses this with a fixed regex — wrong col3 format causes the row to be silently skipped):
 
 ```
 | <Project Name> | YYYY-MM-DD | [[projects/<slug>/hot]] |
@@ -70,7 +70,7 @@ Files responsible for session continuity — separate from the type taxonomy abo
 Column semantics:
 - col 1 (name): preserved as-is from the existing row
 - col 2 (date): **ignored on read** — rebuilt from `projects/<slug>/hot.md` frontmatter `updated:` (falls back to today if the file is absent)
-- col 3 (wikilink): must be exactly `[[projects/<slug>/hot]]` — no trailing path, no markdown link `[text](url)`
+- col 3 (wikilink): must be `[[projects/<slug>/hot]]` — no trailing path, no markdown link `[text](url)`. Extra trailing columns are discarded during canonical rebuild (not dropped).
 
 ---
 

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -61,6 +61,17 @@ Files responsible for session continuity — separate from the type taxonomy abo
 - Session start: root `hot.md` → project `hot.md` → `session-state.md`
 - Session close: update project `hot.md` (what was done) + `session-state.md` (what to do next) + root `hot.md`
 
+**Pointer table row format** (`hypo-hot-rebuild.mjs` parses this with a fixed regex — any deviation causes silent row drop):
+
+```
+| <Project Name> | YYYY-MM-DD | [[projects/<slug>/hot]] |
+```
+
+Column semantics:
+- col 1 (name): preserved as-is from the existing row
+- col 2 (date): **ignored on read** — rebuilt from `projects/<slug>/hot.md` frontmatter `updated:` (falls back to today if the file is absent)
+- col 3 (wikilink): must be exactly `[[projects/<slug>/hot]]` — no trailing path, no markdown link `[text](url)`
+
 ---
 
 ## 3. Required Frontmatter Fields

--- a/templates/hot.md
+++ b/templates/hot.md
@@ -14,6 +14,8 @@ tags: [wiki, operations]
 
 | Project | Last Session | Hot Cache |
 |---|---|---|
+<!-- Row format: | Project Name | YYYY-MM-DD | [[projects/slug/hot]] | -->
+<!-- col2 date is rebuilt from projects/<slug>/hot.md frontmatter on each session close -->
 
 ## Session Start Checklist
 

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -74,6 +74,8 @@ Skip session close for: single bug fix, single-file edit, Q&A only.
 
 ### Ingest (external source → wiki)
 
+**Auto-trigger rule**: after any `WebFetch` / `WebSearch` that yields new knowledge relevant to the current task, run `/hypo:ingest` immediately — do not wait for the user to ask.
+
 1. Save raw source to `sources/<slug>.<ext>` (never edit after)
 2. Read and synthesize
 3. Update or create pages in `pages/` with frontmatter `source: <slug>`
@@ -85,6 +87,7 @@ Skip session close for: single bug fix, single-file edit, Q&A only.
 1. Read `index.md` first
 2. Cross-reference related pages
 3. Synthesize answer — cite `[[page-slug]]` links
+4. **On miss**: research externally (`WebFetch` / `WebSearch`), then auto-ingest — omitting `/hypo:ingest` after external research is a defect
 
 ---
 

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -65,6 +65,8 @@ Over time, new sources *update* pages more than they *create* them — that's wh
 
 Trigger: explicit close mention, `/compact` request, or context limit approaching.
 
+**Auto-trigger rule**: when the user sends a natural-language close signal — "세션 마무리하자", "오늘 여기까지", "이만 종료", "wrap up", "signing off", or equivalent — run the session close checklist immediately without waiting for an explicit `/compact` or `/hypo:crystallize`. If the intent is ambiguous, confirm with a single question before proceeding.
+
 1. Update `projects/<name>/session-state.md` (next tasks, overwrite)
 2. Update `projects/<name>/hot.md` (what was done, ≤500 words, overwrite)
 3. Append to `projects/<name>/session-log/YYYY-MM.md` (narrative entry, append-only)

--- a/templates/pages/observability/_index.md
+++ b/templates/pages/observability/_index.md
@@ -1,0 +1,77 @@
+---
+title: Observability Index
+type: reference
+updated: YYYY-MM-DD
+tags: [observability, autonomy, wiki-health]
+---
+
+# Observability
+
+> Tracks how often and how well the wiki is used per session. Score = proxy for autonomous wiki engagement (not ground truth).
+
+---
+
+## 1. Data flow
+
+```
+Stop hook (hypo-session-record.mjs)
+    │  appends one JSONL entry per session
+    ▼
+.cache/sessions/index.jsonl
+    │
+    ▼
+scripts/session-audit.mjs   ← per-session metrics + classification
+    │
+    ▼
+scripts/weekly-report.mjs   ← weekly autonomy score
+    │
+    ▼
+pages/observability/<YYYY-WW>.md
+```
+
+---
+
+## 2. Session classification
+
+| Class | Rule |
+|---|---|
+| `staleness-skip` | `recorded_at` older than `--max-age-days` (default 30) |
+| `ingest-missed` | `urls >= 2` and `ingest_count == 0` |
+| `search-many` | `search_count >= 5` |
+| `search-0` | `search_count == 0` |
+| `normal` | otherwise |
+
+Counted tools: `Grep`, `WebSearch`, `WebFetch`. Counted commands: `/hypo:query`, `/hypo:ingest`, `/hypo:feedback`.
+
+---
+
+## 3. Autonomy score formula (heuristic v0)
+
+Score is clamped to `[0, 100]`. `staleness-skip` sessions are excluded.
+
+```
+numerator   = Σ min(search_count, 3) + ingest_count × 3 + feedback_count × 2
+denominator = Σ 1 + (urls > 0 ? min(urls, 5) × 2 : 0)
+score       = clamp(round(numerator / denominator × 100), 0, 100)
+```
+
+- Each real session contributes 1 to denominator (baseline expectation).
+- URLs raise the bar: each external URL is a missed-ingest opportunity (weight 2, capped at 5).
+- Ingest (weight 3) and feedback (weight 2) are the strongest positive signals.
+- Search (weight 1, capped at 3) is a weaker signal.
+
+---
+
+## 4. Four-week baseline plan
+
+Capture v0 scores for 4 weeks before introducing LLM-judge classification or changing formula weights. Goal: establish a baseline before tuning.
+
+| Week | Score | Notes |
+|---|---|---|
+| <!-- YYYY-WW --> | <!-- % --> | <!-- first run --> |
+
+---
+
+## 5. Privacy
+
+Weekly reports emit only `session_id` plus aggregate counts — no transcript content, no URLs, no tool inputs. Transcripts live under `~/.claude/projects/` or `.cache/sessions/`, excluded by `.hypoignore`.

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1195,6 +1195,35 @@ test('growth ignores wikilinks introduced outside pages/projects', () => {
   });
 });
 
+suite('hypo-lookup.mjs — type-prior boost');
+
+test('output is always valid JSON', () => {
+  const r = runHook('hypo-lookup.mjs', { prompt: 'hello world' });
+  assert.doesNotThrow(() => JSON.parse(r.stdout), `stdout: ${r.stdout}`);
+});
+
+test('ADR entry ranked above plain entry with same keyword', () => {
+  withTmpDir(dir => {
+    // pageMap searches pages/ and projects/ subdirs; put both files there
+    mkdirSync(join(dir, 'pages', 'decisions'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'decisions', '0001-use-bm25.md'), '# ADR\n');
+    writeFileSync(join(dir, 'pages', 'bm25-notes.md'), '# BM25 Notes\n');
+    const indexContent = [
+      '# Index',
+      '- [[decisions/0001-use-bm25]] — bm25 scoring decision adr',
+      '- [[bm25-notes]] — bm25 scoring general notes',
+    ].join('\n');
+    writeFileSync(join(dir, 'index.md'), indexContent);
+    const r = runHook('hypo-lookup.mjs', { prompt: 'bm25 scoring' }, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    const adrPos   = ctx.indexOf('decisions/0001-use-bm25');
+    const plainPos = ctx.indexOf('bm25-notes');
+    assert.ok(adrPos !== -1, 'ADR entry should appear in context');
+    assert.ok(adrPos < plainPos || plainPos === -1, 'ADR should rank before plain entry');
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -793,8 +793,9 @@ test('valid wikilink row is preserved in rebuilt hot.md', () => {
   });
 });
 
-test('markdown link row is silently dropped (not valid pointer format)', () => {
+test('markdown link row is silently excluded when mixed with a valid wikilink row', () => {
   withTmpDir(dir => {
+    // mixed table: one valid wikilink row + one markdown link row
     const hotContent = [
       '---',
       'title: Hot Cache — Pointer',
@@ -805,11 +806,14 @@ test('markdown link row is silently dropped (not valid pointer format)', () => {
       '',
       '# Hot Cache',
       '',
+      '> Read at session start',
+      '',
       '## Active Projects',
       '',
       '| Project | Last Session | Hot Cache |',
       '|---|---|---|',
-      '| my-project | 2026-01-01 | [projects/my-project/hot](projects/my-project/hot.md) |',
+      '| valid-project | 2026-01-01 | [[projects/valid-project/hot]] |',
+      '| bad-project | 2026-01-01 | [projects/bad-project/hot](projects/bad-project/hot.md) |',
       '',
       '## Session Start Checklist',
       '',
@@ -817,12 +821,11 @@ test('markdown link row is silently dropped (not valid pointer format)', () => {
     ].join('\n');
     writeFileSync(join(dir, 'hot.md'), hotContent);
     writeFileSync(join(dir, 'hypo-config.md'), '# config');
-    const before = hotContent;
     const r = runStop('hypo-hot-rebuild.mjs', dir);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    // rebuild returns early when no rows parsed — file unchanged
-    const after = readFileSync(join(dir, 'hot.md'), 'utf-8');
-    assert.equal(after, before, 'markdown link row must not be parsed; file must remain unchanged');
+    const result = readFileSync(join(dir, 'hot.md'), 'utf-8');
+    assert.ok(result.includes('[[projects/valid-project/hot]]'), 'valid wikilink row must be preserved');
+    assert.ok(!result.includes('bad-project'), 'markdown link row must be excluded from rebuilt output');
   });
 });
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -248,7 +248,7 @@ test('JSON output is an array of check objects', () => {
 
 const HOOKS = join(REPO, 'hooks');
 
-const { isCompactCommand, isGateSkipped, buildOutput } = await import(
+const { isCompactCommand, isGateSkipped, buildOutput, isClosePattern } = await import(
   join(HOOKS, 'hypo-shared.mjs')
 );
 
@@ -291,6 +291,60 @@ test('/compact with trailing args → true', () => {
 test('non-compact prompt → false', () => {
   assert.equal(isCompactCommand('hello'), false);
   assert.equal(isCompactCommand('/other'), false);
+});
+
+suite('isClosePattern()');
+
+test('한국어 세션 마무리 패턴 → true', () => {
+  assert.equal(isClosePattern('세션 마무리하자'), true);
+  assert.equal(isClosePattern('세션 종료할게'), true);
+  assert.equal(isClosePattern('세션 끝'), true);
+});
+
+test('한국어 여기까지/이만 패턴 → true', () => {
+  assert.equal(isClosePattern('오늘 여기까지'), true);
+  assert.equal(isClosePattern('오늘은 여기'), true);
+  assert.equal(isClosePattern('여기까지'), true);
+  assert.equal(isClosePattern('이만 마치자'), true);
+  assert.equal(isClosePattern('이만 종료'), true);
+});
+
+test('한국어 작업/그만/슬슬/이만 패턴 → true', () => {
+  assert.equal(isClosePattern('오늘 작업 마무리하자'), true);
+  assert.equal(isClosePattern('작업 마무리 할게'), true);
+  assert.equal(isClosePattern('작업 종료 하자'), true);
+  assert.equal(isClosePattern('그만 하자'), true);
+  assert.equal(isClosePattern('그만 할게'), true);
+  assert.equal(isClosePattern('슬슬 마무리하자'), true);
+  assert.equal(isClosePattern('오늘은 이만'), true);
+});
+
+test('영어 close 패턴 → true', () => {
+  assert.equal(isClosePattern('wrap up'), true);
+  assert.equal(isClosePattern('wrapping up'), true);
+  assert.equal(isClosePattern('done for today'), true);
+  assert.equal(isClosePattern("that's all for today"), true);
+  assert.equal(isClosePattern('signing off'), true);
+  assert.equal(isClosePattern('ending the session'), true);
+  assert.equal(isClosePattern('close the session'), true);
+});
+
+test('일반 작업 문장 → false (false-positive 방지)', () => {
+  assert.equal(isClosePattern('이 함수 마무리하자'), false);
+  assert.equal(isClosePattern('버그 종료하자'), false);
+  assert.equal(isClosePattern('코드 정리'), false);
+  assert.equal(isClosePattern('다음 작업 시작하자'), false);
+  assert.equal(isClosePattern('여기까지 구현하고 테스트해줘'), false);   // Codex P2
+  assert.equal(isClosePattern('작업 종료 조건을 바꿔줘'), false);         // Codex P2
+  assert.equal(isClosePattern('wrap up this PR'), false);               // Codex P2
+  assert.equal(isClosePattern('wrap up this feature'), false);          // Codex P2
+  assert.equal(isClosePattern(''), false);
+  assert.equal(isClosePattern(null), false);
+});
+
+test('혼합 텍스트(트랜스크립트)에서도 패턴 감지', () => {
+  const transcript = '이 PR 리뷰 마저 봐줘\n오늘은 여기까지 하자\n내일 다시 볼게';
+  assert.equal(isClosePattern(transcript), true);
 });
 
 suite('isGateSkipped()');
@@ -380,6 +434,29 @@ test('output is always valid JSON regardless of prompt', () => {
     const r = runHook('hypo-compact-guard.mjs', { prompt });
     assert.doesNotThrow(() => JSON.parse(r.stdout), `invalid JSON for prompt="${prompt}"`);
   }
+});
+
+suite('hypo-personal-check.mjs — close-intent enrichment (#20)');
+
+test('close intent in transcript → block message includes close-intent note', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-close-'));
+  try {
+    const transcript = join(dir, 'transcript.jsonl');
+    writeFileSync(transcript, JSON.stringify({ message: { role: 'user', content: '세션 마무리하자' } }) + '\n');
+    const r = runHook('hypo-personal-check.mjs', { transcript_path: transcript });
+    const out = JSON.parse(r.stdout);
+    assert.ok(out.decision === 'block', 'should still block when session close is incomplete');
+    assert.ok(out.reason.includes('Close intent'), 'block reason should mention close intent detection');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('no close intent → block message does NOT include close-intent note', () => {
+  const r = runHook('hypo-personal-check.mjs', {});
+  const out = JSON.parse(r.stdout);
+  assert.ok(out.decision === 'block');
+  assert.ok(!out.reason.includes('Close intent'), 'block reason should not mention close intent when absent');
 });
 
 suite('hypo-personal-check.mjs — contract');

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -758,6 +758,74 @@ test('hot-rebuild emits no growth line when wiki is clean', () => {
   });
 });
 
+suite('hypo-hot-rebuild.mjs — parsePointerRows row format');
+
+test('valid wikilink row is preserved in rebuilt hot.md', () => {
+  withTmpDir(dir => {
+    const hotContent = [
+      '---',
+      'title: Hot Cache — Pointer',
+      'type: reference',
+      'updated: 2026-01-01',
+      'tags: [wiki, operations]',
+      '---',
+      '',
+      '# Hot Cache',
+      '',
+      '> Read at session start',
+      '',
+      '## Active Projects',
+      '',
+      '| Project | Last Session | Hot Cache |',
+      '|---|---|---|',
+      '| my-project | 2026-01-01 | [[projects/my-project/hot]] |',
+      '',
+      '## Session Start Checklist',
+      '',
+      '1. Check this file',
+    ].join('\n');
+    writeFileSync(join(dir, 'hot.md'), hotContent);
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    const r = runStop('hypo-hot-rebuild.mjs', dir);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const result = readFileSync(join(dir, 'hot.md'), 'utf-8');
+    assert.ok(result.includes('[[projects/my-project/hot]]'), 'valid wikilink row must be preserved');
+  });
+});
+
+test('markdown link row is silently dropped (not valid pointer format)', () => {
+  withTmpDir(dir => {
+    const hotContent = [
+      '---',
+      'title: Hot Cache — Pointer',
+      'type: reference',
+      'updated: 2026-01-01',
+      'tags: [wiki, operations]',
+      '---',
+      '',
+      '# Hot Cache',
+      '',
+      '## Active Projects',
+      '',
+      '| Project | Last Session | Hot Cache |',
+      '|---|---|---|',
+      '| my-project | 2026-01-01 | [projects/my-project/hot](projects/my-project/hot.md) |',
+      '',
+      '## Session Start Checklist',
+      '',
+      '1. Check this file',
+    ].join('\n');
+    writeFileSync(join(dir, 'hot.md'), hotContent);
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    const before = hotContent;
+    const r = runStop('hypo-hot-rebuild.mjs', dir);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    // rebuild returns early when no rows parsed — file unchanged
+    const after = readFileSync(join(dir, 'hot.md'), 'utf-8');
+    assert.equal(after, before, 'markdown link row must not be parsed; file must remain unchanged');
+  });
+});
+
 suite('hypo-auto-commit.mjs / hypo-auto-stage.mjs — .hypoignore honor');
 
 test('auto-commit skips .hypoignore-listed .cache paths', () => {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1202,6 +1202,27 @@ test('output is always valid JSON', () => {
   assert.doesNotThrow(() => JSON.parse(r.stdout), `stdout: ${r.stdout}`);
 });
 
+test('PRD entry ranked above plain entry with same keyword', () => {
+  withTmpDir(dir => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'prd-search.md'), '# PRD\n');
+    writeFileSync(join(dir, 'pages', 'search-notes.md'), '# Notes\n');
+    const indexContent = [
+      '# Index',
+      '- [[prd-search]] — search feature product requirements',
+      '- [[search-notes]] — search feature general notes',
+    ].join('\n');
+    writeFileSync(join(dir, 'index.md'), indexContent);
+    const r = runHook('hypo-lookup.mjs', { prompt: 'search feature' }, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    const prdPos   = ctx.indexOf('prd-search');
+    const plainPos = ctx.indexOf('search-notes');
+    assert.ok(prdPos !== -1, 'PRD entry should appear in context');
+    assert.ok(prdPos < plainPos || plainPos === -1, 'PRD should rank before plain entry');
+  });
+});
+
 test('ADR entry ranked above plain entry with same keyword', () => {
   withTmpDir(dir => {
     // pageMap searches pages/ and projects/ subdirs; put both files there

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -179,9 +179,25 @@ test('actual run creates expected directories', () => {
       '--no-git-init',
     ]);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    for (const sub of ['pages', 'projects', 'sources']) {
+    for (const sub of ['pages', 'projects', 'sources', 'pages/observability']) {
       assert.ok(existsSync(join(hypoDir, sub)), `missing: ${sub}/`);
     }
+  });
+});
+
+test('init creates pages/observability/_index.md stub', () => {
+  withTmpDir(dir => {
+    const hypoDir = join(dir, 'wiki');
+    const r = run('init.mjs', [
+      `--hypo-dir=${hypoDir}`,
+      '--no-hooks',
+      '--no-git-init',
+    ]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const stubPath = join(hypoDir, 'pages', 'observability', '_index.md');
+    assert.ok(existsSync(stubPath), 'pages/observability/_index.md should be created');
+    const content = readFileSync(stubPath, 'utf8');
+    assert.ok(content.includes('autonomy score'), '_index.md should contain autonomy score section');
   });
 });
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1316,6 +1316,40 @@ test('ADR entry ranked above plain entry with same keyword', () => {
   });
 });
 
+// ── query.mjs smoke tests ────────────────────────────────────────────────────
+
+suite('query.mjs — no-results ingest prompt');
+
+test('no results: shows ingest suggestion', () => {
+  withTmpDir(dir => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const r = run('query.mjs', [`--hypo-dir=${dir}`, '--q=xyzzy-nonexistent-term']);
+    assert.equal(r.status, 0, `should exit 0: ${r.stderr}`);
+    assert.ok(r.stdout.includes('/hypo:ingest'), `expected ingest prompt in stdout: ${r.stdout}`);
+  });
+});
+
+test('no results: ingest prompt absent in --json mode', () => {
+  withTmpDir(dir => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const r = run('query.mjs', [`--hypo-dir=${dir}`, '--q=xyzzy-nonexistent-term', '--json']);
+    assert.equal(r.status, 0, `should exit 0: ${r.stderr}`);
+    const parsed = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(parsed), 'JSON output should be an array');
+    assert.equal(parsed.length, 0, 'should be empty array');
+  });
+});
+
+test('with results: ingest prompt not shown', () => {
+  withTmpDir(dir => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'test-page.md'), '---\ntitle: test\ntype: note\n---\nfoo bar baz content here\n');
+    const r = run('query.mjs', [`--hypo-dir=${dir}`, '--q=foo']);
+    assert.equal(r.status, 0, `should exit 0: ${r.stderr}`);
+    assert.ok(!r.stdout.includes('/hypo:ingest'), `ingest prompt should not appear when results exist: ${r.stdout}`);
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
## 개요

#20 — 자연어 close 패턴 감지 (ADR 0022 Layer 1 behavioral rule).

세션 종료를 `/compact`/`/hypo:crystallize` 명시 호출 없이 자연어 신호("세션 마무리하자", "오늘 여기까지", "wrap up" 등)로도 감지하도록 한다.

## 변경 사항

- **`hooks/hypo-shared.mjs`** — `isClosePattern(text)` 추가
  - 한국어 패턴: 세션끝/종료/마무리, 여기까지, 이만마치, 작업마무리/종료, 오늘여기/이만, 그만하자, 슬슬마무리
  - 영어 패턴: wrap up, done for today, that's all, signing off, ending the session, close the session
  - false-positive 방지 negative lookahead: `여기까지 구현해줘`, `작업 종료 조건을`, `wrap up this PR` 등은 매칭 제외
- **`hooks/hypo-personal-check.mjs`** — PreCompact 트랜스크립트 스캔에 `isClosePattern` 적용
  - close intent 감지 시 block 메시지에 `[Close intent detected...]` 맥락 주입
  - bypass/pass 경로에는 영향 없음 (informational only)
- **`templates/hypo-guide.md`** — Session Close auto-trigger 행동 지침 추가
- **`tests/runner.mjs`** — `isClosePattern` 테스트 스위트 + personal-check close-intent 통합 테스트

## 검증

- `npm test`: 96 passed, 0 failed
- Codex 1:codex 검토 (omc-teams): P2 2건 반영 완료
  - `wrap up this PR` false positive → negative lookahead 추가
  - `여기까지 구현하고` / `작업 종료 조건을` false positive → 패턴 tightening
  - P3 (누락 패턴 `슬슬 마무리`/`오늘은 이만`, 통합 테스트) 반영 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)