### PR TITLE
feat(#17): strict 11-step session-close 검증 (PreCompact hard gate + crystallize)

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -30,7 +30,17 @@ Work through each item in order. For an explicit session-close invocation, proce
 
 ## Step 3 — Session-close confirmation
 
-After completing the checklist, report:
+After completing the checklist, verify it with the script before reporting:
+
+```bash
+node <package-root>/scripts/crystallize.mjs --check-session-close [--hypo-dir="<path>"]
+```
+
+This is the same strict check the PreCompact hard gate runs (fix #17). If it
+reports any file as `missing` or `stale`, fix that file and re-run before
+continuing — otherwise `/compact` will be blocked.
+
+Once the check passes, report:
 
 - ✓ session-state.md updated
 - ✓ hot.md (project + root) updated

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -3,7 +3,8 @@
  * hypo-personal-check.mjs — PreCompact hook
  *
  * Hard gate before /compact. Blocks if:
- *   - last substantial wiki op is not a session close
+ *   - the session-close memory files were not updated this session (fix #17:
+ *     session-state.md, project hot.md, root hot.md, session-log, log.md)
  *   - wiki git repo has uncommitted/unpushed changes
  *   - hot.md has forbidden structure
  *   - lint blockers exist
@@ -22,9 +23,9 @@ import { homedir } from 'os';
 import {
   HYPO_DIR,
   PKG_ROOT,
-  lastSubstantialOpIsSession,
   hypoIsClean,
   hotMdIsClean,
+  sessionCloseFileStatus,
   readChecklist,
   isGateSkipped,
   isClosePattern,
@@ -108,9 +109,18 @@ process.stdin.on('end', () => {
   // ── Heavy checks ──
   const today = new Date().toISOString().slice(0, 10);
 
-  const hasSession = lastSubstantialOpIsSession();
   const gitStatus  = hypoIsClean();
   const hotStatus  = hotMdIsClean();
+  // fix #17: strict 11-step session-close — the 6 memory files must be updated.
+  // closeFiles covers files #1-4 + log.md (#6); open-questions.md (#5) is
+  // conditional and not gated.
+  const closeFiles = sessionCloseFileStatus(HYPO_DIR);
+  const closeFilesReason = closeFiles.ok ? '' : `memory files not updated this session: ${
+    [
+      ...closeFiles.missing.map(f => `${f} (missing)`),
+      ...closeFiles.stale.map(f => `${f} (stale)`),
+    ].join(', ')
+  }`;
 
   const lintPath = PKG_ROOT ? join(PKG_ROOT, 'scripts', 'lint.mjs') : null;
   let lintBlockers = [];
@@ -134,7 +144,7 @@ process.stdin.on('end', () => {
   const lintOk          = lintBlockers.length === 0;
   const designHistoryOk = lintW8.length === 0;
 
-  if (hasSession && gitStatus.clean && hotStatus.clean && lintOk && designHistoryOk) {
+  if (gitStatus.clean && hotStatus.clean && lintOk && designHistoryOk && closeFiles.ok) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
@@ -142,9 +152,9 @@ process.stdin.on('end', () => {
   // ── Bypass 3: HYPO_SKIP_GATE ──
   if (isGateSkipped()) {
     const skipped = [
-      !hasSession      ? 'session log missing'                      : '',
       !gitStatus.clean ? gitStatus.reason                           : '',
       !hotStatus.clean ? hotStatus.reason                           : '',
+      !closeFiles.ok   ? closeFilesReason                           : '',
       !designHistoryOk ? `design-history stale (${lintW8.length})` : '',
       lintSkipped      ? 'lint skipped (hypo-pkg.json missing)'     : '',
     ].filter(Boolean).join(', ');
@@ -157,9 +167,9 @@ process.stdin.on('end', () => {
 
   // ── Block ──
   const reasons = [
-    !hasSession      ? 'session log entry missing'                                                   : '',
     !gitStatus.clean ? gitStatus.reason                                                              : '',
     !hotStatus.clean ? hotStatus.reason                                                              : '',
+    !closeFiles.ok   ? closeFilesReason                                                              : '',
     !lintOk          ? `lint blockers: ${lintBlockers.map(b => b.id).join(', ')}`                   : '',
     !designHistoryOk ? `design-history stale: ${lintW8.map(w => w.file.split('/')[1]).join(', ')}` : '',
     lintSkipped      ? 'lint skipped (run `hypomnema init` to enable lint gate)'                    : '',

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -114,6 +114,137 @@ export function hotMdIsClean() {
   return reasons.length === 0 ? { clean: true } : { clean: false, reason: reasons.join(' / ') };
 }
 
+// ── strict 11-step session-close verification (fix #17) ────────────────────
+// spec §5.2.7 / §8.3: a session close must touch 6 memory files. The hard gate
+// (sessionCloseFileStatus) confirms 5 of them — session-state.md, project
+// hot.md, root hot.md, session-log/YYYY-MM.md, and log.md. open-questions.md
+// (file #5) is conditional ("변경 시") and intentionally not gated.
+//
+// Known limitation: freshness is date-based per spec §8.3 ("timestamp가 같음"),
+// so a second session on the same day that skips updating a file still passes
+// if an earlier close that day already stamped it. freshDates() accepting both
+// local and UTC dates widens that window by up to one UTC offset. A per-session
+// boundary is out of scope for fix #17.
+
+/** Parse the frontmatter `updated:` field. Returns the trimmed value or null. */
+function frontmatterUpdated(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const u = m[1].match(/^updated:\s*(.+)$/m);
+  return u ? u[1].trim().replace(/^["']|["']$/g, '') : null;
+}
+
+/** Escape a string for safe literal use inside a RegExp. */
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Date strings that count as "today" for freshness checks. Both the local and
+ * UTC dates are accepted: Claude writes file dates in the user's local zone,
+ * while hypo-hot-rebuild stamps root hot.md with the UTC date. Accepting both
+ * removes the ~timezone-offset window where a correctly closed session would
+ * otherwise false-block.
+ * @returns {string[]} 1-2 ISO dates (YYYY-MM-DD), most-relevant first.
+ */
+export function freshDates() {
+  const d = new Date();
+  const local = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const utc = d.toISOString().slice(0, 10);
+  return local === utc ? [local] : [local, utc];
+}
+
+/**
+ * Resolve the most-recently-active project slug from root hot.md.
+ * Mirrors scripts/resume.mjs resolveActiveProject — kept in sync by hand.
+ * @param {string} hypoDir
+ * @returns {string|null}
+ */
+export function resolveActiveProject(hypoDir) {
+  const hotPath = join(hypoDir, 'hot.md');
+  if (!existsSync(hotPath)) return null;
+  let content;
+  try { content = readFileSync(hotPath, 'utf-8'); } catch { return null; }
+  // Canonical hot.md uses wikilinks: | name | date | [[projects/slug/hot]] |
+  const wikiRows = [...content.matchAll(/\|\s*([^|]+?)\s*\|\s*(\d{4}-\d{2}-\d{2})?\s*\|\s*\[\[projects\/([^\]/]+)\/[^\]]+\]\]/g)]
+    .map(m => ({ name: m[1].trim(), date: m[2] || '', slug: m[3] }));
+  if (wikiRows.length > 0) {
+    wikiRows.sort((a, b) => b.date.localeCompare(a.date));
+    return wikiRows[0].slug;
+  }
+  // Legacy markdown-link rows: | [name](projects/name/...) | ...
+  const mdRow = content.match(/\|\s*\[([^\]]+)\]\(projects\/([^/)]+)/);
+  if (mdRow) return mdRow[2];
+  return null;
+}
+
+/**
+ * Strict session-close verification (fix #17, spec §5.2.7 / §8.3).
+ * Confirms the memory files a session close must touch were updated today:
+ *   - projects/<project>/session-state.md       — frontmatter `updated:` is today
+ *   - projects/<project>/hot.md                 — frontmatter `updated:` is today
+ *   - hot.md (root)                             — frontmatter `updated:` is today
+ *   - projects/<project>/session-log/YYYY-MM.md — has a `## [today]` heading
+ *   - log.md                                    — has a `## [today] session | <project>` entry
+ * The log.md check is project-scoped so a session close left incomplete for
+ * project A can't be masked by a fresh close of project B (and vice versa).
+ * open-questions.md (file #5) is conditional and not gated.
+ *
+ * @param {string} hypoDir
+ * @returns {{ok: boolean, project: string|null, dates: string[], stale: string[], missing: string[]}}
+ */
+export function sessionCloseFileStatus(hypoDir) {
+  const dates = freshDates();
+  const project = resolveActiveProject(hypoDir);
+  if (!project) {
+    return { ok: false, project: null, dates, stale: [], missing: ['hot.md (no active project in pointer table)'] };
+  }
+
+  const stale = [];    // exists but not updated this session
+  const missing = [];  // file does not exist
+  const dateAlt = dates.join('|');
+
+  const checkUpdated = (relPath) => {
+    const full = join(hypoDir, relPath);
+    if (!existsSync(full)) { missing.push(relPath); return; }
+    let content;
+    try { content = readFileSync(full, 'utf-8'); } catch { missing.push(relPath); return; }
+    if (!dates.includes(frontmatterUpdated(content))) stale.push(relPath);
+  };
+
+  checkUpdated(join('projects', project, 'session-state.md'));
+  checkUpdated(join('projects', project, 'hot.md'));
+  checkUpdated('hot.md');
+
+  // session-log: monthly append-only file — must carry a today-dated heading.
+  // Reported under the local date's month (dates[0]) when no match is found.
+  let sessionLogOk = false;
+  for (const date of dates) {
+    const full = join(hypoDir, 'projects', project, 'session-log', `${date.slice(0, 7)}.md`);
+    if (!existsSync(full)) continue;
+    let content = '';
+    try { content = readFileSync(full, 'utf-8'); } catch { continue; }
+    if (new RegExp('^#{1,6} \\[' + date + '\\]', 'm').test(content)) { sessionLogOk = true; break; }
+  }
+  if (!sessionLogOk) {
+    const logRel = join('projects', project, 'session-log', `${dates[0].slice(0, 7)}.md`);
+    (existsSync(join(hypoDir, logRel)) ? stale : missing).push(logRel);
+  }
+
+  // log.md: must carry a today-dated `session` entry for the resolved project.
+  const logFull = join(hypoDir, 'log.md');
+  if (!existsSync(logFull)) {
+    missing.push('log.md');
+  } else {
+    let content = '';
+    try { content = readFileSync(logFull, 'utf-8'); } catch { missing.push('log.md'); }
+    const re = new RegExp('^## \\[(' + dateAlt + ')\\] session \\| ' + escapeRegExp(project) + '\\b', 'm');
+    if (content && !re.test(content)) stale.push('log.md');
+  }
+
+  return { ok: stale.length === 0 && missing.length === 0, project, dates, stale, missing };
+}
+
 // ── sync-state (fix #9/#10/#11) ────────────────────────────────────────────
 // `.cache/sync-state.json` is JSONL: one {timestamp, op, error, host} entry per
 // line. hypo-auto-commit (#9) appends on pull/push failure; hypo-session-start

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -10,27 +10,73 @@
  *   node scripts/crystallize.mjs [options]
  *
  * Options:
- *   --hypo-dir=<path>   Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
- *   --min-group=<n>     Min pages per tag group to report (default: 2)
- *   --json              Output as JSON
+ *   --hypo-dir=<path>        Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
+ *   --min-group=<n>          Min pages per tag group to report (default: 2)
+ *   --check-session-close    Verify the strict 11-step session-close memory files (fix #17)
+ *   --json                   Output as JSON
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, extname } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { sessionCloseFileStatus } from '../hooks/hypo-shared.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, minGroup: 2, json: false };
+  const args = { hypoDir: null, minGroup: 2, json: false, checkSessionClose: false };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir='))    args.hypoDir  = expandHome(arg.slice(11));
     else if (arg.startsWith('--min-group=')) args.minGroup = parseInt(arg.slice(12), 10) || 2;
+    else if (arg === '--check-session-close') args.checkSessionClose = true;
     else if (arg === '--json')             args.json     = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;
+}
+
+// ── session-close check (fix #17, spec §5.2.7 / §8.3) ────────────────────────
+// Mirrors the hard gate in hypo-personal-check.mjs so the /hypo:crystallize
+// flow can self-verify before /compact triggers PreCompact.
+
+function runSessionCloseCheck(args) {
+  const status = sessionCloseFileStatus(args.hypoDir);
+
+  if (args.json) {
+    console.log(JSON.stringify({
+      ok: status.ok,
+      project: status.project,
+      dates: status.dates,
+      stale: status.stale,
+      missing: status.missing,
+    }, null, 2));
+    process.exit(status.ok ? 0 : 1);
+  }
+
+  const proj = status.project || '(unresolved)';
+  console.log(`Session-close check (project: ${proj}, date: ${status.dates.join(' / ')}):\n`);
+
+  const required = status.project ? [
+    `projects/${status.project}/session-state.md`,
+    `projects/${status.project}/hot.md`,
+    'hot.md',
+    `projects/${status.project}/session-log/${status.dates[0].slice(0, 7)}.md`,
+    'log.md',
+  ] : [];
+  for (const f of required) {
+    const bad = status.missing.includes(f) ? 'missing' : status.stale.includes(f) ? 'stale' : '';
+    console.log(`  ${bad ? '✗' : '✓'} ${f}${bad ? ` — ${bad}` : ''}`);
+  }
+  // Surface anything not covered by the canonical list (e.g. unresolved project).
+  for (const f of [...status.missing, ...status.stale]) {
+    if (!required.includes(f)) console.log(`  ✗ ${f}`);
+  }
+  console.log('');
+  console.log(status.ok
+    ? '✓ All required memory files updated this session. (open-questions.md: conditional, not checked)'
+    : '✗ Session close incomplete — update the files marked above, then retry.');
+  process.exit(status.ok ? 0 : 1);
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -75,6 +121,10 @@ function extractWikilinks(content) {
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
+
+if (args.checkSessionClose) {
+  runSessionCloseCheck(args);   // exits
+}
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const pagesDir = join(args.hypoDir, 'pages');

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -49,7 +49,17 @@ If `/hypo:crystallize` was invoked as a session-close action, run through this c
 5. **open-questions** — only if `pages/open-questions.md` exists and questions were raised or resolved this session: move resolved ones out; add newly raised ones. Skip if unchanged.
 6. **log.md** — append a `session` entry to `<wiki-root>/log.md`.
 
-After completing the checklist, report each item with ✓ and ask: "Session closed. Would you like to also run knowledge synthesis now, or stop here?"
+After completing the checklist, verify it before reporting:
+
+```bash
+node <package-root>/scripts/crystallize.mjs --check-session-close [--hypo-dir="<path>"]
+```
+
+This runs the same strict check as the PreCompact hard gate (fix #17). Fix any
+file reported `missing` or `stale` and re-run until it passes — otherwise
+`/compact` will be blocked.
+
+Once it passes, report each item with ✓ and ask: "Session closed. Would you like to also run knowledge synthesis now, or stop here?"
 
 ---
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -467,22 +467,50 @@ function runHook(hookFile, stdinData, extraEnv = {}) {
   });
 }
 
-function withCleanWiki(fn) {
+// Build a fully session-closed wiki tree: root hot.md + log.md plus the 4
+// project memory files (session-state, project hot.md, session-log) all
+// carrying today's date. Mirrors the strict 11-step close (fix #17).
+function buildCleanWikiTree(dir, today) {
+  const ym = today.slice(0, 7);
+  const projDir = join(dir, 'projects', 'test-project');
+  mkdirSync(join(projDir, 'session-log'), { recursive: true });
+  writeFileSync(join(dir, 'hypo-config.md'), '# config');
+  writeFileSync(join(dir, 'log.md'), `## [${today}] session | test-project\n`);
+  writeFileSync(join(dir, 'hot.md'),
+    `---\ntitle: Hot\nupdated: ${today}\n---\n# Hot\n\n## Active Projects\n\n` +
+    `| Project | Last Session | Hot Cache |\n|---|---|---|\n` +
+    `| test-project | ${today} | [[projects/test-project/hot]] |\n`);
+  writeFileSync(join(projDir, 'session-state.md'),
+    `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n## 다음 작업\n\n- next\n`);
+  writeFileSync(join(projDir, 'hot.md'),
+    `---\ntitle: hot\ntype: reference\nupdated: ${today}\n---\n\n# Hot\n`);
+  writeFileSync(join(projDir, 'session-log', `${ym}.md`),
+    `---\ntitle: Session Log\ntype: session-log\nupdated: ${today}\n---\n\n## [${today}] test session\n`);
+}
+
+// Build a clean wiki tree, optionally mutate it before the initial commit,
+// then run `fn(dir, today)`. `mutate` runs pre-commit so tests can make a
+// file stale without leaving the git tree dirty (which would block on a
+// different reason).
+function withWiki(mutate, fn) {
   const dir = mkdtempSync(join(tmpdir(), 'hypo-wiki-'));
   try {
     const today = new Date().toISOString().slice(0, 10);
-    writeFileSync(join(dir, 'hypo-config.md'), '# config');
-    writeFileSync(join(dir, 'log.md'), `## [${today}] session | test-project\n`);
-    writeFileSync(join(dir, 'hot.md'), '---\ntitle: Hot\nupdated: today\n---\n# Hot\n');
+    buildCleanWikiTree(dir, today);
+    if (mutate) mutate(dir, today);
     spawnSync('git', ['init'], { cwd: dir, encoding: 'utf-8' });
     spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir });
     spawnSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
     spawnSync('git', ['add', '-A'], { cwd: dir, encoding: 'utf-8' });
     spawnSync('git', ['commit', '-m', 'init'], { cwd: dir, encoding: 'utf-8' });
-    fn(dir);
+    fn(dir, today);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+}
+
+function withCleanWiki(fn) {
+  withWiki(null, dir => fn(dir));
 }
 
 suite('isCompactCommand()');
@@ -707,6 +735,146 @@ test('clean wiki → suppressOutput:true', () => {
     const out = JSON.parse(r.stdout);
     assert.equal(out.suppressOutput, true);
     assert.equal(out.continue, true);
+  });
+});
+
+suite('hypo-personal-check.mjs — strict 11-step session close (#17)');
+
+test('all 6 memory files fresh → suppressOutput:true', () => {
+  withWiki(null, dir => {
+    const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, `expected pass, got: ${r.stdout}`);
+    assert.equal(out.suppressOutput, true);
+  });
+});
+
+test('project hot.md not updated today → block, reason names the file', () => {
+  withWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'test-project', 'hot.md'),
+      '---\ntitle: hot\ntype: reference\nupdated: 2020-01-01\n---\n\n# Hot\n');
+  }, dir => {
+    const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block', `expected block, got: ${r.stdout}`);
+    assert.ok(out.reason.includes('projects/test-project/hot.md'),
+      `block reason should name the stale file: ${out.reason}`);
+  });
+});
+
+test('session-log missing a today-dated heading → block', () => {
+  withWiki((dir, today) => {
+    const ym = today.slice(0, 7);
+    writeFileSync(join(dir, 'projects', 'test-project', 'session-log', `${ym}.md`),
+      '---\ntitle: Session Log\ntype: session-log\nupdated: 2020-01-01\n---\n\n## [2020-01-01] old session\n');
+  }, dir => {
+    const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block', `expected block, got: ${r.stdout}`);
+    assert.ok(out.reason.includes('session-log'),
+      `block reason should name the session-log file: ${out.reason}`);
+  });
+});
+
+test('open-questions.md absent/stale → still passes (conditional, not gated)', () => {
+  withWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'open-questions.md'),
+      '---\ntitle: Open Questions\ntype: open-questions\nupdated: 2020-01-01\n---\n\n# Open Questions\n');
+  }, dir => {
+    const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, `open-questions is conditional — should not gate: ${r.stdout}`);
+  });
+});
+
+test('log.md missing a today-dated session entry → block', () => {
+  withWiki((dir) => {
+    // log.md exists but its session entry is stale-dated.
+    writeFileSync(join(dir, 'log.md'), '## [2020-01-01] session | test-project — old\n');
+  }, dir => {
+    const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block', `expected block, got: ${r.stdout}`);
+    assert.ok(out.reason.includes('log.md'), `block reason should name log.md: ${out.reason}`);
+  });
+});
+
+test('log.md session entry for a different project → block', () => {
+  withWiki((dir, today) => {
+    // A fresh session entry, but for some other project — must not satisfy
+    // the gate for the resolved project (test-project).
+    writeFileSync(join(dir, 'log.md'), `## [${today}] session | other-project — done\n`);
+  }, dir => {
+    const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block', `cross-project log entry must not pass: ${r.stdout}`);
+    assert.ok(out.reason.includes('log.md'), `block reason should name log.md: ${out.reason}`);
+  });
+});
+
+test('HYPO_SKIP_GATE=1 bypasses an incomplete session close', () => {
+  withWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'test-project', 'session-state.md'),
+      '---\ntitle: session-state\ntype: session-state\nupdated: 2020-01-01\n---\n\n## 다음 작업\n\n- next\n');
+  }, dir => {
+    const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HYPO_SKIP_GATE: '1' });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, `HYPO_SKIP_GATE should bypass: ${r.stdout}`);
+    assert.ok(out.systemMessage.includes('memory files not updated'),
+      `bypass message should still surface the incomplete files: ${out.systemMessage}`);
+  });
+});
+
+suite('crystallize.mjs --check-session-close (#17)');
+
+test('clean session close → exit 0 + ok:true', () => {
+  withWiki(null, dir => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.equal(out.project, 'test-project');
+  });
+});
+
+test('stale memory file → exit 1 + ok:false + names the file', () => {
+  withWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'test-project', 'session-state.md'),
+      '---\ntitle: session-state\ntype: session-state\nupdated: 2020-01-01\n---\n\n## 다음 작업\n\n- next\n');
+  }, dir => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(out.stale.includes('projects/test-project/session-state.md'),
+      `stale list should name the file: ${JSON.stringify(out.stale)}`);
+  });
+});
+
+test('--check-session-close reads log.md from --hypo-dir, not the ambient wiki', () => {
+  withWiki((dir) => {
+    // log.md whose last substantial op is an ingest, not a session close.
+    writeFileSync(join(dir, 'log.md'), '## [2020-01-01] ingest | some-source\n');
+  }, dir => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(out.stale.includes('log.md'),
+      `log.md check must target --hypo-dir and flag it stale: ${r.stdout}`);
+  });
+});
+
+test('missing log.md → exit 1 + log.md in missing list', () => {
+  withWiki((dir) => {
+    rmSync(join(dir, 'log.md'));
+  }, dir => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(out.missing.includes('log.md'), `missing list should name log.md: ${r.stdout}`);
   });
 });
 


### PR DESCRIPTION
## 요약

spec §5.2.7 / §8.3 — 세션 클로즈는 6개 메모리 파일을 갱신해야 한다. PreCompact hard gate(`hypo-personal-check`)와 `crystallize.mjs --check-session-close`가 전수 갱신을 확인하도록 강화.

검사 대상 (하드 게이트 5개):
- `projects/<project>/session-state.md` — frontmatter `updated:` == today
- `projects/<project>/hot.md` — frontmatter `updated:` == today
- `hot.md` (root) — frontmatter `updated:` == today
- `projects/<project>/session-log/YYYY-MM.md` — `## [today]` 헤딩 존재
- `log.md` — `## [today] session | <project>` 엔트리 존재 (project-scoped)

`pages/open-questions.md`는 조건부("변경 시")라 게이트 제외.

## 변경

- **`hooks/hypo-shared.mjs`**: `sessionCloseFileStatus()` + `resolveActiveProject()` + `freshDates()` 추가
- **`hooks/hypo-personal-check.mjs`**: PreCompact 게이트 조건에 `closeFiles.ok` 추가 — 기존 `lastSubstantialOpIsSession` 기반 `hasSession` 체크를 흡수
- **`scripts/crystallize.mjs`**: `--check-session-close` 모드 — 게이트와 동일 로직, 세션 클로즈 자가 검증용
- **`commands/crystallize.md` + `skills/crystallize/SKILL.md`**: 검증 단계 문서화

## Codex 2-worker 검토 반영

| 지적 | 심각도 | 조치 |
|------|--------|------|
| `lastSubstantialOpIsSession`이 fail-open + 날짜 미검사 → missing/stale `log.md`가 게이트 통과 (false-pass) | HIGH | `log.md`를 `sessionCloseFileStatus`에 편입, `## [today] session` 검사 |
| `resolveActiveProject`가 보는 프로젝트와 `log.md` 엔트리 프로젝트 불일치 가능 | HIGH | `log.md` 검사를 project-scoped regex(`session \| <project>`)로 — 위 수정에 통합 |
| 같은 날 2세션 시 날짜 기반만으론 "이번 세션" 증명 불가 | MED | spec §8.3이 명시적으로 날짜 기반 — 코드 주석으로 한계 명시, 미수정 |
| `toISOString()`=UTC → Asia/Seoul 자정~09시 false-block. hot-rebuild(UTC) vs Claude 작성 파일(local) 불일치 | MED | `freshDates()` — UTC·local 양쪽을 "오늘"로 허용 |

## 테스트

133 passed, 0 failed (strict-11 게이트 7개 + crystallize check 4개 신규). `withCleanWiki` 헬퍼를 full project tree로 확장(`withWiki` 빌더 분리). lint 0 errors. 실제 wiki 및 라이브 PreCompact 훅 스모크 체크 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)