### PR TITLE
feat: fix #3 + #13 — first-prompt forces resume summary + cwd-change re-trigger

### DIFF
--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -6,10 +6,16 @@
  * project hot.md. Skips if still within the same project subtree.
  */
 
-import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
-import { HYPO_DIR, buildOutput, loadHypoIgnore, isIgnored } from './hypo-shared.mjs';
+import {
+  HYPO_DIR,
+  buildOutput,
+  loadHypoIgnore,
+  isIgnored,
+  sessionMarkerPath,
+} from './hypo-shared.mjs';
 
 const PROJECTS_DIR = join(HYPO_DIR, 'projects');
 const GLOBAL_HOT = join(HYPO_DIR, 'hot.md');
@@ -49,7 +55,13 @@ function findProjectHot(cwd) {
       : workingDir;
     if (cwd === resolved || cwd.startsWith(resolved + '/')) {
       const hotPath = join(projDir, 'hot.md');
-      return { proj, hotPath: existsSync(hotPath) ? hotPath : null, resolved };
+      const statePath = join(projDir, 'session-state.md');
+      return {
+        proj,
+        hotPath: existsSync(hotPath) ? hotPath : null,
+        statePath: existsSync(statePath) ? statePath : null,
+        resolved,
+      };
     }
   }
   return null;
@@ -67,6 +79,7 @@ process.stdin.on('end', () => {
 
     const newCwd = data.new_cwd || data.new_directory || data.cwd || process.cwd();
     const oldCwd = data.old_cwd || data.old_directory || data.previous_cwd || '';
+    const sessionId = data.session_id || 'default';
 
     // Skip re-injection if still in the same project
     const oldHit = oldCwd ? findProjectHot(oldCwd) : null;
@@ -82,6 +95,28 @@ process.stdin.on('end', () => {
     if (newHit) {
       const fromFile = readIfNotIgnored(newHit.hotPath, ignorePatterns);
       const content = fromFile ?? '(no hot.md yet — will be created at session close)';
+      // fix #13: arm the first-prompt marker so the NEXT user prompt re-triggers
+      // hypo-first-prompt, which forces a "Resuming <project>" summary line.
+      // Only arm when real hot content was actually injected — if hot.md is
+      // missing or .hypoignore'd (fromFile null), there is nothing for the LLM
+      // to summarize, so forcing "Resuming" would be empty noise (codex review).
+      if (fromFile) {
+        try {
+          writeFileSync(
+            sessionMarkerPath(sessionId),
+            JSON.stringify({
+              proj: newHit.proj,
+              hotPath: newHit.hotPath,
+              statePath: newHit.statePath,
+              hasSnapshot: true,
+              source: 'cwd-change',
+              ts: Date.now(),
+            }),
+          );
+        } catch (err) {
+          process.stderr.write(`[wiki-cwd-change] marker write failed: ${err.message}\n`);
+        }
+      }
       console.log(
         JSON.stringify(
           buildOutput(`[WIKI: cwd changed → project=${newHit.proj}]\n\n${content}`, {

--- a/hooks/hypo-first-prompt.mjs
+++ b/hooks/hypo-first-prompt.mjs
@@ -2,19 +2,20 @@
 /**
  * hypo-first-prompt.mjs — UserPromptSubmit hook
  *
- * Consumes the marker written by wiki-session-start.mjs.
- * On the FIRST user prompt of a new session, injects a lightweight decision
- * instruction so the LLM can decide whether to announce the resume context.
+ * Consumes the marker written by hypo-session-start.mjs (source omitted /
+ * 'session-start') or hypo-cwd-change.mjs (source 'cwd-change', fix #13).
+ * On the FIRST user prompt after the marker is written, FORCES a one-line
+ * resume summary into the reply (fix #3 — the old "answer only if related"
+ * conditional is removed; the line is injected unconditionally).
  *
- * hot.md content is NOT re-injected here — wiki-session-start.mjs already
- * injected it on SessionStart. Only the decision hint is added.
+ * hot.md / session-state.md content is NOT re-injected here — the upstream
+ * hook already placed it in additionalContext. This hook only forces the LLM
+ * to lead with the summary line drawn from that context.
  * Marker expires after 10 minutes.
  */
 
 import { readFileSync, unlinkSync, existsSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
-import { buildOutput } from './hypo-shared.mjs';
+import { buildOutput, sessionMarkerPath } from './hypo-shared.mjs';
 
 const MARKER_TTL = 10 * 60 * 1000; // 10 min
 
@@ -27,8 +28,7 @@ process.stdin.on('end', () => {
     try {
       data = JSON.parse(raw);
     } catch {}
-    const sessionId = data.session_id || 'default';
-    const MARKER_FILE = join(tmpdir(), `hypo-session-marker-${sessionId}.json`);
+    const MARKER_FILE = sessionMarkerPath(data.session_id);
 
     if (!existsSync(MARKER_FILE)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -49,11 +49,19 @@ process.stdin.on('end', () => {
 
     const hasSnapshot = marker.hasSnapshot ?? (marker.hotPath && existsSync(marker.hotPath));
     const snapshotNote = hasSnapshot ? '' : ' (no snapshot yet — first session)';
+    // fix #13: a cwd-change re-trigger says "Resuming"; a fresh session start
+    // (default source) says "Previously working on".
+    const verb = marker.source === 'cwd-change' ? 'Resuming' : 'Previously working on';
 
     console.log(
       JSON.stringify(
         buildOutput(
-          `[WIKI SESSION START: project=${marker.proj}${snapshotNote}]\nDecision hint: if the first message relates to this project → answer first, then add one line "Previously working on ${marker.proj} — continue?" If unrelated / simple Q&A → answer only, no mention.`,
+          `[WIKI SESSION START: project=${marker.proj}${snapshotNote}]\n` +
+            `Before addressing the user's message, lead your FIRST reply with exactly one line:\n` +
+            `"${verb} ${marker.proj}: <one-line summary>. Continue with <next task>?"\n` +
+            `Draw <one-line summary> and <next task> from the [HOT] / [SESSION STATE] ` +
+            `context already injected this session. Inject this line unconditionally — ` +
+            `even if the user's first message is unrelated or a simple question — then answer normally.`,
           { continue: true, suppressOutput: true },
         ),
       ),

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -8,7 +8,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
-import { homedir, tmpdir } from 'os';
+import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync, spawn } from 'child_process';
@@ -23,6 +23,7 @@ import {
   clearClearMarker,
   loadHypoIgnore,
   isIgnored,
+  sessionMarkerPath,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -303,7 +304,7 @@ process.stdin.on('end', () => {
     if (updateLine) process.stderr.write(`\n\x1b[33m${updateLine}\x1b[0m\n`);
     const cwd = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || 'default';
-    const MARKER_FILE = join(tmpdir(), `hypo-session-marker-${sessionId}.json`);
+    const MARKER_FILE = sessionMarkerPath(sessionId);
     const hit = findProjectFiles(cwd);
 
     const ignorePatterns = loadHypoIgnore(HYPO_DIR);

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -8,10 +8,21 @@
 
 import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from 'fs';
 import { join, relative, basename } from 'path';
-import { homedir, hostname } from 'os';
+import { homedir, hostname, tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 
 const HOME = homedir();
+
+// ── session marker path ─────────────────────────────────────────────────────
+// hypo-session-start / hypo-cwd-change WRITE this marker; hypo-first-prompt
+// READS + unlinks it. The session_id comes from the Claude Code runtime (a
+// UUID), but we sanitize defensively so a malformed id with path separators or
+// `..` can never escape tmpdir or collide on an empty value (codex review
+// 2026-05-21, fix #3/#13). Non-alphanumeric chars collapse to `_`.
+export function sessionMarkerPath(sessionId) {
+  const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9._-]/g, '_') || 'default';
+  return join(tmpdir(), `hypo-session-marker-${safe}.json`);
+}
 
 // ── wiki root resolution ────────────────────────────────────────────────────
 
@@ -489,7 +500,9 @@ const SESSION_CLOSED_MARKER_STALE_MS = 7 * 24 * 60 * 60 * 1000;
 /** Sanitize session_id for filesystem use — Claude session_ids are UUIDs but
  *  defend against accidental path traversal regardless. */
 function sanitizeSessionId(sessionId) {
-  return String(sessionId).replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 128);
+  return String(sessionId)
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .slice(0, 128);
 }
 
 /** @returns {string} path to the session-closed marker for a given session_id. */

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2711,6 +2711,156 @@ test('cwd-change refuses to inject .hypoignore-matched global hot.md', () => {
   });
 });
 
+// ── first-prompt forced resume summary (fix #3) + cwd-change re-trigger (#13) ──
+suite('hypo-first-prompt.mjs — forced resume summary (fix #3 / #13)');
+
+// first-prompt reads its marker from os.tmpdir(), independent of HOME/HYPO_DIR.
+// Tests use a unique session_id so the marker path never collides.
+function markerPath(sessionId) {
+  return join(tmpdir(), `hypo-session-marker-${sessionId}.json`);
+}
+function writeMarker(sessionId, marker) {
+  writeFileSync(markerPath(sessionId), JSON.stringify({ ts: Date.now(), ...marker }));
+}
+function runFirstPrompt(sessionId) {
+  return spawnSync(process.execPath, [join(HOOKS, 'hypo-first-prompt.mjs')], {
+    input: JSON.stringify({ session_id: sessionId, prompt: 'unrelated weather question' }),
+    encoding: 'utf-8',
+    env: { ...process.env, HYPO_DIR: '/tmp/nonexistent-hypo-99999' },
+  });
+}
+
+test('replay-first-prompt-forces-summary: fresh marker forces unconditional summary line', () => {
+  const sid = `fp-force-${process.pid}-${Date.now()}`;
+  writeMarker(sid, { proj: 'demo', hotPath: null, hasSnapshot: true });
+  try {
+    const r = runFirstPrompt(sid);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout).additionalContext || '';
+    assert.match(out, /Previously working on demo/, 'must force the resume summary line');
+    assert.match(out, /unconditionally/, 'directive must be unconditional (fix #3)');
+    // The old "answer only if related / no mention" escape must be gone.
+    assert.doesNotMatch(out, /answer only, no mention/, 'old conditional hint must be removed');
+  } finally {
+    if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+  }
+});
+
+test('replay-first-prompt-forces-summary: cwd-change marker says "Resuming"', () => {
+  const sid = `fp-resume-${process.pid}-${Date.now()}`;
+  writeMarker(sid, { proj: 'demo', hotPath: null, hasSnapshot: true, source: 'cwd-change' });
+  try {
+    const r = runFirstPrompt(sid);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout).additionalContext || '';
+    assert.match(out, /Resuming demo/, 'cwd-change source must phrase as Resuming (fix #13)');
+    assert.doesNotMatch(out, /Previously working on/, 'must not use the session-start verb');
+  } finally {
+    if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+  }
+});
+
+test('replay-first-prompt-forces-summary: no marker → silent pass-through', () => {
+  const sid = `fp-none-${process.pid}-${Date.now()}`;
+  const r = runFirstPrompt(sid); // no marker written
+  assert.equal(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.additionalContext, undefined, 'no marker → no injected directive');
+  assert.equal(out.suppressOutput, true);
+});
+
+test('replay-first-prompt-forces-summary: expired marker (>10min) → no directive, cleaned up', () => {
+  const sid = `fp-exp-${process.pid}-${Date.now()}`;
+  writeFileSync(
+    markerPath(sid),
+    JSON.stringify({ proj: 'demo', hasSnapshot: true, ts: Date.now() - 11 * 60 * 1000 }),
+  );
+  const r = runFirstPrompt(sid);
+  assert.equal(r.status, 0);
+  assert.equal(JSON.parse(r.stdout).additionalContext, undefined, 'expired marker injects nothing');
+  assert.equal(existsSync(markerPath(sid)), false, 'expired marker is unlinked');
+});
+
+test('replay-cwd-change-triggers-first-prompt: entering a project arms the marker', () => {
+  const sid = `cwd-arm-${process.pid}-${Date.now()}`;
+  withPrivateProject((dir, work) => {
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
+      input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/other-nonproject', session_id: sid }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    try {
+      assert.ok(
+        existsSync(markerPath(sid)),
+        'cwd-change must write a first-prompt marker (fix #13)',
+      );
+      const m = JSON.parse(readFileSync(markerPath(sid), 'utf-8'));
+      assert.equal(m.proj, 'private');
+      assert.equal(m.source, 'cwd-change');
+      // The armed marker drives first-prompt to force a "Resuming" line.
+      const fp = runFirstPrompt(sid);
+      const out = JSON.parse(fp.stdout).additionalContext || '';
+      assert.match(out, /Resuming private/, 'armed marker forces Resuming on next prompt');
+    } finally {
+      if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+    }
+  });
+});
+
+const sharedMod = await import(`${REPO}/hooks/hypo-shared.mjs`);
+
+test('sessionMarkerPath: sanitizes path separators and empty ids (codex fix #3/#13)', () => {
+  const { sessionMarkerPath } = sharedMod;
+  // A crafted id with separators / traversal must collapse to a flat filename
+  // inside tmpdir — never escape it.
+  const evil = sessionMarkerPath('../../etc/passwd');
+  assert.equal(dirname(evil), tmpdir(), 'must stay directly under tmpdir');
+  assert.doesNotMatch(evil, /\/etc\/passwd/, 'separators must not survive');
+  // Empty / missing id falls back to a stable default, never a bare marker name.
+  assert.match(sessionMarkerPath(''), /hypo-session-marker-default\.json$/);
+  assert.match(sessionMarkerPath(undefined), /hypo-session-marker-default\.json$/);
+  // A normal UUID-ish id is preserved verbatim.
+  assert.match(sessionMarkerPath('abc-123_DEF'), /hypo-session-marker-abc-123_DEF\.json$/);
+});
+
+test('replay-cwd-change-triggers-first-prompt: ignored hot.md does NOT arm the marker', () => {
+  const sid = `cwd-ignored-${process.pid}-${Date.now()}`;
+  withPrivateProject((dir, work) => {
+    // hot.md is .hypoignore'd → cwd-change injects a placeholder, so there is
+    // nothing to summarize and the marker must NOT be armed (codex finding #2).
+    writeFileSync(join(dir, '.hypoignore'), 'projects/private/hot.md\n');
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
+      input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/other-nonproject', session_id: sid }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    if (existsSync(markerPath(sid))) {
+      unlinkSync(markerPath(sid));
+      assert.fail('ignored/absent hot content must not arm a "Resuming" marker');
+    }
+  });
+});
+
+test('replay-cwd-change-triggers-first-prompt: same-project move does NOT arm the marker', () => {
+  const sid = `cwd-same-${process.pid}-${Date.now()}`;
+  withPrivateProject((dir, work) => {
+    const sub = join(work, 'subdir');
+    mkdirSync(sub, { recursive: true });
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
+      input: JSON.stringify({ new_cwd: sub, old_cwd: work, session_id: sid }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    if (existsSync(markerPath(sid))) {
+      unlinkSync(markerPath(sid));
+      assert.fail('same-project cwd move must skip and not arm a marker');
+    }
+  });
+});
+
 test('file-watch ignores file outside HYPO_DIR even without .hypoignore', () => {
   withGrowthWiki((dir) => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-file-watch.mjs')], {


### PR DESCRIPTION
## Summary
Stage 6 Phase B slice A — two first-prompt fixes sharing the session-marker mechanism.

- **fix #3** (`hooks/hypo-first-prompt.mjs`): removes the old conditional "answer only if related / no mention" hint and FORCES an unconditional one-line resume summary into the first reply: `"Previously working on X: <summary>. Continue with <next task>?"`, drawn from the `[HOT]` / `[SESSION STATE]` context already injected at SessionStart. (Q-3.8 / Q-5.4.2, spec §513)
- **fix #13** (`hooks/hypo-cwd-change.mjs`): on entering a DIFFERENT project, arms the first-prompt marker (`source:'cwd-change'`) so the next user prompt re-triggers `hypo-first-prompt`, which phrases it `"Resuming X"`. Same-project moves skip; an ignored/absent `hot.md` does not arm. (Q-5.4.11, spec §539/§8.5)

## codex pre-commit review (applied)
1. **IMPORTANT** — `sessionMarkerPath()` shared helper in `hypo-shared.mjs` sanitizes `session_id` so a malformed id with path separators / `..` can't escape `tmpdir` or collide on empty. Adopted by first-prompt, cwd-change, **and** session-start (consistency).
2. **IMPORTANT** — cwd-change arms the marker only when real hot content was injected (ignored/missing `hot.md` → no empty "Resuming" noise).
3. **MINOR** — marker write failure now emits a non-fatal stderr diagnostic instead of being swallowed.

## Tests
309 pass (+8): forced summary line, `Resuming` verb on cwd-change, no/expired marker pass-through, cwd arm/skip/ignored-hot, `sessionMarkerPath` sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)