### PR TITLE
feat: update-notifier (npm + plugin, 24h cache, detached refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Hypomnema are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Update notifier.** The SessionStart hook now shows an "Update available!"
+  banner when a newer Hypomnema version has been published, detecting both
+  distribution channels (npm package and Claude Code plugin) and printing the
+  channel-appropriate update command (`npm install -g hypomnema`, or
+  `/plugin marketplace update hypomnema` + `/reload-plugins`). The check never
+  blocks session start: the hook reads a 24-hour cache only, and a detached
+  worker refreshes it out-of-band, so a newer version surfaces from the next
+  session. Per-channel notification state prevents the same banner from
+  repeating, and `current >= latest` (local dev) is silently skipped. Opt out
+  with `HYPO_NO_UPDATE_CHECK`, `NO_UPDATE_NOTIFIER`, or `CI`.
+
 ## [1.1.0] - 2026-05-13
 
 Minor release. The headline is **observability**: the v1 → v2 thesis is

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -134,5 +134,5 @@
       }
     ]
   },
-  "shared": ["hypo-shared.mjs"]
+  "shared": ["hypo-shared.mjs", "version-check.mjs", "version-check-fetch.mjs"]
 }

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -9,8 +9,9 @@
 
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { homedir, tmpdir } from 'os';
-import { join } from 'path';
-import { spawnSync } from 'child_process';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync, spawn } from 'child_process';
 import {
   HYPO_DIR,
   buildOutput,
@@ -23,6 +24,15 @@ import {
   loadHypoIgnore,
   isIgnored,
 } from './hypo-shared.mjs';
+import {
+  defaultCachePath,
+  detectChannel,
+  readCache,
+  cacheIsFresh,
+  computeNotice,
+  markNotified,
+  isOptedOut,
+} from './version-check.mjs';
 
 // Privacy guard (fix #48, Stage 1): refuse to read+inject .hypoignore-matched
 // wiki files into additionalContext. Without this, a user who lists
@@ -32,6 +42,76 @@ function readIfNotIgnored(path, maxChars, patterns) {
   if (!path) return null;
   if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return null;
   return readFileSync(path, 'utf-8').slice(0, maxChars);
+}
+
+// Directory of the running hook, and the install root one level up
+// (<root>/hooks/...). The root is derived from the RUNNING hook path rather
+// than ~/.claude/hypo-pkg.json so a dual install (npm + plugin) or a stale
+// metadata file can't mislabel the channel (teams review (b), 2026-05-21).
+const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
+const ACTIVE_ROOT = dirname(HOOK_DIR);
+
+function readInstalledVersion(root) {
+  try {
+    return JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')).version || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update-notifier (teams-reviewed 2026-05-21). Reads ONLY the cache — never a
+ * synchronous network call. When the cache is stale, fires a detached worker to
+ * refresh it (shown next session). Fully best-effort: any failure returns ''.
+ */
+function buildUpdateNotice() {
+  try {
+    if (isOptedOut()) return '';
+    const cachePath = defaultCachePath();
+
+    let root = ACTIVE_ROOT;
+    let version = readInstalledVersion(root);
+    if (!version) {
+      try {
+        const meta = JSON.parse(readFileSync(join(homedir(), '.claude', 'hypo-pkg.json'), 'utf-8'));
+        root = meta.pkgRoot || root;
+        version = meta.pkgVersion || readInstalledVersion(root);
+      } catch {
+        /* fallback unavailable */
+      }
+    }
+    if (!version) return '';
+
+    const channel = detectChannel(root);
+    const cache = readCache(cachePath);
+
+    if (!cacheIsFresh(cache)) {
+      try {
+        const worker = join(HOOK_DIR, 'version-check-fetch.mjs');
+        if (existsSync(worker)) {
+          const child = spawn(process.execPath, [worker, cachePath], {
+            detached: true,
+            stdio: 'ignore',
+          });
+          // spawn() failures (EAGAIN/EMFILE/ENOENT) surface ASYNChronously on
+          // the child's 'error' event — the try/catch above only catches the
+          // synchronous throw. Without this listener an unhandled 'error' would
+          // crash SessionStart, violating the best-effort contract.
+          child.on('error', () => {});
+          child.unref();
+        }
+      } catch {
+        /* spawn is best-effort */
+      }
+    }
+
+    const notice = computeNotice(cache, channel, version);
+    if (!notice) return '';
+    markNotified(cachePath, channel, notice.latest);
+    return notice.line;
+  } catch {
+    return '';
+  }
 }
 
 const PROJECTS_DIR = join(HYPO_DIR, 'projects');
@@ -209,16 +289,18 @@ process.stdin.on('end', () => {
     // session-close work that /clear skipped. One-shot: marker is unlinked
     // immediately after read.
     const clearRecoveryLine = buildClearRecoveryLine(data.source);
+    const updateLine = buildUpdateNotice();
     // Intentional dual emit: stderr (yellow/cyan) is the human-visible nudge in
     // the terminal; noticePrefix injects the same plain-text lines into the
     // LLM's additionalContext so model and user start the session looking at
     // the same state. ANSI escapes are kept out of additionalContext on purpose.
-    const notices = [syncLine, growthLine, clearRecoveryLine].filter(Boolean);
+    const notices = [syncLine, growthLine, clearRecoveryLine, updateLine].filter(Boolean);
     const noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
     if (syncLine) process.stderr.write(`\n\x1b[33m${syncLine}\x1b[0m\n`);
     if (growthLine) process.stderr.write(`\n\x1b[36m${growthLine}\x1b[0m\n`);
     if (clearRecoveryLine)
       process.stderr.write(`\n\x1b[33m${clearRecoveryLine.split('\n')[0]}\x1b[0m\n`);
+    if (updateLine) process.stderr.write(`\n\x1b[33m${updateLine}\x1b[0m\n`);
     const cwd = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || 'default';
     const MARKER_FILE = join(tmpdir(), `hypo-session-marker-${sessionId}.json`);

--- a/hooks/version-check-fetch.mjs
+++ b/hooks/version-check-fetch.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * version-check-fetch.mjs — detached update-check worker
+ *
+ * Spawned (detached, unref'd, stdio ignored) by the SessionStart hook ONLY when
+ * the cache is stale. It fetches the latest published versions for both
+ * channels and merges them into the cache, then exits. The hook never waits on
+ * it, so session start stays at 0ms added latency; the refreshed version is
+ * shown from the NEXT session.
+ *
+ * Best-effort throughout: any failure (offline, 404, timeout) leaves the cache
+ * untouched for that channel and exits 0 — never throws back at a hook.
+ *
+ * Usage: node version-check-fetch.mjs [cachePath]
+ */
+
+import { defaultCachePath, mergeLatest } from './version-check.mjs';
+
+const NPM_URL = 'https://registry.npmjs.org/hypomnema/latest';
+const PLUGIN_URL =
+  'https://raw.githubusercontent.com/sk-lim19f/Hypomnema/main/.claude-plugin/marketplace.json';
+const TIMEOUT_MS = 2000;
+
+async function fetchJson(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { accept: 'application/json' } });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchNpmLatest() {
+  const data = await fetchJson(NPM_URL);
+  return data && typeof data.version === 'string' ? data.version : null;
+}
+
+async function fetchPluginLatest() {
+  const data = await fetchJson(PLUGIN_URL);
+  if (!data || !Array.isArray(data.plugins)) return null;
+  // Select by name rather than plugins[0]: a future marketplace.json could list
+  // more than one plugin or reorder entries, which would otherwise read the
+  // wrong version.
+  const entry = data.plugins.find((p) => p && p.name === 'hypomnema');
+  const v = entry && entry.version;
+  return typeof v === 'string' ? v : null;
+}
+
+async function main() {
+  const cachePath = process.argv[2] || defaultCachePath();
+  const [npmLatest, pluginLatest] = await Promise.all([fetchNpmLatest(), fetchPluginLatest()]);
+
+  const latest = {};
+  if (npmLatest) latest.npm = npmLatest;
+  if (pluginLatest) latest.plugin = pluginLatest;
+
+  // Even if both fetches fail we still stamp checkedAt so we don't hammer the
+  // network every single session while offline — the TTL backs off naturally.
+  try {
+    mergeLatest(cachePath, latest);
+  } catch {
+    /* best-effort */
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  () => process.exit(0),
+);

--- a/hooks/version-check.mjs
+++ b/hooks/version-check.mjs
@@ -1,0 +1,184 @@
+/**
+ * version-check.mjs — update-notifier core (pure logic + cache I/O)
+ *
+ * Hypomnema ships through TWO channels — the `hypomnema` npm package and a
+ * Claude Code plugin (marketplace `sk-lim19f/Hypomnema`). This module decides,
+ * given the cached "latest" versions and the installed version, whether to show
+ * an "update available" banner at session start.
+ *
+ * Design constraints (see ADR / teams review 2026-05-21):
+ *   - The SessionStart hook must never make a synchronous network call. It reads
+ *     ONLY the cache here; a detached worker (version-check-fetch.mjs) refreshes
+ *     the cache out-of-band. So everything in this file is offline + cheap.
+ *   - Per-channel state: npm and plugin `latest` can diverge (npm publish vs
+ *     marketplace commit happen at different times), so `latest` and
+ *     `notifiedFor` are keyed by channel — a single scalar would suppress or
+ *     repeat banners when the user switches channels.
+ *   - Cache writes are atomic (tmp + rename); the fetch worker MERGES rather
+ *     than overwrites so it never erases the hook's `notifiedFor` marks.
+ */
+
+import { readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { homedir } from 'os';
+
+export const TTL_MS = 24 * 60 * 60 * 1000; // 24h
+export const CHANNELS = ['npm', 'plugin'];
+
+/**
+ * Cache lives under ~/.claude (Claude-hook-specific state), NOT inside the
+ * Obsidian vault ~/hypomnema — that directory is git-tracked, so a cache file
+ * there would create dirty status, sync noise, and accidental-commit / privacy
+ * risk (teams review (e), 2026-05-21).
+ */
+export function defaultCachePath(home = homedir()) {
+  return join(home, '.claude', 'hypomnema', 'cache', 'version-check.json');
+}
+
+// ── semver ───────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a semver string. Tolerates a leading `v` and ignores build metadata.
+ * Returns null for anything that isn't `MAJOR.MINOR.PATCH[-prerelease][+build]`.
+ */
+export function parseSemver(v) {
+  if (typeof v !== 'string') return null;
+  const m = v
+    .trim()
+    .replace(/^v/, '')
+    .match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/);
+  if (!m) return null;
+  return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4] || '' };
+}
+
+/**
+ * Compare two semver strings. Returns -1 / 0 / 1, or null if either is invalid.
+ * A release outranks a prerelease of the same x.y.z (1.2.3 > 1.2.3-rc.1).
+ */
+export function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  for (const k of ['major', 'minor', 'patch']) {
+    if (pa[k] !== pb[k]) return pa[k] < pb[k] ? -1 : 1;
+  }
+  if (pa.pre === pb.pre) return 0;
+  if (!pa.pre) return 1; // release > prerelease
+  if (!pb.pre) return -1;
+  return pa.pre < pb.pre ? -1 : 1; // lexicographic fallback (good enough)
+}
+
+// ── channel detection ──────────────────────────────────────────────────────
+
+/**
+ * Decide the active install channel from the package root path.
+ *
+ * The caller should pass the root derived from the RUNNING hook path
+ * (import.meta.url → ../..), with ~/.claude/hypo-pkg.json's pkgRoot only as a
+ * fallback: that metadata file has drifted before, and in a dual install
+ * (npm global + plugin) it names just one path. Reporting the inactive channel
+ * would hand the user the wrong update command (teams review (b), 2026-05-21).
+ *
+ * Plugin is checked before npm because a plugin install can itself live under a
+ * node_modules path, but never vice-versa.
+ */
+export function detectChannel(pkgRoot) {
+  if (typeof pkgRoot !== 'string' || !pkgRoot) return 'unknown';
+  const p = pkgRoot.replace(/\\/g, '/');
+  if (p.includes('/plugins/') || p.includes('/.claude/plugins/')) return 'plugin';
+  if (p.includes('/node_modules/')) return 'npm';
+  return 'unknown';
+}
+
+/** Channel-specific one-line update instruction. */
+export function buildUpdateLine(channel, current, latest) {
+  const head = `[Hypomnema] Update available! ${current} → ${latest}`;
+  if (channel === 'plugin') {
+    return `${head}\n  → run: /plugin marketplace update hypomnema  then  /reload-plugins`;
+  }
+  if (channel === 'npm') {
+    return `${head}\n  → run: npm install -g hypomnema`;
+  }
+  return `${head}\n  → npm i -g hypomnema  (or  /plugin marketplace update hypomnema && /reload-plugins)`;
+}
+
+// ── cache freshness + notice decision (pure) ─────────────────────────────────
+
+/**
+ * Is the cache fresh enough to skip a refresh? A `checkedAt` in the future
+ * (clock skew / corrupt cache) is treated as stale so the worker re-fetches.
+ */
+export function cacheIsFresh(cache, now = Date.now(), ttl = TTL_MS) {
+  if (!cache || typeof cache.checkedAt !== 'number') return false;
+  if (cache.checkedAt > now + 60_000) return false;
+  return now - cache.checkedAt < ttl;
+}
+
+/**
+ * Decide whether to show a banner. Returns { latest, line } or null.
+ * Skips when: unknown channel, no cached latest for the channel, invalid
+ * semver, current >= latest (incl. local dev where current > latest), or the
+ * channel was already notified for this exact latest version.
+ */
+export function computeNotice(cache, channel, current) {
+  if (!cache || channel === 'unknown' || !CHANNELS.includes(channel)) return null;
+  const latest = cache.latest && cache.latest[channel];
+  if (!latest) return null;
+  const cmp = compareSemver(current, latest);
+  if (cmp === null || cmp >= 0) return null;
+  const already = cache.notifiedFor && cache.notifiedFor[channel];
+  if (already === latest) return null;
+  return { latest, line: buildUpdateLine(channel, current, latest) };
+}
+
+// ── cache I/O (atomic) ───────────────────────────────────────────────────────
+
+/** Read + parse the cache; returns null on missing/corrupt file. */
+export function readCache(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Atomic write: tmp file in the same dir, then rename (last-writer-wins). */
+export function writeCacheAtomic(path, obj) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  writeFileSync(tmp, JSON.stringify(obj, null, 2));
+  renameSync(tmp, path);
+}
+
+/**
+ * Record that the banner for {channel: latest} has been shown, preserving the
+ * rest of the cache. Read-merge-write so concurrent worker refreshes and hook
+ * marks don't clobber each other's fields. Best-effort: swallows errors.
+ */
+export function markNotified(path, channel, latest) {
+  try {
+    const cache = readCache(path) || {};
+    cache.notifiedFor = { ...(cache.notifiedFor || {}), [channel]: latest };
+    writeCacheAtomic(path, cache);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Merge freshly-fetched latest versions into the cache without erasing
+ * `notifiedFor`. Used by the detached fetch worker.
+ */
+export function mergeLatest(path, latest, now = Date.now()) {
+  const cache = readCache(path) || {};
+  cache.checkedAt = now;
+  cache.latest = { ...(cache.latest || {}), ...latest };
+  cache.notifiedFor = cache.notifiedFor || {};
+  writeCacheAtomic(path, cache);
+  return cache;
+}
+
+/** True if any opt-out env var is set. */
+export function isOptedOut(env = process.env) {
+  return Boolean(env.HYPO_NO_UPDATE_CHECK || env.NO_UPDATE_NOTIFIER || env.CI);
+}

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3558,8 +3558,14 @@ test('replay-auto-minimal-crystallize-on-incomplete-close: mutating + no marker 
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block', `must block, got: ${JSON.stringify(out)}`);
-    assert.ok(/WIKI_AUTOCLOSE/.test(out.reason), `reason must mention WIKI_AUTOCLOSE: ${out.reason}`);
-    assert.ok(/\/hypo:crystallize/.test(out.reason), 'reason must point at /hypo:crystallize skill');
+    assert.ok(
+      /WIKI_AUTOCLOSE/.test(out.reason),
+      `reason must mention WIKI_AUTOCLOSE: ${out.reason}`,
+    );
+    assert.ok(
+      /\/hypo:crystallize/.test(out.reason),
+      'reason must point at /hypo:crystallize skill',
+    );
     assert.ok(out.reason.includes('s-substantial'), 'reason must embed the session_id to use');
   });
 });
@@ -3765,7 +3771,10 @@ test('--mark-session-closed with failing gate → exit 1, no marker', () => {
     assert.equal(r.status, 1);
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
-    assert.ok(!existsSync(join(dir, '.cache', 'session-closed-s-failgate.marker')), 'marker must not be written on failed gate');
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-failgate.marker')),
+      'marker must not be written on failed gate',
+    );
   });
 });
 
@@ -3787,7 +3796,10 @@ test('--mark-session-closed with ok gate but dirty git → exit 1, no marker (AD
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
     assert.ok(out.git_reason, `dirty-git result must carry git_reason: ${JSON.stringify(out)}`);
-    assert.ok(!existsSync(join(dir, '.cache', 'session-closed-s-dirty.marker')), 'marker must not land on dirty git');
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-dirty.marker')),
+      'marker must not land on dirty git',
+    );
   });
 });
 
@@ -3857,6 +3869,150 @@ test('--apply-session-close --session-id leaves payload uncommitted → marker N
       'apply leaves payload writes uncommitted → ADR Q2 git-clean gate skips marker until auto-commit lands',
     );
   });
+});
+
+// ── version-check (update notifier) ──────────────────────────────────────────
+
+const vc = await import(`${REPO}/hooks/version-check.mjs`);
+
+test('compareSemver: basic ordering', () => {
+  assert.equal(vc.compareSemver('1.0.0', '1.0.1'), -1);
+  assert.equal(vc.compareSemver('1.2.0', '1.1.9'), 1);
+  assert.equal(vc.compareSemver('2.0.0', '2.0.0'), 0);
+  assert.equal(vc.compareSemver('v1.1.0', '1.1.0'), 0); // tolerate leading v
+});
+
+test('compareSemver: release outranks prerelease, build metadata ignored', () => {
+  assert.equal(vc.compareSemver('1.2.3-rc.1', '1.2.3'), -1);
+  assert.equal(vc.compareSemver('1.2.3', '1.2.3-rc.1'), 1);
+  assert.equal(vc.compareSemver('1.2.3+build9', '1.2.3'), 0);
+});
+
+test('compareSemver: invalid input returns null', () => {
+  assert.equal(vc.compareSemver('not-a-version', '1.0.0'), null);
+  assert.equal(vc.compareSemver('1.0.0', ''), null);
+  assert.equal(vc.compareSemver('1.0', '1.0.0'), null);
+});
+
+test('detectChannel: npm / plugin / unknown', () => {
+  assert.equal(vc.detectChannel('/usr/local/lib/node_modules/hypomnema'), 'npm');
+  assert.equal(vc.detectChannel('/Users/x/.claude/plugins/cache/hypomnema'), 'plugin');
+  assert.equal(vc.detectChannel('/Users/x/Workspace/hypomnema'), 'unknown');
+  assert.equal(vc.detectChannel(''), 'unknown');
+  assert.equal(vc.detectChannel(undefined), 'unknown');
+});
+
+test('detectChannel: plugin path containing node_modules still resolves to plugin', () => {
+  assert.equal(
+    vc.detectChannel('/Users/x/.claude/plugins/cache/hypomnema/node_modules/foo'),
+    'plugin',
+  );
+});
+
+test('buildUpdateLine: channel-specific update command', () => {
+  assert.match(vc.buildUpdateLine('npm', '1.0.0', '1.1.0'), /npm install -g hypomnema/);
+  assert.match(
+    vc.buildUpdateLine('plugin', '1.0.0', '1.1.0'),
+    /plugin marketplace update hypomnema/,
+  );
+  assert.match(vc.buildUpdateLine('plugin', '1.0.0', '1.1.0'), /reload-plugins/);
+  assert.match(vc.buildUpdateLine('unknown', '1.0.0', '1.1.0'), /1\.0\.0 → 1\.1\.0/);
+});
+
+test('cacheIsFresh: fresh / stale / future / missing', () => {
+  const now = 1_000_000_000_000;
+  assert.equal(vc.cacheIsFresh({ checkedAt: now - 1000 }, now), true);
+  assert.equal(vc.cacheIsFresh({ checkedAt: now - vc.TTL_MS - 1 }, now), false);
+  assert.equal(vc.cacheIsFresh({ checkedAt: now + 5 * 60_000 }, now), false); // future skew
+  assert.equal(vc.cacheIsFresh(null, now), false);
+  assert.equal(vc.cacheIsFresh({}, now), false);
+});
+
+test('computeNotice: shows when latest is newer', () => {
+  const cache = { latest: { npm: '1.2.0' }, notifiedFor: {} };
+  const n = vc.computeNotice(cache, 'npm', '1.1.0');
+  assert.ok(n);
+  assert.equal(n.latest, '1.2.0');
+  assert.match(n.line, /npm install -g hypomnema/);
+});
+
+test('computeNotice: skips when current >= latest (incl. local dev)', () => {
+  assert.equal(vc.computeNotice({ latest: { npm: '1.2.0' } }, 'npm', '1.2.0'), null);
+  assert.equal(vc.computeNotice({ latest: { npm: '1.2.0' } }, 'npm', '1.3.0'), null);
+});
+
+test('computeNotice: skips when already notified for this version', () => {
+  const cache = { latest: { npm: '1.2.0' }, notifiedFor: { npm: '1.2.0' } };
+  assert.equal(vc.computeNotice(cache, 'npm', '1.1.0'), null);
+});
+
+test('computeNotice: unknown channel / missing latest / invalid version → null', () => {
+  assert.equal(vc.computeNotice({ latest: { npm: '1.2.0' } }, 'unknown', '1.1.0'), null);
+  assert.equal(vc.computeNotice({ latest: {} }, 'npm', '1.1.0'), null);
+  assert.equal(vc.computeNotice(null, 'npm', '1.1.0'), null);
+  assert.equal(vc.computeNotice({ latest: { npm: 'garbage' } }, 'npm', '1.1.0'), null);
+});
+
+test('computeNotice: per-channel state is independent (channel switch)', () => {
+  // npm already notified at 1.2.0, but plugin at 1.2.0 has NOT been notified.
+  const cache = {
+    latest: { npm: '1.2.0', plugin: '1.2.0' },
+    notifiedFor: { npm: '1.2.0' },
+  };
+  assert.equal(vc.computeNotice(cache, 'npm', '1.1.0'), null); // suppressed
+  assert.ok(vc.computeNotice(cache, 'plugin', '1.1.0')); // still shows
+});
+
+test('isOptedOut: respects HYPO_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER / CI', () => {
+  assert.equal(vc.isOptedOut({}), false);
+  assert.equal(vc.isOptedOut({ HYPO_NO_UPDATE_CHECK: '1' }), true);
+  assert.equal(vc.isOptedOut({ NO_UPDATE_NOTIFIER: '1' }), true);
+  assert.equal(vc.isOptedOut({ CI: 'true' }), true);
+});
+
+test('cache I/O: atomic write/read round-trip + corrupt file → null', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-vc-'));
+  const path = join(dir, 'version-check.json');
+  try {
+    assert.equal(vc.readCache(path), null); // missing
+    vc.writeCacheAtomic(path, { checkedAt: 42, latest: { npm: '1.0.0' } });
+    assert.equal(vc.readCache(path).checkedAt, 42);
+    writeFileSync(path, '{not json');
+    assert.equal(vc.readCache(path), null); // corrupt
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('markNotified: sets channel mark without erasing other fields', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-vc-'));
+  const path = join(dir, 'version-check.json');
+  try {
+    vc.writeCacheAtomic(path, { checkedAt: 1, latest: { npm: '1.2.0', plugin: '1.1.0' } });
+    vc.markNotified(path, 'npm', '1.2.0');
+    const c = vc.readCache(path);
+    assert.equal(c.notifiedFor.npm, '1.2.0');
+    assert.equal(c.latest.npm, '1.2.0'); // preserved
+    assert.equal(c.latest.plugin, '1.1.0'); // preserved
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('mergeLatest: refreshes latest but preserves notifiedFor', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-vc-'));
+  const path = join(dir, 'version-check.json');
+  try {
+    vc.writeCacheAtomic(path, { latest: { npm: '1.0.0' }, notifiedFor: { npm: '1.0.0' } });
+    vc.mergeLatest(path, { npm: '1.3.0', plugin: '1.3.0' }, 999);
+    const c = vc.readCache(path);
+    assert.equal(c.checkedAt, 999);
+    assert.equal(c.latest.npm, '1.3.0');
+    assert.equal(c.latest.plugin, '1.3.0');
+    assert.equal(c.notifiedFor.npm, '1.0.0'); // NOT erased by the fetch worker
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
SessionStart now shows an **"Update available!"** banner when a newer Hypomnema version has been published, detecting **both** distribution channels (npm package + Claude Code plugin) and printing the channel-appropriate update command.

The check **never blocks session start**: the hook reads a 24h cache only; a detached worker refreshes it out-of-band, so a newer version surfaces from the *next* session.

## Changes
- `hooks/version-check.mjs` — pure semver/channel/notice logic + atomic cache I/O
- `hooks/version-check-fetch.mjs` — detached fetch worker (npm registry + GitHub raw `marketplace.json`), 2s timeout, best-effort
- `hooks/hypo-session-start.mjs` — `buildUpdateNotice()` wired into the existing `notices` array (stderr banner + additionalContext)
- per-channel `notifiedFor` (npm/plugin latest can diverge); `current >= latest` (local dev) silently skipped; opt out via `HYPO_NO_UPDATE_CHECK` / `NO_UPDATE_NOTIFIER` / `CI`
- modules placed in `hooks/` + `hooks.json` `shared` so `init.mjs` copies them flat into `~/.claude/hooks` (there is no `~/.claude/scripts`)
- 16 unit tests in `tests/runner.mjs`

## Channel commands
- npm: `npm install -g hypomnema`
- plugin: `/plugin marketplace update hypomnema` → `/reload-plugins`

## Review
Reviewed by 2× codex (design pass + diff pass). Key hardening applied from review:
- channel detection prefers the **running hook path** over `hypo-pkg.json` (avoids stale-metadata / dual-install mislabeling)
- atomic cache writes (tmp + rename); fetch worker merges rather than overwrites `notifiedFor`
- detached child has an async `'error'` listener so a spawn failure (EAGAIN/EMFILE/ENOENT) **cannot crash SessionStart** (both reviewers flagged this independently; reproduced locally)
- plugin version selected by `name === 'hypomnema'` rather than `plugins[0]`

## Verification
- 16/16 unit tests pass
- live fetch worker reaches npm + GitHub
- installed-layout integration emits correct npm banner via `hypo-pkg.json` fallback
- banner does not repeat (notifiedFor); dev/worktree shows nothing (unknown channel); worker-missing path exits 0 (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)