### PR TITLE
fix(stage-3-#25): detect /clear in compact-guard (ADR 0022 Layer 2)

### DIFF
--- a/hooks/hypo-compact-guard.mjs
+++ b/hooks/hypo-compact-guard.mjs
@@ -2,12 +2,13 @@
 /**
  * hypo-compact-guard.mjs — UserPromptSubmit hook
  *
- * Scope: detects "/compact" typed in chat only.
+ * Scope: detects "/compact" or "/clear" typed in chat only (ADR 0022 Layer 2, fix #25).
  * The CLI built-in /compact does NOT fire UserPromptSubmit — use personal-wiki-check.mjs
- * (PreCompact hook) as the hard gate for that path.
+ * (PreCompact hook) as the hard gate for that path. /clear has no PreCompact event, so
+ * this hook is the only chat-side gate that can prompt session-close before context wipe.
  *
  * Behavior: if session close is incomplete → instruct Claude to run session close
- * immediately before /compact.
+ * immediately before /compact or /clear.
  */
 
 import {
@@ -15,7 +16,8 @@ import {
   hypoIsClean,
   hotMdIsClean,
   readChecklist,
-  isCompactCommand,
+  isClearCommand,
+  isCompactOrClearCommand,
   isGateSkipped,
 } from './hypo-shared.mjs';
 
@@ -29,10 +31,12 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim();
 
-    if (!isCompactCommand(prompt) || isGateSkipped()) {
+    if (!isCompactOrClearCommand(prompt) || isGateSkipped()) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
+
+    const detected = isClearCommand(prompt) ? '/clear' : '/compact';
 
     const hasSession = lastSubstantialOpIsSession();
     const gitStatus = hypoIsClean();
@@ -59,8 +63,8 @@ process.stdin.on('end', () => {
       JSON.stringify({
         continue: true,
         additionalContext: [
-          `[WIKI_AUTOCLOSE] /compact detected — session close incomplete (${reasons.join(', ')}).`,
-          `Do NOT wait for user input. Run wiki session close NOW, then retry /compact.`,
+          `[WIKI_AUTOCLOSE] ${detected} detected — session close incomplete (${reasons.join(', ')}).`,
+          `Do NOT wait for user input. Run wiki session close NOW, then retry ${detected}.`,
           ``,
           body,
           ``,

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -427,6 +427,16 @@ export function isCompactCommand(prompt) {
   return prompt === '/compact' || /^\/compact(\s|$)/.test(prompt);
 }
 
+/** Returns true if the prompt is a /clear command invocation. */
+export function isClearCommand(prompt) {
+  return prompt === '/clear' || /^\/clear(\s|$)/.test(prompt);
+}
+
+/** Returns true if the prompt is either /compact or /clear (ADR 0022 Layer 2, fix #25). */
+export function isCompactOrClearCommand(prompt) {
+  return isCompactCommand(prompt) || isClearCommand(prompt);
+}
+
 /**
  * Returns true if the text contains a natural-language session-close signal.
  * Scans Korean and English close patterns. Designed for transcript user-message

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -573,9 +573,14 @@ test('doctor-codex-paths: --codex flag triggers codex settings.json check', () =
 
 const HOOKS = join(REPO, 'hooks');
 
-const { isCompactCommand, isGateSkipped, buildOutput, isClosePattern } = await import(
-  join(HOOKS, 'hypo-shared.mjs')
-);
+const {
+  isCompactCommand,
+  isClearCommand,
+  isCompactOrClearCommand,
+  isGateSkipped,
+  buildOutput,
+  isClosePattern,
+} = await import(join(HOOKS, 'hypo-shared.mjs'));
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
   return spawnSync(process.execPath, [join(HOOKS, hookFile)], {
@@ -653,6 +658,36 @@ test('/compact with trailing args → true', () => {
 test('non-compact prompt → false', () => {
   assert.equal(isCompactCommand('hello'), false);
   assert.equal(isCompactCommand('/other'), false);
+});
+
+suite('isClearCommand() (fix #25)');
+
+test('/clear → true', () => {
+  assert.equal(isClearCommand('/clear'), true);
+});
+
+test('/clear with trailing args → true', () => {
+  assert.equal(isClearCommand('/clear --all'), true);
+});
+
+test('non-clear prompt → false', () => {
+  assert.equal(isClearCommand('hello'), false);
+  assert.equal(isClearCommand('/clearfoo'), false);
+  assert.equal(isClearCommand('/compact'), false);
+});
+
+suite('isCompactOrClearCommand() (fix #25)');
+
+test('/compact → true', () => {
+  assert.equal(isCompactOrClearCommand('/compact'), true);
+});
+
+test('/clear → true', () => {
+  assert.equal(isCompactOrClearCommand('/clear'), true);
+});
+
+test('other prompt → false', () => {
+  assert.equal(isCompactOrClearCommand('hello'), false);
 });
 
 suite('isClosePattern()');
@@ -800,6 +835,47 @@ test('output is always valid JSON regardless of prompt', () => {
     const r = runHook('hypo-compact-guard.mjs', { prompt });
     assert.doesNotThrow(() => JSON.parse(r.stdout), `invalid JSON for prompt="${prompt}"`);
   }
+});
+
+// ── replay-compact-guard-detects-slash-clear (fix #25, ADR 0022 Layer 2) ──
+
+test('replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE', () => {
+  const r = runHook('hypo-compact-guard.mjs', { prompt: '/clear' });
+  const out = JSON.parse(r.stdout);
+  assert.ok('additionalContext' in out, 'missing additionalContext field on /clear');
+  assert.equal(out.continue, true);
+  assert.ok(out.additionalContext.includes('WIKI_AUTOCLOSE'), 'missing WIKI_AUTOCLOSE marker');
+  assert.ok(out.additionalContext.includes('/clear'), 'message must reference /clear');
+});
+
+test('/clear with trailing args → still detected', () => {
+  const r = runHook('hypo-compact-guard.mjs', { prompt: '/clear something' });
+  const out = JSON.parse(r.stdout);
+  assert.ok('additionalContext' in out);
+  assert.ok(out.additionalContext.includes('/clear'));
+});
+
+test('HYPO_SKIP_GATE=1 + /clear → pass-through', () => {
+  const r = runHook('hypo-compact-guard.mjs', { prompt: '/clear' }, { HYPO_SKIP_GATE: '1' });
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true);
+  assert.equal(out.suppressOutput, true);
+});
+
+test('/clear with clean wiki → pass-through', () => {
+  withCleanWiki((dir) => {
+    const r = runHook('hypo-compact-guard.mjs', { prompt: '/clear' }, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true);
+    assert.equal(out.suppressOutput, true);
+  });
+});
+
+test('/clearfoo (no word boundary) → pass-through (not /clear)', () => {
+  const r = runHook('hypo-compact-guard.mjs', { prompt: '/clearfoo' });
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true);
+  assert.equal(out.suppressOutput, true);
 });
 
 suite('hypo-personal-check.mjs — close-intent enrichment (#20)');


### PR DESCRIPTION
## Summary
- `hypo-compact-guard` UserPromptSubmit hook now nudges session-close on `/clear` as well as `/compact` (ADR 0022 Layer 2, spec §5.4 row 471, fix #25).
- Audit row 1210 flagged that `/clear` had **zero code** in hooks — this PR ships the detection half.

## Background
Stage 3 mapping (drafts/stage-3-mapping.md): fix #25/#26/#27 are ADR 0022 (hook Layers 1/2/3) — not ADR 0029 (crystallize command). Grep verification:

- `hypo-shared.mjs:425-427` `isCompactCommand` matched `/compact` only.
- Zero hits for `/clear`, `isClearCommand` anywhere in `hooks/`.

## Changes
- `hooks/hypo-shared.mjs`: add `isClearCommand` + `isCompactOrClearCommand` exports. `isCompactCommand` left intact for /compact-only callers.
- `hooks/hypo-compact-guard.mjs`: gate on `isCompactOrClearCommand`, `detected="/clear"|"/compact"` interpolated into `WIKI_AUTOCLOSE` message. Removed now-unused `isCompactCommand` import (codex review).
- `tests/runner.mjs`: 11 new tests — `isClearCommand` unit (4) + `isCompactOrClearCommand` unit (3) + `replay-compact-guard-detects-slash-clear` (1) + `/clear` trailing-args + `HYPO_SKIP_GATE` bypass + clean-wiki pass-through + `/clearfoo` word-boundary negative.

## Known limitation (out of scope)
The hook returns `additionalContext` — a soft nudge, not a hard `decision:block`. Stage 0 PoC gate (per ADR 0022) for the hard-block path remains pending — tracked in `drafts/stage-3-mapping.md`. This PR ships the **detection half only**; gate-strength escalation is a separate change (Stage 0 PoC → ADR 0022 amendment).

## Test plan
- [x] `node tests/runner.mjs` → **188 passed, 0 failed** (was 177, +11)
- [x] Runtime probe: `printf '{"prompt":"/clear"}' | node hooks/hypo-compact-guard.mjs` emits `WIKI_AUTOCLOSE` `additionalContext`
- [x] Word-boundary negatives: `/clearfoo`, `/compactly`, `/CLEAR`, `//clear` all pass through
- [x] `/compact` behavior unchanged (existing tests still green)
- [x] `node --check` on both hook files
- [x] Pre-commit codex review (1 worker) → LGTM, 1 non-blocking cleanup applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)