### PR TITLE
feat(#15+#36): lint type-conditional fields + tag vocabulary lock

### DIFF
--- a/commands/ingest.md
+++ b/commands/ingest.md
@@ -73,7 +73,7 @@ Read and synthesize the source:
 
 1. **Check index.md** — does a page on this topic already exist?
    - If yes: update the existing page (merge new information, mark `updated:` today)
-   - If no: create a new page in `pages/` with `type: source-summary` and `source: <slug>`
+   - If no: create a new page in `pages/` with `type: source-summary` and `sources: [<slug>]`
 
 2. **Frontmatter** for new pages:
    ```yaml
@@ -82,7 +82,7 @@ Read and synthesize the source:
    type: source-summary
    updated: YYYY-MM-DD
    tags: [<relevant tags>]
-   source: <slug>
+   sources: [<slug>]
    confidence: high | medium | low
    evidence_strength: direct
    ---

--- a/scripts/feedback.mjs
+++ b/scripts/feedback.mjs
@@ -71,6 +71,8 @@ function writeFeedback(hypoDir, topic, entry, dryRun) {
 title: "Feedback: ${topic}"
 type: feedback
 updated: ${today}
+source: session:${today}
+corrected_at: ${today}
 tags: [feedback]
 ---
 

--- a/scripts/lib/schema-vocab.mjs
+++ b/scripts/lib/schema-vocab.mjs
@@ -3,7 +3,8 @@ import { join } from 'path';
 
 const VOCAB_HEADER_RE = /^##\s+(?:\d+\.\s+)?Tag\s+(?:Vocabulary|Taxonomy)\s*$/m;
 const NEXT_H2_RE = /^##\s+/m;
-const BACKTICK_TOKEN_RE = /`([^`\n]+)`/g;
+const CATEGORY_PREFIX_RE = /^\s*\*\*[^*]+\*\*:\s*/;
+const BACKTICK_TOKEN_RE = /`([^`]+)`/g;
 
 const FORBIDDEN_PATTERNS = [
   { name: 'PascalCase', test: (t) => /[A-Z]/.test(t) },
@@ -25,6 +26,24 @@ export function checkForbidden(tag) {
   return null;
 }
 
+// Extract only backtick tokens from canonical vocabulary lines.
+// A vocabulary line is one whose non-backtick residue (after stripping an
+// optional `**Category**:` prefix) contains only separators (whitespace, commas).
+// This excludes prose like "...`lint` blocks unknown tags..." and table rows
+// in the Forbidden patterns section that mention example tokens.
+function vocabLineTokens(rawLine) {
+  const line = rawLine.replace(CATEGORY_PREFIX_RE, '').trim();
+  if (!line) return [];
+  const residue = line.replace(/`[^`]+`/g, '').trim();
+  if (!/^[\s,]*$/.test(residue)) return [];
+  const tokens = [];
+  for (const m of line.matchAll(BACKTICK_TOKEN_RE)) {
+    const t = m[1].trim();
+    if (t && !t.includes(' ')) tokens.push(t);
+  }
+  return tokens;
+}
+
 export function parseSchemaVocab(hypoDir) {
   const path = join(hypoDir, 'SCHEMA.md');
   if (!existsSync(path)) return new Set();
@@ -39,11 +58,8 @@ export function parseSchemaVocab(hypoDir) {
   const section = nextH2 ? rest.slice(0, nextH2.index) : rest;
 
   const vocab = new Set();
-  for (const m of section.matchAll(BACKTICK_TOKEN_RE)) {
-    const token = m[1].trim();
-    if (!token) continue;
-    if (token.includes(' ')) continue;
-    vocab.add(token);
+  for (const rawLine of section.split('\n')) {
+    for (const token of vocabLineTokens(rawLine)) vocab.add(token);
   }
   return vocab;
 }

--- a/scripts/lib/schema-vocab.mjs
+++ b/scripts/lib/schema-vocab.mjs
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+const VOCAB_HEADER_RE = /^##\s+(?:\d+\.\s+)?Tag\s+(?:Vocabulary|Taxonomy)\s*$/m;
+const NEXT_H2_RE = /^##\s+/m;
+const BACKTICK_TOKEN_RE = /`([^`\n]+)`/g;
+
+const FORBIDDEN_PATTERNS = [
+  { name: 'PascalCase', test: (t) => /[A-Z]/.test(t) },
+  { name: 'whitespace', test: (t) => /\s/.test(t) },
+  {
+    name: 'generic',
+    test: (t) => ['general', 'misc', 'other', 'todo'].includes(t),
+  },
+  {
+    name: 'plural',
+    test: (t) => ['learnings', 'tips', 'feedbacks', 'concepts', 'playbooks'].includes(t),
+  },
+];
+
+export function checkForbidden(tag) {
+  for (const rule of FORBIDDEN_PATTERNS) {
+    if (rule.test(tag)) return rule.name;
+  }
+  return null;
+}
+
+export function parseSchemaVocab(hypoDir) {
+  const path = join(hypoDir, 'SCHEMA.md');
+  if (!existsSync(path)) return new Set();
+  const content = readFileSync(path, 'utf-8');
+
+  const headerMatch = VOCAB_HEADER_RE.exec(content);
+  if (!headerMatch) return new Set();
+
+  const sectionStart = headerMatch.index + headerMatch[0].length;
+  const rest = content.slice(sectionStart);
+  const nextH2 = NEXT_H2_RE.exec(rest);
+  const section = nextH2 ? rest.slice(0, nextH2.index) : rest;
+
+  const vocab = new Set();
+  for (const m of section.matchAll(BACKTICK_TOKEN_RE)) {
+    const token = m[1].trim();
+    if (!token) continue;
+    if (token.includes(' ')) continue;
+    vocab.add(token);
+  }
+  return vocab;
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -49,6 +49,26 @@ function parseFrontmatter(content) {
   return fm;
 }
 
+// type-conditional required fields (spec §6.3, SCHEMA.md §2)
+const TYPE_CONDITIONAL_FIELDS = {
+  prd: ['status', 'started'],
+  adr: ['source', 'status', 'date'],
+  'project-index': ['working_dir', 'status', 'started'],
+  'tool-eval': ['status'],
+  postmortem: ['outcome'],
+  learning: ['source'],
+  feedback: ['source'],
+  'prompt-pattern': ['source'],
+  'source-summary': ['sources'],
+  'weekly-journal': ['week'],
+};
+
+const TYPE_ENUM_FIELDS = {
+  prd: { status: ['draft', 'active', 'completed', 'cancelled', 'archived'] },
+  adr: { status: ['proposed', 'accepted', 'deprecated', 'superseded'] },
+  'tool-eval': { status: ['adopted', 'evaluating', 'rejected'] },
+};
+
 // ── page collector ────────────────────────────────────────────────────────────
 
 function collectPages(dir, root, pages = [], ignorePatterns = []) {
@@ -186,6 +206,28 @@ function lintPage({ path, rel }, slugMap) {
 
   if (!fm.updated) {
     issue('warn', rel, 'Missing frontmatter field: updated', path);
+  }
+
+  // type-conditional required fields (fix #15)
+  if (fm.type && TYPE_CONDITIONAL_FIELDS[fm.type]) {
+    for (const field of TYPE_CONDITIONAL_FIELDS[fm.type]) {
+      if (!fm[field]) {
+        issue('error', rel, `Missing required field for type "${fm.type}": ${field}`);
+      }
+    }
+  }
+
+  // type-specific enum validation
+  if (fm.type && TYPE_ENUM_FIELDS[fm.type]) {
+    for (const [field, allowed] of Object.entries(TYPE_ENUM_FIELDS[fm.type])) {
+      if (fm[field] && !allowed.includes(fm[field])) {
+        issue(
+          'error',
+          rel,
+          `Invalid value for ${field} on type "${fm.type}": "${fm[field]}" (allowed: ${allowed.join(', ')})`,
+        );
+      }
+    }
   }
 
   lintSessionStateHeadings(content, rel);

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -18,6 +18,7 @@ import { join, relative, extname, basename } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { parseSchemaVocab, checkForbidden } from './lib/schema-vocab.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -47,6 +48,23 @@ function parseFrontmatter(content) {
       .replace(/^["']|["']$/g, '');
   }
   return fm;
+}
+
+function parseTagsField(rawValue) {
+  if (rawValue == null) return null;
+  const trimmed = String(rawValue).trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return trimmed
+      .slice(1, -1)
+      .split(',')
+      .map((t) => t.trim().replace(/^["']|["']$/g, ''))
+      .filter(Boolean);
+  }
+  return trimmed
+    .split(',')
+    .map((t) => t.trim().replace(/^["']|["']$/g, ''))
+    .filter(Boolean);
 }
 
 // type-conditional required fields (spec §6.3, SCHEMA.md §2)
@@ -177,7 +195,7 @@ function lintSessionStateHeadings(content, rel) {
   }
 }
 
-function lintPage({ path, rel }, slugMap) {
+function lintPage({ path, rel }, slugMap, tagVocab) {
   let content;
   try {
     content = readFileSync(path, 'utf-8');
@@ -230,6 +248,21 @@ function lintPage({ path, rel }, slugMap) {
     }
   }
 
+  // tag vocabulary + forbidden patterns (fix #36)
+  const tags = parseTagsField(fm.tags);
+  if (tags && tagVocab && tagVocab.size > 0) {
+    for (const tag of tags) {
+      const forbidden = checkForbidden(tag);
+      if (forbidden) {
+        issue('error', rel, `Forbidden tag pattern (${forbidden}): "${tag}"`);
+        continue;
+      }
+      if (!tagVocab.has(tag)) {
+        issue('error', rel, `Unknown tag: "${tag}" (not in SCHEMA.md Tag Vocabulary)`);
+      }
+    }
+  }
+
   lintSessionStateHeadings(content, rel);
 
   for (const link of extractWikilinks(content)) {
@@ -247,8 +280,9 @@ const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects'].map((d) => join(args.hypoDir, d));
 const pages = scanDirs.flatMap((d) => collectPages(d, args.hypoDir, [], ignorePatterns));
 const slugMap = buildSlugMap(pages);
+const tagVocab = parseSchemaVocab(args.hypoDir);
 
-for (const page of pages) lintPage(page, slugMap);
+for (const page of pages) lintPage(page, slugMap, tagVocab);
 
 if (args.fix) {
   const today = new Date().toISOString().slice(0, 10);

--- a/scripts/weekly-report.mjs
+++ b/scripts/weekly-report.mjs
@@ -128,6 +128,8 @@ function renderMarkdown(report) {
   lines.push(`title: Observability — Week ${week}`);
   lines.push('tags: [observability, autonomy, weekly]');
   lines.push('type: weekly-journal');
+  lines.push(`week: ${week}`);
+  lines.push(`generated_by: manual`);
   lines.push(`updated: ${today}`);
   lines.push('---');
   lines.push('');

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -105,7 +105,7 @@ and forbidden patterns (PascalCase, plurals, whitespace, generic words).
 Extend this list (and `~/hypomnema/SCHEMA.md`) before introducing a new tag.
 
 **Meta**: `wiki`, `index`, `pages`, `home`, `overview`, `guide`, `operations`, `schema`, `reference`, `hypo`, `commands`, `hot-cache`
-**Workflow**: `automation`, `hooks`, `observability`, `autonomy`, `wiki-health`
+**Workflow**: `automation`, `hooks`, `observability`, `autonomy`, `wiki-health`, `weekly`
 **Project**: `project`, `prd`, `adr`, `session-state`
 **Domain**: `ai`, `dev`, `ops`, `security`, `data`, `design`, `management`
 **Status**: `active`, `completed`, `archived`, `draft`, `stable`, `deprecated`, `needs-review`, `proposed`, `superseded`

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -100,11 +100,25 @@ verify_by_date: YYYY-MM-DD
 
 ## 4. Tag Vocabulary
 
-Use lowercase, hyphenated tags. Keep the vocabulary small and consistent.
+Use lowercase, hyphenated tags. Vocabulary is locked — `lint` blocks unknown tags
+and forbidden patterns (PascalCase, plurals, whitespace, generic words).
+Extend this list (and `~/hypomnema/SCHEMA.md`) before introducing a new tag.
 
-**Domain tags**: `ai`, `dev`, `ops`, `security`, `data`, `design`, `management`
-**Status tags**: `draft`, `stable`, `deprecated`, `needs-review`
-**Meta tags**: `wiki`, `index`, `operations`, `guide`, `schema`
+**Meta**: `wiki`, `index`, `pages`, `home`, `overview`, `guide`, `operations`, `schema`, `reference`, `hypo`, `commands`, `hot-cache`
+**Workflow**: `automation`, `hooks`, `observability`, `autonomy`, `wiki-health`
+**Project**: `project`, `prd`, `adr`, `session-state`
+**Domain**: `ai`, `dev`, `ops`, `security`, `data`, `design`, `management`
+**Status**: `active`, `completed`, `archived`, `draft`, `stable`, `deprecated`, `needs-review`, `proposed`, `superseded`
+**Content classification**: `learning`, `tip`, `feedback`, `gotcha`, `concept`, `pattern`
+
+### Forbidden patterns
+
+| Pattern | Reason | Use instead |
+|---------|--------|-------------|
+| PascalCase (`Jenkins`, `Claude`) | Inconsistent casing | `jenkins`, `claude-code` |
+| Plurals (`learnings`, `tips`) | Singular form is canonical | `learning`, `tip` |
+| Generic (`general`, `misc`, `other`, `todo`) | No search value | Specific domain tag |
+| Whitespace (`llm wiki`) | Parse breakage | `llm-wiki` |
 
 ---
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1888,6 +1888,31 @@ test('valid tag in vocab → green', () => {
   assert.equal(r.status, 0, `expected green, got ${r.status}`);
 });
 
+test('vocab parser excludes prose backticks and Forbidden table examples', () => {
+  // Codex P3: prior parser accepted every backtick in the section, so `lint`
+  // appearing in explanatory prose and `Jenkins` in the Forbidden table row
+  // were silently added to the vocabulary.
+  const schema =
+    '---\ntitle: SCHEMA\ntype: schema\n---\n# Schema\n\n## 4. Tag Vocabulary\n\n' +
+    'Use lowercase, hyphenated tags. `lint` blocks unknown tags.\n\n' +
+    '**Meta**: `wiki`, `concept`\n\n' +
+    '### Forbidden patterns\n\n' +
+    '| Pattern | Reason | Use instead |\n' +
+    '|---------|--------|-------------|\n' +
+    '| PascalCase (`Jenkins`) | Inconsistent | `jenkins` |\n\n' +
+    '## 5. Next\n';
+  const { r, out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [lint]\n---\nbody\n',
+    schema,
+  );
+  assert.equal(r.status, 1, `expected error for prose-only tag, got ${r.status}`);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Unknown tag: "lint"')),
+    `parser leaked prose token "lint" into vocab: ${r.stdout}`,
+  );
+});
+
 test('vocab check skipped when SCHEMA.md absent (back-compat)', () => {
   const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-novocab-'));
   const pageDir = join(dir, 'pages');

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1836,6 +1836,71 @@ test('all type-conditional fields present → green', () => {
   assert.equal(r.status, 0, `expected green, got ${r.status}`);
 });
 
+suite('lint.mjs tag vocabulary + forbidden patterns');
+
+test('PascalCase tag → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [Jenkins]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Forbidden tag pattern (PascalCase)')),
+    `expected PascalCase error: ${r.stdout}`,
+  );
+});
+
+test('plural tag (learnings) → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [learnings]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(out.errors.some((e) => e.message.includes('Forbidden tag pattern (plural)')));
+});
+
+test('generic tag (todo) → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [todo]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(out.errors.some((e) => e.message.includes('Forbidden tag pattern (generic)')));
+});
+
+test('unknown tag (not in vocab) → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [zzz-unknown]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Unknown tag: "zzz-unknown"')),
+    `expected unknown tag error: ${r.stdout}`,
+  );
+});
+
+test('valid tag in vocab → green', () => {
+  const { r } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [wiki, concept]\n---\nbody\n',
+  );
+  assert.equal(r.status, 0, `expected green, got ${r.status}`);
+});
+
+test('vocab check skipped when SCHEMA.md absent (back-compat)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-novocab-'));
+  const pageDir = join(dir, 'pages');
+  mkdirSync(pageDir, { recursive: true });
+  writeFileSync(
+    join(pageDir, 'x.md'),
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [Jenkins]\n---\nbody\n',
+  );
+  const r = run('lint.mjs', [`--hypo-dir=${dir}`, '--json']);
+  rmSync(dir, { recursive: true, force: true });
+  assert.equal(r.status, 0, `expected green when SCHEMA.md missing, got ${r.status}: ${r.stdout}`);
+});
+
 // ── Lane B: formatGrowthMetrics + growth echo regressions ─────────────────
 
 const { formatGrowthMetrics, computeSessionGrowth } = await import(join(HOOKS, 'hypo-shared.mjs'));

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -16,7 +16,7 @@ import {
   existsSync,
   symlinkSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
@@ -1749,6 +1749,91 @@ test('errors when project session-state lacks a next heading', () => {
     ),
     `missing session-state heading error: ${r.stdout}`,
   );
+});
+
+// ── lint.mjs type-conditional + tag vocab tests (fix #15 + #36) ─────────────
+
+suite('lint.mjs type-conditional required fields');
+
+const VOCAB_SCHEMA =
+  '---\ntitle: SCHEMA\ntype: schema\n---\n# Schema\n\n## 4. Tag Vocabulary\n\n`wiki` `project` `prd` `adr` `concept` `learning` `feedback`\n\n## 5. Next\n';
+
+function lintWithSchema(pageRel, content, schemaContent = VOCAB_SCHEMA) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-cond-'));
+  writeFileSync(join(dir, 'SCHEMA.md'), schemaContent);
+  const fullPath = join(dir, pageRel);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+  const r = run('lint.mjs', [`--hypo-dir=${dir}`, '--json']);
+  const out = JSON.parse(r.stdout);
+  rmSync(dir, { recursive: true, force: true });
+  return { r, out };
+}
+
+test('prd missing started → error', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/prd.md',
+    '---\ntitle: T\ntype: prd\nstatus: active\nupdated: 2026-05-18\ntags: [prd]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1, `expected error, got ${r.status}: ${r.stdout}`);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Missing required field for type "prd": started')),
+    `started error missing: ${r.stdout}`,
+  );
+});
+
+test('adr missing source → error', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/decisions/0001-x.md',
+    '---\ntitle: T\ntype: adr\nstatus: accepted\ndate: 2026-05-18\nupdated: 2026-05-18\ntags: [adr]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Missing required field for type "adr": source')),
+  );
+});
+
+test('project-index missing working_dir → error', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/index.md',
+    '---\ntitle: T\ntype: project-index\nstatus: active\nstarted: 2026-05-18\nupdated: 2026-05-18\ntags: [project]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) =>
+      e.message.includes('Missing required field for type "project-index": working_dir'),
+    ),
+  );
+});
+
+test('postmortem missing outcome → error', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/postmortems/2026-05-18-x.md',
+    '---\ntitle: T\ntype: postmortem\nupdated: 2026-05-18\ntags: [project]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) =>
+      e.message.includes('Missing required field for type "postmortem": outcome'),
+    ),
+  );
+});
+
+test('prd with invalid status enum → error', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/prd.md',
+    '---\ntitle: T\ntype: prd\nstatus: in-progress\nstarted: 2026-05-18\nupdated: 2026-05-18\ntags: [prd]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1);
+  assert.ok(out.errors.some((e) => e.message.includes('Invalid value for status on type "prd"')));
+});
+
+test('all type-conditional fields present → green', () => {
+  const { r } = lintWithSchema(
+    'projects/p/prd.md',
+    '---\ntitle: T\ntype: prd\nstatus: active\nstarted: 2026-05-18\nupdated: 2026-05-18\ntags: [prd]\n---\nbody\n',
+  );
+  assert.equal(r.status, 0, `expected green, got ${r.status}`);
 });
 
 // ── Lane B: formatGrowthMetrics + growth echo regressions ─────────────────


### PR DESCRIPTION
## Summary

Stage 2 작업 1번: **Ship Gate Hardening — lint 강화**. spec §6.3 / §6.5 의도(Q-5.2.2, Q-6.7)를 lint가 실제로 강제하도록 구현.

기존 lint는 generic `title/type`만 검사 → `blockers=0`이 spec contract를 보장하지 못함 (PARTIAL). 이제 type별 frontmatter contract + SCHEMA-locked tag vocabulary를 실제로 차단.

## Changes

### fix #15 — Type-conditional required fields + enum validation
- `TYPE_CONDITIONAL_FIELDS` mapping: prd(`status`,`started`), adr(`source`,`status`,`date`), project-index(`working_dir`,`status`,`started`), tool-eval(`status`), postmortem(`outcome`), learning/feedback/prompt-pattern(`source`), source-summary(`sources`), weekly-journal(`week`)
- `TYPE_ENUM_FIELDS` validation: prd.status ∈ {draft, active, completed, cancelled, archived} 등

### fix #36 — Tag vocabulary lock + Forbidden patterns
- `scripts/lib/schema-vocab.mjs` 신규: SCHEMA.md `## Tag Vocabulary` / `## Tag Taxonomy` 섹션을 parse, canonical 라인만 vocab으로 인정 (prose backtick은 제외)
- `lint.mjs`: tags YAML array 파싱 + vocab miss → error, Forbidden 패턴(PascalCase/plural/generic/whitespace) → error
- `templates/SCHEMA.md §4`: fresh init 실측 tag 기반 44개 vocab seed + Forbidden 표

### Codex review fixes (3rd commit)
- weekly-report.mjs / feedback.mjs / commands/ingest.md: generator·docs가 새 lint contract와 일치하도록 정렬
- `weekly` tag를 vocab에 추가
- schema-vocab parser noise 제거 (prose `lint`, 표 예시 `Jenkins` 누설 차단)

## Ship gate (spec B2)
- `fresh hypo init → node lint.mjs`: ✅ green
- `weekly-report --write → lint`: ✅ green
- `feedback --topic --entry → lint`: ✅ green

## Test plan
- [x] `node tests/runner.mjs` — **172/0** (12 신규)
  - type-conditional 6건: missing started/source/working_dir/outcome, invalid enum, all-present
  - tag vocab 7건: PascalCase/plural/generic/unknown error, valid green, SCHEMA absent green, parser noise regression
- [x] `HOME=$(mktemp -d) node tests/runner.mjs` — sandbox green
- [x] Fresh init dogfood (3 generators) — all lint green
- [x] Codex review: 4 issues raised, all addressed (P2×3, P3×1)

## Follow-ups (out of this PR)
- Stage 2 #2: weekly-report 경로 `pages/observability/` → `journal/weekly/` (spec §6.4 SoT)
- Stage 2 #3: test hermeticity (real HOME write 제거)
- Codex P2 #2 (upgrade migration gate): 별도 PR — 기존 user wiki의 SCHEMA 마이그레이션 prompt를 `upgrade.mjs`에 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)