### PR TITLE
feat(#39): crystallize.mjs probe early-exit (option D)

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -16,7 +16,17 @@
  *   --apply-session-close    Apply a JSON payload that updates the 5 mandatory memory files
  *                            (+ optional open-questions). Idempotent — re-running with the same
  *                            payload is a no-op. Always finishes with the strict gate check.
- *   --payload=<path|->       Required with --apply-session-close. Path to JSON file or `-` for stdin.
+ *
+ *                            Without --payload, runs as a cheap "already complete?" probe:
+ *                            if the strict gate is ok, exits 0 with alreadyComplete:true;
+ *                            otherwise exits 1 with "payload is required". Fix #39 (option D):
+ *                            payload presence = explicit close intent → always full apply
+ *                            (fix #38's per-entry idempotency keeps re-apply cheap).
+ *   --payload=<path|->       Path to JSON payload (file or `-` for stdin). Required for any
+ *                            apply work; omit only for the probe path above.
+ *   --force                  Bypass the no-payload probe early-exit. Payload is still required
+ *                            for any apply work — --force only opts out of the alreadyComplete
+ *                            shortcut. Reserved for explicit diagnostics / scripted recovery.
  *   --json                   Output as JSON
  *
  * Payload schema (fix #38):
@@ -47,7 +57,7 @@ import { sessionCloseFileStatus } from '../hooks/hypo-shared.mjs';
 function parseArgs(argv) {
   const args = {
     hypoDir: null, minGroup: 2, json: false,
-    checkSessionClose: false, applySessionClose: false, payload: null,
+    checkSessionClose: false, applySessionClose: false, payload: null, force: false,
   };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir='))    args.hypoDir  = expandHome(arg.slice(11));
@@ -55,6 +65,7 @@ function parseArgs(argv) {
     else if (arg === '--check-session-close') args.checkSessionClose = true;
     else if (arg === '--apply-session-close') args.applySessionClose = true;
     else if (arg.startsWith('--payload=')) args.payload = arg.slice(10);
+    else if (arg === '--force')            args.force    = true;
     else if (arg === '--json')             args.json     = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
@@ -221,6 +232,37 @@ function validatePayloadShape(payload) {
 }
 
 function applySessionClose(args) {
+  // Fix #39 (option D): early-exit fires only when NO payload was supplied.
+  // Rationale: payload presence is explicit close intent and must always run
+  // the full apply path — fix #38's per-entry idempotency (writeIfChanged +
+  // exact-entry append dedup) keeps re-apply cheap without short-circuiting,
+  // and avoids silent-success when a same-day second close brings new bytes.
+  // Payload-less invocation is treated as a cheap "already complete?" probe.
+  // --force opts out of that probe shortcut only — payload remains required
+  // for any actual apply work (readPayload below surfaces "payload is
+  // required" the same way it always has).
+  if (!args.force && !args.payload) {
+    const probe = sessionCloseFileStatus(args.hypoDir);
+    if (probe.ok) {
+      const result = {
+        ok: true,
+        alreadyComplete: true,
+        project: probe.project,
+        date: probe.dates[0],
+        message: '오늘 이미 close 완료로 보임 (probe 모드 — payload 미지정).',
+      };
+      if (args.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`✓ ${result.message}`);
+        console.log(`  project: ${result.project} / date: ${result.date}`);
+      }
+      process.exit(0);
+    }
+    // gate not ok → fall through to readPayload, which surfaces
+    // "payload is required" with the same error shape as before.
+  }
+
   let payload;
   try { payload = readPayload(args.payload); }
   catch (e) {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -901,10 +901,15 @@ function payloadForCleanWiki(dir, today) {
   };
 }
 
-function runApply(dir, payload) {
+function runApply(dir, payload, { force = false } = {}) {
+  // Fix #39 (option D): payload presence = explicit close intent → always runs
+  // full apply. --force only matters for the no-payload probe path, so tests
+  // that supply a payload do NOT need --force.
   const payloadPath = join(dir, '.payload.json');
   writeFileSync(payloadPath, JSON.stringify(payload));
-  return run('crystallize.mjs', [`--hypo-dir=${dir}`, '--apply-session-close', `--payload=${payloadPath}`, '--json']);
+  const flags = [`--hypo-dir=${dir}`, '--apply-session-close', `--payload=${payloadPath}`, '--json'];
+  if (force) flags.push('--force');
+  return run('crystallize.mjs', flags);
 }
 
 test('clean-wiki payload → ok:true, new entries appended (apply dedup is exact-entry, not date-based)', () => {
@@ -1001,9 +1006,17 @@ test('payload with stale `updated:` → exit 1, no auto-fix (advisor rule)', () 
 });
 
 test('missing payload → exit 1 with clear error', () => {
-  withWiki(null, (dir) => {
+  // With fix #39 (option D) the probe early-exit only fires on a clean wiki.
+  // Mark hot.md stale so the gate fails → no early-exit → payload-required
+  // error is reachable as the original test intends.
+  withWiki((dir) => {
+    writeFileSync(join(dir, 'hot.md'),
+      '---\ntitle: Hot\nupdated: 2020-01-01\n---\n# Hot\n\n## Active Projects\n\n' +
+      '| Project | Last Session | Hot Cache |\n|---|---|---|\n' +
+      '| test-project | 2020-01-01 | [[projects/test-project/hot]] |\n');
+  }, (dir) => {
     const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--apply-session-close', '--json']);
-    assert.equal(r.status, 1);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
     assert.ok(/payload is required/.test(out.error), `error should mention payload: ${out.error}`);
@@ -1088,6 +1101,70 @@ test('hasLogEntry: project "foo" must NOT match "foo-bar" (W2 boundary regressio
     const out = JSON.parse(r.stdout);
     assert.ok(out.stale.includes('log.md') || out.missing.includes('log.md'),
       `log.md must be flagged stale/missing for foo: ${JSON.stringify(out)}`);
+  });
+});
+
+// ── fix #39: probe early-exit (option D) ─────────────────────────────────────
+
+test('probe (#39): no payload + gate ok → exit 0 with alreadyComplete', () => {
+  // buildCleanWikiTree() leaves the wiki in a passing-gate state for `today`.
+  // With no --payload, the helper runs as a cheap "already complete?" probe:
+  // gate ok → exit 0 alreadyComplete:true, no payload required.
+  withWiki(null, (dir, today) => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--apply-session-close', '--json']);
+    assert.equal(r.status, 0, `probe must succeed, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.equal(out.alreadyComplete, true, `alreadyComplete flag must be set: ${r.stdout}`);
+    assert.equal(out.date, today);
+  });
+});
+
+test('apply (#39): payload supplied + gate ok → still full apply (W1-2 guard, no --force)', () => {
+  // Option D core invariant: payload presence = explicit close intent.
+  // Same-day second close with a NEW sessionLog entry must land WITHOUT
+  // requiring --force. fix #38's exact-entry dedup is the only safety net,
+  // and a probe-style short-circuit here would re-introduce W1-2 silent drop.
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog.entry = `## [${today}] 2nd close\n\nnew body\n`;
+    payload.log.entry        = `## [${today}] session | test-project — 2nd\n`;
+    const r = runApply(dir, payload);   // no --force
+    assert.equal(r.status, 0, `payload apply failed: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.ok(!out.alreadyComplete, 'payload path must run full apply, not probe');
+    const sl = readFileSync(join(dir, 'projects', 'test-project', 'session-log', `${today.slice(0, 7)}.md`), 'utf-8');
+    assert.ok(sl.includes('2nd close'), `2nd-close entry must land on disk: ${sl}`);
+  });
+});
+
+test('probe (#39): --force without --payload → payload-required (force does NOT bypass payload gate)', () => {
+  // Lock the documented contract: --force only bypasses the alreadyComplete
+  // probe shortcut. Payload is always required for apply work. (Codex W1
+  // single-worker review — missing edge-case lock.)
+  withWiki(null, (dir) => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--apply-session-close', '--force', '--json']);
+    assert.equal(r.status, 1, `--force alone must error, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(/payload is required/.test(out.error), `must surface payload-required: ${out.error}`);
+  });
+});
+
+test('probe (#39): gate NOT ok + no payload → falls through to payload-required (no skip)', () => {
+  // Stale gate must NOT trigger the alreadyComplete probe — fallthrough
+  // surfaces the "payload is required" error so the caller knows to supply
+  // close content.
+  withWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'test-project', 'hot.md'),
+      `---\ntitle: hot\ntype: reference\nupdated: 2020-01-01\n---\n\n# Hot\n`);
+  }, (dir) => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--apply-session-close', '--json']);
+    assert.equal(r.status, 1, `stale gate + no payload must error, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(/payload is required/.test(out.error), `must surface payload-required: ${out.error}`);
   });
 });
 


### PR DESCRIPTION
## Summary

`/hypo:crystallize` (OSS session-close) helper에 freshness probe early-exit 추가 (ADR 0029 Phase A — fix #39).

- **payload 없이 호출** = "이미 close 완료?" probe. gate ok → `exit 0` + `alreadyComplete:true` (zero-write). gate 미충족 → fallthrough → `payload-required` error.
- **payload 제공** = 명시적 close intent → 항상 full apply. fix #38 per-entry idempotency가 cheap re-apply 보장 + W1-2 (같은 날 2nd close silent drop) 회귀 방지.
- **`--force`** = probe 단축만 우회. payload는 apply 필수. 명시적 진단/scripted recovery.

fix #17 hard gate + fix #38 W1-2 guard 정합성 보존.

## Design 검토

`omc-teams` codex 2라운드:
- **1라운드 (2:codex)** — B(`--force` opt-out)로 구현 → Worker 1이 silent-success 위험 지적 + 옵션 D(payload presence = intent) 권장, Worker 2가 stale-gate coverage 결함 지적.
- **2라운드 (1:codex)** — D로 재구현 → minor (header/comment 정확화 + `--force` w/o payload 엣지 test 잠금).

## Test plan

- [x] `npm test`: 149 passed, 0 failed
- [x] 신규 fix #39 테스트 4건:
  - `probe (#39): no payload + gate ok → exit 0 alreadyComplete`
  - `apply (#39): payload supplied + gate ok → still full apply (W1-2 guard, no --force)`
  - `probe (#39): --force without --payload → payload-required`
  - `probe (#39): gate NOT ok + no payload → falls through to payload-required`
- [x] 기존 fix #38 idempotency / W1-2 / schema 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)