### PR TITLE
feat: fix #37 — feedback-as-SoT projection (ADR 0031, Phase A + #8/#9/#10)

### DIFF
--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -2,23 +2,34 @@
 description: Record an AI behavior correction or preference into the wiki
 ---
 
-You are running `/hypo:feedback`. Capture a behavior correction or preference into `pages/feedback/` for future sessions.
+You are running `/hypo:feedback`. Capture a behavior correction or preference into `pages/feedback/` — the **single source of truth** for learned behaviors (ADR 0031 / fix #37).
 
 ## What this does
 
-- Creates or updates `pages/feedback/<topic>.md` with a dated entry
+- Creates or updates `pages/feedback/<topic>.md` with a dated entry and full classification frontmatter
 - Appends a reference to `log.md`
-- Ensures the feedback is findable in future sessions
+- **Automatically refreshes the projection** into `MEMORY.md` and the user's CLAUDE.md `<learned_behaviors>` via `feedback-sync --write`
+
+> ⚠️ Do **not** hand-edit MEMORY.md or CLAUDE.md `<learned_behaviors>` for feedback. Those are one-way projections derived from the wiki page. Edit the wiki page; the projection follows.
 
 ---
 
 ## Step 1 — Gather feedback details
 
-If the user did not provide them, ask:
+If the user did not provide them, ask. The classification fields are required so the page can project correctly:
 
-1. **Topic** (slug): "What topic does this feedback apply to? (e.g. `response-length`, `commit-style`, `code-comments`)"
-2. **Rule**: "State the rule or correction in one or two sentences."
-3. **Why** (optional): "What was the reason or incident that prompted this?"
+1. **Topic** (slug): "What topic does this feedback apply to? (e.g. `response-length`, `commit-style`)"
+2. **Rule** (entry): "State the rule or correction in one or two sentences."
+3. **Reason**: "What incident or reasoning prompted this?"
+4. **Scope**: "Does this apply globally (all projects) or to this project only?" → `global` | `project:<slug>`
+5. **Tier**: "Is this a hard rule (L1) or a softer preference (L2)?" → `L1` | `L2`
+6. **Targets**: "Where should this project?" → `project-memory` (MEMORY.md) and/or `claude-learned` (global CLAUDE.md). Default `project-memory`.
+7. **Priority** (1–5, higher sorts first; default 3).
+8. **Sensitivity**: `public` (default) or `sanitized` (redacted secrets/paths). `private` is not allowed — the wiki is git-pushed.
+
+If **claude-learned** is among the targets, the page must be `scope: global` + `tier: L1`, and you must also collect:
+- **Global summary**: a one-line summary for the CLAUDE.md learned-behaviors entry.
+- Confirm **promote to global** (the page is only projected to CLAUDE.md when promoted).
 
 ---
 
@@ -30,38 +41,39 @@ To check for an existing topic, locate the Hypomnema package root and run:
 node <package-root>/scripts/feedback.mjs --list [--hypo-dir="<path>"]
 ```
 
-If a matching topic exists, confirm with the user whether to append to it or create a new one.
+If a matching topic exists, appending adds a dated entry and bumps `updated:` (classification frontmatter is preserved).
 
 ---
 
-## Step 3 — Write the feedback entry
+## Step 3 — Write the feedback page
 
-Compose the entry text. Format:
-
-```
-**Rule**: <one-line rule>
-
-**Why**: <reason or incident>
-
-**How to apply**: <when this kicks in>
-```
-
-Then run:
+Run with `--dry-run` first to preview the generated page, then without it to write. Pass every collected field:
 
 ```bash
 node <package-root>/scripts/feedback.mjs \
   --topic="<slug>" \
-  --entry="<formatted entry text>" \
+  --entry="<one-line rule>" \
+  --scope="global|project:<slug>" \
+  --tier="L1|L2" \
+  --targets="project-memory[,claude-learned]" \
+  --priority=<1-5> \
+  --sensitivity="public|sanitized" \
+  --memory-summary="<one-line MEMORY.md summary>" \
+  --reason="<why this rule exists>" \
+  [--global-summary="<one-line CLAUDE.md summary>" --promote-to-global] \
+  [--source="session:<date>"] \
   [--hypo-dir="<path>"] \
   [--dry-run]
 ```
 
-Run with `--dry-run` first to preview, then without it to write.
+When `--targets` includes `claude-learned`, `--global-summary` and `--promote-to-global` are required (and `--scope=global --tier=L1`).
+
+On a real (non-dry-run) write, the script automatically runs `feedback-sync --write` to refresh MEMORY.md / CLAUDE.md. If that post-step reports drift it prints a one-line warning — the page is still saved; reconcile with `hypomnema feedback-sync --check`.
 
 ---
 
-## Step 4 — Confirm and cross-reference
+## Step 4 — Confirm
 
-After writing:
-- Tell the user: "Saved to `pages/feedback/<topic>.md`."
-- If this feedback should also update the project's `session-state.md` or the user's CLAUDE.md `<learned_behaviors>`, ask: "Should I also add this to your CLAUDE.md learned behaviors?"
+After writing, tell the user:
+- "Saved to `pages/feedback/<topic>.md` and refreshed the MEMORY/CLAUDE projection."
+- If the projection post-step warned (over-cap, conflict, unresolved project-id), surface that and suggest `hypomnema feedback-sync --check`.

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -128,7 +128,86 @@ process.stdin.on('end', () => {
   const lintOk = lintBlockers.length === 0;
   const designHistoryOk = lintW8.length === 0;
 
-  if (gitStatus.clean && hotStatus.clean && lintOk && designHistoryOk && closeFiles.ok) {
+  // ── fix #37 Phase C: feedback projection drift (ADR 0031) ──
+  // Single blocking gate invariant (spec §7.5): integrate into THIS hook, never
+  // add a separate PreCompact hook. `feedback-sync --check --strict` reports
+  // projection drift (wiki feedback SoT vs MEMORY / CLAUDE.md learned-behaviors
+  // projection). `--no-input` keeps this non-TTY hook from ever blocking on a
+  // prompt, and the engine's skip-MEMORY warning is *soft* (never escalated by
+  // --strict) so a fresh / external user whose ~/.claude/projects/<id> dir does
+  // not exist yet is never gated (contract §5 step 4). Fail-open on any spawn
+  // error, exactly like the lint check above.
+  const feedbackPath = PKG_ROOT ? join(PKG_ROOT, 'scripts', 'feedback-sync.mjs') : null;
+  let feedbackOk = true;
+  let feedbackReason = '';
+  let feedbackSkipped = false;
+  if (!feedbackPath || !existsSync(feedbackPath)) {
+    feedbackSkipped = true;
+  } else {
+    try {
+      const r = spawnSync(
+        process.execPath,
+        [
+          feedbackPath,
+          '--check',
+          '--strict',
+          '--no-input',
+          '--json',
+          `--hypo-dir=${HYPO_DIR}`,
+          `--claude-home=${join(homedir(), '.claude')}`,
+        ],
+        { encoding: 'utf-8', timeout: 30000 },
+      );
+      if (r.error || r.status === null) {
+        feedbackSkipped = true; // spawn failure → fail-open (never block on tooling)
+      } else if (r.status !== 0) {
+        // exit≠0 alone is ambiguous. A *missing* target file (e.g. a system
+        // whose ~/.claude/CLAUDE.md was never created) reports buildError +
+        // exit 1, which is benign — there is nothing to gate. Decide from the
+        // JSON report's per-target state instead of the raw exit code: block
+        // ONLY when some target has a genuine, actionable issue (drift,
+        // conflict, over-cap, or a malformed managed region). buildError is
+        // never actionable here, so any mix that lacks a real issue fails open
+        // — including memory:clean + claude:buildError (codex review: the prior
+        // `every(buildError)` predicate wrongly blocked that case). Mirrors
+        // doctor's buildError→warn (non-fatal) handling.
+        let report = null;
+        try {
+          report = JSON.parse(r.stdout || '');
+        } catch {
+          /* unparseable → fail-open below */
+        }
+        const targets = report ? Object.values(report.targets || {}) : [];
+        const conflicted = targets.some(
+          (t) =>
+            t.intruder || t.unpaired || t.outOfContainer || (t.conflicts && t.conflicts.length),
+        );
+        const overCap = targets.some((t) => t.overCap);
+        const drifted = targets.some((t) => t.dirty);
+        if (!report || !(conflicted || overCap || drifted)) {
+          feedbackSkipped = true; // missing target / pure warning / unparseable → fail-open
+        } else {
+          feedbackOk = false;
+          feedbackReason = conflicted
+            ? 'feedback projection conflict (manual edit) — run `hypomnema feedback-sync --import-target-change --from=<memory|claude>`'
+            : overCap
+              ? 'feedback projection over cap — demote/archive feedback pages'
+              : 'feedback projection drift — run `hypomnema feedback-sync --write`';
+        }
+      }
+    } catch {
+      feedbackSkipped = true;
+    }
+  }
+
+  if (
+    gitStatus.clean &&
+    hotStatus.clean &&
+    lintOk &&
+    designHistoryOk &&
+    closeFiles.ok &&
+    feedbackOk
+  ) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
@@ -140,7 +219,9 @@ process.stdin.on('end', () => {
       !hotStatus.clean ? hotStatus.reason : '',
       !closeFiles.ok ? closeFilesReason : '',
       !designHistoryOk ? `design-history stale (${lintW8.length})` : '',
+      !feedbackOk ? feedbackReason : '',
       lintSkipped ? 'lint skipped (hypo-pkg.json missing)' : '',
+      feedbackSkipped ? 'feedback-sync skipped (hypo-pkg.json missing)' : '',
     ]
       .filter(Boolean)
       .join(', ');
@@ -162,6 +243,7 @@ process.stdin.on('end', () => {
     !designHistoryOk
       ? `design-history stale: ${lintW8.map((w) => w.file.split('/')[1]).join(', ')}`
       : '',
+    !feedbackOk ? feedbackReason : '',
     lintSkipped ? 'lint skipped (run `hypomnema init` to enable lint gate)' : '',
   ].filter(Boolean);
 

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -44,7 +44,9 @@ function parseArgs(argv) {
     else if (arg.startsWith('--project-id=')) args.projectId = arg.slice(13);
   }
   if (!args.claudeHome) args.claudeHome = join(HOME, '.claude');
-  if (!args.projectId) args.projectId = process.cwd().replace(/[/.]/g, '-');
+  // projectId intentionally left null when not user-supplied — let feedback-sync
+  // derive it and exercise its own "derived dir missing → skip MEMORY" path so
+  // doctor reports "unresolved/skipped" rather than a misleading stale warning.
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;
 }
@@ -587,18 +589,18 @@ function checkCodexPaths() {
 // run `feedback-sync --write` yet is normal and must not block doctor.
 function checkFeedbackProjection(hypoDir, claudeHome, projectId) {
   const cliPath = join(PKG_ROOT, 'scripts', 'feedback-sync.mjs');
-  const r = spawnSync(
-    process.execPath,
-    [
-      cliPath,
-      '--check',
-      '--json',
-      `--hypo-dir=${hypoDir}`,
-      `--claude-home=${claudeHome}`,
-      `--project-id=${projectId}`,
-    ],
-    { encoding: 'utf-8' },
-  );
+  const cliArgs = [
+    cliPath,
+    '--check',
+    '--json',
+    '--no-input', // never let the child block on a TTY prompt under doctor
+    `--hypo-dir=${hypoDir}`,
+    `--claude-home=${claudeHome}`,
+  ];
+  // forward --project-id ONLY when the user supplied one; otherwise let
+  // feedback-sync derive it and run its derived-missing → skip-MEMORY path
+  if (projectId) cliArgs.push(`--project-id=${projectId}`);
+  const r = spawnSync(process.execPath, cliArgs, { encoding: 'utf-8' });
 
   // feedback-sync exits non-zero on drift/over-cap/conflict — that is expected
   // and still prints a JSON report on stdout. Only treat a missing process or

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -35,12 +35,16 @@ const PKG_INTEGRITY_HINT =
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, json: false, codex: false };
+  const args = { hypoDir: null, json: false, codex: false, claudeHome: null, projectId: null };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--json') args.json = true;
     else if (arg === '--codex') args.codex = true;
+    else if (arg.startsWith('--claude-home=')) args.claudeHome = expandHome(arg.slice(14));
+    else if (arg.startsWith('--project-id=')) args.projectId = arg.slice(13);
   }
+  if (!args.claudeHome) args.claudeHome = join(HOME, '.claude');
+  if (!args.projectId) args.projectId = process.cwd().replace(/[/.]/g, '-');
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;
 }
@@ -574,6 +578,95 @@ function checkCodexPaths() {
   }
 }
 
+// ── feedback projection (fix #37 #9 — ADR 0031) ──────────────────────────────
+
+// Spawn feedback-sync.mjs --check --json and map its drift report onto doctor's
+// pass/warn/fail. Integrity violations (exit-3 class: conflict / unpaired marker
+// / intruder line / block out of container) are FAIL. Plain drift, build errors,
+// over-cap, and an unresolved project-id are WARN — a fresh system that has not
+// run `feedback-sync --write` yet is normal and must not block doctor.
+function checkFeedbackProjection(hypoDir, claudeHome, projectId) {
+  const cliPath = join(PKG_ROOT, 'scripts', 'feedback-sync.mjs');
+  const r = spawnSync(
+    process.execPath,
+    [
+      cliPath,
+      '--check',
+      '--json',
+      `--hypo-dir=${hypoDir}`,
+      `--claude-home=${claudeHome}`,
+      `--project-id=${projectId}`,
+    ],
+    { encoding: 'utf-8' },
+  );
+
+  // feedback-sync exits non-zero on drift/over-cap/conflict — that is expected
+  // and still prints a JSON report on stdout. Only treat a missing process or
+  // unparseable stdout as a doctor-level problem (warn, never crash).
+  if (r.error || r.status === null) {
+    warn(
+      'Feedback projection',
+      `feedback-sync could not run: ${r.error?.message || 'no exit code'}`,
+    );
+    return;
+  }
+  let report;
+  try {
+    report = JSON.parse(r.stdout);
+  } catch {
+    warn('Feedback projection', 'feedback-sync produced no JSON report — inspect manually');
+    return;
+  }
+  if (report.error) {
+    warn('Feedback projection', report.error);
+    return;
+  }
+
+  const targets = Object.entries(report.targets || {});
+
+  // 1) integrity violations → FAIL
+  const broken = targets.find(
+    ([, t]) => (t.conflicts && t.conflicts.length) || t.unpaired || t.intruder || t.outOfContainer,
+  );
+  if (broken) {
+    const [name, t] = broken;
+    const reason =
+      t.conflicts && t.conflicts.length
+        ? `conflict (${t.conflicts.join(', ')})`
+        : t.unpaired
+          ? 'unpaired managed marker'
+          : t.intruder
+            ? 'hand-edited line inside managed region'
+            : 'managed block outside its container';
+    fail(
+      'Feedback projection integrity',
+      `${name}: ${reason} — run \`hypomnema feedback-sync --import-target-change\` to reconcile`,
+    );
+  } else {
+    // 2) build error → WARN
+    const buildErr = targets.find(([, t]) => t.buildError);
+    if (buildErr) {
+      warn('Feedback projection', buildErr[1].buildError);
+    } else if (targets.find(([, t]) => t.overCap)) {
+      warn('Feedback projection', 'projection over cap — demote/archive feedback pages');
+    } else if (targets.find(([, t]) => t.dirty)) {
+      warn('Feedback projection', 'projections stale — run `hypomnema feedback-sync --write`');
+    } else {
+      const candidates = targets.reduce((n, [, t]) => n + (t.candidates || 0), 0);
+      if (candidates > 0) pass('Feedback projection', 'in sync');
+      else pass('Feedback projection', 'no projection candidates');
+    }
+  }
+
+  // 3) unresolved project-id is a separate, non-fatal concern (MEMORY skipped)
+  if (report.projectIdResolved === false) {
+    warn(
+      'Feedback projection',
+      `project-id ${report.projectId} unresolved — MEMORY projection skipped; pass --project-id`,
+    );
+  }
+}
+
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
@@ -591,6 +684,7 @@ checkHooks();
 checkSettingsJson();
 if (args.codex) checkCodexPaths();
 if (rootOk) checkSyncState(args.hypoDir);
+if (rootOk) checkFeedbackProjection(args.hypoDir, args.claudeHome, args.projectId);
 checkGit(args.hypoDir);
 
 // ── report ───────────────────────────────────────────────────────────────────

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -20,9 +20,17 @@
  *   node scripts/feedback-sync.mjs [--check|--write|--bootstrap|--import-target-change --from=<memory|claude>]
  *     --hypo-dir=<path>      Hypomnema root (default: HYPO_DIR / hypo-config.md / ~/hypomnema)
  *     --claude-home=<path>   Claude Code home (default: ~/.claude)
- *     --project-id=<id>      Override derived project-id (§5)
+ *     --project-id=<id>      Override derived project-id (§5; always wins, no prompt)
+ *     --no-input             Never prompt; treat unresolved project-id non-interactively
  *     --strict               Promote warnings to failures (PreCompact gate)
  *     --json                 Machine-readable output
+ *
+ * Project-id fallback (§5 step 4): when the derived project-id directory does not
+ * exist AND stdin is an interactive TTY AND --no-input is not set, prompt the user
+ * to confirm the derived id, enter a different one, or skip MEMORY projection.
+ * Non-interactive runs (hooks, CI, pipes — no TTY) NEVER prompt: they keep the
+ * existing behavior (warn + skip MEMORY, exit 0). feedback-sync runs inside the
+ * PreCompact hook non-interactively and must never block waiting on input.
  *
  * Exit codes:
  *   0  clean / write succeeded
@@ -49,6 +57,8 @@ function parseArgs(argv) {
     hypoDir: null,
     claudeHome: null,
     projectId: null,
+    noInput: false,
+    skipMemory: false,
     strict: false,
     json: false,
     cwd: process.cwd(),
@@ -64,6 +74,7 @@ function parseArgs(argv) {
     else if (arg.startsWith('--project-id=')) args.projectId = arg.slice(13);
     else if (arg.startsWith('--cwd='))
       args.cwd = expandHome(arg.slice(6)); // test hook
+    else if (arg === '--no-input') args.noInput = true;
     else if (arg === '--strict') args.strict = true;
     else if (arg === '--json') args.json = true;
   }
@@ -424,9 +435,63 @@ function deriveProjectId(args) {
   return { id, derived: true, exists: existsSync(dir) };
 }
 
+// Default interactive prompt (readline over stdin → stderr, so stdout stays clean
+// for --json). Returns one of: { action: 'confirm' } | { action: 'id', id }
+// | { action: 'skip' }. Isolated so resolveProjectId() can be unit-tested with a
+// fake prompt and so the only thing that can touch stdin is gated behind isTTY.
+async function defaultPrompt({ derivedId, claudeHome }) {
+  const rl = (await import('node:readline/promises')).createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    process.stderr.write(
+      `[feedback-sync] project-id "${derivedId}" has no directory under ${claudeHome}/projects.\n` +
+        '  [Enter] confirm and use it (memory dir will be created on --write)\n' +
+        '  type an id to use a different project-id\n' +
+        '  type "skip" to skip MEMORY projection\n',
+    );
+    const answer = (await rl.question('project-id> ')).trim();
+    if (!answer) return { action: 'confirm' };
+    if (answer.toLowerCase() === 'skip') return { action: 'skip' };
+    return { action: 'id', id: answer };
+  } finally {
+    rl.close();
+  }
+}
+
+// Interactive layer on top of the pure deriveProjectId(). Resolves to
+// { id, derived, exists, skipMemory }. Only prompts when the derived dir is
+// missing AND stdin is a TTY AND --no-input is unset. Non-TTY / --no-input /
+// explicit --project-id paths NEVER call prompt → cannot hang (hook/CI safe).
+// `prompt` is injectable for testing; defaults to readline.
+async function resolveProjectId(args, { prompt = defaultPrompt, isTTY } = {}) {
+  const pid = deriveProjectId(args);
+  // explicit --project-id, or derived dir exists → use as-is (no prompt).
+  if (!pid.derived || pid.exists) return { ...pid, skipMemory: false };
+
+  const interactive = (isTTY ?? Boolean(process.stdin.isTTY)) && !args.noInput;
+  if (!interactive) {
+    // hook / CI / pipe / --no-input: keep current behavior — skip MEMORY, no hang.
+    return { ...pid, skipMemory: true };
+  }
+
+  const choice = await prompt({ derivedId: pid.id, claudeHome: args.claudeHome });
+  if (choice.action === 'skip') return { ...pid, skipMemory: true };
+  if (choice.action === 'id') {
+    const id = choice.id;
+    const exists = existsSync(join(args.claudeHome, 'projects', id));
+    // user-entered id is accepted even if missing (they may be creating it);
+    // the MEMORY dir is created on --write.
+    return { id, derived: false, exists, skipMemory: false };
+  }
+  // confirm: accept the derived id despite the missing dir.
+  return { ...pid, skipMemory: false };
+}
+
 // ── modes ─────────────────────────────────────────────────────────────────────
 
-function run(args) {
+function run(args, resolvedPid = null) {
   if (!existsSync(args.hypoDir)) {
     return { code: 1, error: `wiki not found: ${args.hypoDir}` };
   }
@@ -438,20 +503,34 @@ function run(args) {
   }
 
   const pages = loadFeedbackPages(args.hypoDir);
-  const pid = deriveProjectId(args);
+  // pid may be pre-resolved by the interactive layer in main(); fall back to the
+  // pure derivation for direct callers / tests. `skipMemory` carries the §5 step 4
+  // decision (non-interactive unresolved, or user chose "skip").
+  let pid;
+  if (resolvedPid) {
+    pid = resolvedPid;
+  } else {
+    // direct/sync caller (tests, machine path): no prompting possible here, so
+    // mirror the original non-interactive rule — skip MEMORY when the derived
+    // dir is missing (contract §5 step 4 non-interactive branch).
+    const d = deriveProjectId(args);
+    pid = { ...d, skipMemory: d.derived && !d.exists };
+  }
+  if (args.skipMemory) pid.skipMemory = true;
 
   const targets = [];
-  // MEMORY target only when its project dir is resolvable (contract §5 step 4:
-  // unknown project-id in non-interactive mode → skip, do not hard-fail).
-  if (pid.exists || !pid.derived) {
+  // MEMORY target only when not skipped (contract §5 step 4: unknown project-id
+  // in non-interactive mode, or user-declined → skip, do not hard-fail).
+  if (!pid.skipMemory) {
     targets.push(memoryTarget(args, pid.id));
   }
   targets.push(claudeTarget(args));
 
   const report = { mode: args.mode, projectId: pid.id, projectIdResolved: pid.exists, targets: {} };
+  if (pid.skipMemory) report.skipMemory = true;
   let code = 0;
   const warnings = [];
-  if (pid.derived && !pid.exists) {
+  if (pid.skipMemory) {
     warnings.push(
       `project-id "${pid.id}" dir not found under ${args.claudeHome}/projects — MEMORY projection skipped (pass --project-id to override)`,
     );
@@ -509,9 +588,16 @@ function run(args) {
 
 // ── main ───────────────────────────────────────────────────────────────────────
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv);
-  const out = run(args);
+  // Resolve project-id before run() so the (possibly interactive) prompt happens
+  // exactly once. resolveProjectId only touches stdin when stdin.isTTY is truthy
+  // and --no-input is unset → hooks/CI/pipes never block here.
+  let resolvedPid = null;
+  if (existsSync(args.hypoDir) && args.mode !== 'bootstrap' && args.mode !== 'import') {
+    resolvedPid = await resolveProjectId(args);
+  }
+  const out = run(args, resolvedPid);
 
   if (args.json) {
     console.log(JSON.stringify(out.error ? { error: out.error } : out.report, null, 2));
@@ -547,4 +633,16 @@ function main() {
   process.exit(out.code);
 }
 
-main();
+function isMain() {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+}
+
+if (isMain()) {
+  main();
+}
+
+export { parseArgs, deriveProjectId, resolveProjectId, run };

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -538,19 +538,27 @@ function run(args, resolvedPid = null) {
   const report = { mode: args.mode, projectId: pid.id, projectIdResolved: pid.exists, targets: {} };
   if (pid.skipMemory) report.skipMemory = true;
   let code = 0;
+  // `warnings`: everything surfaced to the human (stderr / JSON report).
+  // `strictWarnings`: the subset `--strict` escalates to a non-zero exit.
+  // These are NOT the same set. The skip-MEMORY warning is an *environmental*
+  // state (a fresh / external user has no ~/.claude/projects/<id>/memory yet),
+  // not actionable drift — contract §5 step 4 promises this never hard-fails,
+  // so it must stay OUT of strictWarnings or the PreCompact gate (#3, which
+  // runs `--check --strict`) would block every first-run user. A private-
+  // sensitivity page IS a real SoT violation (ADR 0031 §7; lint #8 blocks it
+  // at the source) so it stays strict-escalatable as defense-in-depth.
   const warnings = [];
+  const strictWarnings = [];
   if (pid.skipMemory) {
     warnings.push(
       `project-id "${pid.id}" dir not found under ${args.claudeHome}/projects — MEMORY projection skipped (pass --project-id to override)`,
     );
   }
-  // surface pages excluded purely for sensitivity (private is forbidden — ADR
-  // 0031 §7; lint #8 blocks it at the SoT, this is a pre-#8 debugging aid)
   for (const p of pages) {
     if (p.fm.sensitivity && !PUBLIC_SENSITIVITY.has(p.fm.sensitivity)) {
-      warnings.push(
-        `page "${p.slug}" excluded: sensitivity="${p.fm.sensitivity}" (only public|sanitized)`,
-      );
+      const w = `page "${p.slug}" excluded: sensitivity="${p.fm.sensitivity}" (only public|sanitized)`;
+      warnings.push(w);
+      strictWarnings.push(w);
     }
   }
 
@@ -580,7 +588,7 @@ function run(args, resolvedPid = null) {
 
   // strict promotes warnings to a failure; compute it BEFORE the write gate so a
   // --write --strict refuses rather than writing then exiting non-zero (codex LOW).
-  const strictFail = args.strict && warnings.length > 0;
+  const strictFail = args.strict && strictWarnings.length > 0;
 
   // pass 2: write only when nothing blocks (code === 0 ⇒ no conflict, over-cap,
   // build error, or check-mode drift) and no strict failure. Skip clean targets

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+/**
+ * feedback-sync.mjs — project wiki feedback as SoT, external memory as projection (ADR 0031, fix #37)
+ *
+ * Wiki `pages/feedback/<slug>.md` is the single source of truth for
+ * learning/correction knowledge. Two Claude Code memory surfaces are derived
+ * (one-way) from it:
+ *   - Project memory:  <claude-home>/projects/<project-id>/memory/feedback_<slug>.md
+ *                      + MEMORY.md index (managed region)
+ *   - Global learned:  <claude-home>/CLAUDE.md  <learned_behaviors> managed region
+ *
+ * Phase A scope (this file): --check / --write engine + per-slug managed blocks
+ * + sha256 idempotency + conflict (exit 3) + over-cap (exit 2). Bootstrap and
+ * import are later phases (stubbed here).
+ *
+ * Contract: projects/hypomnema/fix-37-contract.md (per-slug managed block model,
+ * sha256 over normalized inner content, sort key, exit matrix, project-id rule).
+ *
+ * Usage:
+ *   node scripts/feedback-sync.mjs [--check|--write|--bootstrap|--import-target-change --from=<memory|claude>]
+ *     --hypo-dir=<path>      Hypomnema root (default: HYPO_DIR / hypo-config.md / ~/hypomnema)
+ *     --claude-home=<path>   Claude Code home (default: ~/.claude)
+ *     --project-id=<id>      Override derived project-id (§5)
+ *     --strict               Promote warnings to failures (PreCompact gate)
+ *     --json                 Machine-readable output
+ *
+ * Exit codes:
+ *   0  clean / write succeeded
+ *   1  drift detected (--check) OR generic error (usage / wiki not found)
+ *   2  over-cap (CLAUDE 10 entries / MEMORY 200 index lines) — human decision required
+ *   3  conflict (managed block hash mismatch = manual edit) — no auto-merge
+ */
+
+import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync, rmSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { parseFrontmatter } from './lib/frontmatter.mjs';
+import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+
+const HOME = homedir();
+
+// ── arg parsing ────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {
+    mode: 'check', // check | write | bootstrap | import
+    from: null,
+    hypoDir: null,
+    claudeHome: null,
+    projectId: null,
+    strict: false,
+    json: false,
+    cwd: process.cwd(),
+  };
+  for (const arg of argv.slice(2)) {
+    if (arg === '--check') args.mode = 'check';
+    else if (arg === '--write') args.mode = 'write';
+    else if (arg === '--bootstrap') args.mode = 'bootstrap';
+    else if (arg === '--import-target-change') args.mode = 'import';
+    else if (arg.startsWith('--from=')) args.from = arg.slice(7);
+    else if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
+    else if (arg.startsWith('--claude-home=')) args.claudeHome = expandHome(arg.slice(14));
+    else if (arg.startsWith('--project-id=')) args.projectId = arg.slice(13);
+    else if (arg.startsWith('--cwd='))
+      args.cwd = expandHome(arg.slice(6)); // test hook
+    else if (arg === '--strict') args.strict = true;
+    else if (arg === '--json') args.json = true;
+  }
+  if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
+  if (!args.claudeHome) args.claudeHome = join(HOME, '.claude');
+  return args;
+}
+
+// ── frontmatter helpers ──────────────────────────────────────────────────────
+
+// parseFrontmatter() flattens list values to their raw "[a, b]" string; split
+// them back into arrays here (same shape lint.mjs uses for tags).
+function parseListField(raw) {
+  if (!raw) return [];
+  const trimmed = String(raw)
+    .trim()
+    .replace(/^\[|\]$/g, '');
+  return trimmed
+    .split(',')
+    .map((t) => t.trim().replace(/^["']|["']$/g, ''))
+    .filter(Boolean);
+}
+
+function loadFeedbackPages(hypoDir) {
+  const dir = join(hypoDir, 'pages', 'feedback');
+  if (!existsSync(dir)) return [];
+  const pages = [];
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith('.md') || entry.startsWith('.') || entry.startsWith('_')) continue;
+    const path = join(dir, entry);
+    const content = readFileSync(path, 'utf-8');
+    const fm = parseFrontmatter(content) || {};
+    pages.push({
+      slug: basename(entry, '.md'),
+      fm,
+      targets: parseListField(fm.targets),
+      content,
+      path,
+    });
+  }
+  return pages;
+}
+
+// ── managed block primitives (contract §1/§2) ────────────────────────────────
+
+const MARK_START = (slug, hash) =>
+  `<!-- HYPO:FEEDBACK-SYNC:START source=${slug} sha256=${hash} -->`;
+const MARK_END = '<!-- HYPO:FEEDBACK-SYNC:END -->';
+const MARK_ANCHOR = '<!-- HYPO:FEEDBACK-SYNC:ANCHOR -->';
+// provenance header stamped on generated full-copy side-files so staleSideFiles
+// only ever deletes files this tool wrote (never a user's hand-written memory)
+const SIDE_MARKER = (slug) => `<!-- HYPO:FEEDBACK-SYNC source=${slug} -->`;
+const SIDE_MARKER_PREFIX = '<!-- HYPO:FEEDBACK-SYNC source=';
+const BLOCK_RE =
+  /<!-- HYPO:FEEDBACK-SYNC:START source=(\S+) sha256=([0-9a-f]{64}) -->\r?\n([\s\S]*?)\r?\n<!-- HYPO:FEEDBACK-SYNC:END -->/g;
+// line-anchored so marker-looking text inside prose/code does not false-count
+const START_RE = /^[ \t]*<!-- HYPO:FEEDBACK-SYNC:START\b/gm;
+const END_RE = /^[ \t]*<!-- HYPO:FEEDBACK-SYNC:END -->[ \t]*$/gm;
+
+// Count raw START/END markers; if they outnumber fully-matched blocks, a marker
+// is malformed/unpaired (truncated, tampered hash, stray) → refuse (conflict).
+function countMarkers(content) {
+  return {
+    starts: (content.match(START_RE) || []).length,
+    ends: (content.match(END_RE) || []).length,
+  };
+}
+
+// sha256 over the normalized inner content (contract §2): inner lines joined by
+// \n, leading/trailing blank lines stripped, no trailing newline.
+function normalizeInner(text) {
+  const lines = String(text).replace(/\r\n/g, '\n').split('\n');
+  while (lines.length && lines[0].trim() === '') lines.shift();
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+  return lines.join('\n');
+}
+
+function hashInner(text) {
+  return createHash('sha256').update(normalizeInner(text), 'utf-8').digest('hex');
+}
+
+function renderBlock(slug, inner) {
+  const norm = normalizeInner(inner);
+  return `${MARK_START(slug, hashInner(norm))}\n${norm}\n${MARK_END}`;
+}
+
+// Find existing managed blocks with their positions. Returns
+// { blocks: [{slug, declaredHash, inner, actualHash, start, end}], firstStart, lastEnd }.
+function findBlocks(content) {
+  const blocks = [];
+  let m;
+  BLOCK_RE.lastIndex = 0;
+  while ((m = BLOCK_RE.exec(content)) !== null) {
+    blocks.push({
+      slug: m[1],
+      declaredHash: m[2],
+      inner: m[3],
+      actualHash: hashInner(m[3]),
+      start: m.index,
+      end: m.index + m[0].length,
+    });
+  }
+  const firstStart = blocks.length ? blocks[0].start : -1;
+  const lastEnd = blocks.length ? blocks[blocks.length - 1].end : -1;
+  return { blocks, firstStart, lastEnd };
+}
+
+// Detect hand-added lines *between* managed blocks. Contract §1 requires manual
+// entries to live outside the contiguous managed span; lines inside it would be
+// silently dropped on rewrite, so we refuse (treated as conflict, exit 3).
+function regionHasIntruders(content) {
+  const { blocks, firstStart, lastEnd } = findBlocks(content);
+  if (blocks.length < 1) return false;
+  const span = content.slice(firstStart, lastEnd).replace(BLOCK_RE, '');
+  return span.trim().length > 0;
+}
+
+// ── projection targets (descriptor abstraction — ADR 0032 reuse) ──────────────
+
+const PUBLIC_SENSITIVITY = new Set(['public', 'sanitized']);
+
+function memoryTarget(args, projectId) {
+  const root = join(args.claudeHome, 'projects', projectId, 'memory');
+  return {
+    name: 'memory',
+    file: join(root, 'MEMORY.md'),
+    dir: root,
+    cap: 200,
+    capKind: 'lines',
+    filter: (p) =>
+      p.fm.status === 'active' &&
+      (p.fm.scope === 'global' || (p.fm.scope || '').startsWith('project:')) &&
+      p.targets.includes('project-memory') &&
+      PUBLIC_SENSITIVITY.has(p.fm.sensitivity),
+    render: (p) =>
+      `- [${p.fm.title || p.slug}](feedback_${p.slug}.md) — ${p.fm.memory_summary || ''}`.trim(),
+    // full-copy individual files owned entirely by sync (contract §7); the
+    // provenance header marks them as tool-generated for safe staleness removal
+    sideFiles: (p) => [
+      {
+        path: join(root, `feedback_${p.slug}.md`),
+        content: `${SIDE_MARKER(p.slug)}\n${p.content}`,
+      },
+    ],
+  };
+}
+
+function claudeTarget(args) {
+  return {
+    name: 'claude',
+    file: join(args.claudeHome, 'CLAUDE.md'),
+    cap: 10,
+    capKind: 'entries',
+    container: 'learned_behaviors', // managed region must live inside <learned_behaviors>
+    filter: (p) =>
+      p.fm.status === 'active' &&
+      p.fm.scope === 'global' && // scope:project:* auto-rejected (contract §6)
+      p.fm.tier === 'L1' &&
+      p.targets.includes('claude-learned') &&
+      String(p.fm.promote_to_global) === 'true' &&
+      PUBLIC_SENSITIVITY.has(p.fm.sensitivity),
+    render: (p) => {
+      const date = (p.fm.updated || p.fm.date || '').slice(0, 10);
+      const datePart = date ? `[${date}] ` : '';
+      return `- ${datePart}${p.fm.global_summary || ''} — 근거: [[${p.slug}]]`;
+    },
+    sideFiles: () => [],
+  };
+}
+
+// ── sort key (contract §3): (priority desc, date desc, slug asc) ──────────────
+
+function sortKey(a, b) {
+  const pa = Number(a.fm.priority) || 3;
+  const pb = Number(b.fm.priority) || 3;
+  if (pa !== pb) return pb - pa;
+  const da = (a.fm.updated || a.fm.date || '1970-01-01').slice(0, 10);
+  const db = (b.fm.updated || b.fm.date || '1970-01-01').slice(0, 10);
+  if (da !== db) return da < db ? 1 : -1;
+  return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+}
+
+// Build the desired ordered block list for a target.
+function computeDesired(pages, target) {
+  return pages
+    .filter(target.filter)
+    .sort(sortKey)
+    .map((p) => {
+      const inner = target.render(p);
+      return { slug: p.slug, inner: normalizeInner(inner), hash: hashInner(inner), page: p };
+    });
+}
+
+// ── region insertion (contract §1) ───────────────────────────────────────────
+
+function buildRegion(desired) {
+  return desired.map((d) => renderBlock(d.slug, d.inner)).join('\n');
+}
+
+// Compute the next file content for a target. Returns { content } on success or
+// { error } when the region cannot be placed (e.g. missing container). Pure — no
+// disk writes — so run() can preflight every target before any write (atomicity).
+function buildNextContent(content, region, target) {
+  const { firstStart, lastEnd } = findBlocks(content);
+  if (firstStart >= 0) {
+    // replace the contiguous managed span (region may be '' to clear it)
+    return { content: content.slice(0, firstStart) + region + content.slice(lastEnd) };
+  }
+  // no existing blocks
+  if (region === '') return { content }; // nothing to place → no-op (idempotent)
+  if (target.container === 'learned_behaviors') {
+    const open = content.indexOf('<learned_behaviors>');
+    const close = content.indexOf('</learned_behaviors>');
+    if (open < 0 || close < 0 || close < open) {
+      return { error: `<learned_behaviors> container not found in ${target.file}` };
+    }
+    // an anchor is honored ONLY when it sits inside the container span
+    const anchorIdx = content.indexOf(MARK_ANCHOR);
+    if (anchorIdx > open && anchorIdx < close) {
+      return {
+        content:
+          content.slice(0, anchorIdx) + region + content.slice(anchorIdx + MARK_ANCHOR.length),
+      };
+    }
+    return { content: content.slice(0, close) + region + '\n' + content.slice(close) };
+  }
+  // memory index: anchor (anywhere) or append
+  const anchorIdx = content.indexOf(MARK_ANCHOR);
+  if (anchorIdx >= 0) {
+    return {
+      content: content.slice(0, anchorIdx) + region + content.slice(anchorIdx + MARK_ANCHOR.length),
+    };
+  }
+  const sep = content.endsWith('\n') ? '' : '\n';
+  return { content: content + sep + region + '\n' };
+}
+
+// sync-owned full-copy files (feedback_<slug>.md) no longer backed by an active
+// candidate → must be removed so deletions/demotions propagate (MEDIUM-1).
+function staleSideFiles(target, desired) {
+  if (!target.dir || !existsSync(target.dir)) return [];
+  const keep = new Set(desired.map((d) => `feedback_${d.slug}.md`));
+  return readdirSync(target.dir)
+    .filter((f) => /^feedback_.+\.md$/.test(f) && !keep.has(f))
+    .map((f) => join(target.dir, f))
+    .filter((p) => {
+      // only delete files THIS tool generated (provenance header on line 1) —
+      // never a user's hand-written feedback_*.md memory file
+      try {
+        return readFileSync(p, 'utf-8').startsWith(SIDE_MARKER_PREFIX);
+      } catch {
+        return false;
+      }
+    });
+}
+
+// ── per-target evaluation (preflight: validates + computes the write plan) ─────
+
+function evaluateTarget(pages, target) {
+  const desired = computeDesired(pages, target);
+  const fileExists = existsSync(target.file);
+  const content = fileExists ? readFileSync(target.file, 'utf-8') : '';
+  const { blocks } = findBlocks(content);
+  const { starts, ends } = countMarkers(content);
+
+  // conflict: on-disk block whose inner content no longer matches its marker
+  const conflicts = blocks.filter((b) => b.actualHash !== b.declaredHash).map((b) => b.slug);
+  // unpaired: a raw START/END marker that BLOCK_RE could not pair (malformed/tampered)
+  const unpaired = starts !== blocks.length || ends !== blocks.length;
+  // intruder: hand-added lines inside the managed span (would be dropped on rewrite)
+  const intruder = regionHasIntruders(content);
+  // out-of-container: an existing managed block sitting outside <learned_behaviors>
+  // (drifted/hand-moved) — replacing it in place would leave it outside the
+  // required region, so refuse and require import.
+  let outOfContainer = false;
+  if (target.container === 'learned_behaviors' && blocks.length) {
+    const open = content.indexOf('<learned_behaviors>');
+    const close = content.indexOf('</learned_behaviors>');
+    outOfContainer = open < 0 || close < 0 || blocks.some((b) => b.start < open || b.end > close);
+  }
+
+  const region = buildRegion(desired);
+  let overCap = false;
+  if (target.capKind === 'entries') overCap = desired.length > target.cap;
+  // count index content lines only — the START/END marker wrappers are sync
+  // bookkeeping, not part of the "200 index lines" budget (codex HIGH).
+  else if (target.capKind === 'lines')
+    overCap = desired.reduce((n, d) => n + d.inner.split('\n').length, 0) > target.cap;
+
+  // build the next content (validation happens here, before any write)
+  let nextContent = null;
+  let buildError = null;
+  if (!fileExists && target.container) {
+    buildError = `target file missing: ${target.file}`;
+  } else {
+    const r = buildNextContent(fileExists ? content : '', region, target);
+    if (r.error) buildError = r.error;
+    else nextContent = r.content;
+  }
+
+  // side-files: writes (current candidates) + deletes (stale sync-owned copies)
+  const sideWrites = [];
+  for (const d of desired) {
+    for (const sf of target.sideFiles(d.page)) sideWrites.push(sf);
+  }
+  const sideDeletes = staleSideFiles(target, desired);
+
+  // dirty: main content would change OR any side-file would change/be removed
+  let dirty = nextContent !== null && nextContent !== (fileExists ? content : '');
+  if (sideDeletes.length) dirty = true;
+  for (const sf of sideWrites) {
+    const cur = existsSync(sf.path) ? readFileSync(sf.path, 'utf-8') : null;
+    if (cur !== sf.content) dirty = true;
+  }
+
+  return {
+    desired,
+    conflicts,
+    unpaired,
+    intruder,
+    outOfContainer,
+    overCap,
+    dirty,
+    content,
+    fileExists,
+    nextContent,
+    buildError,
+    sideWrites,
+    sideDeletes,
+  };
+}
+
+// Pure writer: applies a fully-validated plan. No validation here.
+function applyTarget(target, res) {
+  if (target.dir) mkdirSync(target.dir, { recursive: true });
+  for (const sf of res.sideWrites) {
+    mkdirSync(join(sf.path, '..'), { recursive: true });
+    writeFileSync(sf.path, sf.content);
+  }
+  for (const p of res.sideDeletes) {
+    try {
+      rmSync(p);
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (res.nextContent !== null && res.nextContent !== (res.fileExists ? res.content : '')) {
+    writeFileSync(target.file, res.nextContent);
+  }
+}
+
+// ── project-id derivation (contract §5, OQ-31.3) ──────────────────────────────
+
+function deriveProjectId(args) {
+  if (args.projectId) return { id: args.projectId, derived: false, exists: true };
+  const id = args.cwd.replace(/[/.]/g, '-');
+  const dir = join(args.claudeHome, 'projects', id);
+  return { id, derived: true, exists: existsSync(dir) };
+}
+
+// ── modes ─────────────────────────────────────────────────────────────────────
+
+function run(args) {
+  if (!existsSync(args.hypoDir)) {
+    return { code: 1, error: `wiki not found: ${args.hypoDir}` };
+  }
+  if (args.mode === 'bootstrap' || args.mode === 'import') {
+    return {
+      code: 1,
+      error: `mode --${args.mode === 'import' ? 'import-target-change' : 'bootstrap'} not implemented in Phase A`,
+    };
+  }
+
+  const pages = loadFeedbackPages(args.hypoDir);
+  const pid = deriveProjectId(args);
+
+  const targets = [];
+  // MEMORY target only when its project dir is resolvable (contract §5 step 4:
+  // unknown project-id in non-interactive mode → skip, do not hard-fail).
+  if (pid.exists || !pid.derived) {
+    targets.push(memoryTarget(args, pid.id));
+  }
+  targets.push(claudeTarget(args));
+
+  const report = { mode: args.mode, projectId: pid.id, projectIdResolved: pid.exists, targets: {} };
+  let code = 0;
+  const warnings = [];
+  if (pid.derived && !pid.exists) {
+    warnings.push(
+      `project-id "${pid.id}" dir not found under ${args.claudeHome}/projects — MEMORY projection skipped (pass --project-id to override)`,
+    );
+  }
+  // surface pages excluded purely for sensitivity (private is forbidden — ADR
+  // 0031 §7; lint #8 blocks it at the SoT, this is a pre-#8 debugging aid)
+  for (const p of pages) {
+    if (p.fm.sensitivity && !PUBLIC_SENSITIVITY.has(p.fm.sensitivity)) {
+      warnings.push(
+        `page "${p.slug}" excluded: sensitivity="${p.fm.sensitivity}" (only public|sanitized)`,
+      );
+    }
+  }
+
+  // pass 1: preflight every target before touching disk — validates the write
+  // plan (container/anchor, markers) and computes next content. A conflict /
+  // over-cap / build error in ANY target blocks writes to ALL (atomicity — ADR
+  // 0031 Decision §6 "no auto-merge"; avoids a partial write where one target
+  // lands and another refuses).
+  const evals = targets.map((target) => ({ target, res: evaluateTarget(pages, target) }));
+  for (const { target, res } of evals) {
+    report.targets[target.name] = {
+      candidates: res.desired.length,
+      conflicts: res.conflicts,
+      unpaired: res.unpaired,
+      intruder: res.intruder,
+      outOfContainer: res.outOfContainer,
+      overCap: res.overCap,
+      dirty: res.dirty,
+      ...(res.buildError ? { buildError: res.buildError } : {}),
+    };
+    if (res.conflicts.length || res.intruder || res.unpaired || res.outOfContainer)
+      code = Math.max(code, 3);
+    else if (res.overCap) code = Math.max(code, 2);
+    else if (res.buildError) code = Math.max(code, 1);
+    else if (res.dirty && args.mode === 'check') code = Math.max(code, 1);
+  }
+
+  // strict promotes warnings to a failure; compute it BEFORE the write gate so a
+  // --write --strict refuses rather than writing then exiting non-zero (codex LOW).
+  const strictFail = args.strict && warnings.length > 0;
+
+  // pass 2: write only when nothing blocks (code === 0 ⇒ no conflict, over-cap,
+  // build error, or check-mode drift) and no strict failure. Skip clean targets
+  // so writes stay byte-idempotent.
+  if (args.mode === 'write' && code === 0 && !strictFail) {
+    for (const { target, res } of evals) {
+      if (res.dirty) applyTarget(target, res);
+    }
+  }
+
+  if (strictFail) code = Math.max(code, 1);
+  return { code, report, warnings };
+}
+
+// ── main ───────────────────────────────────────────────────────────────────────
+
+function main() {
+  const args = parseArgs(process.argv);
+  const out = run(args);
+
+  if (args.json) {
+    console.log(JSON.stringify(out.error ? { error: out.error } : out.report, null, 2));
+  } else if (out.error) {
+    console.error(`[feedback-sync] ${out.error}`);
+  } else {
+    for (const w of out.warnings || []) console.error(`[feedback-sync] warn: ${w}`);
+    for (const [name, t] of Object.entries(out.report.targets)) {
+      if (t.conflicts.length || t.intruder || t.unpaired || t.outOfContainer) {
+        const why = t.conflicts.length
+          ? `block(s) manually edited: ${t.conflicts.join(', ')}`
+          : t.unpaired
+            ? 'malformed/unpaired HYPO:FEEDBACK-SYNC marker'
+            : t.outOfContainer
+              ? 'managed block sits outside <learned_behaviors>'
+              : 'managed region has unrecognized lines (move them outside the HYPO blocks)';
+        console.error(
+          `[feedback-sync] CONFLICT: ${name} ${why}\n` +
+            `  Run \`hypomnema feedback-sync --import-target-change --from=${name}\` to import.`,
+        );
+      } else if (t.buildError) console.error(`[feedback-sync] ERROR: ${name} ${t.buildError}`);
+      else if (t.overCap)
+        console.error(
+          `[feedback-sync] OVER-CAP: ${name} has ${t.candidates} candidates (cap ${name === 'claude' ? '10 entries' : '200 lines'}) — demote/archive required.`,
+        );
+      else if (t.dirty && args.mode === 'check')
+        console.error(`[feedback-sync] drift: ${name} projection is stale (run --write).`);
+    }
+    if (out.code === 0 && args.mode === 'write')
+      console.error('[feedback-sync] projections written.');
+  }
+
+  process.exit(out.code);
+}
+
+main();

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -39,10 +39,19 @@
  *   3  conflict (managed block hash mismatch = manual edit) — no auto-merge
  */
 
-import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  mkdirSync,
+  rmSync,
+  realpathSync,
+} from 'node:fs';
 import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 
@@ -635,7 +644,12 @@ async function main() {
 
 function isMain() {
   try {
-    return import.meta.url === `file://${process.argv[1]}`;
+    // normalize via realpathSync + pathToFileURL so paths with spaces /
+    // URL-significant chars / symlinks compare correctly. Node resolves
+    // import.meta.url through realpath, so argv[1] must be realpath'd too
+    // (e.g. macOS /tmp → /private/tmp); a raw `file://${argv[1]}` silently no-ops.
+    if (!process.argv[1]) return false;
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
   } catch {
     return false;
   }

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -9,9 +9,10 @@
  *                      + MEMORY.md index (managed region)
  *   - Global learned:  <claude-home>/CLAUDE.md  <learned_behaviors> managed region
  *
- * Phase A scope (this file): --check / --write engine + per-slug managed blocks
- * + sha256 idempotency + conflict (exit 3) + over-cap (exit 2). Bootstrap and
- * import are later phases (stubbed here).
+ * --check / --write engine: per-slug managed blocks + sha256 idempotency +
+ * conflict (exit 3) + over-cap (exit 2) [Phase A]. --bootstrap / --import-target-
+ * change: reverse one-time helpers that scaffold pages/feedback/_drafts/ for human
+ * review — never write pages/feedback/<slug>.md directly [Phase D].
  *
  * Contract: projects/hypomnema/fix-37-contract.md (per-slug managed block model,
  * sha256 over normalized inner content, sort key, exit matrix, project-id rule).
@@ -24,6 +25,7 @@
  *     --no-input             Never prompt; treat unresolved project-id non-interactively
  *     --strict               Promote warnings to failures (PreCompact gate)
  *     --json                 Machine-readable output
+ *     --dry-run              (bootstrap/import) report planned drafts, write nothing
  *
  * Project-id fallback (§5 step 4): when the derived project-id directory does not
  * exist AND stdin is an interactive TTY AND --no-input is not set, prompt the user
@@ -48,7 +50,7 @@ import {
   rmSync,
   realpathSync,
 } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
@@ -70,6 +72,7 @@ function parseArgs(argv) {
     skipMemory: false,
     strict: false,
     json: false,
+    dryRun: false,
     cwd: process.cwd(),
   };
   for (const arg of argv.slice(2)) {
@@ -86,6 +89,7 @@ function parseArgs(argv) {
     else if (arg === '--no-input') args.noInput = true;
     else if (arg === '--strict') args.strict = true;
     else if (arg === '--json') args.json = true;
+    else if (arg === '--dry-run') args.dryRun = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   if (!args.claudeHome) args.claudeHome = join(HOME, '.claude');
@@ -498,18 +502,296 @@ async function resolveProjectId(args, { prompt = defaultPrompt, isTTY } = {}) {
   return { ...pid, skipMemory: false };
 }
 
+// ── bootstrap + import (contract §11, fix #37 Phase D) ────────────────────────
+//
+// Both modes are *reverse* one-time helpers that scaffold wiki DRAFTS under
+// pages/feedback/_drafts/ — they NEVER write pages/feedback/<slug>.md directly
+// (the single-direction invariant, ADR 0031 §6). A human reviews each draft,
+// fills the decision fields (scope/tier/targets/promote_to_global), and moves
+// it into pages/feedback/. _drafts/ is excluded from sync candidates
+// (loadFeedbackPages) and from lint (collectPages skips `_`-dirs), so an
+// incomplete scaffold never trips required-field errors or projection.
+
+// Provenance header so re-running bootstrap/import is recognisable and humans
+// see at a glance the file is a generated scaffold awaiting review.
+const DRAFT_MARKER = (origin) => `<!-- HYPO:FEEDBACK-SYNC:DRAFT origin=${origin} -->`;
+
+// Slug from free text: keep unicode letters/digits (Korean rules stay readable),
+// collapse every other run to a single dash, length-cap for filesystem sanity.
+function kebabSlug(text, max = 48) {
+  const s = String(text)
+    .replace(/\*\*/g, '') // markdown bold
+    .replace(/`[^`]*`/g, ' ') // inline code spans
+    .normalize('NFC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '');
+  return s.slice(0, max).replace(/-+$/g, '') || 'entry';
+}
+
+// Reduce an externally-sourced slug (MEMORY index name, managed-block `source=`)
+// to a single safe path segment. basename() collapses any `../` traversal to the
+// final component, then we strip everything but unicode word chars / . _ - and
+// leading dots. Returns null when nothing safe remains → caller skips it. Without
+// this a crafted `source=../evil` / `feedback_../evil.md` would let --bootstrap /
+// --import write outside _drafts (e.g. into pages/feedback/), breaking the
+// one-way invariant (codex BLOCKER, fix #37 Phase D review).
+function safeDraftSlug(raw) {
+  const seg = basename(String(raw).replace(/\\/g, '/'));
+  const cleaned = seg
+    .replace(/[^\p{L}\p{N}._-]+/gu, '-')
+    .replace(/^[.-]+/, '')
+    .replace(/-+$/g, '');
+  return cleaned && cleaned !== '.' && cleaned !== '..' ? cleaned : null;
+}
+
+// Defense-in-depth: refuse to write a draft whose resolved path escapes _drafts.
+function assertUnderDrafts(draftsDir, target) {
+  const root = resolve(draftsDir) + sep;
+  if (!resolve(target).startsWith(root)) {
+    throw new Error(`refusing to write outside _drafts: ${target}`);
+  }
+}
+
+// One-line summary from a rule body: drop markdown noise, cap length.
+function oneLineSummary(text, max = 100) {
+  const s = String(text).replace(/\*\*/g, '').replace(/\r?\n/g, ' ').replace(/\s+/g, ' ').trim();
+  return s.length > max ? s.slice(0, max - 1).trimEnd() + '…' : s;
+}
+
+// Parse <learned_behaviors> hand-written lines into {date, rule}. Lines INSIDE a
+// HYPO:FEEDBACK-SYNC managed block are skipped — those already have a wiki SoT
+// and are not legacy entries to migrate.
+function parseLearnedBehaviors(content) {
+  const open = content.indexOf('<learned_behaviors>');
+  const close = content.indexOf('</learned_behaviors>');
+  if (open < 0 || close < 0 || close < open) return [];
+  const inner = content.slice(open + '<learned_behaviors>'.length, close);
+  const scrubbed = inner.replace(BLOCK_RE, ''); // blank out already-projected blocks
+  const out = [];
+  for (const line of scrubbed.split('\n')) {
+    const m = line.match(/^- \[(\d{4}-\d{2}-\d{2})\]\s+(.*\S)\s*$/);
+    if (m) out.push({ date: m[1], rule: m[2].trim() });
+  }
+  return out;
+}
+
+// Parse MEMORY.md index for sync-shaped feedback entries:
+//   `- [Title](feedback_<name>.md) — summary`
+// Non-`feedback_*` index lines are out of scope (not feedback projections).
+function parseMemoryIndex(content) {
+  const out = [];
+  // scrub already-projected managed blocks first (parity with parseLearnedBehaviors):
+  // index lines inside a HYPO:FEEDBACK-SYNC block already have a wiki SoT and must
+  // not be re-drafted as legacy entries (codex IMPORTANT, fix #37 Phase D review).
+  const scrubbed = content.replace(BLOCK_RE, '');
+  const re = /^- \[([^\]]*)\]\(feedback_([^)]+?)\.md\)\s*(?:—\s*(.*\S))?\s*$/gm;
+  let m;
+  while ((m = re.exec(scrubbed)) !== null) {
+    out.push({ title: m[1].trim(), name: m[2].trim(), summary: (m[3] || '').trim() });
+  }
+  return out;
+}
+
+// Frontmatter skeleton for a bootstrap draft. Decision fields the human must set
+// are left as `TODO` (the file is excluded from lint, so this never errors).
+function bootstrapDraftContent({ title, summary, body, date, origin }) {
+  const lines = [
+    DRAFT_MARKER(origin),
+    '---',
+    `title: ${title}`,
+    'type: feedback',
+    'status: draft',
+    'scope: TODO              # global | project:<slug>',
+    'tier: TODO               # L1 (CLAUDE.md <learned_behaviors> candidate) | L2',
+    'targets: [project-memory]   # + claude-learned for a global L1 rule',
+    'sensitivity: public      # public | sanitized (private is forbidden)',
+    'priority: 3              # 1-5, higher wins over-cap',
+    `memory_summary: ${summary}`,
+    `global_summary: ${summary}`,
+    'promote_to_global: false # set true to project into <learned_behaviors>',
+    'reason: TODO',
+    `source: ${date ? `session:${date}` : 'TODO'}`,
+  ];
+  if (date) lines.push(`created: ${date}`, `updated: ${date}`);
+  lines.push(`bootstrap_origin: ${origin}`, '---', '', `# ${title}`, '', body, '');
+  return lines.join('\n');
+}
+
+// Frontmatter skeleton for an import draft: captures the on-disk (hand-edited)
+// managed block content as the body so the human can reconcile it into the SoT.
+function importDraftContent({ slug, inner, from }) {
+  return [
+    DRAFT_MARKER(`import-${from}`),
+    '---',
+    `title: imported ${slug}`,
+    'type: feedback',
+    'status: draft',
+    'scope: TODO',
+    'tier: TODO',
+    'targets: [project-memory]',
+    'sensitivity: public',
+    'priority: 3',
+    `memory_summary: ${oneLineSummary(inner)}`,
+    `global_summary: ${oneLineSummary(inner)}`,
+    'promote_to_global: false',
+    `reason: imported from ${from} <learned_behaviors>/MEMORY managed block (hand-edited)`,
+    'source: TODO',
+    `imported_from: ${from}`,
+    '---',
+    '',
+    `# imported ${slug}`,
+    '',
+    '> The managed block below was edited outside the wiki. Reconcile it into',
+    `> pages/feedback/${slug}.md (the SoT), then re-run feedback-sync --write.`,
+    '',
+    inner,
+    '',
+  ].join('\n');
+}
+
+function existingPageSlugs(hypoDir) {
+  const dir = join(hypoDir, 'pages', 'feedback');
+  if (!existsSync(dir)) return new Set();
+  return new Set(
+    readdirSync(dir)
+      .filter((f) => f.endsWith('.md') && !f.startsWith('.') && !f.startsWith('_'))
+      .map((f) => basename(f, '.md')),
+  );
+}
+
+// --bootstrap: read the two legacy projection surfaces (CLAUDE.md
+// <learned_behaviors> + MEMORY.md feedback_* index) and scaffold drafts.
+function runBootstrap(args) {
+  const draftsDir = join(args.hypoDir, 'pages', 'feedback', '_drafts');
+  const existing = existingPageSlugs(args.hypoDir);
+  const report = { mode: 'bootstrap', dryRun: args.dryRun, created: [], skipped: [] };
+  const warnings = [];
+  const candidates = [];
+
+  const claudeFile = join(args.claudeHome, 'CLAUDE.md');
+  if (existsSync(claudeFile)) {
+    for (const lb of parseLearnedBehaviors(readFileSync(claudeFile, 'utf-8'))) {
+      const slug = `legacy-claude-${lb.date.replace(/-/g, '')}-${kebabSlug(lb.rule)}`;
+      candidates.push({
+        slug,
+        origin: 'claude-learned',
+        title: oneLineSummary(lb.rule, 60),
+        summary: oneLineSummary(lb.rule),
+        body: lb.rule,
+        date: lb.date,
+      });
+    }
+  } else {
+    warnings.push(`CLAUDE.md not found at ${claudeFile} — learned_behaviors source skipped`);
+  }
+
+  const pid = deriveProjectId(args);
+  const memFile = join(args.claudeHome, 'projects', pid.id, 'memory', 'MEMORY.md');
+  if (existsSync(memFile)) {
+    for (const e of parseMemoryIndex(readFileSync(memFile, 'utf-8'))) {
+      const slug = safeDraftSlug(e.name.replace(/_/g, '-'));
+      if (!slug) {
+        report.skipped.push({ slug: e.name, reason: 'unsafe-slug' });
+        continue;
+      }
+      candidates.push({
+        slug,
+        origin: 'memory-index',
+        title: e.title || slug,
+        summary: e.summary,
+        body: e.summary || e.title || slug,
+        date: '',
+      });
+    }
+  } else {
+    warnings.push(
+      `MEMORY.md not found for project-id "${pid.id}" at ${memFile} — memory source skipped`,
+    );
+  }
+
+  const seen = new Set();
+  for (const c of candidates) {
+    if (seen.has(c.slug)) {
+      report.skipped.push({ slug: c.slug, reason: 'duplicate-in-batch' });
+      continue;
+    }
+    seen.add(c.slug);
+    if (existing.has(c.slug)) {
+      report.skipped.push({ slug: c.slug, reason: 'page-exists' });
+      continue;
+    }
+    const draftPath = join(draftsDir, `${c.slug}.md`);
+    if (existsSync(draftPath)) {
+      report.skipped.push({ slug: c.slug, reason: 'draft-exists' });
+      continue;
+    }
+    assertUnderDrafts(draftsDir, draftPath);
+    report.created.push({ slug: c.slug, origin: c.origin, path: draftPath });
+    if (!args.dryRun) {
+      mkdirSync(draftsDir, { recursive: true });
+      writeFileSync(draftPath, bootstrapDraftContent(c));
+    }
+  }
+  return { code: 0, report, warnings };
+}
+
+// --import-target-change --from=<memory|claude>: capture hand-edited (conflict)
+// managed blocks back into drafts so the human can reconcile them into the SoT.
+function runImport(args) {
+  if (args.from !== 'memory' && args.from !== 'claude') {
+    return { code: 1, error: '--import-target-change requires --from=memory|claude' };
+  }
+  const file =
+    args.from === 'claude'
+      ? join(args.claudeHome, 'CLAUDE.md')
+      : join(args.claudeHome, 'projects', deriveProjectId(args).id, 'memory', 'MEMORY.md');
+  if (!existsSync(file)) return { code: 1, error: `target file not found: ${file}` };
+
+  const { blocks } = findBlocks(readFileSync(file, 'utf-8'));
+  const conflicts = blocks.filter((b) => b.actualHash !== b.declaredHash);
+  const report = { mode: 'import', from: args.from, dryRun: args.dryRun, imported: [] };
+  const warnings = [];
+  if (!conflicts.length) {
+    warnings.push(`no hand-edited (conflicting) managed blocks in ${file} — nothing to import`);
+    return { code: 0, report, warnings };
+  }
+  const draftsDir = join(args.hypoDir, 'pages', 'feedback', '_drafts');
+  const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  report.skipped = [];
+  for (const b of conflicts) {
+    // sanitize the marker-supplied slug (a tampered `source=../x` must not escape
+    // _drafts — codex BLOCKER), then pick a collision-free name so a re-run / a
+    // same-day import from both targets never clobbers a prior draft (or human
+    // edits to it — codex IMPORTANT). `from` is in the name to disambiguate
+    // memory vs claude imports of the same slug.
+    const slug = safeDraftSlug(b.slug);
+    if (!slug) {
+      report.skipped.push({ slug: b.slug, reason: 'unsafe-slug' });
+      continue;
+    }
+    let draftPath = join(draftsDir, `${slug}.import-${args.from}-${stamp}.md`);
+    for (let n = 2; existsSync(draftPath); n++) {
+      draftPath = join(draftsDir, `${slug}.import-${args.from}-${stamp}-${n}.md`);
+    }
+    assertUnderDrafts(draftsDir, draftPath);
+    report.imported.push({ slug, path: draftPath });
+    if (!args.dryRun) {
+      mkdirSync(draftsDir, { recursive: true });
+      writeFileSync(draftPath, importDraftContent({ slug, inner: b.inner, from: args.from }));
+    }
+  }
+  return { code: 0, report, warnings };
+}
+
 // ── modes ─────────────────────────────────────────────────────────────────────
 
 function run(args, resolvedPid = null) {
   if (!existsSync(args.hypoDir)) {
     return { code: 1, error: `wiki not found: ${args.hypoDir}` };
   }
-  if (args.mode === 'bootstrap' || args.mode === 'import') {
-    return {
-      code: 1,
-      error: `mode --${args.mode === 'import' ? 'import-target-change' : 'bootstrap'} not implemented in Phase A`,
-    };
-  }
+  if (args.mode === 'bootstrap') return runBootstrap(args);
+  if (args.mode === 'import') return runImport(args);
 
   const pages = loadFeedbackPages(args.hypoDir);
   // pid may be pre-resolved by the interactive layer in main(); fall back to the
@@ -620,6 +902,28 @@ async function main() {
     console.log(JSON.stringify(out.error ? { error: out.error } : out.report, null, 2));
   } else if (out.error) {
     console.error(`[feedback-sync] ${out.error}`);
+  } else if (out.report.mode === 'bootstrap') {
+    for (const w of out.warnings || []) console.error(`[feedback-sync] warn: ${w}`);
+    const verb = out.report.dryRun ? 'would create' : 'created';
+    for (const c of out.report.created)
+      console.error(
+        `[feedback-sync] ${verb} draft: pages/feedback/_drafts/${c.slug}.md (${c.origin})`,
+      );
+    for (const s of out.report.skipped)
+      console.error(`[feedback-sync] skipped ${s.slug}: ${s.reason}`);
+    console.error(
+      `[feedback-sync] bootstrap: ${out.report.created.length} ${verb}, ${out.report.skipped.length} skipped. ` +
+        `Fill scope/tier/targets/promote_to_global and move into pages/feedback/.`,
+    );
+  } else if (out.report.mode === 'import') {
+    for (const w of out.warnings || []) console.error(`[feedback-sync] warn: ${w}`);
+    const verb = out.report.dryRun ? 'would import' : 'imported';
+    for (const i of out.report.imported)
+      console.error(`[feedback-sync] ${verb} ${i.slug} → ${i.path}`);
+    if (out.report.imported.length)
+      console.error(
+        `[feedback-sync] import: ${out.report.imported.length} draft(s). Reconcile into the SoT page, then feedback-sync --write.`,
+      );
   } else {
     for (const w of out.warnings || []) console.error(`[feedback-sync] warn: ${w}`);
     for (const [name, t] of Object.entries(out.report.targets)) {

--- a/scripts/feedback.mjs
+++ b/scripts/feedback.mjs
@@ -2,33 +2,98 @@
 /**
  * Hypomnema feedback script
  *
- * Creates or appends to pages/feedback/<topic>.md with a feedback entry.
- * Also appends a log entry to log.md.
+ * Creates or appends to pages/feedback/<topic>.md with a behaviour-correction
+ * entry. The wiki feedback page is the single source of truth (ADR 0031 / fix
+ * #37); MEMORY.md and CLAUDE.md <learned_behaviors> are one-way *projections*
+ * derived from it. Never hand-edit those targets — this script writes the page
+ * and then runs `feedback-sync --write` to refresh the projection automatically.
+ *
  * Used by /hypo:feedback after Claude drafts the feedback content.
  *
  * Usage:
- *   node scripts/feedback.mjs --topic=<slug> --entry=<text> [options]
+ *   node scripts/feedback.mjs --topic=<slug> --entry=<text> [classification flags]
  *
- * Options:
- *   --hypo-dir=<path>   Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
- *   --topic=<slug>      Feedback topic slug (e.g. "response-length", "code-style")
- *   --entry=<text>      Feedback entry text (one-line rule or short paragraph)
- *   --dry-run           Preview without writing
- *   --list              List existing feedback topics
+ * Page write:
+ *   --topic=<slug>          Feedback topic slug (e.g. "response-length")
+ *   --entry=<text>          Rule body (one-line rule or short paragraph)
+ *   --title=<text>          Frontmatter title (default: topic)
+ *
+ * Classification (lint #8 schema — required on create):
+ *   --scope=<v>             global | project:<slug>           (required)
+ *   --tier=<v>              L1 | L2                            (required)
+ *   --targets=<list>        comma list of project-memory,claude-learned (default: project-memory)
+ *   --sensitivity=<v>       public | sanitized                (default: public)
+ *   --priority=<1-5>        projection sort weight             (default: 3)
+ *   --memory-summary=<t>    one-line MEMORY.md index summary   (required)
+ *   --reason=<t>            why this rule exists               (required)
+ *   --source=<t>            provenance (default: session:<today>)
+ *   --behavior=<t>          optional: the behaviour being corrected
+ *
+ * Required only when --targets includes claude-learned:
+ *   --global-summary=<t>    one-line CLAUDE.md learned-behaviour summary
+ *   --promote-to-global     mark the page for global CLAUDE.md projection
+ *
+ * Modes:
+ *   --hypo-dir=<path>       Hypomnema root (default: HYPO_DIR / hypo-config.md / ~/hypomnema)
+ *   --claude-home=<path>    Projection target home for the post-step (default: ~/.claude)
+ *   --project-id=<id>       Projection MEMORY project-id for the post-step (default: derived from cwd)
+ *   --no-sync               Skip the automatic `feedback-sync --write` post-step
+ *   --dry-run               Preview without writing (also skips projection)
+ *   --list                  List existing feedback topics
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
-import { join, resolve, sep } from 'path';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+
+const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, topic: null, entry: null, dryRun: false, list: false };
+  const args = {
+    hypoDir: null,
+    topic: null,
+    entry: null,
+    title: null,
+    scope: null,
+    tier: null,
+    targets: null,
+    sensitivity: 'public',
+    priority: '3',
+    memorySummary: null,
+    globalSummary: null,
+    promoteToGlobal: false,
+    reason: null,
+    source: null,
+    behavior: null,
+    claudeHome: null,
+    projectId: null,
+    noSync: false,
+    dryRun: false,
+    list: false,
+  };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg.startsWith('--topic=')) args.topic = arg.slice(8);
     else if (arg.startsWith('--entry=')) args.entry = arg.slice(8);
+    else if (arg.startsWith('--title=')) args.title = arg.slice(8);
+    else if (arg.startsWith('--scope=')) args.scope = arg.slice(8);
+    else if (arg.startsWith('--tier=')) args.tier = arg.slice(7);
+    else if (arg.startsWith('--targets=')) args.targets = arg.slice(10);
+    else if (arg.startsWith('--sensitivity=')) args.sensitivity = arg.slice(14);
+    else if (arg.startsWith('--priority=')) args.priority = arg.slice(11);
+    else if (arg.startsWith('--memory-summary=')) args.memorySummary = arg.slice(17);
+    else if (arg.startsWith('--global-summary=')) args.globalSummary = arg.slice(17);
+    else if (arg === '--promote-to-global') args.promoteToGlobal = true;
+    else if (arg.startsWith('--reason=')) args.reason = arg.slice(9);
+    else if (arg.startsWith('--source=')) args.source = arg.slice(9);
+    else if (arg.startsWith('--behavior=')) args.behavior = arg.slice(11);
+    else if (arg.startsWith('--claude-home=')) args.claudeHome = expandHome(arg.slice(14));
+    else if (arg.startsWith('--project-id=')) args.projectId = arg.slice(13);
+    else if (arg === '--no-sync') args.noSync = true;
     else if (arg === '--dry-run') args.dryRun = true;
     else if (arg === '--list') args.list = true;
   }
@@ -53,56 +118,195 @@ function listTopics(hypoDir) {
   for (const f of files) console.log(`  ${f.replace(/\.md$/, '')}`);
 }
 
-// ── write feedback entry ──────────────────────────────────────────────────────
+// ── classification validation (mirrors lint #8 / ADR 0031 §6) ──────────────────
 
-function writeFeedback(hypoDir, topic, entry, dryRun) {
-  const feedbackDir = join(hypoDir, 'pages', 'feedback');
-  const filePath = join(feedbackDir, `${topic}.md`);
-  const today = new Date().toISOString().slice(0, 10);
+const SCOPE_RE = /^(global|project:[a-z0-9][a-z0-9-]*)$/;
+const TIER_ENUM = ['L1', 'L2'];
+const SENSITIVITY_ENUM = ['public', 'sanitized']; // private is forbidden (wiki is git-public)
+const TARGET_ENUM = ['project-memory', 'claude-learned'];
+
+function parseTargets(raw) {
+  return String(raw || '')
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+// Validate the create-mode classification. Returns an array of error strings.
+function validateClassification(args, targets) {
+  const errs = [];
+  if (!args.scope) errs.push('--scope is required (global | project:<slug>)');
+  else if (!SCOPE_RE.test(args.scope)) errs.push(`--scope invalid: "${args.scope}"`);
+  if (!args.tier) errs.push('--tier is required (L1 | L2)');
+  else if (!TIER_ENUM.includes(args.tier)) errs.push(`--tier invalid: "${args.tier}"`);
+  if (!SENSITIVITY_ENUM.includes(args.sensitivity))
+    errs.push(
+      `--sensitivity invalid: "${args.sensitivity}" (public | sanitized; private is forbidden)`,
+    );
+  if (!targets.length) errs.push('--targets is required (project-memory[,claude-learned])');
+  for (const t of targets)
+    if (!TARGET_ENUM.includes(t)) errs.push(`--targets invalid member: "${t}"`);
+  const pri = Number(args.priority);
+  if (!Number.isInteger(pri) || pri < 1 || pri > 5)
+    errs.push(`--priority must be an integer 1-5 (got "${args.priority}")`);
+  if (!args.memorySummary) errs.push('--memory-summary is required');
+  if (!args.reason) errs.push('--reason is required');
+
+  // CLAUDE.md projection candidates must be global + L1 (ADR 0031 §6 filter), and
+  // carry the two conditional fields (lint #8). Enforce here so we never write a
+  // claude-learned page that lint rejects or that silently never projects.
+  if (targets.includes('claude-learned')) {
+    if (!args.globalSummary)
+      errs.push('--global-summary is required when --targets includes claude-learned');
+    if (!args.promoteToGlobal)
+      errs.push('--promote-to-global is required when --targets includes claude-learned');
+    if (args.scope !== 'global')
+      errs.push('claude-learned projection requires --scope=global (ADR 0031 §6)');
+    if (args.tier !== 'L1') errs.push('claude-learned projection requires --tier=L1 (ADR 0031 §6)');
+  }
+  return errs;
+}
+
+// ── frontmatter rendering ──────────────────────────────────────────────────────
+
+// Frontmatter scalars are written one-per-line as `key: value`. A raw newline in
+// a value would inject a forged frontmatter key (e.g. a `reason` containing
+// "\nstatus: archived"), silently overriding classification AFTER validation.
+// These fields are one-liners by contract, so collapse any whitespace run
+// (including newlines / control chars) to a single space and trim.
+function oneLine(v) {
+  return String(v ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function renderPage(args, targets, today) {
+  const title = oneLine(args.title || args.topic);
+  const lines = [
+    '---',
+    `title: ${title}`,
+    'tags: [feedback]',
+    'type: feedback',
+    'status: active',
+    `scope: ${args.scope}`,
+    `tier: ${args.tier}`,
+    `targets: [${targets.join(', ')}]`,
+    `sensitivity: ${args.sensitivity}`,
+    `priority: ${Number(args.priority)}`,
+    `memory_summary: ${oneLine(args.memorySummary)}`,
+  ];
+  if (targets.includes('claude-learned')) {
+    lines.push(`global_summary: ${oneLine(args.globalSummary)}`);
+    lines.push(`promote_to_global: ${args.promoteToGlobal}`);
+  }
+  lines.push(`reason: ${oneLine(args.reason)}`);
+  lines.push(`source: ${oneLine(args.source || `session:${today}`)}`);
+  lines.push(`corrected_at: ${today}`);
+  lines.push(`updated: ${today}`);
+  lines.push(`created: ${today}`);
+  if (args.behavior) lines.push(`behavior: ${oneLine(args.behavior)}`);
+  lines.push('---');
+  lines.push('');
+  lines.push(`# ${title}`);
+  lines.push('');
+  lines.push('## 규칙');
+  lines.push('');
+  lines.push(args.entry);
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ── write feedback page ─────────────────────────────────────────────────────────
+
+// Append-mode `updated:` bump: appending a dated entry to an existing page makes
+// it the freshest correction, so it should sort first. Rewrite the `updated:`
+// line ONLY inside the leading frontmatter block (between the first pair of
+// `---` fences). A naive multiline replace would also rewrite any body line that
+// happens to start with "updated:" (codex review) — so we scope to the fence.
+function bumpUpdated(content, today) {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return content; // no frontmatter → nothing to bump
+  const fm = m[1];
+  const bumped = /^updated:\s*/m.test(fm)
+    ? fm.replace(/^(updated:\s*).*$/m, `$1${today}`)
+    : `${fm}\nupdated: ${today}`;
+  return content.replace(m[0], `---\n${bumped}\n---`);
+}
+
+function writeFeedback(args, today) {
+  const feedbackDir = join(args.hypoDir, 'pages', 'feedback');
+  const filePath = join(feedbackDir, `${args.topic}.md`);
+  const targets = parseTargets(args.targets || 'project-memory');
 
   let content;
-
+  let mode;
   if (existsSync(filePath)) {
-    content = readFileSync(filePath, 'utf-8');
-    const newEntry = `\n## ${today}\n\n${entry}\n`;
-    content = content.trimEnd() + '\n' + newEntry;
+    // Append a dated entry; preserve existing frontmatter classification.
+    mode = 'append';
+    const existing = readFileSync(filePath, 'utf-8');
+    const appended = existing.trimEnd() + `\n\n## ${today}\n\n${args.entry}\n`;
+    content = bumpUpdated(appended, today);
   } else {
-    content = `---
-title: "Feedback: ${topic}"
-type: feedback
-updated: ${today}
-source: session:${today}
-corrected_at: ${today}
-tags: [feedback]
----
-
-# Feedback: ${topic}
-
-## ${today}
-
-${entry}
-`;
+    mode = 'create';
+    const errs = validateClassification(args, targets);
+    if (errs.length) {
+      console.error('Error: feedback classification incomplete:');
+      for (const e of errs) console.error(`  - ${e}`);
+      process.exit(1);
+    }
+    content = renderPage(args, targets, today);
   }
 
-  if (dryRun) {
+  if (args.dryRun) {
     console.log('[DRY RUN — no changes made]\n');
-    console.log(`Would write to: ${filePath}\n`);
+    console.log(`Would ${mode}: ${filePath}\n`);
     console.log(content);
-    return;
+    return { wrote: false };
   }
 
   if (!existsSync(feedbackDir)) mkdirSync(feedbackDir, { recursive: true });
   writeFileSync(filePath, content);
-  console.log(`✓ Written: ${filePath}`);
+  console.log(`✓ ${mode === 'create' ? 'Created' : 'Updated'}: ${filePath}`);
 
   // append to log.md
-  const logPath = join(hypoDir, 'log.md');
-  const logEntry = `\n- ${today} feedback: [[pages/feedback/${topic}]] — ${entry.split('\n')[0].slice(0, 80)}\n`;
+  const logPath = join(args.hypoDir, 'log.md');
+  const logEntry = `\n- ${today} feedback: [[pages/feedback/${args.topic}]] — ${args.entry
+    .split('\n')[0]
+    .slice(0, 80)}\n`;
   if (existsSync(logPath)) {
     const log = readFileSync(logPath, 'utf-8');
     writeFileSync(logPath, log.trimEnd() + logEntry);
     console.log(`↪ Appended to log.md`);
   }
+  return { wrote: true };
+}
+
+// ── projection post-step (ADR 0031) ────────────────────────────────────────────
+
+// Refresh the MEMORY.md / CLAUDE.md projection from the just-written page. This
+// is best-effort and NON-blocking: a projection failure (over-cap, conflict,
+// unresolved project-id) must not fail the page write — the SoT is already
+// saved. We surface a one-line stderr warning and let the user reconcile.
+function runProjection(args) {
+  const cli = join(SCRIPT_DIR, 'feedback-sync.mjs');
+  if (!existsSync(cli)) return;
+  // Forward --claude-home / --project-id when given so the projection targets a
+  // caller-controlled location (tests, CI) instead of always defaulting to the
+  // real ~/.claude. Omitted → feedback-sync's own defaults (the production path:
+  // ~/.claude + project-id derived from cwd).
+  const cliArgs = [cli, '--write', '--no-input', `--hypo-dir=${args.hypoDir}`];
+  if (args.claudeHome) cliArgs.push(`--claude-home=${args.claudeHome}`);
+  if (args.projectId) cliArgs.push(`--project-id=${args.projectId}`);
+  const r = spawnSync(process.execPath, cliArgs, { encoding: 'utf-8' });
+  if (r.status === 0) {
+    console.log('↪ Projection refreshed (MEMORY.md / CLAUDE.md learned-behaviors)');
+    return;
+  }
+  const detail = (r.stderr || '').trim().split('\n').slice(-1)[0] || `exit ${r.status}`;
+  console.error(
+    `⚠ feedback-sync --write did not complete cleanly (${detail}). ` +
+      `The page is saved; run \`hypomnema feedback-sync --check\` to reconcile the projection.`,
+  );
 }
 
 // ── main ─────────────────────────────────────────────────────────────────────
@@ -129,4 +333,7 @@ if (!args.entry) {
   process.exit(1);
 }
 
-writeFeedback(args.hypoDir, args.topic, args.entry, args.dryRun);
+const today = new Date().toISOString().slice(0, 10);
+const { wrote } = writeFeedback(args, today);
+
+if (wrote && !args.noSync) runProjection(args);

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -82,7 +82,7 @@ function sha256(buf) {
 // keeps running init for backwards compatibility — that's the documented
 // Path-B onboarding command. An explicit `hypomnema init` is accepted too,
 // and is stripped before flag parsing so the rest of this file is unchanged.
-const KNOWN_SUBCOMMANDS = new Set(['init', 'upgrade', 'doctor', 'uninstall']);
+const KNOWN_SUBCOMMANDS = new Set(['init', 'upgrade', 'doctor', 'uninstall', 'feedback-sync']);
 const _verb = process.argv[2];
 if (_verb && KNOWN_SUBCOMMANDS.has(_verb) && _verb !== 'init') {
   const _target = join(SCRIPT_DIR, `${_verb}.mjs`);
@@ -117,6 +117,8 @@ Commands:
                           installed package (use --check for dry-run, --apply to commit)
   doctor                  Health check: directories, files, hooks, settings.json, git
   uninstall               Remove hooks and registrations (dry-run by default; pass --apply)
+  feedback-sync           Project feedback (SoT) → MEMORY.md / CLAUDE.md learned-behaviors
+                          projection (--check default, --write to apply; ADR 0031)
 
   Running \`hypomnema\` with no command is equivalent to \`hypomnema init\`.
 

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -114,6 +114,11 @@ function collectPages(dir, root, pages = [], ignorePatterns = []) {
     if (isIgnored(full, root, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) {
+      // `_`-prefixed dirs (e.g. pages/feedback/_drafts) hold scaffolds / scratch
+      // not yet promoted to content — skip so incomplete frontmatter never errors
+      // (mirrors loadFeedbackPages in feedback-sync.mjs). `_`-prefixed *files*
+      // (e.g. _index.md) are still linted.
+      if (entry.startsWith('_')) continue;
       collectPages(full, root, pages, ignorePatterns);
     } else if (extname(entry) === '.md' && !entry.startsWith('.')) {
       pages.push({ path: full, rel: relative(root, full) });

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -75,7 +75,18 @@ const TYPE_CONDITIONAL_FIELDS = {
   'tool-eval': ['status'],
   postmortem: ['outcome'],
   learning: ['source'],
-  feedback: ['source'],
+  // feedback: ADR 0031 / fix #37 — projection SoT requires full classification
+  feedback: [
+    'status',
+    'scope',
+    'tier',
+    'targets',
+    'sensitivity',
+    'priority',
+    'memory_summary',
+    'reason',
+    'source',
+  ],
   'prompt-pattern': ['source'],
   'source-summary': ['sources'],
   'weekly-journal': ['week'],
@@ -85,6 +96,13 @@ const TYPE_ENUM_FIELDS = {
   prd: { status: ['draft', 'active', 'completed', 'cancelled', 'archived'] },
   adr: { status: ['proposed', 'accepted', 'deprecated', 'superseded'] },
   'tool-eval': { status: ['adopted', 'evaluating', 'rejected'] },
+  // feedback: ADR 0031 / fix #37 — sensitivity:private is forbidden (wiki is a
+  // git-pushed public surface)
+  feedback: {
+    status: ['active', 'superseded', 'archived'],
+    tier: ['L1', 'L2'],
+    sensitivity: ['public', 'sanitized'],
+  },
 };
 
 // ── page collector ────────────────────────────────────────────────────────────
@@ -244,6 +262,26 @@ function lintPage({ path, rel }, slugMap, tagVocab) {
           rel,
           `Invalid value for ${field} on type "${fm.type}": "${fm[field]}" (allowed: ${allowed.join(', ')})`,
         );
+      }
+    }
+  }
+
+  // feedback: scope vocabulary + conditional claude-learned fields (ADR 0031 / fix #37)
+  if (fm.type === 'feedback') {
+    const scope = fm.scope || '';
+    if (scope && scope !== 'global' && !/^project:[a-z0-9][a-z0-9-]*$/.test(scope)) {
+      issue('error', rel, `Invalid feedback scope: "${scope}" (allowed: global | project:<slug>)`);
+    }
+    const fbTargets = parseTagsField(fm.targets) || [];
+    if (fbTargets.includes('claude-learned')) {
+      for (const field of ['global_summary', 'promote_to_global']) {
+        if (!fm[field]) {
+          issue(
+            'error',
+            rel,
+            `Missing required field for feedback with targets:claude-learned: ${field}`,
+          );
+        }
       }
     }
   }

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -124,6 +124,85 @@ try {
     }
   }
 
+  step('hypomnema feedback-sync (installed) — check/write idempotency + bootstrap');
+  // Seed a fixture wiki + claude-home and exercise the feedback-sync surface
+  // through the installed CLI (proves the subcommand is routed + shipped and the
+  // Phase D bootstrap helper runs end-to-end). --check exits 1 on a fresh
+  // (un-written) projection, so use spawnSync (run() throws on non-zero).
+  const fbWiki = join(work, 'fb-wiki');
+  const fbHome = join(work, 'fb-home');
+  const fbProject = 'smoke';
+  run('mkdir', ['-p', join(fbWiki, 'pages', 'feedback')]);
+  run('mkdir', ['-p', join(fbHome, 'projects', fbProject, 'memory')]);
+  writeFileSync(
+    join(fbWiki, 'hypo-config.md'),
+    '---\ntitle: config\ntype: reference\n---\n# config\n',
+  );
+  writeFileSync(
+    join(fbWiki, 'pages', 'feedback', 'smoke-rule.md'),
+    [
+      '---',
+      'title: Smoke Rule',
+      'type: feedback',
+      'status: active',
+      'scope: global',
+      'tier: L1',
+      'targets: [project-memory, claude-learned]',
+      'sensitivity: public',
+      'priority: 4',
+      'memory_summary: smoke rule for the packed CLI',
+      'global_summary: always smoke-test the packed CLI',
+      'promote_to_global: true',
+      'reason: catch packaging regressions',
+      'source: session:2026-05-21',
+      'updated: 2026-05-21',
+      '---',
+      'body',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(
+    join(fbHome, 'CLAUDE.md'),
+    '# Global\n<learned_behaviors>\n- [2026-05-20] legacy hand rule — 이유: bootstrap source\n</learned_behaviors>\n',
+  );
+  writeFileSync(join(fbHome, 'projects', fbProject, 'memory', 'MEMORY.md'), '# Memory Index\n');
+
+  const fbArgs = [`--hypo-dir=${fbWiki}`, `--claude-home=${fbHome}`, `--project-id=${fbProject}`];
+  const fbRun = (extra) =>
+    spawnSync(cliBin, ['feedback-sync', ...extra, ...fbArgs], { encoding: 'utf-8' });
+
+  const fbCheck1 = fbRun(['--check']);
+  if (fbCheck1.status !== 1) {
+    throw new Error(
+      `feedback-sync --check on fresh projection expected exit 1, got ${fbCheck1.status}`,
+    );
+  }
+  const fbWrite = fbRun(['--write']);
+  if (fbWrite.status !== 0) {
+    throw new Error(
+      `feedback-sync --write expected exit 0, got ${fbWrite.status}: ${fbWrite.stderr}`,
+    );
+  }
+  if (
+    !readFileSync(join(fbHome, 'CLAUDE.md'), 'utf-8').includes(
+      'HYPO:FEEDBACK-SYNC:START source=smoke-rule',
+    )
+  ) {
+    throw new Error('feedback-sync --write did not project the managed block into CLAUDE.md');
+  }
+  const fbCheck2 = fbRun(['--check']);
+  if (fbCheck2.status !== 0) {
+    throw new Error(
+      `feedback-sync --check after --write expected clean exit 0, got ${fbCheck2.status}`,
+    );
+  }
+  const fbBootstrap = fbRun(['--bootstrap', '--dry-run']);
+  if (fbBootstrap.status !== 0 || !/would create draft/.test(fbBootstrap.stderr)) {
+    throw new Error(
+      `feedback-sync --bootstrap --dry-run did not announce drafts (exit ${fbBootstrap.status})`,
+    );
+  }
+
   console.log('\n✓ smoke-pack passed');
   cleanupOk = true;
 } catch (err) {

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -96,6 +96,31 @@ verify_by: <question to re-check at next review>
 verify_by_date: YYYY-MM-DD
 ```
 
+### 3.1. `feedback` type — projection fields (ADR 0031)
+
+Feedback pages are the single source of truth for behavior corrections;
+`hypomnema feedback-sync` projects them one-way into Claude Code's `MEMORY.md`
+and `~/.claude/CLAUDE.md` `<learned_behaviors>`. They require:
+
+```yaml
+status: active | superseded | archived
+scope: global | project:<slug>           # global → eligible for CLAUDE.md projection
+tier: L1 | L2                            # L1 required for CLAUDE.md <learned_behaviors>
+targets: [project-memory, claude-learned] # which projection surfaces to derive
+sensitivity: public | sanitized          # `private` forbidden (wiki is git-pushed)
+priority: 1-5                            # over-cap sort key (higher first)
+memory_summary: <one line for the MEMORY.md index>
+reason: <why this rule is needed>
+source: session:YYYY-MM-DD | commit:<hash> | pr:<n> | https://...
+
+# conditional — required when `targets` includes `claude-learned`:
+global_summary: <one line for the <learned_behaviors> entry>
+promote_to_global: true                  # explicit opt-in to global projection
+```
+
+Edit the feedback page only — never hand-edit the generated
+`<!-- HYPO:FEEDBACK-SYNC:START … -->` managed blocks (sync detects tampering as a conflict).
+
 ---
 
 ## 4. Tag Vocabulary

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2070,6 +2070,124 @@ test('weekly-journal under journal/weekly missing week → error (scanDirs cover
   );
 });
 
+// feedback type — ADR 0031 / fix #37 conditional schema (#8)
+const FB_FM_OK =
+  '---\ntitle: T\ntype: feedback\nstatus: active\nscope: global\ntier: L1\n' +
+  'targets: [project-memory, claude-learned]\nsensitivity: public\npriority: 3\n' +
+  'memory_summary: m\nglobal_summary: g\npromote_to_global: true\nreason: r\n' +
+  'source: session:2026-05-20\nupdated: 2026-05-20\ntags: [feedback]\n---\nbody\n';
+
+test('feedback fully populated → no error', () => {
+  const { r } = lintWithSchema('pages/feedback/ok.md', FB_FM_OK);
+  assert.equal(r.status, 0, `expected clean, got ${r.status}: ${r.stdout}`);
+});
+
+test('feedback missing tier → error', () => {
+  const { r, out } = lintWithSchema('pages/feedback/x.md', FB_FM_OK.replace('tier: L1\n', ''));
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Missing required field for type "feedback": tier')),
+    `tier error missing: ${r.stdout}`,
+  );
+});
+
+test('feedback sensitivity:private → error (forbidden vocabulary)', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('sensitivity: public', 'sensitivity: private'),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Invalid value for sensitivity')),
+    `private sensitivity must error: ${r.stdout}`,
+  );
+});
+
+test('feedback claude-learned target without global_summary → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('global_summary: g\n', ''),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('targets:claude-learned: global_summary')),
+    `conditional global_summary error missing: ${r.stdout}`,
+  );
+});
+
+test('feedback project-memory-only target does NOT require global_summary', () => {
+  const { r } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('targets: [project-memory, claude-learned]', 'targets: [project-memory]')
+      .replace('global_summary: g\n', '')
+      .replace('promote_to_global: true\n', '')
+      .replace('scope: global', 'scope: project:hypomnema')
+      .replace('tier: L1', 'tier: L2'),
+  );
+  assert.equal(r.status, 0, `project-memory-only feedback should be clean: ${r.stdout}`);
+});
+
+test('feedback invalid scope → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('scope: global', 'scope: team'),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Invalid feedback scope')),
+    `invalid scope must error: ${r.stdout}`,
+  );
+});
+
+test('feedback status:superseded + sensitivity:sanitized → no error (allowed enums)', () => {
+  const { r } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('status: active', 'status: superseded').replace(
+      'sensitivity: public',
+      'sensitivity: sanitized',
+    ),
+  );
+  assert.equal(r.status, 0, `superseded+sanitized must be clean: ${r.stdout}`);
+});
+
+test('feedback invalid tier → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('tier: L1', 'tier: L3'),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Invalid value for tier')),
+    `invalid tier must error: ${r.stdout}`,
+  );
+});
+
+test('feedback claude-learned target without promote_to_global → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('promote_to_global: true\n', ''),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('targets:claude-learned: promote_to_global')),
+    `conditional promote_to_global error missing: ${r.stdout}`,
+  );
+});
+
+test('feedback missing targets → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('targets: [project-memory, claude-learned]\n', ''),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) =>
+      e.message.includes('Missing required field for type "feedback": targets'),
+    ),
+    `missing targets error: ${r.stdout}`,
+  );
+});
+
 suite('lint.mjs tag vocabulary + forbidden patterns');
 
 test('PascalCase tag → error', () => {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -13,6 +13,7 @@ import {
   rmSync,
   writeFileSync,
   readFileSync,
+  readdirSync,
   existsSync,
   symlinkSync,
   statSync,
@@ -4627,6 +4628,245 @@ test('feedback-sync-explicit-project-id-wins: MEMORY target present, no prompt p
     assert.equal(rep.projectIdResolved, true);
     assert.equal(rep.skipMemory, undefined, 'no skip for explicit project-id');
     assert.ok('memory' in rep.targets, 'MEMORY target present for explicit project-id');
+  });
+});
+
+// ── feedback-sync.mjs — bootstrap + import (fix #37 Phase D) ──────────────────
+
+suite('feedback-sync.mjs — bootstrap + import (fix #37 Phase D)');
+
+test('feedback-sync-bootstrap-creates-drafts: legacy surfaces → _drafts scaffolds, idempotent', () => {
+  const claudeMd =
+    '# Global\n<learned_behaviors>\n' +
+    '- [2026-05-20] always run the formatter before commit — 이유: consistency\n' +
+    '- [2026-05-19] push after every wiki commit — 이유: hook only pushes staged\n' +
+    '</learned_behaviors>\n';
+  const memoryMd =
+    '# Memory Index\n' +
+    '- [Teams usage](feedback_omc_teams_usage.md) — heavy tasks use teams\n' +
+    '- [Plain note](some_other_note.md) — not a feedback projection (skipped)\n';
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ wiki, runFb }) => {
+      const r = runFb(['--bootstrap', '--json']);
+      assert.equal(r.status, 0, r.stderr);
+      const rep = JSON.parse(r.stdout);
+      // 2 learned_behaviors + 1 feedback_* memory entry = 3; non-feedback_ entry ignored
+      assert.equal(rep.created.length, 3, `expected 3 drafts, got ${rep.created.length}`);
+      const draftsDir = join(wiki, 'pages', 'feedback', '_drafts');
+      const files = readdirSync(draftsDir);
+      assert.ok(
+        files.some((f) => f.startsWith('legacy-claude-20260520-')),
+        'claude draft slug',
+      );
+      assert.ok(files.includes('omc-teams-usage.md'), 'memory slug: feedback_ stripped, _→-');
+      assert.ok(!files.some((f) => f.includes('some-other-note')), 'non-feedback_ entry skipped');
+      const draft = readFileSync(join(draftsDir, 'omc-teams-usage.md'), 'utf-8');
+      assert.ok(draft.startsWith('<!-- HYPO:FEEDBACK-SYNC:DRAFT'), 'provenance marker present');
+      assert.ok(/^type: feedback$/m.test(draft) && /^scope:/m.test(draft), 'frontmatter scaffold');
+      // idempotent: second run creates nothing, all skipped as draft-exists
+      const r2 = JSON.parse(runFb(['--bootstrap', '--json']).stdout);
+      assert.equal(r2.created.length, 0, 'second bootstrap creates nothing');
+      assert.ok(
+        r2.skipped.length >= 3 && r2.skipped.every((s) => s.reason === 'draft-exists'),
+        'all skipped as draft-exists',
+      );
+    },
+    { claudeMd, memoryMd },
+  );
+});
+
+test('feedback-sync-bootstrap-dry-run-writes-nothing: --dry-run reports but creates no files', () => {
+  const claudeMd =
+    '# Global\n<learned_behaviors>\n- [2026-05-20] a rule — 이유: x\n</learned_behaviors>\n';
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ wiki, runFb }) => {
+      const rep = JSON.parse(runFb(['--bootstrap', '--dry-run', '--json']).stdout);
+      assert.equal(rep.dryRun, true);
+      assert.ok(rep.created.length >= 1, 'dry-run still reports planned drafts');
+      assert.ok(!existsSync(join(wiki, 'pages', 'feedback', '_drafts')), 'no _drafts dir written');
+    },
+    { claudeMd },
+  );
+});
+
+test('feedback-sync-import-target-change: hand-edited block → draft, SoT page untouched', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ wiki, claudeHome, runFb }) => {
+    runFb(['--write']); // project rule-a into CLAUDE.md
+    const p = join(claudeHome, 'CLAUDE.md');
+    writeFileSync(p, readFileSync(p, 'utf-8').replace('always do A', 'HAND EDITED externally'));
+    assert.equal(runFb(['--check']).status, 3, 'precondition: conflict detected');
+    const r = runFb(['--import-target-change', '--from=claude', '--json']);
+    assert.equal(r.status, 0, r.stderr);
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.imported.length, 1);
+    assert.equal(rep.imported[0].slug, 'rule-a');
+    const draftsDir = join(wiki, 'pages', 'feedback', '_drafts');
+    const f = readdirSync(draftsDir).find((x) => x.startsWith('rule-a.import-'));
+    assert.ok(f, 'import draft created with import-<date> suffix');
+    assert.ok(
+      readFileSync(join(draftsDir, f), 'utf-8').includes('HAND EDITED externally'),
+      'draft captures the hand-edited content',
+    );
+    assert.ok(
+      !readFileSync(join(wiki, 'pages', 'feedback', 'rule-a.md'), 'utf-8').includes('HAND EDITED'),
+      'pages/feedback/rule-a.md (SoT) must not be modified',
+    );
+  });
+});
+
+test('feedback-sync-import-no-conflict-noop: clean target imports nothing, exit 0', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runFb }) => {
+    runFb(['--write']);
+    const r = runFb(['--import-target-change', '--from=claude', '--json']);
+    assert.equal(r.status, 0);
+    assert.equal(JSON.parse(r.stdout).imported.length, 0, 'no conflict → nothing imported');
+  });
+});
+
+test('feedback-sync-import-bad-from-errors: missing/invalid --from → exit 1', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runFb }) => {
+    assert.equal(runFb(['--import-target-change']).status, 1, 'missing --from rejected');
+    assert.equal(
+      runFb(['--import-target-change', '--from=bogus']).status,
+      1,
+      'invalid --from rejected',
+    );
+  });
+});
+
+test('feedback-sync-bootstrap-traversal-slug-stays-in-drafts: MEMORY ../ neutralized, pure-dots rejected', () => {
+  // codex BLOCKER regression: a crafted `feedback_../escaped.md` must NOT escape
+  // _drafts into pages/feedback/. basename() collapses traversal to the final
+  // segment; a slug that reduces to nothing (`..`) is rejected as unsafe-slug.
+  const memoryMd =
+    '# Memory Index\n' +
+    '- [Evil](feedback_../escaped.md) — traversal collapses to basename\n' +
+    '- [Dots](feedback_...md) — reduces to nothing, rejected\n';
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ wiki, runFb }) => {
+      const rep = JSON.parse(runFb(['--bootstrap', '--json']).stdout);
+      assert.ok(
+        !existsSync(join(wiki, 'pages', 'feedback', 'escaped.md')),
+        'must not escape into pages/feedback/',
+      );
+      assert.ok(
+        existsSync(join(wiki, 'pages', 'feedback', '_drafts', 'escaped.md')),
+        'traversal neutralized to a draft under _drafts',
+      );
+      assert.ok(
+        rep.skipped.some((s) => s.reason === 'unsafe-slug'),
+        'pure-dots slug rejected as unsafe-slug',
+      );
+    },
+    { memoryMd },
+  );
+});
+
+test('feedback-sync-bootstrap-skips-managed-memory-block: projected MEMORY entries not re-drafted', () => {
+  // codex IMPORTANT regression: parseMemoryIndex must scrub HYPO:FEEDBACK-SYNC
+  // managed regions (parity with parseLearnedBehaviors) so already-projected
+  // index lines are not resurrected as legacy drafts.
+  const memoryMd =
+    '# Memory Index\n' +
+    `<!-- HYPO:FEEDBACK-SYNC:START source=managed-x sha256=${'a'.repeat(64)} -->\n` +
+    '- [Managed X](feedback_managed_x.md) — already projected\n' +
+    '<!-- HYPO:FEEDBACK-SYNC:END -->\n' +
+    '- [Loose Y](feedback_loose_y.md) — legacy hand entry\n';
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ wiki, runFb }) => {
+      runFb(['--bootstrap']);
+      const draftsDir = join(wiki, 'pages', 'feedback', '_drafts');
+      const drafts = existsSync(draftsDir) ? readdirSync(draftsDir) : [];
+      assert.ok(drafts.includes('loose-y.md'), 'loose legacy MEMORY entry is drafted');
+      assert.ok(!drafts.includes('managed-x.md'), 'managed-block entry must NOT be re-drafted');
+    },
+    { memoryMd },
+  );
+});
+
+test('feedback-sync-import-traversal-source-stays-in-drafts: tampered source= neutralized', () => {
+  // codex BLOCKER regression: a tampered `source=../escaped` managed marker must
+  // not let --import write outside _drafts.
+  const claudeMd =
+    '# Global\n<learned_behaviors>\n' +
+    `<!-- HYPO:FEEDBACK-SYNC:START source=../escaped sha256=${'0'.repeat(64)} -->\n` +
+    'tampered inner content\n' +
+    '<!-- HYPO:FEEDBACK-SYNC:END -->\n' +
+    '</learned_behaviors>\n';
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ wiki, runFb }) => {
+      const r = runFb(['--import-target-change', '--from=claude', '--json']);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(
+        !readdirSync(join(wiki, 'pages', 'feedback')).some((f) => f.includes('escaped')),
+        'nothing named escaped at pages/feedback top level',
+      );
+      assert.ok(
+        readdirSync(join(wiki, 'pages', 'feedback', '_drafts')).some((f) =>
+          f.startsWith('escaped.import-claude-'),
+        ),
+        'tampered source neutralized into _drafts',
+      );
+    },
+    { claudeMd },
+  );
+});
+
+test('feedback-sync-import-no-clobber: re-import same day preserves the prior draft', () => {
+  // codex IMPORTANT regression: a same-day re-import (or human-edited draft) must
+  // not be overwritten — the writer picks a collision-free numbered name.
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ wiki, claudeHome, runFb }) => {
+    runFb(['--write']);
+    const p = join(claudeHome, 'CLAUDE.md');
+    writeFileSync(p, readFileSync(p, 'utf-8').replace('always do A', 'HAND EDITED'));
+    runFb(['--import-target-change', '--from=claude']);
+    const draftsDir = join(wiki, 'pages', 'feedback', '_drafts');
+    const first = readdirSync(draftsDir).find((x) => x.startsWith('rule-a.import-claude-'));
+    writeFileSync(join(draftsDir, first), 'HUMAN RECONCILED');
+    runFb(['--import-target-change', '--from=claude']); // second import, same day
+    assert.equal(
+      readFileSync(join(draftsDir, first), 'utf-8'),
+      'HUMAN RECONCILED',
+      'prior (human-edited) draft must be preserved',
+    );
+    assert.equal(
+      readdirSync(draftsDir).filter((x) => x.startsWith('rule-a.import-claude-')).length,
+      2,
+      'second import created a new numbered draft, not a clobber',
+    );
+  });
+});
+
+test('feedback-sync-existing-9-pages-pass-new-schema: schema-complete pages lint green + parse', () => {
+  // 9 schema-complete feedback pages (mirroring the canonical frontmatter the
+  // real wiki ships) must pass the new feedback conditional-required lint AND be
+  // parsed by feedback-sync without error. Hermetic — no dependency on ~/hypomnema
+  // (§8.13 verification #4 dogfooding, expressed as a hermetic regression guard).
+  const pages = {};
+  for (let i = 1; i <= 7; i++)
+    pages[`global-${i}`] = {
+      ...FB_GLOBAL_L1,
+      title: `Global ${i}`,
+      global_summary: `g${i}`,
+      memory_summary: `m${i}`,
+    };
+  for (let i = 1; i <= 2; i++)
+    pages[`proj-${i}`] = { ...FB_PROJECT_L2, title: `Proj ${i}`, memory_summary: `pm${i}` };
+  withFeedbackEnv(pages, ({ wiki, runFb }) => {
+    const lint = run('lint.mjs', [`--hypo-dir=${wiki}`]);
+    assert.equal(
+      lint.status,
+      0,
+      `lint must pass schema-complete feedback pages:\n${lint.stdout}${lint.stderr}`,
+    );
+    const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+    assert.equal(rep.targets.claude.candidates, 7, 'L1 global pages reach CLAUDE');
+    assert.equal(rep.targets.memory.candidates, 9, 'all 9 reach MEMORY');
   });
 });
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -4801,6 +4801,199 @@ test('doctor-derived-missing-project-id: unresolved warn, not a misleading stale
   });
 });
 
+// ── feedback.mjs — /hypo:feedback page writer (fix #37 Phase C) ───────────────
+// feedback.mjs must emit lint #8-complete frontmatter so the page is a valid
+// projection SoT, and must reject incomplete classification rather than write a
+// page lint would later block. --no-sync keeps these tests from touching
+// ~/.claude (the projection post-step is exercised manually / in feedback-sync).
+suite('feedback.mjs — /hypo:feedback page writer (fix #37 Phase C)');
+
+function withFeedbackWriterWiki(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-fbw-'));
+  try {
+    mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('feedback.mjs create: full classification → page written + lint-clean', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [
+      '--topic=test-rule',
+      '--entry=항상 X를 한다.',
+      '--scope=global',
+      '--tier=L1',
+      '--targets=project-memory,claude-learned',
+      '--priority=4',
+      '--memory-summary=X를 항상 수행',
+      '--global-summary=항상 X 수행',
+      '--promote-to-global',
+      '--reason=Y 실수 방지',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+    ]);
+    assert.equal(r.status, 0, `feedback create failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'test-rule.md'), 'utf-8');
+    for (const f of [
+      'type: feedback',
+      'status: active',
+      'scope: global',
+      'tier: L1',
+      'targets: [project-memory, claude-learned]',
+      'sensitivity: public',
+      'priority: 4',
+      'memory_summary:',
+      'global_summary:',
+      'promote_to_global: true',
+      'reason:',
+      'source:',
+    ]) {
+      assert.ok(page.includes(f), `frontmatter missing "${f}":\n${page}`);
+    }
+    // lint #8 must accept the generated page (zero errors)
+    const lint = run('lint.mjs', ['--json', `--hypo-dir=${dir}`]);
+    const report = JSON.parse(lint.stdout);
+    assert.equal(report.errors.length, 0, `lint errors on generated page: ${lint.stdout}`);
+  });
+});
+
+test('feedback.mjs create: projection post-step targets --claude-home (no ~/.claude touch)', () => {
+  withFeedbackWriterWiki((dir) => {
+    // Isolated projection target: --claude-home keeps the post-step out of the
+    // real ~/.claude. Proves the auto `feedback-sync --write` runs and projects.
+    const cHome = mkdtempSync(join(tmpdir(), 'hypo-fbw-claude-'));
+    try {
+      mkdirSync(join(cHome, 'projects', 'pid', 'memory'), { recursive: true });
+      writeFileSync(
+        join(cHome, 'CLAUDE.md'),
+        '# Global\n<learned_behaviors>\n</learned_behaviors>\n',
+      );
+      writeFileSync(join(cHome, 'projects', 'pid', 'memory', 'MEMORY.md'), '# Memory Index\n');
+      const r = run('feedback.mjs', [
+        '--topic=proj-rule',
+        '--entry=항상 P를 한다.',
+        '--scope=global',
+        '--tier=L1',
+        '--targets=project-memory,claude-learned',
+        '--priority=5',
+        '--memory-summary=P 수행',
+        '--global-summary=항상 P',
+        '--promote-to-global',
+        '--reason=Q 방지',
+        `--claude-home=${cHome}`,
+        '--project-id=pid',
+        `--hypo-dir=${dir}`,
+      ]);
+      assert.equal(r.status, 0, `feedback create+sync failed: ${r.stderr}`);
+      const claudeMd = readFileSync(join(cHome, 'CLAUDE.md'), 'utf-8');
+      assert.ok(
+        claudeMd.includes('HYPO:FEEDBACK-SYNC:START source=proj-rule'),
+        `projection should write a managed block:\n${claudeMd}`,
+      );
+    } finally {
+      rmSync(cHome, { recursive: true, force: true });
+    }
+  });
+});
+
+test('feedback.mjs create: missing --memory-summary → exit 1, no page', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [
+      '--topic=incomplete',
+      '--entry=무언가',
+      '--scope=global',
+      '--tier=L2',
+      '--targets=project-memory',
+      '--reason=이유',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+    ]);
+    assert.equal(r.status, 1, 'incomplete classification must fail');
+    assert.ok(/memory-summary/.test(r.stderr), `error should name the missing field: ${r.stderr}`);
+    assert.ok(
+      !existsSync(join(dir, 'pages', 'feedback', 'incomplete.md')),
+      'no page should be written on validation failure',
+    );
+  });
+});
+
+test('feedback.mjs create: claude-learned with project scope → exit 1 (ADR 0031 §6)', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [
+      '--topic=mis-scoped',
+      '--entry=무언가',
+      '--scope=project:foo',
+      '--tier=L1',
+      '--targets=project-memory,claude-learned',
+      '--priority=3',
+      '--memory-summary=요약',
+      '--global-summary=전역요약',
+      '--promote-to-global',
+      '--reason=이유',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+    ]);
+    assert.equal(r.status, 1, 'claude-learned requires scope=global');
+    assert.ok(/scope=global/.test(r.stderr), `error should explain the §6 filter: ${r.stderr}`);
+  });
+});
+
+test('feedback.mjs create: newline in a scalar cannot inject a frontmatter key', () => {
+  // Regression (codex review): raw interpolation let a value with an embedded
+  // newline forge a frontmatter key (e.g. reason="legit\nstatus: archived").
+  // oneLine() collapses whitespace so the injected text stays on the value line.
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [
+      '--topic=inject',
+      '--entry=rule body',
+      '--scope=global',
+      '--tier=L2',
+      '--targets=project-memory',
+      '--priority=3',
+      '--memory-summary=ok',
+      '--reason=legit\nstatus: archived',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+    ]);
+    assert.equal(r.status, 0, `create failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'inject.md'), 'utf-8');
+    const fm = page.split('---')[1];
+    assert.ok(/^status: active$/m.test(fm), 'real status must stay active');
+    assert.ok(!/^status: archived$/m.test(fm), 'injected key must NOT appear as its own line');
+    assert.ok(/^reason: legit status: archived$/m.test(fm), 'newline collapsed into the value');
+  });
+});
+
+test('feedback.mjs append: bumpUpdated leaves a body "updated:" line untouched', () => {
+  // Regression (codex review): a multiline replace would rewrite a body line
+  // starting with "updated:". bumpUpdated must only touch the frontmatter fence.
+  withFeedbackWriterWiki((dir) => {
+    const p = join(dir, 'pages', 'feedback', 'existing.md');
+    writeFileSync(
+      p,
+      '---\ntitle: x\ntype: feedback\nupdated: 2020-01-01\n---\n\n# x\n\nupdated: 2019-12-31 (body line)\n',
+    );
+    const r = run('feedback.mjs', [
+      '--topic=existing',
+      '--entry=new dated entry',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+    ]);
+    assert.equal(r.status, 0, `append failed: ${r.stderr}`);
+    const out = readFileSync(p, 'utf-8');
+    assert.ok(out.includes('updated: 2019-12-31 (body line)'), 'body updated: line preserved');
+    const today = new Date().toISOString().slice(0, 10);
+    const fm = out.split('\n---')[0];
+    assert.ok(
+      new RegExp(`^updated: ${today}$`, 'm').test(fm),
+      'frontmatter updated bumped to today',
+    );
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -17,6 +17,7 @@ import {
   symlinkSync,
   statSync,
   unlinkSync,
+  cpSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -4509,7 +4510,9 @@ suite('feedback-sync.mjs — project-id fallback (fix #37 #10)');
 // NO hang. The child has no controlling TTY under spawnSync, so this IS the
 // non-interactive proof. --no-input makes it explicit + belt-and-suspenders.
 test('feedback-sync-no-input-non-tty: derived-missing project-id skips MEMORY, exit 0, no hang', () => {
-  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ wiki, claudeHome }) => {
+  // MEMORY-only fixture (project-scoped, no CLAUDE candidate) so the clean run
+  // genuinely exits 0 — proving the non-TTY skip path AND a clean exit code.
+  withFeedbackEnv({ 'rule-b': FB_PROJECT_L2 }, ({ wiki, claudeHome }) => {
     const r = run('feedback-sync.mjs', [
       '--check',
       '--no-input',
@@ -4520,6 +4523,7 @@ test('feedback-sync-no-input-non-tty: derived-missing project-id skips MEMORY, e
     ]);
     // spawnSync returns (no timeout), proving the non-TTY path never blocks.
     assert.equal(r.signal, null, 'process must exit on its own (no hang/kill)');
+    assert.equal(r.status, 0, `clean MEMORY-only run must exit 0: ${r.stderr}`);
     const rep = JSON.parse(r.stdout);
     assert.equal(rep.projectIdResolved, false);
     assert.equal(rep.skipMemory, true, 'skipMemory flag surfaced in report');
@@ -4644,6 +4648,70 @@ await testAsync('resolveProjectId: non-TTY never prompts (hook/CI safety)', asyn
   );
   assert.equal(called, false, 'non-TTY must never call prompt');
   assert.equal(r.skipMemory, true);
+});
+
+// ── integration-review fixes (entry guard, doctor project-id) ────────────────
+
+suite('feedback-sync.mjs / doctor.mjs — integration review fixes (fix #37)');
+
+test('feedback-sync-entry-guard-tolerates-space-in-path: CLI runs, not a silent no-op', () => {
+  // a path with a space: raw `file://${argv[1]}` mismatches the percent-encoded
+  // import.meta.url, so the pre-fix entry guard skipped main() and exited 0 silently.
+  const base = mkdtempSync(join(tmpdir(), 'hypo fb space-'));
+  try {
+    cpSync(SCRIPTS, join(base, 'scripts'), { recursive: true }); // incl. lib/ for relative imports
+    const wiki = join(base, 'wiki');
+    mkdirSync(join(wiki, 'pages', 'feedback'), { recursive: true });
+    writeFileSync(join(wiki, 'hypo-config.md'), '# config');
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(base, 'scripts', 'feedback-sync.mjs'),
+        '--check',
+        '--json',
+        '--no-input',
+        `--hypo-dir=${wiki}`,
+        `--claude-home=${join(base, 'claude')}`,
+        `--cwd=${join(tmpdir(), 'no-such-cwd')}`,
+      ],
+      { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+    );
+    assert.ok(
+      r.stdout.trim().length > 0,
+      `CLI must produce output even from a spaced path (entry guard): ${JSON.stringify({ status: r.status, stdout: r.stdout, stderr: r.stderr })}`,
+    );
+    const rep = JSON.parse(r.stdout);
+    assert.ok('claude' in rep.targets, 'a real report must be produced');
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('doctor-derived-missing-project-id: unresolved warn, not a misleading stale warn', () => {
+  withDoctorFeedbackEnv({ 'rule-b': FB_PROJECT_L2 }, ({ wiki, claudeHome }) => {
+    // run doctor from a cwd whose derived project dir does not exist, WITHOUT
+    // --project-id — doctor must forward neither, letting feedback-sync skip MEMORY.
+    const noCwd = mkdtempSync(join(tmpdir(), 'hypo-doc-nocwd-'));
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'doctor.mjs'), `--hypo-dir=${wiki}`, `--claude-home=${claudeHome}`, '--json'],
+      {
+        encoding: 'utf-8',
+        cwd: noCwd,
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    rmSync(noCwd, { recursive: true, force: true });
+    const fb = JSON.parse(r.stdout).filter((c) => c.label.startsWith('Feedback projection'));
+    assert.ok(
+      fb.some((c) => c.status === 'warn' && /unresolved|skipped/i.test(c.detail || '')),
+      `expected unresolved/skipped warn: ${JSON.stringify(fb)}`,
+    );
+    assert.ok(
+      !fb.some((c) => /feedback-sync --write/.test(c.detail || '')),
+      `must NOT emit a stale-projection warn when project-id is unresolved: ${JSON.stringify(fb)}`,
+    );
+  });
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -4067,6 +4067,71 @@ const FB_PROJECT_L2 = {
   updated: '2026-05-19',
 };
 
+// ── hypo-personal-check.mjs — feedback projection gate (fix #37 Phase C) ──────
+// The PreCompact gate runs `feedback-sync --check --strict`; projection drift
+// must surface as a block, but only when PKG_ROOT resolves (a custom HOME with
+// hypo-pkg.json). The single-blocking-gate invariant (spec §7.5) means this is
+// integrated into hypo-personal-check, not a separate hook.
+suite('hypo-personal-check.mjs — feedback projection gate (fix #37 Phase C)');
+
+test('feedback projection drift → block names feedback projection', () => {
+  withWiki(
+    (dir) => {
+      // A global-L1 page is a CLAUDE projection candidate; the controlled
+      // CLAUDE.md below has an empty <learned_behaviors> with no managed region
+      // yet, so `--check` sees the projection as stale → exit 1.
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'feedback', 'rule-a.md'), fbPage(FB_GLOBAL_L1));
+    },
+    (dir) => {
+      // Custom HOME so the hook's PKG_ROOT resolves (enabling the feedback
+      // check) and the projection target is a controlled empty CLAUDE.md.
+      const home = mkdtempSync(join(tmpdir(), 'hypo-fbhook-home-'));
+      try {
+        mkdirSync(join(home, '.claude'), { recursive: true });
+        writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+        writeFileSync(
+          join(home, '.claude', 'CLAUDE.md'),
+          '# Global\n<learned_behaviors>\n</learned_behaviors>\n',
+        );
+        const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+        const out = JSON.parse(r.stdout);
+        assert.equal(out.decision, 'block', `expected block, got: ${r.stdout}`);
+        assert.ok(
+          out.reason.includes('feedback projection'),
+          `block reason should name feedback projection: ${out.reason}`,
+        );
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+test('feedback gate: memory clean + missing CLAUDE.md → fail-open (no false block)', () => {
+  // Regression (codex review): the prior `every(buildError)` predicate blocked
+  // when the memory target was clean but the claude target only had a buildError
+  // (e.g. ~/.claude/CLAUDE.md never created). With no feedback pages the memory
+  // target has 0 candidates (clean) and the missing CLAUDE.md is benign — the
+  // gate must fail-open, not report drift.
+  withWiki(null, (dir) => {
+    const home = mkdtempSync(join(tmpdir(), 'hypo-fbgate-home-'));
+    try {
+      const derivedId = process.cwd().replace(/[/.]/g, '-');
+      const memDir = join(home, '.claude', 'projects', derivedId, 'memory');
+      mkdirSync(memDir, { recursive: true });
+      writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+      writeFileSync(join(memDir, 'MEMORY.md'), '# Memory Index\n');
+      // intentionally NO CLAUDE.md → claude target buildError
+      const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.continue, true, `missing CLAUDE.md must not block: ${r.stdout}`);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 suite('feedback-sync.mjs — ADR 0031 / fix #37 Phase A');
 
 test('feedback-sync-check-detects-drift: fresh projection targets are dirty → exit 1', () => {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -21,6 +21,9 @@ import {
 import { join, dirname } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+// static import (no top-level await) — feedback-sync.mjs guards main() behind an
+// entry check, so importing it for unit tests does not run the CLI.
+import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync.mjs';
 
 const HOME = homedir();
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -4496,6 +4499,151 @@ test('tampered managed block (conflict) → fail Feedback projection integrity',
     );
     assert.equal(r.status, 1, 'doctor exits 1 when any check fails');
   });
+});
+
+// ── feedback-sync.mjs — project-id fallback (fix #37 #10) ─────────────────────
+
+suite('feedback-sync.mjs — project-id fallback (fix #37 #10)');
+
+// Non-TTY / hook / CI path: derived dir missing → skip MEMORY, exit 0, NO prompt,
+// NO hang. The child has no controlling TTY under spawnSync, so this IS the
+// non-interactive proof. --no-input makes it explicit + belt-and-suspenders.
+test('feedback-sync-no-input-non-tty: derived-missing project-id skips MEMORY, exit 0, no hang', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ wiki, claudeHome }) => {
+    const r = run('feedback-sync.mjs', [
+      '--check',
+      '--no-input',
+      '--json',
+      `--hypo-dir=${wiki}`,
+      `--claude-home=${claudeHome}`,
+      `--cwd=${join(tmpdir(), 'no-such-cwd-xyz')}`,
+    ]);
+    // spawnSync returns (no timeout), proving the non-TTY path never blocks.
+    assert.equal(r.signal, null, 'process must exit on its own (no hang/kill)');
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.projectIdResolved, false);
+    assert.equal(rep.skipMemory, true, 'skipMemory flag surfaced in report');
+    assert.equal(rep.targets.memory, undefined, 'MEMORY skipped on unresolved project-id');
+    assert.ok('claude' in rep.targets, 'claude target still evaluated');
+  });
+});
+
+// Explicit --project-id always wins, no prompt, MEMORY present even on TTY-less run.
+test('feedback-sync-explicit-project-id-wins: MEMORY target present, no prompt path', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runFb }) => {
+    const r = runFb(['--check', '--json']); // withFeedbackEnv passes a valid --project-id
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.projectIdResolved, true);
+    assert.equal(rep.skipMemory, undefined, 'no skip for explicit project-id');
+    assert.ok('memory' in rep.targets, 'MEMORY target present for explicit project-id');
+  });
+});
+
+// Injected-prompt unit tests: drive resolveProjectId() directly with isTTY:true
+// and a fake prompt, exercising the interactive branches without a real TTY.
+await testAsync(
+  'resolveProjectId: explicit --project-id resolves without calling prompt',
+  async () => {
+    let called = false;
+    const r = await fbResolveProjectId(
+      { projectId: 'explicit-id', claudeHome: '/no/such', cwd: '/x', noInput: false },
+      {
+        isTTY: true,
+        prompt: () => {
+          called = true;
+          return { action: 'confirm' };
+        },
+      },
+    );
+    assert.equal(r.id, 'explicit-id');
+    assert.equal(r.skipMemory, false);
+    assert.equal(called, false, 'explicit project-id must not prompt');
+  },
+);
+
+await testAsync('resolveProjectId: derived dir exists resolves without prompting', async () => {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-rpid-'));
+  try {
+    const claudeHome = join(base, 'claude');
+    const id = '-x'; // matches cwd "/x" → "/x".replace(/[/.]/g,'-') === "-x"
+    mkdirSync(join(claudeHome, 'projects', id), { recursive: true });
+    const r = await fbResolveProjectId(
+      { projectId: null, claudeHome, cwd: '/x', noInput: false },
+      {
+        isTTY: true,
+        prompt: () => {
+          throw new Error('prompt must not be called when derived dir exists');
+        },
+      },
+    );
+    assert.equal(r.id, id);
+    assert.equal(r.exists, true);
+    assert.equal(r.skipMemory, false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+await testAsync(
+  'resolveProjectId: prompt "confirm" accepts derived id, MEMORY not skipped',
+  async () => {
+    const r = await fbResolveProjectId(
+      { projectId: null, claudeHome: '/no/such', cwd: '/some/path', noInput: false },
+      { isTTY: true, prompt: () => ({ action: 'confirm' }) },
+    );
+    assert.equal(r.id, '-some-path');
+    assert.equal(r.skipMemory, false, 'confirm includes MEMORY despite missing dir');
+  },
+);
+
+await testAsync('resolveProjectId: prompt "id" returns chosen id, MEMORY not skipped', async () => {
+  const r = await fbResolveProjectId(
+    { projectId: null, claudeHome: '/no/such', cwd: '/some/path', noInput: false },
+    { isTTY: true, prompt: () => ({ action: 'id', id: 'chosen-id' }) },
+  );
+  assert.equal(r.id, 'chosen-id');
+  assert.equal(r.derived, false, 'user-entered id is treated as explicit');
+  assert.equal(r.skipMemory, false, 'chosen id still projects MEMORY (created on --write)');
+});
+
+await testAsync('resolveProjectId: prompt "skip" sets skipMemory', async () => {
+  const r = await fbResolveProjectId(
+    { projectId: null, claudeHome: '/no/such', cwd: '/some/path', noInput: false },
+    { isTTY: true, prompt: () => ({ action: 'skip' }) },
+  );
+  assert.equal(r.skipMemory, true);
+});
+
+await testAsync('resolveProjectId: --no-input never prompts even with isTTY true', async () => {
+  let called = false;
+  const r = await fbResolveProjectId(
+    { projectId: null, claudeHome: '/no/such', cwd: '/some/path', noInput: true },
+    {
+      isTTY: true,
+      prompt: () => {
+        called = true;
+        return { action: 'confirm' };
+      },
+    },
+  );
+  assert.equal(called, false, '--no-input must short-circuit before prompting');
+  assert.equal(r.skipMemory, true);
+});
+
+await testAsync('resolveProjectId: non-TTY never prompts (hook/CI safety)', async () => {
+  let called = false;
+  const r = await fbResolveProjectId(
+    { projectId: null, claudeHome: '/no/such', cwd: '/some/path', noInput: false },
+    {
+      isTTY: false,
+      prompt: () => {
+        called = true;
+        return { action: 'confirm' };
+      },
+    },
+  );
+  assert.equal(called, false, 'non-TTY must never call prompt');
+  assert.equal(r.skipMemory, true);
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -4391,6 +4391,113 @@ test('feedback-sync-write-strict-refuses-before-write: strict warning blocks the
   );
 });
 
+// ── doctor.mjs — feedback projection (fix #37 #9) ────────────────────────────
+
+// Build a wiki + claude-home with feedback pages, then run doctor wired to the
+// same --claude-home/--project-id used by feedback-sync. Returns the parsed
+// `Feedback projection` check entries (doctor's other checks fire on the
+// synthetic wiki, so assert on the entry, not the process exit code).
+function withDoctorFeedbackEnv(pages, fn, { claudeMd, memoryMd } = {}) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-doc-fb-'));
+  const wiki = join(base, 'wiki');
+  const claudeHome = join(base, 'claude');
+  const projectId = 'proj';
+  const memDir = join(claudeHome, 'projects', projectId, 'memory');
+  try {
+    mkdirSync(join(wiki, 'pages', 'feedback'), { recursive: true });
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(join(wiki, 'hypo-config.md'), '# config');
+    for (const [slug, fields] of Object.entries(pages)) {
+      writeFileSync(join(wiki, 'pages', 'feedback', `${slug}.md`), fbPage(fields));
+    }
+    writeFileSync(
+      join(claudeHome, 'CLAUDE.md'),
+      claudeMd ?? '# Global\n<learned_behaviors>\n- manual entry\n</learned_behaviors>\n',
+    );
+    writeFileSync(join(memDir, 'MEMORY.md'), memoryMd ?? '# Memory Index\n');
+    const runFb = (args) =>
+      run('feedback-sync.mjs', [
+        ...args,
+        `--hypo-dir=${wiki}`,
+        `--claude-home=${claudeHome}`,
+        `--project-id=${projectId}`,
+      ]);
+    const runDoctor = () => {
+      const r = run('doctor.mjs', [
+        `--hypo-dir=${wiki}`,
+        `--claude-home=${claudeHome}`,
+        `--project-id=${projectId}`,
+        '--json',
+      ]);
+      const checks = JSON.parse(r.stdout);
+      return {
+        r,
+        checks,
+        fb: checks.filter((c) => c.label.startsWith('Feedback projection')),
+      };
+    };
+    fn({ base, wiki, claudeHome, projectId, memDir, runFb, runDoctor });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+suite('doctor.mjs — feedback projection (fix #37 #9)');
+
+test('clean (post --write) projection → pass, no fail entry', () => {
+  withDoctorFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runFb, runDoctor }) => {
+    assert.equal(runFb(['--write']).status, 0, 'seed write must succeed');
+    const { fb } = runDoctor();
+    assert.ok(fb.length >= 1, 'expected a Feedback projection check entry');
+    assert.ok(
+      fb.every((c) => c.status !== 'fail'),
+      `clean projection must not fail: ${JSON.stringify(fb)}`,
+    );
+    assert.ok(
+      fb.some((c) => c.status === 'pass' && c.label === 'Feedback projection'),
+      `clean projection should pass: ${JSON.stringify(fb)}`,
+    );
+  });
+});
+
+test('no feedback pages → pass with "no projection candidates"', () => {
+  withDoctorFeedbackEnv({}, ({ runDoctor }) => {
+    const { fb } = runDoctor();
+    assert.ok(
+      fb.some((c) => c.status === 'pass' && c.detail.includes('no projection candidates')),
+      `expected no-candidates pass: ${JSON.stringify(fb)}`,
+    );
+  });
+});
+
+test('drifted projection (never written) → warn, never fail', () => {
+  withDoctorFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runDoctor }) => {
+    const { fb } = runDoctor();
+    assert.ok(
+      fb.every((c) => c.status !== 'fail'),
+      `drift must be warn not fail: ${JSON.stringify(fb)}`,
+    );
+    assert.ok(
+      fb.some((c) => c.status === 'warn' && c.detail.includes('feedback-sync --write')),
+      `expected stale-projection warn: ${JSON.stringify(fb)}`,
+    );
+  });
+});
+
+test('tampered managed block (conflict) → fail Feedback projection integrity', () => {
+  withDoctorFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runFb, claudeHome, runDoctor }) => {
+    runFb(['--write']);
+    const cp = join(claudeHome, 'CLAUDE.md');
+    writeFileSync(cp, readFileSync(cp, 'utf-8').replace('always do A', 'HAND EDITED'));
+    const { r, fb } = runDoctor();
+    assert.ok(
+      fb.some((c) => c.status === 'fail' && c.label === 'Feedback projection integrity'),
+      `conflict must fail: ${JSON.stringify(fb)}`,
+    );
+    assert.equal(r.status, 1, 'doctor exits 1 when any check fails');
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3558,8 +3558,14 @@ test('replay-auto-minimal-crystallize-on-incomplete-close: mutating + no marker 
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block', `must block, got: ${JSON.stringify(out)}`);
-    assert.ok(/WIKI_AUTOCLOSE/.test(out.reason), `reason must mention WIKI_AUTOCLOSE: ${out.reason}`);
-    assert.ok(/\/hypo:crystallize/.test(out.reason), 'reason must point at /hypo:crystallize skill');
+    assert.ok(
+      /WIKI_AUTOCLOSE/.test(out.reason),
+      `reason must mention WIKI_AUTOCLOSE: ${out.reason}`,
+    );
+    assert.ok(
+      /\/hypo:crystallize/.test(out.reason),
+      'reason must point at /hypo:crystallize skill',
+    );
     assert.ok(out.reason.includes('s-substantial'), 'reason must embed the session_id to use');
   });
 });
@@ -3765,7 +3771,10 @@ test('--mark-session-closed with failing gate → exit 1, no marker', () => {
     assert.equal(r.status, 1);
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
-    assert.ok(!existsSync(join(dir, '.cache', 'session-closed-s-failgate.marker')), 'marker must not be written on failed gate');
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-failgate.marker')),
+      'marker must not be written on failed gate',
+    );
   });
 });
 
@@ -3787,7 +3796,10 @@ test('--mark-session-closed with ok gate but dirty git → exit 1, no marker (AD
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
     assert.ok(out.git_reason, `dirty-git result must carry git_reason: ${JSON.stringify(out)}`);
-    assert.ok(!existsSync(join(dir, '.cache', 'session-closed-s-dirty.marker')), 'marker must not land on dirty git');
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-dirty.marker')),
+      'marker must not land on dirty git',
+    );
   });
 });
 
@@ -3857,6 +3869,408 @@ test('--apply-session-close --session-id leaves payload uncommitted → marker N
       'apply leaves payload writes uncommitted → ADR Q2 git-clean gate skips marker until auto-commit lands',
     );
   });
+});
+
+// ── feedback-sync.mjs (ADR 0031, fix #37 Phase A) ─────────────────────────────
+
+function fbPage(fields) {
+  const fm = Object.entries(fields)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  return `---\n${fm}\n---\nbody\n`;
+}
+
+// Build a wiki + claude-home pair, seed feedback pages, run feedback-sync.
+// `pages` is { slug: fieldsObject }. Returns { dir, claudeHome, projectId, runFb(args) }.
+function withFeedbackEnv(pages, fn, { claudeMd, memoryMd } = {}) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-fb-'));
+  const wiki = join(base, 'wiki');
+  const claudeHome = join(base, 'claude');
+  const projectId = 'proj';
+  const memDir = join(claudeHome, 'projects', projectId, 'memory');
+  try {
+    mkdirSync(join(wiki, 'pages', 'feedback'), { recursive: true });
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(join(wiki, 'hypo-config.md'), '# config');
+    for (const [slug, fields] of Object.entries(pages)) {
+      writeFileSync(join(wiki, 'pages', 'feedback', `${slug}.md`), fbPage(fields));
+    }
+    writeFileSync(
+      join(claudeHome, 'CLAUDE.md'),
+      claudeMd ?? '# Global\n<learned_behaviors>\n- manual entry\n</learned_behaviors>\n',
+    );
+    writeFileSync(join(memDir, 'MEMORY.md'), memoryMd ?? '# Memory Index\n');
+    const runFb = (args) =>
+      run('feedback-sync.mjs', [
+        ...args,
+        `--hypo-dir=${wiki}`,
+        `--claude-home=${claudeHome}`,
+        `--project-id=${projectId}`,
+      ]);
+    fn({ base, wiki, claudeHome, projectId, memDir, runFb });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+const FB_GLOBAL_L1 = {
+  title: 'Rule A',
+  type: 'feedback',
+  status: 'active',
+  scope: 'global',
+  tier: 'L1',
+  targets: '[project-memory, claude-learned]',
+  sensitivity: 'public',
+  priority: 5,
+  memory_summary: 'do A',
+  global_summary: 'always do A',
+  promote_to_global: true,
+  reason: 'because A',
+  source: 'session:2026-05-20',
+  updated: '2026-05-20',
+};
+
+const FB_PROJECT_L2 = {
+  title: 'Rule B',
+  type: 'feedback',
+  status: 'active',
+  scope: 'project:hypomnema',
+  tier: 'L2',
+  targets: '[project-memory]',
+  sensitivity: 'public',
+  priority: 2,
+  memory_summary: 'do B',
+  reason: 'because B',
+  source: 'session:2026-05-19',
+  updated: '2026-05-19',
+};
+
+suite('feedback-sync.mjs — ADR 0031 / fix #37 Phase A');
+
+test('feedback-sync-check-detects-drift: fresh projection targets are dirty → exit 1', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runFb }) => {
+    const r = runFb(['--check', '--json']);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}: ${r.stderr}`);
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.targets.claude.dirty, true);
+    assert.equal(rep.targets.memory.dirty, true);
+  });
+});
+
+test('feedback-sync-write-idempotent: second --write is byte-identical + post-check clean', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1, 'rule-b': FB_PROJECT_L2 },
+    ({ claudeHome, memDir, runFb }) => {
+      assert.equal(runFb(['--write']).status, 0);
+      const claude1 = readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8');
+      const mem1 = readFileSync(join(memDir, 'MEMORY.md'), 'utf-8');
+      assert.ok(claude1.includes('- manual entry'), 'manual entry must survive');
+      assert.ok(claude1.includes('HYPO:FEEDBACK-SYNC:START source=rule-a'));
+      assert.equal(runFb(['--write']).status, 0);
+      assert.equal(
+        readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8'),
+        claude1,
+        'CLAUDE.md not byte-identical',
+      );
+      assert.equal(
+        readFileSync(join(memDir, 'MEMORY.md'), 'utf-8'),
+        mem1,
+        'MEMORY.md not byte-identical',
+      );
+      assert.equal(runFb(['--check']).status, 0, 'post-write check must be clean');
+    },
+  );
+});
+
+test('feedback-sync-conflict-fails-without-merge: hand-edited block → exit 3, no overwrite', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runFb }) => {
+    runFb(['--write']);
+    const p = join(claudeHome, 'CLAUDE.md');
+    writeFileSync(p, readFileSync(p, 'utf-8').replace('always do A', 'HAND EDITED'));
+    assert.equal(runFb(['--check']).status, 3, 'check must report conflict');
+    assert.equal(runFb(['--write']).status, 3, 'write must refuse');
+    assert.ok(
+      readFileSync(p, 'utf-8').includes('HAND EDITED'),
+      'conflict block must not be auto-merged',
+    );
+  });
+});
+
+test('feedback-sync-scope-project-rejected-from-claude: project scope only reaches memory', () => {
+  withFeedbackEnv({ 'rule-b': FB_PROJECT_L2 }, ({ runFb }) => {
+    const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+    assert.equal(rep.targets.claude.candidates, 0, 'scope:project:* must be rejected from CLAUDE');
+    assert.equal(rep.targets.memory.candidates, 1, 'project scope still projects to memory');
+  });
+});
+
+test('feedback-sync-over-cap-exits-2: >10 CLAUDE candidates → exit 2', () => {
+  const pages = {};
+  for (let i = 1; i <= 11; i++) {
+    pages[`cap-${i}`] = {
+      ...FB_GLOBAL_L1,
+      title: `Cap ${i}`,
+      global_summary: `g${i}`,
+      memory_summary: `m${i}`,
+    };
+  }
+  withFeedbackEnv(pages, ({ runFb }) => {
+    const r = runFb(['--check', '--json']);
+    assert.equal(r.status, 2, `expected exit 2, got ${r.status}: ${r.stderr}`);
+    assert.equal(JSON.parse(r.stdout).targets.claude.overCap, true);
+  });
+});
+
+test('feedback-sync-write-atomic-on-conflict: stale target not written when another conflicts', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ wiki, claudeHome, memDir, runFb }) => {
+    runFb(['--write']); // both projections clean now
+    const memBefore = readFileSync(join(memDir, 'MEMORY.md'), 'utf-8');
+    // make MEMORY genuinely stale (memory_summary change only affects MEMORY render)
+    const pagePath = join(wiki, 'pages', 'feedback', 'rule-a.md');
+    writeFileSync(
+      pagePath,
+      readFileSync(pagePath, 'utf-8').replace('memory_summary: do A', 'memory_summary: do A v2'),
+    );
+    // create a CLAUDE conflict by hand-editing its managed block
+    const cp = join(claudeHome, 'CLAUDE.md');
+    writeFileSync(cp, readFileSync(cp, 'utf-8').replace('always do A', 'HAND EDITED'));
+    const r = runFb(['--write']);
+    assert.equal(r.status, 3, `expected conflict exit 3, got ${r.status}: ${r.stderr}`);
+    assert.equal(
+      readFileSync(join(memDir, 'MEMORY.md'), 'utf-8'),
+      memBefore,
+      'stale MEMORY must NOT be written when CLAUDE conflicts (atomicity)',
+    );
+  });
+});
+
+test('feedback-sync-intruder-in-region-refuses: hand line between blocks → exit 3, preserved', () => {
+  withFeedbackEnv(
+    {
+      'rule-a': FB_GLOBAL_L1,
+      'cap-x': { ...FB_GLOBAL_L1, title: 'X', global_summary: 'gx', memory_summary: 'mx' },
+    },
+    ({ claudeHome, runFb }) => {
+      runFb(['--write']);
+      const cp = join(claudeHome, 'CLAUDE.md');
+      // inject a manual line between the two managed END/START boundaries
+      const content = readFileSync(cp, 'utf-8').replace(
+        '<!-- HYPO:FEEDBACK-SYNC:END -->\n<!-- HYPO:FEEDBACK-SYNC:START',
+        '<!-- HYPO:FEEDBACK-SYNC:END -->\n- intruder line\n<!-- HYPO:FEEDBACK-SYNC:START',
+      );
+      writeFileSync(cp, content);
+      assert.equal(runFb(['--check']).status, 3, 'intruder must be flagged');
+      assert.equal(runFb(['--write']).status, 3, 'write must refuse with intruder present');
+      assert.ok(
+        readFileSync(cp, 'utf-8').includes('- intruder line'),
+        'intruder must be preserved',
+      );
+    },
+  );
+});
+
+test('feedback-sync-project-id-unknown-skips-memory: derived dir missing → no hard fail', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ wiki, claudeHome }) => {
+    const r = run('feedback-sync.mjs', [
+      '--check',
+      '--json',
+      `--hypo-dir=${wiki}`,
+      `--claude-home=${claudeHome}`,
+      `--cwd=${join(tmpdir(), 'no-such-cwd-xyz')}`,
+    ]);
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.projectIdResolved, false);
+    assert.equal(rep.targets.memory, undefined, 'memory target skipped when project-id unresolved');
+    assert.ok('claude' in rep.targets, 'claude target still evaluated');
+  });
+});
+
+// ── codex review fixes (HIGH-1..4 / MEDIUM-1) ─────────────────────────────────
+
+test('feedback-sync-crlf-block-idempotent: CRLF managed block is recognized, no duplicate region', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runFb }) => {
+    runFb(['--write']);
+    const cp = join(claudeHome, 'CLAUDE.md');
+    writeFileSync(cp, readFileSync(cp, 'utf-8').replace(/\n/g, '\r\n')); // simulate CRLF editor
+    // must NOT treat CRLF block as "no blocks" and append a second region
+    assert.equal(runFb(['--write']).status, 0);
+    const after = readFileSync(cp, 'utf-8');
+    const starts = (after.match(/HYPO:FEEDBACK-SYNC:START/g) || []).length;
+    assert.equal(starts, 1, `CRLF block duplicated: ${starts} START markers`);
+  });
+});
+
+test('feedback-sync-unpaired-marker-refuses: stray START marker → exit 3', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runFb }) => {
+    runFb(['--write']);
+    const cp = join(claudeHome, 'CLAUDE.md');
+    writeFileSync(
+      cp,
+      readFileSync(cp, 'utf-8') +
+        '\n<!-- HYPO:FEEDBACK-SYNC:START source=ghost sha256=deadbeef -->\n',
+    );
+    assert.equal(runFb(['--check']).status, 3, 'unpaired START must be flagged');
+    assert.equal(runFb(['--write']).status, 3, 'write must refuse with unpaired marker');
+  });
+});
+
+test('feedback-sync-anchor-outside-container-ignored: region stays inside <learned_behaviors>', () => {
+  // anchor placed OUTSIDE the container — must NOT be used as insertion point
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ claudeHome, runFb }) => {
+      assert.equal(runFb(['--write']).status, 0);
+      const c = readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8');
+      const open = c.indexOf('<learned_behaviors>');
+      const close = c.indexOf('</learned_behaviors>');
+      const block = c.indexOf('HYPO:FEEDBACK-SYNC:START');
+      assert.ok(block > open && block < close, 'managed block must land inside the container');
+      assert.ok(c.indexOf('ANCHOR') < open, 'out-of-container anchor must remain untouched');
+    },
+    {
+      claudeMd:
+        '# Global\n<!-- HYPO:FEEDBACK-SYNC:ANCHOR -->\n<learned_behaviors>\n- manual entry\n</learned_behaviors>\n',
+    },
+  );
+});
+
+test('feedback-sync-missing-container-no-partial-write: MEMORY untouched when CLAUDE has no container', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ claudeHome, memDir, runFb }) => {
+      const memBefore = readFileSync(join(memDir, 'MEMORY.md'), 'utf-8');
+      const sideBefore = existsSync(join(memDir, 'feedback_rule-a.md'));
+      const r = runFb(['--write']);
+      assert.notEqual(r.status, 0, 'write must fail when CLAUDE lacks <learned_behaviors>');
+      assert.equal(
+        readFileSync(join(memDir, 'MEMORY.md'), 'utf-8'),
+        memBefore,
+        'MEMORY index must NOT be written (atomic preflight)',
+      );
+      assert.equal(
+        existsSync(join(memDir, 'feedback_rule-a.md')),
+        sideBefore,
+        'MEMORY side-file must NOT be written',
+      );
+    },
+    { claudeMd: '# Global\n(no learned_behaviors block here)\n' },
+  );
+});
+
+test('feedback-sync-zero-candidate-idempotent: no candidates → --write does not grow the file', () => {
+  // a page that matches NO target (status archived) → zero candidates
+  withFeedbackEnv(
+    { 'rule-x': { ...FB_GLOBAL_L1, status: 'archived' } },
+    ({ claudeHome, runFb }) => {
+      assert.equal(runFb(['--write']).status, 0);
+      const c1 = readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8');
+      assert.equal(runFb(['--write']).status, 0);
+      const c2 = readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8');
+      assert.equal(c1, c2, 'zero-candidate --write must be byte-identical (no appended newline)');
+      assert.ok(!c1.includes('HYPO:FEEDBACK-SYNC'), 'no managed block when no candidates');
+    },
+  );
+});
+
+test('feedback-sync-stale-side-file-removed: demoting a page deletes its feedback_<slug>.md copy', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ wiki, memDir, runFb }) => {
+    runFb(['--write']);
+    assert.ok(existsSync(join(memDir, 'feedback_rule-a.md')), 'side-file created on first write');
+    // demote: flip status to archived so the page is no longer a candidate
+    const pagePath = join(wiki, 'pages', 'feedback', 'rule-a.md');
+    writeFileSync(
+      pagePath,
+      readFileSync(pagePath, 'utf-8').replace('status: active', 'status: archived'),
+    );
+    assert.equal(runFb(['--write']).status, 0);
+    assert.ok(
+      !existsSync(join(memDir, 'feedback_rule-a.md')),
+      'stale side-file must be removed when page is demoted',
+    );
+  });
+});
+
+// ── second-pass review fixes (HIGH cap / HIGH provenance / MEDIUM container / LOW) ──
+
+test('feedback-sync-stale-skips-non-sync-file: hand-written feedback_*.md is NOT deleted', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ memDir, runFb }) => {
+    // a user's own memory file with the same naming pattern but no provenance header
+    const manual = join(memDir, 'feedback_my_manual_note.md');
+    writeFileSync(manual, '# my own note, not from sync\n');
+    assert.equal(runFb(['--write']).status, 0);
+    assert.ok(existsSync(manual), 'non-sync (no provenance header) file must be preserved');
+    // and the generated one carries the provenance header
+    assert.ok(
+      readFileSync(join(memDir, 'feedback_rule-a.md'), 'utf-8').startsWith(
+        '<!-- HYPO:FEEDBACK-SYNC source=',
+      ),
+      'generated side-file must carry provenance header',
+    );
+  });
+});
+
+test('feedback-sync-memory-cap-counts-index-lines-only: 100 one-line entries not over-cap', () => {
+  const pages = {};
+  for (let i = 1; i <= 100; i++) {
+    // project-scoped → MEMORY only (not CLAUDE), one-line index entry each
+    pages[`m-${i}`] = { ...FB_PROJECT_L2, title: `M ${i}`, memory_summary: `s${i}` };
+  }
+  withFeedbackEnv(pages, ({ runFb }) => {
+    const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+    assert.equal(rep.targets.memory.candidates, 100);
+    assert.equal(
+      rep.targets.memory.overCap,
+      false,
+      '100 one-line index entries (< 200) must not over-cap (markers excluded)',
+    );
+  });
+});
+
+test('feedback-sync-block-outside-container-refuses: managed block outside <learned_behaviors> → exit 3', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runFb }) => {
+      assert.equal(runFb(['--check']).status, 3, 'block outside container must be flagged');
+      assert.equal(runFb(['--write']).status, 3, 'write must refuse');
+    },
+    {
+      // a managed block sitting BEFORE the container (drifted/hand-moved)
+      claudeMd:
+        '# Global\n<!-- HYPO:FEEDBACK-SYNC:START source=rule-a sha256=' +
+        '0'.repeat(64) +
+        ' -->\n- stray\n<!-- HYPO:FEEDBACK-SYNC:END -->\n<learned_behaviors>\n- manual\n</learned_behaviors>\n',
+    },
+  );
+});
+
+test('feedback-sync-marker-in-prose-not-counted: mid-line marker text does not trip unpaired', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runFb }) => {
+      // a clean write must still succeed; the prose mention must not be seen as a marker
+      assert.equal(runFb(['--write']).status, 0, 'mid-line marker-looking text must be ignored');
+    },
+    {
+      claudeMd:
+        '# Global\nExample doc: <!-- HYPO:FEEDBACK-SYNC:START source=x --> appears mid-line here.\n<learned_behaviors>\n- manual\n</learned_behaviors>\n',
+    },
+  );
+});
+
+test('feedback-sync-write-strict-refuses-before-write: strict warning blocks the write', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1, priv: { ...FB_PROJECT_L2, sensitivity: 'private' } },
+    ({ claudeHome, runFb }) => {
+      const before = readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8');
+      const r = runFb(['--write', '--strict']);
+      assert.notEqual(r.status, 0, 'strict warning (private page) must fail');
+      assert.equal(
+        readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8'),
+        before,
+        'strict --write must NOT write before failing',
+      );
+    },
+  );
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -4532,6 +4532,28 @@ test('feedback-sync-no-input-non-tty: derived-missing project-id skips MEMORY, e
   });
 });
 
+// --strict must NOT escalate the skip-MEMORY warning. A fresh / external user
+// whose ~/.claude/projects/<id>/memory does not exist yet runs the PreCompact
+// gate (#3: `--check --strict`); contract §5 step 4 promises this never hard-
+// fails. skipMemory is an environmental state, not actionable drift.
+test('feedback-sync-strict-does-not-escalate-skip-memory: derived-missing + --strict → exit 0', () => {
+  withFeedbackEnv({ 'rule-b': FB_PROJECT_L2 }, ({ wiki, claudeHome }) => {
+    const r = run('feedback-sync.mjs', [
+      '--check',
+      '--strict',
+      '--no-input',
+      '--json',
+      `--hypo-dir=${wiki}`,
+      `--claude-home=${claudeHome}`,
+      `--cwd=${join(tmpdir(), 'no-such-cwd-xyz')}`,
+    ]);
+    assert.equal(r.signal, null, 'process must exit on its own (no hang)');
+    assert.equal(r.status, 0, `skip-MEMORY warning must not be escalated by --strict: ${r.stderr}`);
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.skipMemory, true, 'skipMemory still surfaced in report');
+  });
+});
+
 // Explicit --project-id always wins, no prompt, MEMORY present even on TTY-less run.
 test('feedback-sync-explicit-project-id-wins: MEMORY target present, no prompt path', () => {
   withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ runFb }) => {


### PR DESCRIPTION
## What

Implements **fix #37 / ADR 0031** — wiki `pages/feedback/<slug>.md` becomes the single source of truth for behavior corrections, projected **one-way** into Claude Code memory surfaces (`MEMORY.md` index + `feedback_<slug>.md` copies, and `CLAUDE.md` `<learned_behaviors>`).

This PR covers **Phase A (engine)** + the cleanly-separable **#8/#9/#10** lanes. Phase C (wiring: `/hypo:feedback --write`, `hypo-personal-check` PreCompact gate) and Phase D (`--bootstrap` CLI) are follow-ups.

## Commits
- `feedback-sync.mjs` projection engine — per-slug managed blocks, sha256 idempotency, two-pass atomic preflight, exit codes 0/1/2/3 (clean/drift/over-cap/conflict), project-id derivation, target-descriptor abstraction (reusable for the deferred ADR 0032).
- **#8** lint: feedback frontmatter schema enforced (status/scope/tier/targets/sensitivity/priority/memory_summary/reason/source + conditional global_summary/promote_to_global; `sensitivity:private` forbidden). The 9 existing wiki feedback pages were migrated to the schema (paired wiki-repo commit) to keep lint green.
- **#9** doctor: `checkFeedbackProjection` runs `feedback-sync --check` and reports — integrity violations fail, drift/over-cap/unresolved-project-id warn.
- **#10** interactive project-id fallback — prompts only on a TTY; hooks/CI never block on input (`--no-input` + non-TTY skip).

## Hardening
Reviewed across **4 codex rounds** (16 findings fixed), incl. data-integrity items: managed-block conflict/intruder refusal, partial-write prevention, provenance-gated stale side-file removal (never deletes a user's hand-written `feedback_*.md`), and an entry-guard fix so the CLI is not a silent no-op on paths with spaces or symlinks (macOS `/tmp`→`/private/tmp`).

## Verification
`npm test` **259 pass** · `npm run lint` **0 errors** · `npm run smoke-pack` **green**. End-to-end projection verified against the real wiki (9 entries, sorted, byte-idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)