### PR TITLE
feat(#38): crystallize.mjs --apply-session-close --payload helper (ADR 0029 Phase A)

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -144,6 +144,35 @@ function escapeRegExp(s) {
 }
 
 /**
+ * True if `content` carries an ATX heading dated `date` (YYYY-MM-DD), e.g.
+ *   `## [2026-05-15] something`. Matches H1-H6.
+ * Shared by sessionCloseFileStatus() and the crystallize apply helper so both
+ * use the same definition of "session-log already updated for today".
+ */
+export function hasSessionLogHeading(content, date) {
+  return new RegExp('^#{1,6} \\[' + escapeRegExp(date) + '\\]', 'm').test(content || '');
+}
+
+/**
+ * True if `content` carries a today-dated `## [date] session | <project>` entry
+ * in log.md.
+ *
+ * Bounded with an explicit `(?=\s|$)` lookahead, NOT `\b`: a regex word boundary
+ * matches between word and non-word chars, so `\b` after "foo" still matches in
+ * "foo-bar" (hyphen is non-word). The canonical log format always separates the
+ * project slug from anything that follows by whitespace or end-of-line, so the
+ * lookahead correctly rejects "session | foo-bar" when looking for "foo".
+ * (Reported by codex review of fix #38 — was a pre-existing bug in
+ * sessionCloseFileStatus that the helper extraction inherited.)
+ */
+export function hasLogEntry(content, date, project) {
+  return new RegExp(
+    '^## \\[' + escapeRegExp(date) + '\\] session \\| ' + escapeRegExp(project) + '(?=\\s|$)',
+    'm',
+  ).test(content || '');
+}
+
+/**
  * Date strings that count as "today" for freshness checks. Both the local and
  * UTC dates are accepted: Claude writes file dates in the user's local zone,
  * while hypo-hot-rebuild stamps root hot.md with the UTC date. Accepting both
@@ -206,7 +235,6 @@ export function sessionCloseFileStatus(hypoDir) {
 
   const stale = [];    // exists but not updated this session
   const missing = [];  // file does not exist
-  const dateAlt = dates.join('|');
 
   const checkUpdated = (relPath) => {
     const full = join(hypoDir, relPath);
@@ -228,7 +256,7 @@ export function sessionCloseFileStatus(hypoDir) {
     if (!existsSync(full)) continue;
     let content = '';
     try { content = readFileSync(full, 'utf-8'); } catch { continue; }
-    if (new RegExp('^#{1,6} \\[' + date + '\\]', 'm').test(content)) { sessionLogOk = true; break; }
+    if (hasSessionLogHeading(content, date)) { sessionLogOk = true; break; }
   }
   if (!sessionLogOk) {
     const logRel = join('projects', project, 'session-log', `${dates[0].slice(0, 7)}.md`);
@@ -242,8 +270,8 @@ export function sessionCloseFileStatus(hypoDir) {
   } else {
     let content = '';
     try { content = readFileSync(logFull, 'utf-8'); } catch { missing.push('log.md'); }
-    const re = new RegExp('^## \\[(' + dateAlt + ')\\] session \\| ' + escapeRegExp(project) + '\\b', 'm');
-    if (content && !re.test(content)) stale.push('log.md');
+    const logFresh = content && dates.some(d => hasLogEntry(content, d, project));
+    if (content && !logFresh) stale.push('log.md');
   }
 
   return { ok: stale.length === 0 && missing.length === 0, project, dates, stale, missing };

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -13,11 +13,31 @@
  *   --hypo-dir=<path>        Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
  *   --min-group=<n>          Min pages per tag group to report (default: 2)
  *   --check-session-close    Verify the strict session-close memory files — 5 mandatory + open-questions conditional (fix #17)
+ *   --apply-session-close    Apply a JSON payload that updates the 5 mandatory memory files
+ *                            (+ optional open-questions). Idempotent — re-running with the same
+ *                            payload is a no-op. Always finishes with the strict gate check.
+ *   --payload=<path|->       Required with --apply-session-close. Path to JSON file or `-` for stdin.
  *   --json                   Output as JSON
+ *
+ * Payload schema (fix #38):
+ *   {
+ *     "project":      "<slug>",                       // optional — defaults to resolveActiveProject()
+ *     "date":         "YYYY-MM-DD",                   // optional — defaults to today (local)
+ *     "sessionState": { "content": "<full file>" },   // overwrite (idempotent: identical bytes → skip)
+ *     "projectHot":   { "content": "<full file>" },   // overwrite
+ *     "rootHot":      { "content": "<full file>" },   // overwrite
+ *     "sessionLog":   { "entry":   "## [date] ..." }, // append, skip if heading already present
+ *     "log":          { "entry":   "## [date] session | <project> ..." }, // append, skip if entry present
+ *     "openQuestions":{ "content": "<full file>" }    // optional overwrite
+ *   }
+ *
+ * The helper does NOT auto-fix `updated:` frontmatter. If a payload field carries a
+ * stale date, the final sessionCloseFileStatus check fails with a clear error so the
+ * caller fixes the payload and retries. Silent rewrites would mask payload bugs.
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { join, relative, extname } from 'path';
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, renameSync } from 'fs';
+import { join, relative, extname, dirname } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import { sessionCloseFileStatus } from '../hooks/hypo-shared.mjs';
@@ -25,11 +45,16 @@ import { sessionCloseFileStatus } from '../hooks/hypo-shared.mjs';
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, minGroup: 2, json: false, checkSessionClose: false };
+  const args = {
+    hypoDir: null, minGroup: 2, json: false,
+    checkSessionClose: false, applySessionClose: false, payload: null,
+  };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir='))    args.hypoDir  = expandHome(arg.slice(11));
     else if (arg.startsWith('--min-group=')) args.minGroup = parseInt(arg.slice(12), 10) || 2;
     else if (arg === '--check-session-close') args.checkSessionClose = true;
+    else if (arg === '--apply-session-close') args.applySessionClose = true;
+    else if (arg.startsWith('--payload=')) args.payload = arg.slice(10);
     else if (arg === '--json')             args.json     = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
@@ -79,6 +104,217 @@ function runSessionCloseCheck(args) {
   process.exit(status.ok ? 0 : 1);
 }
 
+// ── session-close apply (fix #38) ────────────────────────────────────────────
+// Idempotent payload-driven application of the 5 mandatory session-close memory
+// files (+ optional open-questions). Used by the LLM session-close flow as the
+// canonical entrypoint instead of issuing 5+ Write tool calls by hand.
+//
+// Idempotency:
+//   • full-content fields (sessionState/projectHot/rootHot/openQuestions): write
+//     only when on-disk bytes differ — re-running with same payload is a no-op.
+//   • append fields (sessionLog/log): skip when the dated heading/entry is
+//     already present (regex shared with sessionCloseFileStatus via hypo-shared).
+//
+// Validation: never auto-fixes the payload. The final sessionCloseFileStatus
+// check fails fast on stale `updated:` or missing entries so the caller fixes
+// the payload and retries — silent rewrites would hide payload bugs (advisor #3).
+
+function readPayload(source) {
+  if (!source) throw new Error('--payload is required with --apply-session-close (path or `-` for stdin)');
+  let raw;
+  if (source === '-') {
+    // Synchronous stdin read; payloads are tiny (a few hundred KB at most).
+    raw = readFileSync(0, 'utf-8');
+  } else {
+    const path = expandHome(source);
+    if (!existsSync(path)) throw new Error(`payload file not found: ${path}`);
+    raw = readFileSync(path, 'utf-8');
+  }
+  try { return JSON.parse(raw); }
+  catch (e) { throw new Error(`payload is not valid JSON: ${e.message}`); }
+}
+
+/** Atomic write via tmp+rename. `<path>.<pid>.<rand>.tmp` so concurrent helpers
+ * don't fight over the same shared `<path>.tmp` slot. */
+function atomicWrite(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+}
+
+/** Atomic write that skips when on-disk bytes already match `content`. */
+function writeIfChanged(path, content) {
+  if (existsSync(path)) {
+    try {
+      if (readFileSync(path, 'utf-8') === content) return false;  // idempotent skip
+    } catch { /* fall through to overwrite */ }
+  }
+  atomicWrite(path, content);
+  return true;
+}
+
+/**
+ * Append `entry` to `path` only if `alreadyPresent(content)` is false.
+ * Atomic: rebuilds the full file content and writes via atomicWrite — a crash
+ * mid-append cannot leave log.md or session-log/YYYY-MM.md half-written, which
+ * matters for these append-only history files (codex review of fix #38).
+ */
+function appendIfAbsent(path, entry, alreadyPresent) {
+  let content = '';
+  if (existsSync(path)) {
+    try { content = readFileSync(path, 'utf-8'); } catch { content = ''; }
+  }
+  if (alreadyPresent(content)) return false;
+  // Ensure single blank line between existing tail and new entry, no trailing dup.
+  const sep = content === '' ? '' : (content.endsWith('\n\n') ? '' : content.endsWith('\n') ? '\n' : '\n\n');
+  const next = entry.endsWith('\n') ? entry : entry + '\n';
+  atomicWrite(path, content + sep + next);
+  return true;
+}
+
+function todayLocal() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+// Spec §5.2.7 / §8.3 + ADR 0029: 5 mandatory + 1 conditional. The payload
+// shape MUST mirror that contract — missing a mandatory field is a payload
+// bug, not a no-op. Caller is the LLM session-close flow, which composes the
+// payload deliberately; partial payloads must fail loudly so caller fixes them
+// rather than silently relying on yesterday's freshness state. (Codex review
+// of fix #38 — Worker 1 finding 1.)
+const REQUIRED_PAYLOAD_FIELDS = [
+  ['sessionState',  'content'],
+  ['projectHot',    'content'],
+  ['rootHot',       'content'],
+  ['sessionLog',    'entry'],
+  ['log',           'entry'],
+];
+
+function validatePayloadShape(payload) {
+  const errs = [];
+  if (!payload || typeof payload !== 'object') {
+    errs.push('payload must be a JSON object');
+    return errs;
+  }
+  for (const [field, key] of REQUIRED_PAYLOAD_FIELDS) {
+    const slot = payload[field];
+    if (!slot || typeof slot !== 'object') {
+      errs.push(`payload.${field} is required (object with .${key})`);
+      continue;
+    }
+    if (typeof slot[key] !== 'string') {
+      errs.push(`payload.${field}.${key} must be a string`);
+    }
+  }
+  if (payload.openQuestions !== undefined) {
+    if (!payload.openQuestions || typeof payload.openQuestions !== 'object'
+        || typeof payload.openQuestions.content !== 'string') {
+      errs.push('payload.openQuestions, when present, must be { content: string }');
+    }
+  }
+  if (payload.date !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(String(payload.date))) {
+    errs.push('payload.date, when present, must be YYYY-MM-DD');
+  }
+  return errs;
+}
+
+function applySessionClose(args) {
+  let payload;
+  try { payload = readPayload(args.payload); }
+  catch (e) {
+    const out = { ok: false, error: e.message };
+    console.log(args.json ? JSON.stringify(out, null, 2) : `✗ ${e.message}`);
+    process.exit(1);
+  }
+
+  const schemaErrs = validatePayloadShape(payload);
+  if (schemaErrs.length > 0) {
+    const out = { ok: false, error: 'payload schema invalid', details: schemaErrs };
+    console.log(args.json
+      ? JSON.stringify(out, null, 2)
+      : `✗ payload schema invalid:\n  ${schemaErrs.join('\n  ')}`);
+    process.exit(1);
+  }
+
+  // Resolve project: explicit payload.project wins; else fall back to active project.
+  // Done via sessionCloseFileStatus to keep one source of truth (and so a
+  // missing pointer table surfaces the same error shape as --check-session-close).
+  const probe = sessionCloseFileStatus(args.hypoDir);
+  const project = payload.project || probe.project;
+  if (!project) {
+    const msg = 'no project resolved (payload.project missing and root hot.md has no active-project row)';
+    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+    process.exit(1);
+  }
+  const date = payload.date || todayLocal();
+  const ym   = date.slice(0, 7);
+
+  const applied = [];
+  const skipped = [];
+
+  const overwrite = (key, relPath, field) => {
+    if (!field || typeof field.content !== 'string') return;  // optional / absent
+    const wrote = writeIfChanged(join(args.hypoDir, relPath), field.content);
+    (wrote ? applied : skipped).push(`${key} (${relPath})`);
+  };
+
+  overwrite('sessionState', join('projects', project, 'session-state.md'), payload.sessionState);
+  overwrite('projectHot',   join('projects', project, 'hot.md'),           payload.projectHot);
+  overwrite('rootHot',      'hot.md',                                       payload.rootHot);
+  overwrite('openQuestions', join('pages', 'open-questions.md'),            payload.openQuestions);
+
+  // Append idempotency: dedup by exact-entry presence, not by "any heading
+  // dated today". The freshness gate (sessionCloseFileStatus) is what answers
+  // "was this file touched today?"; that's a different concern and must not
+  // be reused for apply-time dedup, or a legitimate same-day second close gets
+  // silently dropped (Codex review of fix #38 — Worker 1 finding 2).
+  const entryAlreadyPresent = entry => content =>
+    content.includes(entry.endsWith('\n') ? entry.replace(/\n+$/, '') : entry);
+
+  {
+    const rel = join('projects', project, 'session-log', `${ym}.md`);
+    const wrote = appendIfAbsent(
+      join(args.hypoDir, rel),
+      payload.sessionLog.entry,
+      entryAlreadyPresent(payload.sessionLog.entry),
+    );
+    (wrote ? applied : skipped).push(`sessionLog (${rel})`);
+  }
+
+  {
+    const wrote = appendIfAbsent(
+      join(args.hypoDir, 'log.md'),
+      payload.log.entry,
+      entryAlreadyPresent(payload.log.entry),
+    );
+    (wrote ? applied : skipped).push('log (log.md)');
+  }
+
+  const verification = sessionCloseFileStatus(args.hypoDir);
+  const result = { ok: verification.ok, project, date, applied, skipped, verification };
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Session-close apply (project: ${project}, date: ${date}):`);
+    for (const a of applied) console.log(`  ✓ wrote ${a}`);
+    for (const s of skipped) console.log(`  · skipped ${s} (already current)`);
+    if (verification.ok) {
+      console.log('\n✓ session-close verified — all 5 mandatory files fresh.');
+    } else {
+      const bad = [
+        ...verification.missing.map(f => `${f} (missing)`),
+        ...verification.stale.map(f => `${f} (stale)`),
+      ].join(', ');
+      console.log(`\n✗ session-close still incomplete after apply: ${bad}`);
+      console.log('  Fix the payload (likely an `updated:` field) and retry.');
+    }
+  }
+  process.exit(verification.ok ? 0 : 1);
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 function collectPages(dir, root, acc = [], ignorePatterns = []) {
@@ -121,6 +357,10 @@ function extractWikilinks(content) {
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
+
+if (args.applySessionClose) {
+  applySessionClose(args);   // exits
+}
 
 if (args.checkSessionClose) {
   runSessionCloseCheck(args);   // exits

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -879,6 +879,230 @@ test('missing log.md → exit 1 + log.md in missing list', () => {
   });
 });
 
+// ── fix #38: --apply-session-close --payload <json> ───────────────────────────
+// Idempotent payload-driven entrypoint that writes the 5 mandatory memory files
+// (+ optional open-questions) and finishes with the strict gate. ADR 0029 Phase A.
+
+suite('crystallize.mjs --apply-session-close (#38)');
+
+// Helper: build a payload that re-asserts today's already-clean state on a wiki
+// produced by buildCleanWikiTree(). Used to test idempotency without changing
+// any fixture content.
+function payloadForCleanWiki(dir, today) {
+  const ym = today.slice(0, 7);
+  return {
+    project: 'test-project',
+    date: today,
+    sessionState: { content: readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8') },
+    projectHot:   { content: readFileSync(join(dir, 'projects', 'test-project', 'hot.md'),           'utf-8') },
+    rootHot:      { content: readFileSync(join(dir, 'hot.md'),                                       'utf-8') },
+    sessionLog:   { entry:   `## [${today}] re-applied session\n` },
+    log:          { entry:   `## [${today}] session | test-project — re-applied\n` },
+  };
+}
+
+function runApply(dir, payload) {
+  const payloadPath = join(dir, '.payload.json');
+  writeFileSync(payloadPath, JSON.stringify(payload));
+  return run('crystallize.mjs', [`--hypo-dir=${dir}`, '--apply-session-close', `--payload=${payloadPath}`, '--json']);
+}
+
+test('clean-wiki payload → ok:true, new entries appended (apply dedup is exact-entry, not date-based)', () => {
+  withWiki(null, (dir, today) => {
+    // payloadForCleanWiki uses NEW entry text ("re-applied"), not the fixture's
+    // existing "test session" entry. Apply must append the new entries — using
+    // the freshness gate as a dedup signal would silently drop a legitimate
+    // same-day second close (codex review of fix #38, Worker 1 finding 2).
+    const r = runApply(dir, payloadForCleanWiki(dir, today));
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    const appliedSlots = out.applied.join(' ');
+    assert.ok(/sessionLog/.test(appliedSlots), `sessionLog should be appended (new entry): ${JSON.stringify(out)}`);
+    assert.ok(/log \(log\.md\)/.test(appliedSlots), `log.md should be appended (new entry): ${JSON.stringify(out)}`);
+  });
+});
+
+test('idempotent: re-running same payload produces no new bytes (file mtimes unchanged)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    const r1 = runApply(dir, payload);
+    assert.equal(r1.status, 0, `first apply failed: ${r1.stdout}\n${r1.stderr}`);
+    const sl = join(dir, 'projects', 'test-project', 'session-log', `${today.slice(0, 7)}.md`);
+    const sizeBefore = readFileSync(sl, 'utf-8').length;
+    const logBefore  = readFileSync(join(dir, 'log.md'), 'utf-8').length;
+
+    const r2 = runApply(dir, payload);
+    assert.equal(r2.status, 0, `second apply failed: ${r2.stdout}\n${r2.stderr}`);
+    const sizeAfter = readFileSync(sl, 'utf-8').length;
+    const logAfter  = readFileSync(join(dir, 'log.md'), 'utf-8').length;
+    assert.equal(sizeAfter, sizeBefore, 'session-log must not grow on re-apply (idempotent append)');
+    assert.equal(logAfter,  logBefore,  'log.md must not grow on re-apply (idempotent append)');
+  });
+});
+
+test('--hypo-dir isolation: overwrite fields land in the supplied dir', () => {
+  // run() forces HYPO_DIR='' in env, so any write that lands inside `dir` is
+  // proof --hypo-dir was honored. Use an overwrite field (sessionState) with a
+  // unique sentinel — append fields are per-day deduped so they're a poor
+  // isolation probe.
+  withWiki(null, (dir, today) => {
+    const sentinel = `<!-- isolation-probe-${Date.now()} -->`;
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionState = {
+      content: `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n${sentinel}\n\n## 다음 작업\n\n- next\n`,
+    };
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 0, `apply failed: ${r.stdout}\n${r.stderr}`);
+    const onDisk = readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8');
+    assert.ok(onDisk.includes(sentinel), 'sentinel must land in --hypo-dir, proving isolation');
+  });
+});
+
+test('open-questions absent in payload → still passes (conditional, ungated)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    delete payload.openQuestions;  // explicitly omit
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true, 'open-questions is conditional — apply must succeed without it');
+    assert.ok(!out.applied.some(a => /openQuestions/.test(a)), 'openQuestions slot should not appear when omitted');
+  });
+});
+
+test('open-questions stale on disk → still passes (apply does not gate it)', () => {
+  withWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'open-questions.md'),
+      '---\ntitle: Open Questions\ntype: open-questions\nupdated: 2020-01-01\n---\n\n# Open Questions\n');
+  }, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    delete payload.openQuestions;
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 0, `stale open-questions must not gate: ${r.stdout}`);
+  });
+});
+
+test('payload with stale `updated:` → exit 1, no auto-fix (advisor rule)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    // Inject a stale-dated session-state. Helper must NOT silently rewrite it.
+    payload.sessionState = {
+      content: '---\ntitle: session-state\ntype: session-state\nupdated: 2020-01-01\n---\n\n## 다음 작업\n\n- next\n',
+    };
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `stale payload must fail final gate, got status=${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(out.verification.stale.includes('projects/test-project/session-state.md'),
+      `stale field should be flagged: ${JSON.stringify(out.verification)}`);
+  });
+});
+
+test('missing payload → exit 1 with clear error', () => {
+  withWiki(null, (dir) => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--apply-session-close', '--json']);
+    assert.equal(r.status, 1);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(/payload is required/.test(out.error), `error should mention payload: ${out.error}`);
+  });
+});
+
+test('same-day second close: distinct entries are both appended (W1 regression)', () => {
+  // Sub-session within the same day must produce a second log entry, not be
+  // silently deduped because today's heading already exists. This was the
+  // major flaw codex review surfaced — apply dedup vs freshness gate.
+  withWiki(null, (dir, today) => {
+    const p1 = payloadForCleanWiki(dir, today);
+    p1.sessionLog.entry = `## [${today}] morning sub-session\n\nbody A\n`;
+    p1.log.entry        = `## [${today}] session | test-project — morning\n`;
+    const r1 = runApply(dir, p1);
+    assert.equal(r1.status, 0, `first apply failed: ${r1.stdout}\n${r1.stderr}`);
+
+    const p2 = payloadForCleanWiki(dir, today);
+    p2.sessionLog.entry = `## [${today}] afternoon sub-session\n\nbody B\n`;
+    p2.log.entry        = `## [${today}] session | test-project — afternoon\n`;
+    const r2 = runApply(dir, p2);
+    assert.equal(r2.status, 0, `second apply failed: ${r2.stdout}\n${r2.stderr}`);
+
+    const sl  = readFileSync(join(dir, 'projects', 'test-project', 'session-log', `${today.slice(0, 7)}.md`), 'utf-8');
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.ok(sl.includes('morning sub-session'),   `session-log should keep morning entry: ${sl}`);
+    assert.ok(sl.includes('afternoon sub-session'), `session-log should append afternoon entry: ${sl}`);
+    assert.ok(log.includes('— morning'),   `log.md should keep morning entry: ${log}`);
+    assert.ok(log.includes('— afternoon'), `log.md should append afternoon entry: ${log}`);
+  });
+});
+
+test('payload schema: missing mandatory field → exit 1 with named field (W1 fail-loud)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    delete payload.projectHot;  // drop a mandatory slot
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `missing mandatory must fail, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(/projectHot/.test(JSON.stringify(out.details || out.error)),
+      `error must name the missing field: ${r.stdout}`);
+  });
+});
+
+test('payload schema: invalid date format → exit 1', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.date = '2026/05/15';
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1);
+    const out = JSON.parse(r.stdout);
+    assert.ok(/YYYY-MM-DD/.test(JSON.stringify(out.details || out.error)),
+      `error must mention date format: ${r.stdout}`);
+  });
+});
+
+test('hasLogEntry: project "foo" must NOT match "foo-bar" (W2 boundary regression)', () => {
+  // Pre-existing bug in sessionCloseFileStatus that the helper extraction
+  // inherited. \b after "foo" matches before "-" (non-word char), so the
+  // bounded regex must use (?=\\s|$) instead.
+  withWiki((dir, today) => {
+    // Replace root hot.md to declare project "foo" as the active project,
+    // and seed log.md with a session entry for "foo-bar" only.
+    writeFileSync(join(dir, 'hot.md'),
+      `---\ntitle: Hot\nupdated: ${today}\n---\n# Hot\n\n## Active Projects\n\n` +
+      `| Project | Last Session | Hot Cache |\n|---|---|---|\n` +
+      `| foo | ${today} | [[projects/foo/hot]] |\n`);
+    mkdirSync(join(dir, 'projects', 'foo', 'session-log'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'foo', 'session-state.md'),
+      `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n## 다음 작업\n\n- next\n`);
+    writeFileSync(join(dir, 'projects', 'foo', 'hot.md'),
+      `---\ntitle: hot\ntype: reference\nupdated: ${today}\n---\n\n# Hot\n`);
+    writeFileSync(join(dir, 'projects', 'foo', 'session-log', `${today.slice(0, 7)}.md`),
+      `---\ntitle: Session Log\ntype: session-log\nupdated: ${today}\n---\n\n## [${today}] foo session\n`);
+    // log.md only carries an entry for the LOOK-ALIKE project name.
+    writeFileSync(join(dir, 'log.md'), `## [${today}] session | foo-bar — should not satisfy "foo" gate\n`);
+  }, dir => {
+    // Plain --check-session-close must reject "foo" because no foo entry exists.
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+    assert.equal(r.status, 1, `foo must not match foo-bar in log.md, got status=${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.ok(out.stale.includes('log.md') || out.missing.includes('log.md'),
+      `log.md must be flagged stale/missing for foo: ${JSON.stringify(out)}`);
+  });
+});
+
+test('payload via stdin (`--payload=-`) works the same as a file', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    const r = spawnSync(process.execPath,
+      [join(REPO, 'scripts', 'crystallize.mjs'), `--hypo-dir=${dir}`, '--apply-session-close', '--payload=-', '--json'],
+      { input: JSON.stringify(payload), encoding: 'utf-8' });
+    assert.equal(r.status, 0, `stdin apply failed: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+  });
+});
+
 // ── upgrade.mjs smoke tests ───────────────────────────────────────────────────
 
 suite('upgrade.mjs --json');


### PR DESCRIPTION
## Summary

Adds `--apply-session-close --payload <json>` mode to `scripts/crystallize.mjs` — the canonical entrypoint for applying the strict session-close memory file set from a single JSON payload. ADR 0029 Phase A item 2 of 4 (after PR #22).

## Contract

**Payload schema** (validated up front, fail-loud on missing):
- `sessionState.content` — full file overwrite
- `projectHot.content` — full file overwrite
- `rootHot.content` — full file overwrite
- `sessionLog.entry` — appended (exact-entry dedup)
- `log.entry` — appended (exact-entry dedup)
- `openQuestions.content` — optional (conditional per spec §5.2.7)

**Idempotency**:
- Overwrite fields: byte-equal skip
- Append fields: exact-entry substring dedup (NOT date-based — separates apply concern from freshness gate)

**Atomicity**: all writes via tmp+rename with unique pid+rand suffix.

**No silent corruption**: helper does not auto-fix `updated:` frontmatter. If a payload field is stale-dated, the final `sessionCloseFileStatus` gate fails with a clear error so caller fixes the payload.

## Codex review (omc-teams 2:codex)

All 4 findings addressed with regression coverage:

| Severity | Finding | Fix |
|---|---|---|
| major | `\b` boundary in `hasLogEntry` false-matched project `foo` against `foo-bar` | `(?=\s\|$)` lookahead |
| medium | `appendIfAbsent` non-atomic (writeFileSync direct) | `atomicWrite()` (tmp+rename, unique suffix) for all writes |
| major | Payload mandatory fields not enforced — silent ok:true if disk already fresh | `validatePayloadShape()` requires 5 mandatory + date format |
| major | Append dedup by "any today heading" silently dropped same-day second close | dedup is now exact-entry substring; freshness gate stays date-based |

## Test plan

- 145 passed / 0 failed (was 133, +12 new tests in `crystallize.mjs --apply-session-close (#38)` suite)
- `npm run lint`: 0 errors
- New tests cover: idempotency (size-stable on re-apply), `--hypo-dir` isolation, open-questions absent/stale conditional, stale `updated:` fail-fast, missing payload error, stdin payload, same-day second close (W1 regression), schema rejection on missing field / bad date format, foo-vs-foo-bar project boundary (W2 regression).

## Scope boundary

This PR is fix #38 only — payload entrypoint + idempotent apply + final strict gate.
- fix #39 (helper early-exit when already-clean): separate PR
- fix #40 (lint preflight + final strict separation): separate PR

## Refs

- ADR 0029 (`projects/hypomnema/decisions/0029-...md`) — Phase A justification
- spec §5.2.7 / §8.3 — 5 mandatory + open-questions conditional contract
- previous PR #22 (terminology alignment, merged 0050deb→6b3dba1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)