### PR TITLE
feat(lint): flag pages/ subdirs absent from SCHEMA taxonomy (B6)

### DIFF
--- a/scripts/lib/schema-vocab.mjs
+++ b/scripts/lib/schema-vocab.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 const VOCAB_HEADER_RE = /^##\s+(?:\d+\.\s+)?Tag\s+(?:Vocabulary|Taxonomy)\s*$/m;
+const TYPE_TAXONOMY_HEADER_RE = /^##\s+(?:\d+\.\s+)?Page\s+Type\s+Taxonomy\s*$/m;
+const PAGE_DIR_TOKEN_RE = /`pages\/([a-z0-9-]+)\//g;
 const NEXT_H2_RE = /^##\s+/m;
 const CATEGORY_PREFIX_RE = /^\s*\*\*[^*]+\*\*:\s*/;
 const BACKTICK_TOKEN_RE = /`([^`]+)`/g;
@@ -62,4 +64,33 @@ export function parseSchemaVocab(hypoDir) {
     for (const token of vocabLineTokens(rawLine)) vocab.add(token);
   }
   return vocab;
+}
+
+// Derive the set of valid immediate subdirectories under pages/ from the
+// SCHEMA "Page Type Taxonomy" table (e.g. learnings, feedback, people). Single
+// source of truth — adding a type+dir row to SCHEMA automatically widens the
+// whitelist. Returns an empty Set when SCHEMA.md or the table is absent, which
+// callers treat as "skip the check" for back-compat with minimal wikis.
+export function parseSchemaPageDirs(hypoDir) {
+  const path = join(hypoDir, 'SCHEMA.md');
+  if (!existsSync(path)) return new Set();
+  const content = readFileSync(path, 'utf-8');
+
+  const headerMatch = TYPE_TAXONOMY_HEADER_RE.exec(content);
+  if (!headerMatch) return new Set();
+
+  const sectionStart = headerMatch.index + headerMatch[0].length;
+  const rest = content.slice(sectionStart);
+  const nextH2 = NEXT_H2_RE.exec(rest);
+  const section = nextH2 ? rest.slice(0, nextH2.index) : rest;
+
+  // Only scan table rows (lines starting with `|`) so a backticked path that
+  // appears in surrounding prose (e.g. an example of a *wrong* dir) can never
+  // leak into the whitelist.
+  const dirs = new Set();
+  for (const rawLine of section.split('\n')) {
+    if (!rawLine.trimStart().startsWith('|')) continue;
+    for (const m of rawLine.matchAll(PAGE_DIR_TOKEN_RE)) dirs.add(m[1]);
+  }
+  return dirs;
 }

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -18,7 +18,7 @@ import { join, relative, extname, basename } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
-import { parseSchemaVocab, checkForbidden } from './lib/schema-vocab.mjs';
+import { parseSchemaVocab, checkForbidden, parseSchemaPageDirs } from './lib/schema-vocab.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -195,7 +195,28 @@ function lintSessionStateHeadings(content, rel) {
   }
 }
 
-function lintPage({ path, rel }, slugMap, tagVocab) {
+function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
+  // Directory whitelist: a content page under pages/<subdir>/ must live in a
+  // SCHEMA-defined directory. Catches typo'd dirs (e.g. pages/learning/ vs the
+  // canonical pages/learnings/) regardless of frontmatter, since a directory
+  // absent from SCHEMA breaks wikilink resolution and crystallize routing.
+  // `_`-prefixed files (e.g. pages/observability/_index.md) are scaffold/section
+  // markers, not content — exempt them so packaged scaffold dirs that aren't a
+  // page *type* (e.g. observability, a topical grouping of reference pages) don't
+  // trip the guard. A real typo dir is created with content, not just an index.
+  // Skipped entirely when pageDirs is empty (SCHEMA.md or the table absent) for
+  // back-compat with minimal wikis — mirrors the tag-vocab check.
+  if (pageDirs && pageDirs.size > 0 && !basename(rel).startsWith('_')) {
+    const segs = rel.replace(/\\/g, '/').split('/');
+    if (segs[0] === 'pages' && segs.length > 2 && !pageDirs.has(segs[1])) {
+      issue(
+        'error',
+        rel,
+        `Undefined pages/ directory: "pages/${segs[1]}/" not in SCHEMA.md (likely a typo — defined: ${[...pageDirs].sort().join(', ')})`,
+      );
+    }
+  }
+
   let content;
   try {
     content = readFileSync(path, 'utf-8');
@@ -281,8 +302,9 @@ const scanDirs = ['pages', 'projects', 'journal'].map((d) => join(args.hypoDir, 
 const pages = scanDirs.flatMap((d) => collectPages(d, args.hypoDir, [], ignorePatterns));
 const slugMap = buildSlugMap(pages);
 const tagVocab = parseSchemaVocab(args.hypoDir);
+const pageDirs = parseSchemaPageDirs(args.hypoDir);
 
-for (const page of pages) lintPage(page, slugMap, tagVocab);
+for (const page of pages) lintPage(page, slugMap, tagVocab, pageDirs);
 
 if (args.fix) {
   const today = new Date().toISOString().slice(0, 10);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2160,6 +2160,99 @@ test('vocab check skipped when SCHEMA.md absent (back-compat)', () => {
   assert.equal(r.status, 0, `expected green when SCHEMA.md missing, got ${r.status}: ${r.stdout}`);
 });
 
+// ── lint.mjs pages/ directory whitelist (B6 — SCHEMA dir typo guard) ─────────
+
+suite('lint.mjs pages/ directory whitelist');
+
+const DIR_SCHEMA = [
+  '---',
+  'title: SCHEMA',
+  'type: schema',
+  '---',
+  '# Schema',
+  '',
+  '## 1. Page Type Taxonomy',
+  '',
+  '| type | directory | desc |',
+  '|------|-----------|------|',
+  '| `learning` | `pages/learnings/` | gotchas |',
+  '| `feedback` | `pages/feedback/` | corrections |',
+  '',
+  '## 4. Tag Vocabulary',
+  '',
+  '`wiki` `concept`',
+  '',
+  '## 5. Next',
+  '',
+].join('\n');
+
+// type: concept has no conditional-required fields and no tags → isolates B6 as
+// the only possible error, since the check keys off the path, not frontmatter.
+const PLAIN_PAGE = '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\n---\nbody\n';
+
+test('typo directory (pages/learning/) → error', () => {
+  const { r, out } = lintWithSchema('pages/learning/x.md', PLAIN_PAGE, DIR_SCHEMA);
+  assert.equal(r.status, 1, `expected error, got ${r.status}: ${r.stdout}`);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Undefined pages/ directory: "pages/learning/"')),
+    `expected undefined-dir error: ${r.stdout}`,
+  );
+});
+
+test('canonical directory (pages/learnings/) → green', () => {
+  const { r } = lintWithSchema('pages/learnings/x.md', PLAIN_PAGE, DIR_SCHEMA);
+  assert.equal(r.status, 0, `expected green, got ${r.status}: ${r.stdout}`);
+});
+
+test('root-level pages/ file (no subdir) → green', () => {
+  const { r } = lintWithSchema('pages/x.md', PLAIN_PAGE, DIR_SCHEMA);
+  assert.equal(r.status, 0, `expected green, got ${r.status}: ${r.stdout}`);
+});
+
+test('dir check skipped when Page Type Taxonomy table absent (back-compat)', () => {
+  // VOCAB_SCHEMA has no "## 1. Page Type Taxonomy" table → whitelist empty → skip.
+  const { r } = lintWithSchema('pages/learning/x.md', PLAIN_PAGE);
+  assert.equal(r.status, 0, `expected green when table absent, got ${r.status}: ${r.stdout}`);
+});
+
+test('_index.md in an undefined dir → green (scaffold exemption)', () => {
+  // pages/observability/ ships via init but is a topical grouping, not a page
+  // *type*, so it is absent from the taxonomy table. Its _index.md scaffold must
+  // not trip the guard.
+  const { r } = lintWithSchema('pages/observability/_index.md', PLAIN_PAGE, DIR_SCHEMA);
+  assert.equal(r.status, 0, `expected green for _index scaffold, got ${r.status}: ${r.stdout}`);
+});
+
+test('content file in an undefined dir still errors despite the _index exemption', () => {
+  // The exemption must not blunt the guard: a real content page (no `_` prefix)
+  // in a typo dir is still the original bug we are catching.
+  const { r, out } = lintWithSchema('pages/learning/real-content.md', PLAIN_PAGE, DIR_SCHEMA);
+  assert.equal(r.status, 1, `expected error, got ${r.status}: ${r.stdout}`);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Undefined pages/ directory: "pages/learning/"')),
+    `expected undefined-dir error: ${r.stdout}`,
+  );
+});
+
+test('fresh init wiki passes lint (regression: observability scaffold vs B6)', () => {
+  // Worker-1 caught that B6 would fail a freshly initialized wiki because
+  // init.mjs scaffolds pages/observability/_index.md, a dir absent from the
+  // taxonomy table. Drive the real init.mjs + lint.mjs, not a fixture.
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-init-lint-'));
+  const initR = run('init.mjs', [`--hypo-dir=${dir}`, '--no-hooks', '--no-git-init']);
+  assert.equal(initR.status, 0, `init failed: ${initR.stderr || initR.stdout}`);
+  const lintR = run('lint.mjs', [`--hypo-dir=${dir}`, '--json']);
+  const out = JSON.parse(lintR.stdout);
+  rmSync(dir, { recursive: true, force: true });
+  const dirErrors = out.errors.filter((e) => /Undefined pages\/ directory/.test(e.message));
+  assert.equal(dirErrors.length, 0, `B6 fired on fresh init wiki: ${JSON.stringify(dirErrors)}`);
+  assert.equal(
+    lintR.status,
+    0,
+    `fresh init wiki should lint green, got ${lintR.status}: ${lintR.stdout}`,
+  );
+});
+
 // ── Lane B: formatGrowthMetrics + growth echo regressions ─────────────────
 
 const { formatGrowthMetrics, computeSessionGrowth } = await import(join(HOOKS, 'hypo-shared.mjs'));
@@ -3558,8 +3651,14 @@ test('replay-auto-minimal-crystallize-on-incomplete-close: mutating + no marker 
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block', `must block, got: ${JSON.stringify(out)}`);
-    assert.ok(/WIKI_AUTOCLOSE/.test(out.reason), `reason must mention WIKI_AUTOCLOSE: ${out.reason}`);
-    assert.ok(/\/hypo:crystallize/.test(out.reason), 'reason must point at /hypo:crystallize skill');
+    assert.ok(
+      /WIKI_AUTOCLOSE/.test(out.reason),
+      `reason must mention WIKI_AUTOCLOSE: ${out.reason}`,
+    );
+    assert.ok(
+      /\/hypo:crystallize/.test(out.reason),
+      'reason must point at /hypo:crystallize skill',
+    );
     assert.ok(out.reason.includes('s-substantial'), 'reason must embed the session_id to use');
   });
 });
@@ -3765,7 +3864,10 @@ test('--mark-session-closed with failing gate → exit 1, no marker', () => {
     assert.equal(r.status, 1);
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
-    assert.ok(!existsSync(join(dir, '.cache', 'session-closed-s-failgate.marker')), 'marker must not be written on failed gate');
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-failgate.marker')),
+      'marker must not be written on failed gate',
+    );
   });
 });
 
@@ -3787,7 +3889,10 @@ test('--mark-session-closed with ok gate but dirty git → exit 1, no marker (AD
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
     assert.ok(out.git_reason, `dirty-git result must carry git_reason: ${JSON.stringify(out)}`);
-    assert.ok(!existsSync(join(dir, '.cache', 'session-closed-s-dirty.marker')), 'marker must not land on dirty git');
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-dirty.marker')),
+      'marker must not land on dirty git',
+    );
   });
 });
 


### PR DESCRIPTION
## What

`lint.mjs` now errors when a page lives under `pages/<subdir>/` where `<subdir>` is not defined in the SCHEMA **Page Type Taxonomy** table. Such a directory is almost always a typo — e.g. the singular `pages/learning/` when the canonical dir is `pages/learnings/` — and silently breaks wikilink resolution and crystallize routing.

Originated from a real incident: a stray `pages/learning/` (singular) directory was created by an LLM and went undetected.

## How

- **`scripts/lib/schema-vocab.mjs`** — new `parseSchemaPageDirs()` derives the whitelist from the taxonomy **table rows** (single source of truth; mirrors `parseSchemaVocab`). Returns an empty Set when `SCHEMA.md` or the table is absent → the check is skipped (back-compat with minimal wikis).
- **`scripts/lint.mjs`** — path-based check in `lintPage`, independent of frontmatter. Exempts `_`-prefixed scaffold files (e.g. `pages/observability/_index.md`, a packaged section index that is not a page *type*) so a freshly `init`'d wiki stays green; a real typo dir carries content, not just an index.
- **`tests/runner.mjs`** — 7 cases: typo→error, canonical→green, root file→green, table-absent→green, `_index` scaffold→green, content-in-typo-dir→error, and a real `init.mjs`→`lint.mjs` regression for the observability scaffold.

## Review

Two independent codex passes (pre-commit gate): round 1 caught a blocker — B6 failing a fresh `init` wiki because of the `pages/observability/_index.md` scaffold — and round 2 confirmed the `_`-prefix fix and audited every runtime `pages/<subdir>` writer (init, feedback, feedback-sync, crystallize, weekly-report); none is wrongly flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)