### PR TITLE
fix(stage-3-#26): remove capacity bypass from personal-check (ADR 0022)

### DIFF
--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -9,11 +9,14 @@
  *   - hot.md has forbidden structure
  *   - lint blockers exist
  *
- * Bypass options (checked in order, short-circuits before heavy checks):
- *   1. wiki-context-critical.json exists (context ≥ 90% — hard limit imminent)
- *   2. HYPO_SKIP_GATE=1 env var
- *   3. HYPO_SKIP_GATE=1 in a recent *user-role* transcript message
+ * Bypass options (checked in order, per ADR 0022 / spec §7.5):
+ *   1. HYPO_SKIP_GATE=1 env var
+ *   2. HYPO_SKIP_GATE=1 in a recent *user-role* transcript message
  *      (assistant/tool output is excluded to prevent self-triggering from block reason text)
+ *
+ * NOTE: capacity bypass (wiki-context-critical.json ≥90%) was REMOVED by fix #26
+ * (ADR 0022 amendment 2026-05-13). Spec §7.5: even at full context, minimal
+ * session-close is mandatory — auto-bypass on capacity caused silent state loss.
  */
 
 import { spawnSync } from 'child_process';
@@ -31,7 +34,6 @@ import {
   isClosePattern,
 } from './hypo-shared.mjs';
 
-const CRITICAL_FILE = join(homedir(), '.claude', 'state', 'wiki-context-critical.json');
 const WARNING_FILE = join(homedir(), '.claude', 'state', 'wiki-context-warning.json');
 
 /** Parse JSONL transcript and return concatenated text of user-role messages only.
@@ -74,20 +76,9 @@ process.stdin.on('end', () => {
     /* fail-open */
   }
 
-  // ── Bypass 1: context critical (≥90%) — short-circuit BEFORE all checks ──
-  if (existsSync(CRITICAL_FILE)) {
-    try {
-      unlinkSync(CRITICAL_FILE);
-    } catch {}
-    console.log(
-      JSON.stringify({
-        continue: true,
-        systemMessage:
-          '[WIKI CHECK] gate auto-bypassed (context ≥90% critical). Session close pending next session.',
-      }),
-    );
-    return;
-  }
+  // ── Capacity bypass (≥90%) REMOVED — fix #26, ADR 0022 amendment 2026-05-13.
+  //    Even at full context, minimal session-close is mandatory (spec §7.5).
+  //    Bypass paths are now only: HYPO_SKIP_GATE env / HYPO_SKIP_GATE in transcript.
 
   // ── Block 1.5: context warning (≥70%) — request session-compact before compact ──
   if (existsSync(WARNING_FILE)) {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -16,6 +16,7 @@ import {
   existsSync,
   symlinkSync,
   statSync,
+  unlinkSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -578,10 +579,19 @@ const { isCompactCommand, isGateSkipped, buildOutput, isClosePattern } = await i
 );
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
+  // Hermeticity invariant (mirrors run() helper, PR #30 / stage-2-#3): child hook
+  // must NOT see the developer's real $HOME. Default HOME to SESSION_TMP_HOME so
+  // any hook that reads ~/.claude/state/, ~/.claude/, or homedir() lands in the
+  // tmp scratch dir. extraEnv may still override HOME explicitly.
   return spawnSync(process.execPath, [join(HOOKS, hookFile)], {
     input: typeof stdinData === 'string' ? stdinData : JSON.stringify(stdinData),
     encoding: 'utf-8',
-    env: { ...process.env, HYPO_DIR: '/tmp/nonexistent-hypo-99999', ...extraEnv },
+    env: {
+      ...process.env,
+      HOME: SESSION_TMP_HOME,
+      HYPO_DIR: '/tmp/nonexistent-hypo-99999',
+      ...extraEnv,
+    },
   });
 }
 
@@ -1001,6 +1011,65 @@ test('HYPO_SKIP_GATE=1 bypasses an incomplete session close', () => {
         out.systemMessage.includes('memory files not updated'),
         `bypass message should still surface the incomplete files: ${out.systemMessage}`,
       );
+    },
+  );
+});
+
+// ── replay-personal-check-bypass-order (fix #26, ADR 0022 amendment 2026-05-13) ──
+// Capacity bypass (wiki-context-critical.json ≥90%) was removed. Spec §7.5:
+// the only bypass paths are HYPO_SKIP_GATE env / transcript user-role message.
+
+test('replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (fix #26 negative control)', () => {
+  withWiki(
+    (dir) => {
+      // Make session-close stale so the gate would normally block.
+      writeFileSync(
+        join(dir, 'projects', 'test-project', 'session-state.md'),
+        '---\ntitle: session-state\ntype: session-state\nupdated: 2020-01-01\n---\n\n## 다음 작업\n\n- next\n',
+      );
+    },
+    (dir) => {
+      // Write the (now-defunct) capacity marker into the session-scoped tmp HOME,
+      // and force the child hook to see THAT HOME — never the developer's real
+      // ~/.claude/state/. This mirrors the test-hermeticity invariant established
+      // by PR #30 (stage-2-#3): every hook test must scope HOME to SESSION_TMP_HOME.
+      const stateDir = join(SESSION_TMP_HOME, '.claude', 'state');
+      mkdirSync(stateDir, { recursive: true });
+      const criticalPath = join(stateDir, 'wiki-context-critical.json');
+      writeFileSync(criticalPath, JSON.stringify({ percent: 95 }));
+
+      try {
+        const r = runHook('hypo-personal-check.mjs', '', {
+          HYPO_DIR: dir,
+          HOME: SESSION_TMP_HOME,
+        });
+        const out = JSON.parse(r.stdout);
+
+        // Pre-fix: would have continue:true + "gate auto-bypassed (context ≥90% critical)".
+        // Post-fix: capacity flag is ignored → normal block path runs.
+        assert.equal(
+          out.decision,
+          'block',
+          `CRITICAL_FILE must NOT bypass — gate should still block: ${r.stdout}`,
+        );
+        assert.ok(
+          !(out.systemMessage || '').includes('context ≥90% critical'),
+          'capacity-bypass message must no longer appear',
+        );
+
+        // Negative control: the file MUST remain — fix #26 removed the unlink path too.
+        // If it's gone, the old bypass code is still wired somewhere.
+        assert.ok(
+          existsSync(criticalPath),
+          'wiki-context-critical.json should not be consumed (bypass path removed)',
+        );
+      } finally {
+        if (existsSync(criticalPath)) {
+          try {
+            unlinkSync(criticalPath);
+          } catch {}
+        }
+      }
     },
   );
 });


### PR DESCRIPTION
## Summary
- Removes the `wiki-context-critical.json` (≥90%) auto-bypass from `hypo-personal-check` per ADR 0022 amendment 2026-05-13 + spec §7.5 (fix #26).
- Audit row 1211 flagged this as STALE_MERGED — the policy was removed but the code (lines 34, 77-90) still ran.
- WARNING_FILE (≥70% → `decision:block`) preserved — it's a capacity-driven *block*, not a *bypass*; out of scope.

## Background
Stage 3 mapping (`drafts/stage-3-mapping.md`). Grep verification: `hypo-personal-check.mjs:34` `CRITICAL_FILE` constant + `:78` `existsSync` + `:80` `unlinkSync` → `continue:true` short-circuit, all intact on main. ADR 0022 amendment says "context critical(≥90%) auto-bypass 폐지. capacity 가득해도 minimal session-close 강제."

## Changes
- `hooks/hypo-personal-check.mjs`:
  - Delete `CRITICAL_FILE` constant + the `existsSync→unlinkSync→continue:true` block.
  - Header comment now lists only `HYPO_SKIP_GATE` env / transcript as bypass paths, with a back-pointer to fix #26 / ADR 0022.
- `tests/runner.mjs`:
  - `replay-personal-check-bypass-order`: write `wiki-context-critical.json` into `SESSION_TMP_HOME/.claude/state/`, run hook against a stale wiki, assert `decision:"block"` + capacity-bypass message absent + marker file **not consumed**. Negative control — pre-fix code would have returned `continue:true` with `"context ≥90% critical"`.
  - **`runHook` helper** now defaults `HOME=SESSION_TMP_HOME` for every hook spawn — mirrors `run()` helper hermeticity invariant established by PR #30 (stage-2-#3). Prevents future tests from clobbering or deleting markers under the developer's real `~/.claude/state/`.
  - `unlinkSync` import added.

## Test plan
- [x] `node tests/runner.mjs` → **178 passed, 0 failed** (+1)
- [x] Negative control: `HOME=$HOME npm test` → real `~/.claude/state/wiki-context-critical.json` still absent after run (no leak)
- [x] Existing fix #17 strict session-close suite still green
- [x] Pre-commit codex review (1 worker) → caught initial test hermeticity gap (`process.env.HOME` reachable), fixed by scoping to `SESSION_TMP_HOME` + tightening `runHook` defaults

## Note
No other code in this repo writes `wiki-context-critical.json`, so the behavior change for OSS users is effectively a no-op (dead bypass removal). The value is spec/code alignment and elimination of an external-trigger silent-fail surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)