### PR TITLE
feat(#9/#10): git sync 실패 기록 + session-start 노출 파이프라인

### DIFF
--- a/hooks/hypo-auto-commit.mjs
+++ b/hooks/hypo-auto-commit.mjs
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { HYPO_DIR, loadHypoIgnore, isIgnored } from './hypo-shared.mjs';
+import { HYPO_DIR, loadHypoIgnore, isIgnored, appendSyncFailure } from './hypo-shared.mjs';
 import { join } from 'path';
 
 function git(...args) {
@@ -42,8 +42,13 @@ if (staged) {
 }
 
 if (hasRemote()) {
-  git('pull', '--no-rebase', '-q');
-  git('push');
+  // fix #9: pull/push failures must not stop the session, but they can no
+  // longer be swallowed silently — record each to .cache/sync-state.json so
+  // session-start (#10) and doctor (#11) can surface them next session.
+  const pull = git('pull', '--no-rebase', '-q');
+  if (pull.status !== 0) appendSyncFailure(HYPO_DIR, 'pull', pull.stderr || pull.stdout);
+  const push = git('push');
+  if (push.status !== 0) appendSyncFailure(HYPO_DIR, 'push', push.stderr || push.stdout);
 }
 
 console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -11,7 +11,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from '
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { spawnSync } from 'child_process';
-import { HYPO_DIR, buildOutput, SESSION_STATE_NEXT_HEADINGS, formatGrowthMetrics } from './hypo-shared.mjs';
+import { HYPO_DIR, buildOutput, SESSION_STATE_NEXT_HEADINGS, formatGrowthMetrics, readSyncState, clearSyncState } from './hypo-shared.mjs';
 
 const PROJECTS_DIR  = join(HYPO_DIR, 'projects');
 const GROWTH_CACHE  = join(HYPO_DIR, '.cache', 'last-session-growth.json');
@@ -26,9 +26,44 @@ function readLastGrowthLine() {
   }
 }
 
+/** Pull the wiki repo. Returns true only when the pull actually succeeded. */
 function gitPull(dir) {
-  if (!existsSync(join(dir, '.git'))) return;
-  spawnSync('git', ['-C', dir, 'pull', '--ff-only', '--quiet'], { stdio: 'pipe', timeout: 10000 });
+  if (!existsSync(join(dir, '.git'))) return false;
+  const r = spawnSync('git', ['-C', dir, 'pull', '--ff-only', '--quiet'], { stdio: 'pipe', timeout: 10000 });
+  return r.status === 0;
+}
+
+/**
+ * fix #10: surface unresolved sync failures recorded by a prior session's
+ * Stop hook (#9). The entry is cleared only once this session's pull has
+ * succeeded AND there is no unpushed commit left behind by a failed push
+ * (`[ahead N]`).
+ *
+ * Resolution deliberately checks only the ahead-of-remote state, not the full
+ * working tree: uncommitted/untracked files are not a sync failure, and a
+ * fresh `hypo init` wiki does not git-ignore `.cache/`, so a broader cleanliness
+ * check would see the sync-state file itself and never clear.
+ *
+ * @returns {string} a `[WIKI: last sync failed: ...]` line, or '' when clear.
+ */
+function syncStateNotice(pullOk) {
+  const { entries, parseError } = readSyncState(HYPO_DIR);
+  // A corrupt JSONL file is still an "open" failure — surface it (doctor warns
+  // too) but never clear it, so the unreadable record survives for inspection.
+  if (parseError) return '[WIKI: last sync failed: sync-state.json unreadable — inspect manually]';
+  if (entries.length === 0) return '';
+  let resolved = false;
+  if (pullOk) {
+    const r = spawnSync('git', ['-C', HYPO_DIR, 'status', '--branch', '--porcelain'],
+      { encoding: 'utf-8', timeout: 10000 });
+    resolved = r.status === 0 && !/\[ahead \d+\]/.test(r.stdout || '');
+  }
+  if (resolved) {
+    clearSyncState(HYPO_DIR);
+    return '';
+  }
+  const last = entries[entries.length - 1];
+  return `[WIKI: last sync failed: ${last.op || '?'} — ${last.error || 'unknown'}]`;
 }
 const GLOBAL_HOT   = join(HYPO_DIR, 'hot.md');
 const HOT_CHARS    = 2000;
@@ -107,13 +142,16 @@ process.stdin.on('end', () => {
     let data = {};
     try { data = JSON.parse(raw); } catch {}
 
-    gitPull(HYPO_DIR);
+    const pullOk = gitPull(HYPO_DIR);
+    const syncLine = syncStateNotice(pullOk);
     const growthLine = readLastGrowthLine();
-    // Intentional dual emit: stderr (cyan) is the human-visible nudge in the
-    // terminal; growthPrefix injects the same plain-text line into the LLM's
-    // additionalContext so model and user start the session looking at the
-    // same state. ANSI escapes are kept out of additionalContext on purpose.
-    const growthPrefix = growthLine ? `${growthLine}\n\n` : '';
+    // Intentional dual emit: stderr (yellow/cyan) is the human-visible nudge in
+    // the terminal; noticePrefix injects the same plain-text lines into the
+    // LLM's additionalContext so model and user start the session looking at
+    // the same state. ANSI escapes are kept out of additionalContext on purpose.
+    const notices = [syncLine, growthLine].filter(Boolean);
+    const noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
+    if (syncLine)   process.stderr.write(`\n\x1b[33m${syncLine}\x1b[0m\n`);
     if (growthLine) process.stderr.write(`\n\x1b[36m${growthLine}\x1b[0m\n`);
     const cwd = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || 'default';
@@ -131,21 +169,22 @@ process.stdin.on('end', () => {
         if (hotContent)   parts.push(`[HOT]\n${hotContent}`);
         if (stateContent) parts.push(`[SESSION STATE — 다음 작업]\n${stateContent}`);
         console.log(JSON.stringify(
-          buildOutput(`${growthPrefix}[WIKI HOT CACHE: project=${hit.proj}]\n\n${parts.join('\n\n')}`, { continue: true, suppressOutput: true })
+          buildOutput(`${noticePrefix}[WIKI HOT CACHE: project=${hit.proj}]\n\n${parts.join('\n\n')}`, { continue: true, suppressOutput: true })
         ));
       } else {
         process.stderr.write(`\n\x1b[36m[Hypomnema]\x1b[0m project: \x1b[1m${hit.proj}\x1b[0m (no snapshot yet)\n\n`);
         writeFileSync(MARKER_FILE, JSON.stringify({ proj: hit.proj, hotPath: null, ts: Date.now() }));
         console.log(JSON.stringify(
-          buildOutput(`${growthPrefix}[WIKI HOT CACHE: project=${hit.proj}, no snapshot yet]`, { continue: true, suppressOutput: true })
+          buildOutput(`${noticePrefix}[WIKI HOT CACHE: project=${hit.proj}, no snapshot yet]`, { continue: true, suppressOutput: true })
         ));
       }
       return;
     }
 
     if (!existsSync(GLOBAL_HOT)) {
-      if (growthLine) {
-        console.log(JSON.stringify(buildOutput(growthLine, { continue: true, suppressOutput: true })));
+      const notice = notices.join('\n\n');
+      if (notice) {
+        console.log(JSON.stringify(buildOutput(notice, { continue: true, suppressOutput: true })));
       } else {
         console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       }
@@ -154,7 +193,7 @@ process.stdin.on('end', () => {
 
     const globalContent = readFileSync(GLOBAL_HOT, 'utf-8').slice(0, HOT_CHARS);
     console.log(JSON.stringify(
-      buildOutput(`${growthPrefix}[WIKI HOT CACHE: global — no project matched cwd=${cwd}]\n\n${globalContent}`, { continue: true, suppressOutput: true })
+      buildOutput(`${noticePrefix}[WIKI HOT CACHE: global — no project matched cwd=${cwd}]\n\n${globalContent}`, { continue: true, suppressOutput: true })
     ));
 
   } catch {

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -6,9 +6,9 @@
  * Hooks are deployed to ~/.claude/hooks/ — no external imports allowed.
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from 'fs';
 import { join, relative, basename } from 'path';
-import { homedir } from 'os';
+import { homedir, hostname } from 'os';
 import { spawnSync } from 'child_process';
 
 const HOME = homedir();
@@ -112,6 +112,71 @@ export function hotMdIsClean() {
   }
 
   return reasons.length === 0 ? { clean: true } : { clean: false, reason: reasons.join(' / ') };
+}
+
+// ── sync-state (fix #9/#10/#11) ────────────────────────────────────────────
+// `.cache/sync-state.json` is JSONL: one {timestamp, op, error, host} entry per
+// line. hypo-auto-commit (#9) appends on pull/push failure; hypo-session-start
+// (#10) surfaces open entries and clears them once sync is healthy again;
+// doctor (#11) warns while entries remain. Keep the schema defined here only.
+
+/** @returns {string} path to the sync-state JSONL file for a wiki root. */
+function syncStatePath(hypoDir) {
+  return join(hypoDir, '.cache', 'sync-state.json');
+}
+
+/**
+ * Append a sync failure entry. Best-effort — never throws, since a failed
+ * failure-log must not break the Stop hook that calls it.
+ *
+ * @param {string} hypoDir
+ * @param {'pull'|'push'} op
+ * @param {string} error  raw stderr/stdout; first non-empty line is kept
+ */
+export function appendSyncFailure(hypoDir, op, error) {
+  try {
+    const cacheDir = join(hypoDir, '.cache');
+    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+    const firstLine = String(error || '')
+      .split('\n').map(l => l.trim()).find(Boolean) || 'unknown error';
+    const entry = {
+      timestamp: new Date().toISOString(),
+      op,
+      error: firstLine.slice(0, 200),
+      host: hostname(),
+    };
+    appendFileSync(syncStatePath(hypoDir), JSON.stringify(entry) + '\n');
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Read sync-state entries.
+ * @param {string} hypoDir
+ * @returns {{entries: object[], parseError: boolean}}
+ */
+export function readSyncState(hypoDir) {
+  const path = syncStatePath(hypoDir);
+  if (!existsSync(path)) return { entries: [], parseError: false };
+  try {
+    const entries = readFileSync(path, 'utf-8')
+      .split('\n')
+      .filter(l => l.trim())
+      .map(l => JSON.parse(l));
+    return { entries, parseError: false };
+  } catch {
+    return { entries: [], parseError: true };
+  }
+}
+
+/** Remove the sync-state file. Called once sync is healthy again. Best-effort. */
+export function clearSyncState(hypoDir) {
+  try {
+    rmSync(syncStatePath(hypoDir), { force: true });
+  } catch {
+    // best-effort
+  }
 }
 
 // ── session-close checklist ────────────────────────────────────────────────

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
+import { readSyncState } from '../hooks/hypo-shared.mjs';
 
 const HOME     = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -410,18 +411,11 @@ function checkVerifyBy(hypoDir, ignorePatterns = []) {
 }
 
 function checkSyncState(hypoDir) {
-  // "open" = file exists with ≥1 entries; session-start (fix #10) clears after user resolves
-  const syncStatePath = join(hypoDir, '.cache', 'sync-state.json');
-  if (!existsSync(syncStatePath)) {
-    pass('Sync state', 'No unresolved sync failures');
-    return;
-  }
+  // "open" = file exists with ≥1 entries; session-start (fix #10) clears once
+  // sync is healthy again. Schema + parsing live in hooks/hypo-shared.mjs.
+  const { entries, parseError } = readSyncState(hypoDir);
 
-  let entries;
-  try {
-    const lines = readFileSync(syncStatePath, 'utf-8').split('\n').filter(l => l.trim());
-    entries = lines.map(l => JSON.parse(l));
-  } catch {
+  if (parseError) {
     warn('Sync state', 'Cannot parse .cache/sync-state.json — inspect manually');
     return;
   }

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1126,6 +1126,110 @@ test('session-start emits no growth line when cache absent', () => {
   });
 });
 
+// ── sync-state replay (fix #9/#10) ───────────────────────────────────────────
+
+// A wiki repo wired to a working bare remote and pushed in sync — the baseline
+// for exercising session-start's clear/preserve logic.
+function withSyncedWiki(fn) {
+  const base   = mkdtempSync(join(tmpdir(), 'hypo-sync-'));
+  const dir    = join(base, 'wiki');
+  const remote = join(base, 'remote.git');
+  try {
+    spawnSync('git', ['init', '--bare', '-q', remote]);
+    spawnSync('git', ['init', '-q', dir]);
+    spawnSync('git', ['-C', dir, 'config', 'user.email', 'test@test.com']);
+    spawnSync('git', ['-C', dir, 'config', 'user.name', 'Test']);
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    writeFileSync(join(dir, 'hot.md'),
+      '---\ntitle: Hot\nupdated: today\n---\n## Active Projects\n\n| Project | Last Session | Hot Cache |\n|---|---|---|\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'init']);
+    spawnSync('git', ['-C', dir, 'remote', 'add', 'origin', remote]);
+    spawnSync('git', ['-C', dir, 'push', '-q', '-u', 'origin', 'HEAD']);
+    fn(dir);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function readSyncEntries(dir) {
+  return readFileSync(join(dir, '.cache', 'sync-state.json'), 'utf-8')
+    .split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+suite('hypo-auto-commit.mjs / hypo-session-start.mjs — sync-state replay');
+
+test('replay-auto-commit-writes-sync-state: pull/push failure appends entries', () => {
+  withGrowthWiki(dir => {
+    // a remote that does not exist → both pull and push fail
+    spawnSync('git', ['-C', dir, 'remote', 'add', 'origin', join(dir, 'no-such-remote.git')]);
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'note.md'), '# note\n');
+    const r = runStop('hypo-auto-commit.mjs', dir);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(existsSync(join(dir, '.cache', 'sync-state.json')),
+      'sync-state.json must be created on sync failure');
+    const entries = readSyncEntries(dir);
+    assert.ok(entries.length >= 1, `expected ≥1 failure entry, got ${entries.length}`);
+    assert.ok(entries.every(e => e.op === 'pull' || e.op === 'push'),
+      `unexpected op: ${JSON.stringify(entries)}`);
+    assert.ok(entries.every(e => e.timestamp && e.host && e.error),
+      `entries must carry timestamp/host/error: ${JSON.stringify(entries)}`);
+  });
+});
+
+test('replay-session-start-exposes-sync-state: open entry surfaces in additionalContext', () => {
+  withGrowthWiki(dir => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({ timestamp: '2026-05-14T00:00:00Z', op: 'push', error: 'network timeout', host: 'test' }) + '\n');
+    const r = runStart(dir);
+    const ctx = (JSON.parse(r.stdout).additionalContext) || '';
+    assert.ok(ctx.includes('last sync failed'), `sync notice missing: ${ctx}`);
+    assert.ok(ctx.includes('network timeout'), `error detail missing: ${ctx}`);
+  });
+});
+
+test('replay-session-start-clears-resolved-sync-state: healthy repo clears the entry', () => {
+  withSyncedWiki(dir => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const p = join(dir, '.cache', 'sync-state.json');
+    writeFileSync(p, JSON.stringify({ timestamp: '2026-05-14T00:00:00Z', op: 'pull', error: 'network timeout', host: 'test' }) + '\n');
+    const r = runStart(dir);
+    const ctx = (JSON.parse(r.stdout).additionalContext) || '';
+    assert.ok(!ctx.includes('last sync failed'), `resolved sync should not surface: ${ctx}`);
+    assert.ok(!existsSync(p), 'sync-state.json must be cleared once sync is healthy');
+  });
+});
+
+test('replay-session-start-surfaces-unreadable-sync-state: corrupt JSONL is not silently hidden', () => {
+  withGrowthWiki(dir => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const p = join(dir, '.cache', 'sync-state.json');
+    writeFileSync(p, JSON.stringify({ timestamp: '2026-05-14T00:00:00Z', op: 'push', error: 'x', host: 'test' }) + '\nnot-json\n');
+    const r = runStart(dir);
+    const ctx = (JSON.parse(r.stdout).additionalContext) || '';
+    assert.ok(ctx.includes('last sync failed'), `corrupt sync-state must still surface: ${ctx}`);
+    assert.ok(existsSync(p), 'unreadable sync-state.json must be preserved for inspection');
+  });
+});
+
+test('replay-session-start-preserves-sync-state-when-ahead: unpushed commit keeps the entry', () => {
+  withSyncedWiki(dir => {
+    // simulate a prior failed push: a local commit not on the remote
+    writeFileSync(join(dir, 'unpushed.md'), '# unpushed\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'unpushed work']);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const p = join(dir, '.cache', 'sync-state.json');
+    writeFileSync(p, JSON.stringify({ timestamp: '2026-05-14T00:00:00Z', op: 'push', error: 'connection refused', host: 'test' }) + '\n');
+    const r = runStart(dir);
+    const ctx = (JSON.parse(r.stdout).additionalContext) || '';
+    assert.ok(ctx.includes('last sync failed'), `unresolved push failure must stay surfaced: ${ctx}`);
+    assert.ok(existsSync(p), 'sync-state.json must not be cleared while local is ahead of remote');
+  });
+});
+
 // ── weekly-report.mjs (Lane E) ───────────────────────────────────────────────
 
 suite('weekly-report.mjs');


### PR DESCRIPTION
## 요약

Sync/Privacy 단계 (#9/#10). git pull/push 실패를 silent ignore하던 동작을 `.cache/sync-state.json`에 기록 → 다음 세션 시작 시 노출 → 해소되면 자동 clear하는 파이프라인.

## 변경

- **refactor (prep)**: `.cache/sync-state.json` JSONL 스키마(`{timestamp, op, error, host}`)와 read/append/clear 로직을 `hooks/hypo-shared.mjs` 공유 헬퍼(`appendSyncFailure`/`readSyncState`/`clearSyncState`)로 통합. `scripts/doctor.mjs`(#11)도 `readSyncState` 사용 — 스키마 단일 출처.
- **#9** `hypo-auto-commit.mjs`: Stop 훅에서 pull/push status를 더 이상 무시하지 않고 실패 시 각각 `appendSyncFailure` 기록. 세션은 멈추지 않음(best-effort).
- **#10** `hypo-session-start.mjs`: open 엔트리 감지 → `[WIKI: last sync failed: ...]`를 `additionalContext` + stderr 모든 경로에 노출. **해소 판정 = 이번 세션 pull 성공 && `[ahead N]` 아님** — uncommitted 변경은 sync 실패가 아니고, fresh `hypo init` wiki는 `.cache/`를 git-ignore하지 않으므로 `hypoIsClean()` 같은 광범위 체크 대신 ahead 상태만 좁게 검사. 손상된 JSONL은 generic 노출 + 보존(clear 안 함).

## 테스트

`tests/runner.mjs`에 replay 5건 추가 — 113 passed, 0 failed:
- `replay-auto-commit-writes-sync-state` — pull/push 실패 시 엔트리 append
- `replay-session-start-exposes-sync-state` — open 엔트리 노출
- `replay-session-start-clears-resolved-sync-state` — 해소 시 clear
- `replay-session-start-surfaces-unreadable-sync-state` — 손상 JSONL 노출 + 보존
- `replay-session-start-preserves-sync-state-when-ahead` — unpushed commit 시 보존

## 검토

Codex 1:codex 검토 → P2 1건(`parseError` 무시로 손상 파일 silent hide) 교차 검증 후 반영. P0/P1 없음.