### PR TITLE
fix(stage-3-#25-PR-A2): SessionEnd marker + SessionStart source=clear recovery (ADR 0022 amendment)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/hypo-session-end.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/hooks/hypo-session-end.mjs
+++ b/hooks/hypo-session-end.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * hypo-session-end.mjs — SessionEnd hook (fix #25 PR-A2, ADR 0022 Layer 2)
+ *
+ * `/clear` cannot be blocked: it never fires UserPromptSubmit (Stage 0 PoC,
+ * 2026-05-14). The only intervention point is the SessionEnd(reason='clear')
+ * → SessionStart(source='clear') pair. This hook captures the dying session's
+ * identity into `.cache/clear-marker.json` so hypo-session-start can issue a
+ * recovery nudge on the next session.
+ *
+ * Scope: writing the marker on reason='clear' only. Other reasons
+ * ('prompt_input_exit', 'logout', etc.) are deliberate user exits and need no
+ * recovery — touching them would pollute the unrelated next session.
+ *
+ * Silent: never blocks, never emits user-visible output. Failures are stderr
+ * debug lines only.
+ */
+
+import { HYPO_DIR, writeClearMarker } from './hypo-shared.mjs';
+import { existsSync } from 'fs';
+
+function emitContinue() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+let raw = '';
+process.stdin.setEncoding('utf-8');
+process.stdin.on('data', (chunk) => (raw += chunk));
+process.stdin.on('end', () => {
+  try {
+    let payload = {};
+    try {
+      payload = JSON.parse(raw) || {};
+    } catch {}
+
+    const reason = payload.reason || '';
+    if (reason !== 'clear') {
+      emitContinue();
+      return;
+    }
+
+    // Wiki absent → nothing to recover into; skip silently.
+    if (!existsSync(HYPO_DIR)) {
+      emitContinue();
+      return;
+    }
+
+    writeClearMarker(HYPO_DIR, {
+      prev_session_id: payload.session_id || payload.sessionId || null,
+      prev_transcript_path: payload.transcript_path || payload.transcriptPath || null,
+      prev_cwd: payload.cwd || null,
+    });
+  } catch {
+    // Best-effort: a marker failure must not break /clear itself.
+  }
+  emitContinue();
+});

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -18,6 +18,8 @@ import {
   formatGrowthMetrics,
   readSyncState,
   clearSyncState,
+  readClearMarker,
+  clearClearMarker,
   loadHypoIgnore,
   isIgnored,
 } from './hypo-shared.mjs';
@@ -43,6 +45,32 @@ function readLastGrowthLine() {
   } catch {
     return '';
   }
+}
+
+/**
+ * fix #25 PR-A2 (ADR 0022 amendment 2026-05-14): if the prior session ended
+ * via `/clear`, hypo-session-end stashed its identity in `.cache/clear-marker.json`.
+ * Read it (with 7-day stale guard), unlink it (one-shot), and return a
+ * `[WIKI_AUTOCLOSE]` recovery line for additionalContext + stderr.
+ *
+ * @param {string|undefined} source SessionStart payload `source` field
+ * @returns {string} recovery line, or '' when no recovery is needed
+ */
+function buildClearRecoveryLine(source) {
+  if (source !== 'clear') return '';
+  const marker = readClearMarker(HYPO_DIR);
+  if (!marker) return '';
+  clearClearMarker(HYPO_DIR);
+  const prevId = marker.prev_session_id || 'unknown';
+  const prevTr = marker.prev_transcript_path || null;
+  const prevCwd = marker.prev_cwd || null;
+  const trLine = prevTr ? `\n  prev_transcript: ${prevTr}` : '';
+  const cwdLine = prevCwd ? `\n  prev_cwd: ${prevCwd}` : '';
+  return (
+    `[WIKI_AUTOCLOSE] 이전 세션(${prevId})이 /clear로 강제 종료됨.${trLine}${cwdLine}\n` +
+    `  session-close가 미완료라면 지금 즉시 실행할 것 ` +
+    `(hot.md + session-state.md + log.md 최소 갱신).`
+  );
 }
 
 /** Pull the wiki repo. Returns true only when the pull actually succeeded. */
@@ -176,14 +204,21 @@ process.stdin.on('end', () => {
     const pullOk = gitPull(HYPO_DIR);
     const syncLine = syncStateNotice(pullOk);
     const growthLine = readLastGrowthLine();
+    // fix #25 PR-A2 (ADR 0022 amendment): on source='clear', surface the dying
+    // session's identity that hypo-session-end stashed so Claude can recover
+    // session-close work that /clear skipped. One-shot: marker is unlinked
+    // immediately after read.
+    const clearRecoveryLine = buildClearRecoveryLine(data.source);
     // Intentional dual emit: stderr (yellow/cyan) is the human-visible nudge in
     // the terminal; noticePrefix injects the same plain-text lines into the
     // LLM's additionalContext so model and user start the session looking at
     // the same state. ANSI escapes are kept out of additionalContext on purpose.
-    const notices = [syncLine, growthLine].filter(Boolean);
+    const notices = [syncLine, growthLine, clearRecoveryLine].filter(Boolean);
     const noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
     if (syncLine) process.stderr.write(`\n\x1b[33m${syncLine}\x1b[0m\n`);
     if (growthLine) process.stderr.write(`\n\x1b[36m${growthLine}\x1b[0m\n`);
+    if (clearRecoveryLine)
+      process.stderr.write(`\n\x1b[33m${clearRecoveryLine.split('\n')[0]}\x1b[0m\n`);
     const cwd = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || 'default';
     const MARKER_FILE = join(tmpdir(), `hypo-session-marker-${sessionId}.json`);

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -6,7 +6,7 @@
  * Hooks are deployed to ~/.claude/hooks/ — no external imports allowed.
  */
 
-import { readFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from 'fs';
 import { join, relative, basename } from 'path';
 import { homedir, hostname } from 'os';
 import { spawnSync } from 'child_process';
@@ -384,6 +384,91 @@ export function readSyncState(hypoDir) {
 export function clearSyncState(hypoDir) {
   try {
     rmSync(syncStatePath(hypoDir), { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+// ── clear-marker (fix #25 PR-A2, ADR 0022 amendment 2026-05-14) ────────────
+// `/clear` cannot be blocked (no UserPromptSubmit fire). The only intervention
+// point is the SessionEnd(reason='clear') → SessionStart(source='clear') pair:
+// SessionEnd writes `.cache/clear-marker.json` with the dying session's id +
+// transcript path; SessionStart on `source=clear` reads, injects a recovery
+// nudge into additionalContext, and unlinks (one-shot). A 7-day stale guard
+// prevents an orphaned marker (SessionEnd fired but new session never began)
+// from polluting an unrelated later session.
+
+const CLEAR_MARKER_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** @returns {string} path to the clear-marker file for a wiki root. */
+function clearMarkerPath(hypoDir) {
+  return join(hypoDir, '.cache', 'clear-marker.json');
+}
+
+/**
+ * Persist the dying session's identity so the next SessionStart(source=clear)
+ * can issue a recovery nudge. Single-file by design (see ADR 0022 amendment):
+ * /clear is a single-client UX action, multi-marker disambiguation buys no
+ * safety and breaks the 1-of-1 read-and-unlink contract.
+ *
+ * Best-effort: a failure here only loses the recovery nudge, never the user's
+ * `/clear` itself.
+ *
+ * @param {string} hypoDir
+ * @param {{prev_session_id: string, prev_transcript_path: string, prev_cwd?: string}} info
+ */
+export function writeClearMarker(hypoDir, info) {
+  try {
+    const cacheDir = join(hypoDir, '.cache');
+    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+    const payload = {
+      prev_session_id: info.prev_session_id || null,
+      prev_transcript_path: info.prev_transcript_path || null,
+      prev_cwd: info.prev_cwd || null,
+      ts: new Date().toISOString(),
+    };
+    writeFileSync(clearMarkerPath(hypoDir), JSON.stringify(payload) + '\n');
+  } catch (err) {
+    process.stderr.write(`[hypo] clear-marker write failed: ${err?.message || err}\n`);
+  }
+}
+
+/**
+ * Read the clear-marker if present and not stale (>7 days). Returns null when
+ * absent, unreadable, or expired. Stale markers are unlinked here so a single
+ * SessionStart cleans them up — no separate cron needed.
+ *
+ * @param {string} hypoDir
+ * @returns {object|null}
+ */
+export function readClearMarker(hypoDir) {
+  const path = clearMarkerPath(hypoDir);
+  if (!existsSync(path)) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8'));
+    const ts = Date.parse(data?.ts || '');
+    if (!Number.isFinite(ts) || Date.now() - ts > CLEAR_MARKER_STALE_MS) {
+      rmSync(path, { force: true });
+      return null;
+    }
+    return data;
+  } catch (err) {
+    // Corrupt marker: emit a debug line AND unlink so the next SessionStart
+    // does not log the same parse error forever (self-cleanup invariant).
+    process.stderr.write(`[hypo] clear-marker read failed: ${err?.message || err}\n`);
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      // best-effort
+    }
+    return null;
+  }
+}
+
+/** Delete the clear-marker. One-shot contract — caller is SessionStart. */
+export function clearClearMarker(hypoDir) {
+  try {
+    rmSync(clearMarkerPath(hypoDir), { force: true });
   } catch {
     // best-effort
   }

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2764,6 +2764,190 @@ test('replay-session-start-preserves-sync-state-when-ahead: unpushed commit keep
   });
 });
 
+// ── hypo-session-end / clear-marker (fix #25 PR-A2, ADR 0022 amendment) ────
+
+suite('hypo-session-end.mjs / hypo-session-start.mjs — clear-marker replay');
+
+function runSessionEnd(dir, payload) {
+  return spawnSync(process.execPath, [join(HOOKS, 'hypo-session-end.mjs')], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+  });
+}
+
+function runStartWithSource(dir, source) {
+  return spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+    input: JSON.stringify({ cwd: dir, session_id: 'new-session', source }),
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+  });
+}
+
+function readMarker(dir) {
+  const p = join(dir, '.cache', 'clear-marker.json');
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, 'utf-8'));
+}
+
+test('replay-session-end-writes-clear-marker-on-clear: reason=clear stashes session identity', () => {
+  withGrowthWiki((dir) => {
+    const r = runSessionEnd(dir, {
+      reason: 'clear',
+      session_id: 'dying-session',
+      transcript_path: '/tmp/transcript-xyz.jsonl',
+      cwd: '/Users/x/Workspace/foo',
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const marker = readMarker(dir);
+    assert.ok(marker, 'clear-marker.json must be written');
+    assert.equal(marker.prev_session_id, 'dying-session');
+    assert.equal(marker.prev_transcript_path, '/tmp/transcript-xyz.jsonl');
+    assert.equal(marker.prev_cwd, '/Users/x/Workspace/foo');
+    assert.ok(marker.ts, 'ts must be present');
+  });
+});
+
+test('replay-session-end-skips-marker-on-non-clear-reason: prompt_input_exit is a deliberate exit', () => {
+  withGrowthWiki((dir) => {
+    const r = runSessionEnd(dir, {
+      reason: 'prompt_input_exit',
+      session_id: 'normal-exit',
+      transcript_path: '/tmp/t.jsonl',
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(readMarker(dir), null, 'non-clear reason must not write marker');
+  });
+});
+
+test('replay-session-end-skips-marker-on-logout: any non-clear reason is skipped', () => {
+  withGrowthWiki((dir) => {
+    runSessionEnd(dir, { reason: 'logout', session_id: 's', transcript_path: '/t' });
+    assert.equal(readMarker(dir), null);
+  });
+});
+
+test('replay-session-start-injects-clear-recovery-on-source-clear: marker drives [WIKI_AUTOCLOSE]', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'clear-marker.json'),
+      JSON.stringify({
+        prev_session_id: 'dying-session-42',
+        prev_transcript_path: '/tmp/transcript-42.jsonl',
+        prev_cwd: '/Users/x/repo',
+        ts: new Date().toISOString(),
+      }) + '\n',
+    );
+    const r = runStartWithSource(dir, 'clear');
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(ctx.includes('[WIKI_AUTOCLOSE]'), `recovery line missing: ${ctx}`);
+    assert.ok(ctx.includes('dying-session-42'), `prev_session_id missing: ${ctx}`);
+    assert.ok(ctx.includes('/tmp/transcript-42.jsonl'), `prev_transcript_path missing: ${ctx}`);
+    assert.ok(ctx.includes('/Users/x/repo'), `prev_cwd missing from recovery line: ${ctx}`);
+  });
+});
+
+test('replay-session-end-emits-suppressed-continue: stdout JSON is well-formed', () => {
+  withGrowthWiki((dir) => {
+    const r = runSessionEnd(dir, {
+      reason: 'clear',
+      session_id: 's',
+      transcript_path: '/t',
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, 'must emit continue:true');
+    assert.equal(out.suppressOutput, true, 'must emit suppressOutput:true');
+  });
+});
+
+test('replay-session-end-graceful-when-hypo-dir-missing: no marker created in nonexistent wiki', () => {
+  const ghostDir = join(tmpdir(), `hypo-ghost-${process.pid}-${Date.now()}`);
+  const r = runSessionEnd(ghostDir, { reason: 'clear', session_id: 's', transcript_path: '/t' });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.ok(!existsSync(ghostDir), 'hook must not create the wiki tree it is missing');
+});
+
+test('replay-session-start-removes-corrupt-marker: invalid JSON triggers self-cleanup', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const p = join(dir, '.cache', 'clear-marker.json');
+    writeFileSync(p, '{not valid json');
+    const r = runStartWithSource(dir, 'clear');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `corrupt marker must not fire: ${ctx}`);
+    assert.ok(!existsSync(p), 'corrupt marker must be unlinked on read failure');
+  });
+});
+
+test('replay-session-start-removes-marker-after-read: one-shot contract', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const p = join(dir, '.cache', 'clear-marker.json');
+    writeFileSync(
+      p,
+      JSON.stringify({
+        prev_session_id: 's',
+        prev_transcript_path: '/t',
+        prev_cwd: '/c',
+        ts: new Date().toISOString(),
+      }) + '\n',
+    );
+    runStartWithSource(dir, 'clear');
+    assert.ok(!existsSync(p), 'marker must be unlinked after read (one-shot)');
+  });
+});
+
+test('replay-session-start-graceful-when-source-clear-but-no-marker: missing marker is silent', () => {
+  withGrowthWiki((dir) => {
+    const r = runStartWithSource(dir, 'clear');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `recovery line should not fire: ${ctx}`);
+  });
+});
+
+test('replay-session-start-ignores-clear-marker-on-source-startup: marker only consumed on source=clear', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const p = join(dir, '.cache', 'clear-marker.json');
+    writeFileSync(
+      p,
+      JSON.stringify({
+        prev_session_id: 's',
+        prev_transcript_path: '/t',
+        ts: new Date().toISOString(),
+      }) + '\n',
+    );
+    const r = runStartWithSource(dir, 'startup');
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `marker must not fire on source=startup: ${ctx}`);
+    assert.ok(existsSync(p), 'marker must be preserved when source !== clear');
+  });
+});
+
+test('replay-session-start-drops-stale-clear-marker: >7 day marker is discarded', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const p = join(dir, '.cache', 'clear-marker.json');
+    const stale = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    writeFileSync(
+      p,
+      JSON.stringify({
+        prev_session_id: 's',
+        prev_transcript_path: '/t',
+        ts: stale,
+      }) + '\n',
+    );
+    const r = runStartWithSource(dir, 'clear');
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `stale marker must not fire: ${ctx}`);
+    assert.ok(!existsSync(p), 'stale marker must be cleaned up');
+  });
+});
+
 // ── weekly-report.mjs (Lane E) ───────────────────────────────────────────────
 
 suite('weekly-report.mjs');


### PR DESCRIPTION
## Summary

- Wires the second half of fix #25 (ADR 0022 Layer 2): SessionEnd captures the dying session's identity to `.cache/clear-marker.json` on `reason='clear'`, SessionStart consumes it on `source='clear'` and surfaces a `[WIKI_AUTOCLOSE]` recovery line into `additionalContext`. PR #31 wired the chat-side `/compact|/clear` nudge; this closes the audit row 1210 leftover that `/clear` cannot fire UserPromptSubmit (Stage 0 PoC, 2026-05-14).
- New `hooks/hypo-session-end.mjs` + 3 shared helpers (`writeClearMarker` / `readClearMarker` / `clearClearMarker`) with 7-day TTL, immediate one-shot unlink, corrupt-JSON self-cleanup, and silent best-effort failure semantics that mirror `hypo-session-record` / `hypo-auto-commit`.
- 11 new replay tests (writes-on-clear, skips-non-clear-reasons, suppressed-continue stdout shape, HYPO_DIR-absent grace, recovery-line injection asserting `prev_session_id` + `prev_transcript_path` + `prev_cwd`, one-shot unlink, missing-marker grace, source-startup ignore, 7-day stale drop, corrupt-marker self-cleanup). Resolves spec audit row 1210 (PARTIAL → resolved).

## Design decisions (codex 2-worker pre-implementation review)

1. Single `.cache/clear-marker.json` — /clear is a single-client UX action, multi-marker disambiguation buys no safety and breaks the 1-of-1 read-and-unlink contract.
2. Immediate unlink + 7-day stale guard on read so an orphan SessionEnd (no following SessionStart) cannot pollute a much-later session.
3. Recovery line placement: after `sync` / `growth` notices, before `[WIKI HOT CACHE]` body — HOT/STATE content stays in its normal slot.
4. `reason === 'clear'` only — `prompt_input_exit`, `logout`, etc. are intentional user exits and would pollute the next unrelated session.
5. `prev_cwd` included in marker payload AND recovery line (codex worker 1 MAJOR catch: saved but originally unused → dead data).
6. Silent best-effort + stderr debug line.
7. SessionEnd hook scope: clear-marker write only. `log.md` auto-close stub and telemetry are explicitly out of scope.

## Test plan

- [x] `node tests/runner.mjs` → 200 passed, 0 failed (was 189, +11)
- [x] `npx prettier --write` over changed files (only `tests/runner.mjs` + `hypo-session-start.mjs` reformatted; no behavior change)
- [x] Pre-commit codex review (omc-teams 2:codex). W2 LGTM. W1 surfaced: untracked file (resolved by staging), `prev_cwd` unused in recovery line (fixed), corrupt-marker no self-cleanup (fixed). NIT `r.status` assertion on every test declined as low-ROI.
- [x] Manual: `printf '{"reason":"clear","session_id":"x","transcript_path":"/t","cwd":"/c"}' | node hooks/hypo-session-end.mjs` → writes `.cache/clear-marker.json`; then `printf '{"source":"clear","cwd":"/c","session_id":"new"}' | node hooks/hypo-session-start.mjs` → emits `[WIKI_AUTOCLOSE]` + unlinks the marker.
- [x] Install sync: `~/.claude/hooks/hypo-session-end.mjs` copied, `~/.claude/settings.json` `SessionEnd` entry added (project_hypomnema_sync rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)