### PR TITLE
feat(stage-6-fix-12): unified [hypo-<name>] error: stderr logging across lifecycle hooks (spec §7.5)

### DIFF
--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -59,8 +59,7 @@ function emitBlock(sessionId) {
   // alias; passing --session-id there writes the per-session marker that clears
   // this block. CLI fallback + bypass live in commands/crystallize.md, not here
   // — keep the Stop reason terse so the actionable instruction stands out.
-  const reason =
-    `[WIKI_AUTOCLOSE] session-close 미완료 — /hypo:crystallize 실행으로 마무리 (session_id=${sessionId}).`;
+  const reason = `[WIKI_AUTOCLOSE] session-close 미완료 — /hypo:crystallize 실행으로 마무리 (session_id=${sessionId}).`;
   console.log(
     JSON.stringify({
       decision: 'block',
@@ -78,9 +77,12 @@ process.stdin.on('end', () => {
     let payload = {};
     try {
       payload = JSON.parse(raw) || {};
-    } catch {
+    } catch (err) {
       // Any malformed payload is fail-open — we never want a parse error to
       // strand Claude in a blocked Stop with no recovery context.
+      process.stderr.write(
+        `[hypo-auto-minimal-crystallize] error: ${err?.message ?? String(err)}\n`,
+      );
       emitContinue();
       return;
     }
@@ -102,10 +104,8 @@ process.stdin.on('end', () => {
       return;
     }
 
-    const sessionId =
-      payload.session_id || payload.sessionId || null;
-    const transcriptPath =
-      payload.transcript_path || payload.transcriptPath || null;
+    const sessionId = payload.session_id || payload.sessionId || null;
+    const transcriptPath = payload.transcript_path || payload.transcriptPath || null;
 
     // 3. substantial-session gate. Read-only / Q&A sessions skip the block.
     if (!hasMutatingTranscriptActivity(transcriptPath)) {
@@ -137,8 +137,9 @@ process.stdin.on('end', () => {
     }
 
     emitBlock(sessionId);
-  } catch {
+  } catch (err) {
     // Fail-open on any unexpected error.
+    process.stderr.write(`[hypo-auto-minimal-crystallize] error: ${err?.message ?? String(err)}\n`);
     emitContinue();
   }
 });

--- a/hooks/hypo-auto-stage.mjs
+++ b/hooks/hypo-auto-stage.mjs
@@ -16,7 +16,8 @@ try {
     process.stdin.on('end', () => r(d));
   });
   input = JSON.parse(raw);
-} catch {
+} catch (err) {
+  process.stderr.write(`[hypo-auto-stage] error: ${err?.message ?? String(err)}\n`);
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   process.exit(0);
 }

--- a/hooks/hypo-compact-guard.mjs
+++ b/hooks/hypo-compact-guard.mjs
@@ -72,8 +72,9 @@ process.stdin.on('end', () => {
         ].join('\n'),
       }),
     );
-  } catch {
+  } catch (err) {
     // Fail-open: any parse/runtime error must not block the user's prompt.
+    process.stderr.write(`[hypo-compact-guard] error: ${err?.message ?? String(err)}\n`);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   }
 });

--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -114,7 +114,9 @@ process.stdin.on('end', () => {
             }),
           );
         } catch (err) {
-          process.stderr.write(`[wiki-cwd-change] marker write failed: ${err.message}\n`);
+          process.stderr.write(
+            `[hypo-cwd-change] marker write failed: ${err?.message ?? String(err)}\n`,
+          );
         }
       }
       console.log(
@@ -147,7 +149,7 @@ process.stdin.on('end', () => {
       ),
     );
   } catch (err) {
-    process.stderr.write(`[wiki-cwd-change] error: ${err.message}\n`);
+    process.stderr.write(`[hypo-cwd-change] error: ${err?.message ?? String(err)}\n`);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   }
 });

--- a/hooks/hypo-file-watch.mjs
+++ b/hooks/hypo-file-watch.mjs
@@ -53,7 +53,8 @@ process.stdin.on('end', () => {
         additionalContext: `[WIKI FILE UPDATED: ${relPath}]\n\n${content}`,
       }),
     );
-  } catch {
+  } catch (err) {
+    process.stderr.write(`[hypo-file-watch] error: ${err?.message ?? String(err)}\n`);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   }
 });

--- a/hooks/hypo-first-prompt.mjs
+++ b/hooks/hypo-first-prompt.mjs
@@ -66,7 +66,8 @@ process.stdin.on('end', () => {
         ),
       ),
     );
-  } catch {
+  } catch (err) {
+    process.stderr.write(`[hypo-first-prompt] error: ${err?.message ?? String(err)}\n`);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   }
 });

--- a/hooks/hypo-hot-rebuild.mjs
+++ b/hooks/hypo-hot-rebuild.mjs
@@ -104,10 +104,14 @@ function emitGrowth() {
 
 try {
   rebuild();
-} catch {}
+} catch (err) {
+  process.stderr.write(`[hypo-hot-rebuild] error: ${err?.message ?? String(err)}\n`);
+}
 try {
   emitGrowth();
-} catch {}
+} catch (err) {
+  process.stderr.write(`[hypo-hot-rebuild] error: ${err?.message ?? String(err)}\n`);
+}
 
 try {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/hooks/hypo-lookup.mjs
+++ b/hooks/hypo-lookup.mjs
@@ -277,7 +277,8 @@ process.stdin.on('end', () => {
         ),
       ),
     );
-  } catch {
+  } catch (err) {
+    process.stderr.write(`[hypo-lookup] error: ${err?.message ?? String(err)}\n`);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   }
 });

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -120,8 +120,9 @@ process.stdin.on('end', () => {
       const parsed = JSON.parse(r.stdout || '{}');
       lintBlockers = parsed.errors || [];
       lintW8 = (parsed.warns || []).filter((w) => w.id === 'W8');
-    } catch {
+    } catch (err) {
       /* fail-open */
+      process.stderr.write(`[hypo-personal-check] error: ${err?.message ?? String(err)}\n`);
     }
   }
 
@@ -195,8 +196,9 @@ process.stdin.on('end', () => {
               : 'feedback projection drift — run `hypomnema feedback-sync --write`';
         }
       }
-    } catch {
+    } catch (err) {
       feedbackSkipped = true;
+      process.stderr.write(`[hypo-personal-check] error: ${err?.message ?? String(err)}\n`);
     }
   }
 

--- a/hooks/hypo-session-end.mjs
+++ b/hooks/hypo-session-end.mjs
@@ -50,8 +50,9 @@ process.stdin.on('end', () => {
       prev_transcript_path: payload.transcript_path || payload.transcriptPath || null,
       prev_cwd: payload.cwd || null,
     });
-  } catch {
+  } catch (err) {
     // Best-effort: a marker failure must not break /clear itself.
+    process.stderr.write(`[hypo-session-end] error: ${err?.message ?? String(err)}\n`);
   }
   emitContinue();
 });

--- a/hooks/hypo-session-record.mjs
+++ b/hooks/hypo-session-record.mjs
@@ -52,8 +52,9 @@ process.stdin.on('end', () => {
       cwd: payload.cwd || process.cwd(),
     };
     appendFileSync(INDEX_PATH, JSON.stringify(entry) + '\n');
-  } catch {
+  } catch (err) {
     // Audit is best-effort observability — never let it block session close.
+    process.stderr.write(`[hypo-session-record] error: ${err?.message ?? String(err)}\n`);
   }
   emitContinue();
 });

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -379,7 +379,8 @@ process.stdin.on('end', () => {
         ),
       ),
     );
-  } catch {
+  } catch (err) {
+    process.stderr.write(`[hypo-session-start] error: ${err?.message ?? String(err)}\n`);
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   }
 });

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -5621,6 +5621,66 @@ test('mergeLatest: refreshes latest but preserves notifiedFor', () => {
   }
 });
 
+// ── #12: unified hook stderr log format ────────────────────────────────────────
+// spec §7.5: every lifecycle hook's fail-open path must emit `[hypo-<name>] error:
+// <message>` to stderr (debugging, user-visible) while still returning the
+// fail-open output. <name> = hook filename minus `.mjs` (proven by the
+// wiki-cwd-change → hypo-cwd-change normalization).
+suite('hooks-stderr-log-format — unified [hypo-<name>] error: logging (#12)');
+
+const STDERR_LOG_HOOKS = [
+  'hypo-session-start',
+  'hypo-session-end',
+  'hypo-session-record',
+  'hypo-hot-rebuild',
+  'hypo-cwd-change',
+  'hypo-first-prompt',
+  'hypo-compact-guard',
+  'hypo-file-watch',
+  'hypo-lookup',
+  'hypo-personal-check',
+  'hypo-auto-minimal-crystallize',
+  'hypo-auto-stage',
+];
+
+for (const name of STDERR_LOG_HOOKS) {
+  test(`hooks-stderr-log-format: ${name}.mjs carries the unified [${name}] error: tag`, () => {
+    const src = readFileSync(join(HOOKS, `${name}.mjs`), 'utf-8');
+    // Unified tag present in a stderr write.
+    assert.ok(
+      new RegExp(`process\\.stderr\\.write\\(\`\\[${name}\\] error: `).test(src),
+      `${name}.mjs must log to stderr with the unified [${name}] error: format`,
+    );
+    // Hardened err access — bare `${err.message}` throws if a non-Error (null/
+    // undefined) is ever thrown, which would break the fail-open invariant.
+    assert.ok(
+      !/\$\{err\.message\}/.test(src),
+      `${name}.mjs must use \`err?.message ?? String(err)\`, not bare err.message`,
+    );
+    // No legacy [wiki-*] tag must survive the normalization (scoped to stderr
+    // writes so legitimate [WIKI ...] injection markers never false-fail).
+    assert.ok(
+      !/process\.stderr\.write\(`\[wiki-/.test(src),
+      `${name}.mjs must not retain a legacy [wiki-*] stderr tag`,
+    );
+  });
+}
+
+test('hooks-stderr-log-format: forced catch emits [hypo-compact-guard] error: + preserves fail-open', () => {
+  const r = runHook('hypo-compact-guard.mjs', 'not-json');
+  assert.match(r.stderr, /^\[hypo-compact-guard\] error: /m);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true); // fail-open invariant intact
+});
+
+test('hooks-stderr-log-format: forced catch emits [hypo-auto-stage] error: + preserves fail-open', () => {
+  const r = runHook('hypo-auto-stage.mjs', 'not-json');
+  assert.match(r.stderr, /^\[hypo-auto-stage\] error: /m);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true);
+  assert.equal(r.status, 0);
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
## Summary

Stage 6 Phase B 슬라이스 B = **fix #12** (spec §7.5). 모든 lifecycle hook의 fail-open catch 경로가 통일 형식 `[hypo-<name>] error: <message>`를 stderr로 출력하도록 정비. `<name>` = hook 파일명(`.mjs` 제외).

## Changes

- **12 hook sweep**: `session-start`/`end`/`record`, `hot-rebuild`(rebuild + emitGrowth), `cwd-change`(레거시 `[wiki-cwd-change]` → `[hypo-cwd-change]` 정규화), `first-prompt`, `compact-guard`, `file-watch`, `lookup`, `personal-check`(lint + feedback-sync tooling catch), `auto-minimal-crystallize`(top-level + 내부 malformed-payload catch), `auto-stage`.
- **auto-commit 제외**: top-level catch 없음. pull/push 실패는 이미 fix #9의 `appendSyncFailure` 경유.
- **err 접근 hardening**: 14개 stderr 사이트 `err?.message ?? String(err)` — 비-Error throw가 fail-open 불변식을 깨지 못하게.
- **신규 테스트** `hooks-stderr-log-format`: 소스 커버리지 12(통일 태그 존재 / bare err.message 부재 / 레거시 `[wiki-*]` stderr 태그 부재) + 동작 2(catch 강제 → 태그 출력 AND `continue:true` 보존).

## Review & Test

- codex 2-worker pre-commit 리뷰(둘 다 REQUEST_CHANGES) → 지적 전부 반영: emitGrowth/inner-payload catch 누락 보강, err.message hardening, test assertion 한정.
- `npm test` → **323 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)