### PR TITLE
feat(stage-6): auto-project creation on cwd match — fix #1/#4/#23 (ADR 0023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Auto-project creation on cwd match (ADR 0023).** When you start a session
+  (or change directory) inside a git repository that carries a project marker
+  (`package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`, `pom.xml`,
+  `build.gradle`, `composer.json`, `Gemfile`) but matches no existing wiki
+  project's `working_dir`, the SessionStart/CwdChanged hook now offers to create
+  one. The offer is a nudge only; on "Y" Claude runs the new internal scaffold
+  helper (`scripts/lib/project-create.mjs`) which materializes the project from
+  `templates/projects/_template/` with token substitution, adds the root
+  `hot.md` pointer row, and logs the creation. On "N" the cwd is recorded under
+  `skips[]` in `.cache/project-suggestions.json` and never offered again (a
+  5-minute per-cwd cooldown also suppresses repeats within a session). Temp and
+  marker-less directories never trigger the offer. `hypomnema doctor` validates
+  the skip-persistence file's schema. The deprecated `hypomnema project new`
+  subcommand is not introduced (ADR 0023). Also strengthens the templated
+  Session Start guidance: the first response must lead with a resume summary.
 - **Update notifier.** The SessionStart hook now shows an "Update available!"
   banner when a newer Hypomnema version has been published, detecting both
   distribution channels (npm package and Claude Code plugin) and printing the

--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -15,6 +15,9 @@ import {
   loadHypoIgnore,
   isIgnored,
   sessionMarkerPath,
+  shouldSuggestProjectCreation,
+  buildProjectSuggestionLine,
+  recordSuggestionCooldown,
 } from './hypo-shared.mjs';
 
 const PROJECTS_DIR = join(HYPO_DIR, 'projects');
@@ -130,20 +133,36 @@ process.stdin.on('end', () => {
       return;
     }
 
-    if (!existsSync(GLOBAL_HOT)) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
-      return;
+    // MISS: cwd matches no project. fix #23 / ADR 0023 — offer to create one
+    // when the trigger conditions hold. Same nudge-only model as session-start.
+    let suggestPrefix = '';
+    if (shouldSuggestProjectCreation(newCwd, HYPO_DIR)) {
+      const suggestLine = buildProjectSuggestionLine(newCwd);
+      suggestPrefix = `${suggestLine}\n\n`;
+      recordSuggestionCooldown(HYPO_DIR, newCwd);
+      process.stderr.write(`\n\x1b[33m${suggestLine}\x1b[0m\n`);
     }
 
-    const globalContent = readIfNotIgnored(GLOBAL_HOT, ignorePatterns);
+    const globalContent = existsSync(GLOBAL_HOT)
+      ? readIfNotIgnored(GLOBAL_HOT, ignorePatterns)
+      : null;
+
     if (!globalContent) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      if (suggestPrefix) {
+        console.log(
+          JSON.stringify(
+            buildOutput(suggestPrefix.trimEnd(), { continue: true, suppressOutput: true }),
+          ),
+        );
+      } else {
+        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      }
       return;
     }
     console.log(
       JSON.stringify(
         buildOutput(
-          `[WIKI: cwd changed → no project match, injecting global hot]\n\n${globalContent}`,
+          `${suggestPrefix}[WIKI: cwd changed → no project match, injecting global hot]\n\n${globalContent}`,
           { continue: true, suppressOutput: true },
         ),
       ),

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -24,6 +24,9 @@ import {
   loadHypoIgnore,
   isIgnored,
   sessionMarkerPath,
+  shouldSuggestProjectCreation,
+  buildProjectSuggestionLine,
+  recordSuggestionCooldown,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -296,7 +299,7 @@ process.stdin.on('end', () => {
     // LLM's additionalContext so model and user start the session looking at
     // the same state. ANSI escapes are kept out of additionalContext on purpose.
     const notices = [syncLine, growthLine, clearRecoveryLine, updateLine].filter(Boolean);
-    const noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
+    let noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
     if (syncLine) process.stderr.write(`\n\x1b[33m${syncLine}\x1b[0m\n`);
     if (growthLine) process.stderr.write(`\n\x1b[36m${growthLine}\x1b[0m\n`);
     if (clearRecoveryLine)
@@ -356,6 +359,18 @@ process.stdin.on('end', () => {
       return;
     }
 
+    // MISS: cwd matches no project. fix #23 / ADR 0023 — offer to create one
+    // when the ADR trigger conditions hold (git repo + project marker + no
+    // cooldown + not previously declined). The actual scaffold is the LLM's
+    // job on a "Y" reply (scripts/lib/project-create.mjs); the hook only nudges.
+    if (shouldSuggestProjectCreation(cwd, HYPO_DIR)) {
+      const suggestLine = buildProjectSuggestionLine(cwd);
+      notices.push(suggestLine);
+      noticePrefix = `${notices.join('\n\n')}\n\n`;
+      recordSuggestionCooldown(HYPO_DIR, cwd);
+      process.stderr.write(`\n\x1b[33m${suggestLine}\x1b[0m\n`);
+    }
+
     if (!existsSync(GLOBAL_HOT)) {
       const notice = notices.join('\n\n');
       if (notice) {
@@ -368,7 +383,15 @@ process.stdin.on('end', () => {
 
     const globalContent = readIfNotIgnored(GLOBAL_HOT, HOT_CHARS, ignorePatterns);
     if (!globalContent) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      // GLOBAL_HOT exists but is empty or .hypoignore'd — still surface any
+      // pending notices (sync state, growth, AND the auto-project offer), which
+      // would otherwise be silently dropped here (codex review 2026-05-22).
+      const notice = notices.join('\n\n');
+      if (notice) {
+        console.log(JSON.stringify(buildOutput(notice, { continue: true, suppressOutput: true })));
+      } else {
+        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      }
       return;
     }
     console.log(

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -400,6 +400,127 @@ export function clearSyncState(hypoDir) {
   }
 }
 
+// ── auto-project suggestion (fix #23, ADR 0023) ────────────────────────────
+// `.cache/project-suggestions.json` is a single JSON object:
+//   { "skips": [{cwd, declined_at, reason}], "cooldowns": {"<cwd>": "<iso>"} }
+// `skips` is written by the LLM (Layer-1 behavioral rule) when the user answers
+// "N" to an auto-project offer — permanent per-cwd suppression (no TTL).
+// `cooldowns` is written by the hook each time it emits an offer — a 5-minute
+// same-cwd noise guard. The two live in one file so doctor validates a single
+// schema. Both reads/writes are best-effort; a failure only loses the offer,
+// never breaks SessionStart/CwdChanged.
+
+const PROJECT_MARKERS = [
+  'package.json',
+  'Cargo.toml',
+  'go.mod',
+  'pyproject.toml',
+  'pom.xml',
+  'build.gradle',
+  'composer.json',
+  'Gemfile',
+];
+const SUGGESTION_COOLDOWN_MS = 5 * 60 * 1000;
+
+/** @returns {string} path to the project-suggestions file for a wiki root. */
+export function projectSuggestionsPath(hypoDir) {
+  return join(hypoDir, '.cache', 'project-suggestions.json');
+}
+
+/**
+ * Read the project-suggestions store.
+ * @param {string} hypoDir
+ * @returns {{skips: object[], cooldowns: Record<string,string>, parseError: boolean}}
+ */
+export function readProjectSuggestions(hypoDir) {
+  const path = projectSuggestionsPath(hypoDir);
+  if (!existsSync(path)) return { skips: [], cooldowns: {}, parseError: false };
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8'));
+    return {
+      skips: Array.isArray(data.skips) ? data.skips : [],
+      cooldowns: data.cooldowns && typeof data.cooldowns === 'object' ? data.cooldowns : {},
+      parseError: false,
+    };
+  } catch {
+    return { skips: [], cooldowns: {}, parseError: true };
+  }
+}
+
+/**
+ * Record that an offer was just emitted for `cwd`, starting the cooldown.
+ * Preserves the existing skips array. Best-effort.
+ */
+export function recordSuggestionCooldown(hypoDir, cwd, now = new Date()) {
+  try {
+    const cacheDir = join(hypoDir, '.cache');
+    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+    const { skips, cooldowns } = readProjectSuggestions(hypoDir);
+    cooldowns[cwd] = now.toISOString();
+    writeFileSync(
+      projectSuggestionsPath(hypoDir),
+      JSON.stringify({ skips, cooldowns }, null, 2) + '\n',
+    );
+  } catch {
+    // best-effort
+  }
+}
+
+/** True when `cwd` carries one of the recognized project-root markers. */
+export function cwdHasProjectMarker(cwd) {
+  return PROJECT_MARKERS.some((m) => existsSync(join(cwd, m)));
+}
+
+/**
+ * Decide whether SessionStart/CwdChanged should offer to create a project for
+ * `cwd`. The caller MUST have already confirmed `cwd` matches no project's
+ * `working_dir` (the hook's MISS branch); this evaluates the remaining ADR 0023
+ * trigger conditions: (a) cwd is a git repo, (b) carries a project marker
+ * (`.git` alone is a weak signal — §8.11), (c) not in cooldown, (d) not a cwd
+ * the user previously declined. A corrupt store stays silent (doctor surfaces).
+ *
+ * @param {string} cwd
+ * @param {string} [hypoDir]
+ * @param {number} [now] epoch ms, injectable for tests
+ * @returns {boolean}
+ */
+export function shouldSuggestProjectCreation(cwd, hypoDir = HYPO_DIR, now = Date.now()) {
+  if (!cwd) return false;
+  if (!existsSync(join(cwd, '.git'))) return false;
+  if (!cwdHasProjectMarker(cwd)) return false;
+  const { skips, cooldowns, parseError } = readProjectSuggestions(hypoDir);
+  if (parseError) return false;
+  if (skips.some((s) => s && s.cwd === cwd)) return false;
+  const ts = cooldowns[cwd];
+  if (ts) {
+    const t = Date.parse(ts);
+    if (Number.isFinite(t) && now - t < SUGGESTION_COOLDOWN_MS) return false;
+  }
+  return true;
+}
+
+/**
+ * Build the §8.11 auto-project offer line for a cwd. The display name is the
+ * cwd basename, which is attacker-influenced (a directory name can contain
+ * newlines/control chars on Unix). Strip control characters and length-cap it
+ * so a crafted dir name cannot spoof extra instructions in additionalContext
+ * (codex review 2026-05-22).
+ */
+export function buildProjectSuggestionLine(cwd) {
+  // Replace any control char (code < 0x20 or === 0x7F) with a space so a
+  // crafted dir name cannot inject newlines/instructions into additionalContext
+  // (codex review 2026-05-22). Done by codepoint to keep control bytes out of
+  // this source file.
+  const sanitized = Array.from(basename(cwd))
+    .map((ch) => {
+      const code = ch.codePointAt(0);
+      return code < 0x20 || code === 0x7f ? ' ' : ch;
+    })
+    .join('');
+  const safe = sanitized.slice(0, 80).trim() || 'project';
+  return `[WIKI: cwd '${safe}'에 매칭되는 프로젝트가 없습니다. 자동 생성할까요? (Y/n)]`;
+}
+
 // ── clear-marker (fix #25 PR-A2, ADR 0022 amendment 2026-05-14) ────────────
 // `/clear` cannot be blocked (no UserPromptSubmit fire). The only intervention
 // point is the SessionEnd(reason='clear') → SessionStart(source='clear') pair:

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
-import { readSyncState } from '../hooks/hypo-shared.mjs';
+import { readSyncState, projectSuggestionsPath } from '../hooks/hypo-shared.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -510,6 +510,57 @@ function checkSyncState(hypoDir) {
   }
 }
 
+function checkProjectSuggestions(hypoDir) {
+  // fix #23 / ADR 0023: the auto-project skip-persistence store. Absent file is
+  // healthy (no offers declined yet). Validate the RAW JSON shape here rather
+  // than via readProjectSuggestions(): that helper deliberately normalizes a
+  // non-array `skips` to [] for fail-open hook reads, which would mask a
+  // malformed file and silently break permanent "N" suppression (codex review
+  // 2026-05-22). Doctor must catch the malformation the helper hides.
+  const path = projectSuggestionsPath(hypoDir);
+  if (!existsSync(path)) {
+    pass('Auto-project suggestions', 'No skip-persistence file (clean)');
+    return;
+  }
+  let data;
+  try {
+    data = JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    warn(
+      'Auto-project suggestions',
+      'Cannot parse .cache/project-suggestions.json — inspect manually',
+    );
+    return;
+  }
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    warn('Auto-project suggestions', 'project-suggestions.json must be a JSON object');
+    return;
+  }
+  if (!Array.isArray(data.skips)) {
+    warn(
+      'Auto-project suggestions',
+      '`skips` must be an array — declined-cwd suppression will not work',
+    );
+    return;
+  }
+  if (
+    data.cooldowns !== undefined &&
+    (typeof data.cooldowns !== 'object' || data.cooldowns === null || Array.isArray(data.cooldowns))
+  ) {
+    warn('Auto-project suggestions', '`cooldowns` must be a plain object');
+    return;
+  }
+  const bad = data.skips.filter((s) => !s || typeof s.cwd !== 'string' || !s.cwd);
+  if (bad.length > 0) {
+    warn(
+      'Auto-project suggestions',
+      `${bad.length} malformed skip entr(ies) missing a string \`cwd\` in .cache/project-suggestions.json`,
+    );
+  } else {
+    pass('Auto-project suggestions', `${data.skips.length} declined cwd(s) recorded`);
+  }
+}
+
 function checkCodexPaths() {
   const codexHooks = join(HOME, '.codex', 'hooks');
   const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
@@ -686,6 +737,7 @@ checkHooks();
 checkSettingsJson();
 if (args.codex) checkCodexPaths();
 if (rootOk) checkSyncState(args.hypoDir);
+if (rootOk) checkProjectSuggestions(args.hypoDir);
 if (rootOk) checkFeedbackProjection(args.hypoDir, args.claudeHome, args.projectId);
 checkGit(args.hypoDir);
 

--- a/scripts/lib/project-create.mjs
+++ b/scripts/lib/project-create.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * project-create.mjs — atomic auto-project scaffold (fix #23, ADR 0023)
+ *
+ * Invoked by the LLM (NOT a user-facing subcommand — ADR 0023 deprecated
+ * `hypomnema project new`) after the user answers "Y" to a SessionStart /
+ * CwdChanged auto-project offer. One call materializes a whole project:
+ *
+ *   1. mkdir projects/<name>/{decisions,session-log}
+ *   2. copy templates/projects/_template/*.md with token substitution
+ *        <project-name> → name, <started> → date, <working_dir> → cwd,
+ *        YYYY-MM-DD     → today  (frontmatter `updated:` only)
+ *   3. append a row to root hot.md "Active Projects" table
+ *   4. append a `## [today] project-create | <name>` entry to log.md
+ *
+ * Idempotent: existing files/rows/entries are preserved, never overwritten or
+ * duplicated, so a re-run after a partial failure converges.
+ *
+ * CLI:
+ *   node scripts/lib/project-create.mjs --name <slug> --working-dir <path> \
+ *        [--hypo-dir <path>] [--started <YYYY-MM-DD>] [--json]
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'fs';
+import { join, dirname, resolve, sep } from 'path';
+import { fileURLToPath } from 'url';
+import { resolveHypoRoot, expandHome } from './hypo-root.mjs';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(SCRIPT_DIR, '..', '..');
+const TEMPLATE_DIR = join(PKG_ROOT, 'templates', 'projects', '_template');
+
+const TEMPLATE_FILES = ['index.md', 'prd.md', 'hot.md', 'session-state.md'];
+
+function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Substitute the project tokens in a template file's content.
+ * @param {string} content
+ * @param {{name: string, started: string, workingDir: string, today: string}} vars
+ */
+export function substituteTokens(content, { name, started, workingDir, today }) {
+  return content
+    .split('<project-name>')
+    .join(name)
+    .split('<started>')
+    .join(started)
+    .split('<working_dir>')
+    .join(workingDir)
+    .split('YYYY-MM-DD')
+    .join(today);
+}
+
+/**
+ * Insert a project row into the root hot.md "Active Projects" table.
+ * Idempotent: returns the original content unchanged if a row already links
+ * to `[[projects/<name>/hot]]`. Returns null if the table cannot be located.
+ * @returns {string|null} new content, or null when no table marker is found
+ */
+export function insertHotRow(content, name, today) {
+  const link = `[[projects/${name}/hot]]`;
+  if (content.includes(link)) return content; // already present
+  const lines = content.split('\n');
+  // Scope the search to the "## Active Projects" section so a table appearing
+  // earlier in hot.md can't capture the row (codex review 2026-05-22). Start
+  // looking from the heading; stop at the next H2 so we never cross sections.
+  const headingIdx = lines.findIndex((l) => /^##\s+Active Projects\s*$/.test(l));
+  if (headingIdx === -1) return null;
+  let sepIdx = -1;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    if (/^##\s/.test(lines[i])) break; // next section — table not found in scope
+    if (/^\|\s*-{2,}\s*\|/.test(lines[i])) {
+      sepIdx = i;
+      break;
+    }
+  }
+  if (sepIdx === -1) return null;
+  const row = `| ${name} | ${today} | ${link} |`;
+  lines.splice(sepIdx + 1, 0, row);
+  return lines.join('\n');
+}
+
+/**
+ * Create a project. Idempotent and best-effort per side effect: a missing root
+ * hot.md / log.md is reported in `warnings` rather than thrown, so the core
+ * project files still land.
+ *
+ * @param {{hypoDir: string, name: string, workingDir: string, started?: string, today?: string}} opts
+ * @returns {{created: string[], skipped: string[], warnings: string[], projectDir: string}}
+ */
+export function createProject(opts) {
+  const { name, workingDir } = opts;
+  // Name must be a single path segment with at least one alnum. The charset
+  // alone is not enough: `.`, `..`, `...` all pass `[A-Za-z0-9._-]+` yet would
+  // resolve `projects/<name>` to the wiki root or `projects/` itself (codex
+  // review 2026-05-22, both workers). Reject dot-only names and require alnum.
+  if (!name || !/^[A-Za-z0-9._-]+$/.test(name) || /^\.+$/.test(name) || !/[A-Za-z0-9]/.test(name)) {
+    throw new Error(
+      `invalid project name: ${JSON.stringify(name)} (need a single segment with ≥1 alnum, charset A-Za-z0-9._-, not "."/"..")`,
+    );
+  }
+  if (!workingDir) throw new Error('workingDir is required');
+
+  const hypoDir = opts.hypoDir || resolveHypoRoot();
+  const today = opts.today || todayISO();
+  const started = opts.started || today;
+  const vars = { name, started, workingDir, today };
+
+  const created = [];
+  const skipped = [];
+  const warnings = [];
+
+  const projectsRoot = resolve(hypoDir, 'projects');
+  const projectDir = join(projectsRoot, name);
+  // Defense in depth: the resolved target must stay strictly inside projects/.
+  if (
+    resolve(projectDir) !== join(projectsRoot, name) ||
+    !resolve(projectDir).startsWith(projectsRoot + sep)
+  ) {
+    throw new Error(`project name escapes projects/: ${JSON.stringify(name)}`);
+  }
+  for (const sub of ['decisions', 'session-log']) {
+    mkdirSync(join(projectDir, sub), { recursive: true });
+  }
+
+  for (const file of TEMPLATE_FILES) {
+    const src = join(TEMPLATE_DIR, file);
+    const dest = join(projectDir, file);
+    if (!existsSync(src)) {
+      warnings.push(`template missing: ${file}`);
+      continue;
+    }
+    if (existsSync(dest)) {
+      skipped.push(`projects/${name}/${file}`);
+      continue;
+    }
+    writeFileSync(dest, substituteTokens(readFileSync(src, 'utf-8'), vars));
+    created.push(`projects/${name}/${file}`);
+  }
+
+  // root hot.md pointer row
+  const hotPath = join(hypoDir, 'hot.md');
+  if (existsSync(hotPath)) {
+    const orig = readFileSync(hotPath, 'utf-8');
+    const next = insertHotRow(orig, name, today);
+    if (next === null) {
+      warnings.push('root hot.md: no Active Projects table found — add row manually');
+    } else if (next !== orig) {
+      writeFileSync(hotPath, next);
+      created.push('hot.md row');
+    } else {
+      skipped.push('hot.md row');
+    }
+  } else {
+    warnings.push('root hot.md missing — skipped pointer row');
+  }
+
+  // log.md entry
+  const logPath = join(hypoDir, 'log.md');
+  const entry = `## [${today}] project-create | ${name}`;
+  if (existsSync(logPath)) {
+    const log = readFileSync(logPath, 'utf-8');
+    if (log.includes(entry)) {
+      skipped.push('log.md entry');
+    } else {
+      writeFileSync(logPath, log.replace(/\s*$/, '\n') + `\n${entry}\n`);
+      created.push('log.md entry');
+    }
+  } else {
+    warnings.push('log.md missing — skipped activity entry');
+  }
+
+  return { created, skipped, warnings, projectDir };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const args = { json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') args.json = true;
+    else if (a === '--name') args.name = argv[++i];
+    else if (a === '--working-dir') args.workingDir = expandHome(argv[++i]);
+    else if (a === '--hypo-dir') args.hypoDir = expandHome(argv[++i]);
+    else if (a === '--started') args.started = argv[++i];
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+const USAGE = `Usage: project-create.mjs --name <slug> --working-dir <path> [--hypo-dir <path>] [--started YYYY-MM-DD] [--json]`;
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  if (!args.name || !args.workingDir) {
+    console.error(`Error: --name and --working-dir are required\n${USAGE}`);
+    process.exit(1);
+  }
+  let result;
+  try {
+    result = createProject(args);
+  } catch (err) {
+    console.error(`Error: ${err?.message ?? String(err)}`);
+    process.exit(1);
+  }
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    result.created.forEach((c) => console.log(`✓ created ${c}`));
+    result.skipped.forEach((s) => console.log(`· skipped ${s} (exists)`));
+    result.warnings.forEach((w) => console.warn(`⚠ ${w}`));
+    console.log(`\nProject '${args.name}' ready at ${result.projectDir}`);
+  }
+}
+
+// Run as CLI only when invoked directly, not when imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -59,7 +59,7 @@ Over time, new sources *update* pages more than they *create* them — that's wh
 1. Read root `hot.md` → identify active project
 2. If `cwd` matches `projects/<name>/index.md`'s `working_dir:` field → read `projects/<name>/session-state.md` first
 3. Read `projects/<name>/hot.md` for background context
-4. Offer: "Continuing [X] from last session — shall we pick up?"
+4. **Your first response must lead with the resume**: a one-line summary of last session + the concrete next task(s) from `session-state.md`, then "Continuing [X] — shall we pick up?". Do not wait for the user to ask; this is mandatory whenever a project matched (not a soft offer).
 
 ### Session Close
 
@@ -124,6 +124,32 @@ projects/<name>/
 ```
 
 Add to root `hot.md` active projects table.
+
+#### Auto-project offer (ADR 0023)
+
+When SessionStart / CwdChanged injects a line like
+`[WIKI: cwd '<name>'에 매칭되는 프로젝트가 없습니다. 자동 생성할까요? (Y/n)]`,
+the current working directory is a real project (git repo + a project marker
+like `package.json`) that has no matching wiki project. **Act on it — do not
+ignore it:**
+
+1. Ask the user with `AskUserQuestion` (or a plain Y/n question) whether to
+   create the project.
+2. **On Yes** — run the scaffold helper once (it substitutes tokens, creates
+   the project files, adds the root `hot.md` row, and logs the entry):
+   ```
+   node <pkg-root>/scripts/lib/project-create.mjs --name <slug> --working-dir "$(pwd)"
+   ```
+   Then tell the user: "Created project `<name>` at
+   `~/hypomnema/projects/<name>/`. Edit `index.md` to refine." Do **not** hand-write
+   the five files — the helper keeps substitution and registration consistent.
+3. **On No** — record the refusal so this cwd is never offered again: append an
+   entry to `~/hypomnema/.cache/project-suggestions.json` under `skips`:
+   ```json
+   { "skips": [ { "cwd": "<absolute cwd>", "declined_at": "<ISO date>", "reason": "user_decline" } ] }
+   ```
+   (preserve any existing `skips` / `cooldowns` keys). The hook reads this and
+   stays silent for that cwd permanently.
 
 ### Close a project
 

--- a/templates/projects/_template/index.md
+++ b/templates/projects/_template/index.md
@@ -2,9 +2,9 @@
 title: <project-name> — Index
 type: project-index
 status: active
-started: YYYY-MM-DD
+started: <started>
 updated: YYYY-MM-DD
-working_dir: ~/path/to/project
+working_dir: <working_dir>
 tags: [project]
 ---
 

--- a/templates/projects/_template/prd.md
+++ b/templates/projects/_template/prd.md
@@ -2,7 +2,7 @@
 title: <project-name> — PRD
 type: prd
 status: active
-started: YYYY-MM-DD
+started: <started>
 updated: YYYY-MM-DD
 tags: [project, prd]
 ---

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -26,6 +26,8 @@ import { fileURLToPath } from 'node:url';
 // static import (no top-level await) — feedback-sync.mjs guards main() behind an
 // entry check, so importing it for unit tests does not run the CLI.
 import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync.mjs';
+import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
+import { buildProjectSuggestionLine } from '../hooks/hypo-shared.mjs';
 
 const HOME = homedir();
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -531,6 +533,96 @@ test('doctor-sync-state-warn: open sync-state.json entries → warn', () => {
     const check = out.find((c) => c.label === 'Sync state');
     assert.ok(check, 'Sync state check not found');
     assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+  });
+});
+
+// fix #23: doctor-project-suggestions skip-persistence schema check
+suite('doctor.mjs — fix #23: auto-project skip-persistence');
+
+function withDoctorWiki(fn) {
+  withTmpDir((dir) => {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'projects'), { recursive: true });
+    mkdirSync(join(dir, 'sources'), { recursive: true });
+    fn(dir);
+  });
+}
+
+test('doctor-project-suggestions: no file → pass', () => {
+  withDoctorWiki((dir) => {
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Auto-project suggestions');
+    assert.ok(check, 'check not found');
+    assert.equal(check.status, 'pass', `expected pass: ${check.detail}`);
+  });
+});
+
+test('doctor-project-suggestions: valid skips[] → pass', () => {
+  withDoctorWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'project-suggestions.json'),
+      JSON.stringify({
+        skips: [{ cwd: '/x/y', declined_at: '2026-05-21T00:00:00Z' }],
+        cooldowns: {},
+      }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Auto-project suggestions');
+    assert.equal(check.status, 'pass', `expected pass: ${check.detail}`);
+  });
+});
+
+test('doctor-project-suggestions: malformed skip entry → warn', () => {
+  withDoctorWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'project-suggestions.json'),
+      JSON.stringify({ skips: [{ declined_at: '2026-05-21T00:00:00Z' }], cooldowns: {} }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Auto-project suggestions');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+  });
+});
+
+test('doctor-project-suggestions: corrupt JSON → warn', () => {
+  withDoctorWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, '.cache', 'project-suggestions.json'), '{not json');
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Auto-project suggestions');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+  });
+});
+
+// codex review 2026-05-22 (MAJOR): a non-array `skips` (which the hook helper
+// silently normalizes to []) must still be flagged by doctor, since it breaks
+// permanent "N" suppression.
+test('doctor-project-suggestions: non-array skips → warn', () => {
+  withDoctorWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'project-suggestions.json'),
+      JSON.stringify({ skips: { cwd: '/x' }, cooldowns: {} }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Auto-project suggestions');
+    assert.equal(check.status, 'warn', `expected warn for non-array skips: ${check.detail}`);
+  });
+});
+
+test('doctor-project-suggestions: non-object cooldowns → warn', () => {
+  withDoctorWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'project-suggestions.json'),
+      JSON.stringify({ skips: [], cooldowns: [] }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Auto-project suggestions');
+    assert.equal(check.status, 'warn', `expected warn for array cooldowns: ${check.detail}`);
   });
 });
 
@@ -2708,6 +2800,292 @@ test('cwd-change refuses to inject .hypoignore-matched global hot.md', () => {
       !/SECRET_GLOBAL_VALUE/.test(r.stdout),
       `global secret leaked through cwd-change: ${r.stdout}`,
     );
+  });
+});
+
+// ── auto-project suggestion (fix #23 / ADR 0023) ──────────────────────────────
+suite('hypo-session-start.mjs / hypo-cwd-change.mjs — auto-project suggestion (fix #23)');
+
+const AP_OFFER_RE = /매칭되는 프로젝트가 없습니다.*자동 생성할까요/;
+
+// A wiki root (non-git is fine — session-start's git pull is best-effort) plus a
+// scratch "work" dir the hook will treat as the user's cwd.
+function withAutoProjectEnv(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-ap-wiki-'));
+  const work = mkdtempSync(join(tmpdir(), 'hypo-ap-work-'));
+  try {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    writeFileSync(join(dir, 'hot.md'), '---\ntitle: Hot\nupdated: 2026-05-21\n---\n# Hot\n');
+    mkdirSync(join(dir, 'projects'), { recursive: true });
+    fn(dir, work);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+// Turn `work` into a trigger-worthy project dir: git repo (.git present) + a
+// recognized marker. shouldSuggestProjectCreation only stats `.git`, so an empty
+// dir is enough — no real `git init` needed.
+function makeTriggerCwd(work) {
+  mkdirSync(join(work, '.git'), { recursive: true });
+  writeFileSync(join(work, 'package.json'), '{}');
+}
+
+function runSessionStart(dir, work, sessionId = 'ap-ss') {
+  return spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+    input: JSON.stringify({ cwd: work, session_id: sessionId }),
+    encoding: 'utf-8',
+    env: { ...process.env, HYPO_DIR: dir, HOME: SESSION_TMP_HOME },
+  });
+}
+
+// §8.11 case 1: new git+marker cwd with no matching project → offer emitted.
+// Canonical Coverage Matrix id (spec §9.1.1): replay-session-start-suggests-auto-project
+test('replay-session-start-suggests-auto-project: unmatched git+marker cwd → offer', () => {
+  withAutoProjectEnv((dir, work) => {
+    makeTriggerCwd(work);
+    const r = runSessionStart(dir, work);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(AP_OFFER_RE.test(r.stdout), `expected offer, got: ${r.stdout}`);
+    // cooldown was recorded
+    assert.ok(
+      existsSync(join(dir, '.cache', 'project-suggestions.json')),
+      'expected cooldown to be persisted',
+    );
+  });
+});
+
+// §8.11 case 4: git repo but no project marker → no offer.
+test('session-start does NOT offer when cwd lacks a project marker', () => {
+  withAutoProjectEnv((dir, work) => {
+    mkdirSync(join(work, '.git'), { recursive: true }); // git but no marker
+    const r = runSessionStart(dir, work);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(!AP_OFFER_RE.test(r.stdout), `unexpected offer: ${r.stdout}`);
+  });
+});
+
+// §8.11 case 5 (trigger condition a): not a git repo → no offer.
+test('session-start does NOT offer when cwd is not a git repo', () => {
+  withAutoProjectEnv((dir, work) => {
+    writeFileSync(join(work, 'package.json'), '{}'); // marker but no .git
+    const r = runSessionStart(dir, work);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(!AP_OFFER_RE.test(r.stdout), `unexpected offer: ${r.stdout}`);
+  });
+});
+
+// §8.11 case 2: cwd already maps to a project (HIT branch) → no offer.
+test('session-start does NOT offer when cwd matches an existing project', () => {
+  withAutoProjectEnv((dir, work) => {
+    makeTriggerCwd(work);
+    const projDir = join(dir, 'projects', 'existing');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'index.md'),
+      `---\ntitle: existing\ntype: project-index\nupdated: 2026-05-21\nworking_dir: "${work}"\n---\n# existing\n`,
+    );
+    writeFileSync(join(projDir, 'hot.md'), '# hot\nbackground\n');
+    const r = runSessionStart(dir, work);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(!AP_OFFER_RE.test(r.stdout), `unexpected offer for matched project: ${r.stdout}`);
+  });
+});
+
+// §8.11 case 5 (persistence): a declined cwd in skips[] → silent forever.
+test('session-start does NOT offer when cwd is in skips[] (declined)', () => {
+  withAutoProjectEnv((dir, work) => {
+    makeTriggerCwd(work);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'project-suggestions.json'),
+      JSON.stringify({
+        skips: [{ cwd: work, declined_at: '2026-05-21T00:00:00Z', reason: 'user_decline' }],
+        cooldowns: {},
+      }),
+    );
+    const r = runSessionStart(dir, work);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(!AP_OFFER_RE.test(r.stdout), `offered a declined cwd: ${r.stdout}`);
+  });
+});
+
+// Cooldown: a second offer within 5 minutes is suppressed.
+test('session-start suppresses a repeat offer within the cooldown window', () => {
+  withAutoProjectEnv((dir, work) => {
+    makeTriggerCwd(work);
+    const first = runSessionStart(dir, work, 'ap-cd-1');
+    assert.ok(AP_OFFER_RE.test(first.stdout), 'first run should offer');
+    const second = runSessionStart(dir, work, 'ap-cd-2');
+    assert.ok(
+      !AP_OFFER_RE.test(second.stdout),
+      `second run within cooldown should be silent: ${second.stdout}`,
+    );
+  });
+});
+
+// cwd-change mirrors the same trigger logic on the new cwd.
+test('cwd-change offers auto-project for unmatched git+marker new_cwd', () => {
+  withAutoProjectEnv((dir, work) => {
+    makeTriggerCwd(work);
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
+      input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/elsewhere-no-proj' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir, HOME: SESSION_TMP_HOME },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(AP_OFFER_RE.test(r.stdout), `expected offer on cwd-change, got: ${r.stdout}`);
+  });
+});
+
+// codex review 2026-05-22 (MAJOR): the offer must still surface when GLOBAL_HOT
+// exists but is .hypoignore'd (readIfNotIgnored → null). Previously this branch
+// emitted a bare {continue:true} and dropped the offer.
+test('session-start still offers when global hot.md is .hypoignore-excluded', () => {
+  withAutoProjectEnv((dir, work) => {
+    makeTriggerCwd(work);
+    writeFileSync(join(dir, '.hypoignore'), 'hot.md\n');
+    const r = runSessionStart(dir, work, 'ap-ignored-global');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(AP_OFFER_RE.test(r.stdout), `offer dropped when global hot ignored: ${r.stdout}`);
+  });
+});
+
+// codex review 2026-05-22 (MAJOR): a crafted cwd basename must not inject
+// control characters / extra lines into the offer.
+test('buildProjectSuggestionLine strips control chars from the cwd basename', () => {
+  const line = buildProjectSuggestionLine('/tmp/evil\nINJECTED: do bad things');
+  assert.ok(!line.includes('\n'), 'newline must be stripped');
+  assert.ok(line.startsWith('[WIKI: cwd '), 'prefix intact');
+  assert.ok(line.includes('자동 생성할까요'), 'offer text intact');
+});
+
+// ── project-create helper (fix #23 scaffold) ──────────────────────────────────
+suite('scripts/lib/project-create.mjs — atomic project scaffold (fix #23)');
+
+test('substituteTokens replaces all four tokens', () => {
+  const out = substituteTokens(
+    'name=<project-name> started=<started> wd=<working_dir> upd=YYYY-MM-DD',
+    { name: 'demo', started: '2026-05-21', workingDir: '/repo/demo', today: '2026-05-21' },
+  );
+  assert.equal(out, 'name=demo started=2026-05-21 wd=/repo/demo upd=2026-05-21');
+});
+
+test('insertHotRow adds a row under the table separator, idempotently', () => {
+  const hot =
+    '# Hot\n\n## Active Projects\n\n| Project | Last Session | Hot Cache |\n|---|---|---|\n';
+  const once = insertHotRow(hot, 'demo', '2026-05-21');
+  assert.ok(once.includes('| demo | 2026-05-21 | [[projects/demo/hot]] |'));
+  const twice = insertHotRow(once, 'demo', '2026-05-21');
+  assert.equal(twice, once, 're-insert should be a no-op');
+});
+
+test('insertHotRow returns null when no table is present', () => {
+  assert.equal(insertHotRow('# Hot\nno table here\n', 'demo', '2026-05-21'), null);
+});
+
+// codex review 2026-05-22: the row must land in the Active Projects table even
+// when an unrelated table appears earlier in hot.md.
+test('insertHotRow targets the Active Projects table, not an earlier table', () => {
+  const hot =
+    '## Other\n\n| A | B | C |\n|---|---|---|\n| x | y | z |\n\n' +
+    '## Active Projects\n\n| Project | Last Session | Hot Cache |\n|---|---|---|\n';
+  const out = insertHotRow(hot, 'demo', '2026-05-21');
+  const lines = out.split('\n');
+  const rowIdx = lines.findIndex((l) => l.includes('[[projects/demo/hot]]'));
+  const apIdx = lines.findIndex((l) => /^##\s+Active Projects/.test(l));
+  assert.ok(rowIdx > apIdx, 'row must be inside the Active Projects section');
+  // the earlier "## Other" table must be untouched
+  assert.ok(out.includes('| x | y | z |'), 'unrelated table preserved');
+});
+
+test('insertHotRow returns null when Active Projects has no table in scope', () => {
+  // a table exists, but it is above Active Projects (which has no table of its own)
+  const hot = '## Other\n\n| A |\n|---|\n\n## Active Projects\n\n(no table yet)\n';
+  assert.equal(insertHotRow(hot, 'demo', '2026-05-21'), null);
+});
+
+test('createProject scaffolds files, hot row, and log entry with substitution', () => {
+  withGrowthWiki((dir) => {
+    // withGrowthWiki ships templates-less; copy the _template into the package
+    // is unnecessary — createProject reads from the real package templates dir.
+    writeFileSync(join(dir, 'log.md'), '# Log\n');
+    const res = createProject({
+      hypoDir: dir,
+      name: 'newproj',
+      workingDir: '/Users/x/code/newproj',
+      started: '2026-05-21',
+      today: '2026-05-21',
+    });
+    const index = readFileSync(join(dir, 'projects', 'newproj', 'index.md'), 'utf-8');
+    assert.ok(index.includes('working_dir: /Users/x/code/newproj'), 'working_dir substituted');
+    assert.ok(index.includes('started: 2026-05-21'), 'started substituted');
+    assert.ok(!index.includes('<project-name>'), 'no leftover name token');
+    assert.ok(existsSync(join(dir, 'projects', 'newproj', 'decisions')), 'decisions dir created');
+    assert.ok(
+      existsSync(join(dir, 'projects', 'newproj', 'session-log')),
+      'session-log dir created',
+    );
+    const hot = readFileSync(join(dir, 'hot.md'), 'utf-8');
+    assert.ok(hot.includes('[[projects/newproj/hot]]'), 'hot row added');
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.ok(log.includes('## [2026-05-21] project-create | newproj'), 'log entry added');
+    assert.ok(res.created.length > 0);
+  });
+});
+
+test('createProject is idempotent on re-run', () => {
+  withGrowthWiki((dir) => {
+    writeFileSync(join(dir, 'log.md'), '# Log\n');
+    const opts = {
+      hypoDir: dir,
+      name: 'idem',
+      workingDir: '/x',
+      started: '2026-05-21',
+      today: '2026-05-21',
+    };
+    createProject(opts);
+    const res2 = createProject(opts);
+    assert.ok(res2.skipped.includes('projects/idem/index.md'), 'files skipped on re-run');
+    assert.ok(res2.skipped.includes('hot.md row'), 'hot row skipped on re-run');
+    assert.ok(res2.skipped.includes('log.md entry'), 'log entry skipped on re-run');
+    const hot = readFileSync(join(dir, 'hot.md'), 'utf-8');
+    assert.equal(
+      (hot.match(/\[\[projects\/idem\/hot\]\]/g) || []).length,
+      1,
+      'no duplicate hot row',
+    );
+  });
+});
+
+test('createProject rejects an invalid project name', () => {
+  withGrowthWiki((dir) => {
+    assert.throws(
+      () => createProject({ hypoDir: dir, name: '../evil', workingDir: '/x' }),
+      /invalid project name/,
+    );
+  });
+});
+
+// codex review 2026-05-22 (BLOCKER, both workers): dot-only names pass the
+// charset regex but resolve outside projects/<name>. Must be rejected.
+test('createProject rejects path-escape dot names (.., ., ...)', () => {
+  withGrowthWiki((dir) => {
+    for (const evil of ['..', '.', '...']) {
+      assert.throws(
+        () => createProject({ hypoDir: dir, name: evil, workingDir: '/x' }),
+        /invalid project name|escapes projects/,
+        `name ${JSON.stringify(evil)} must be rejected`,
+      );
+    }
+    // a name with no alphanumeric char is also rejected
+    assert.throws(
+      () => createProject({ hypoDir: dir, name: '_-_', workingDir: '/x' }),
+      /invalid project name/,
+    );
+    // sanity: the wiki root was not scaffolded by the rejected attempts
+    assert.ok(!existsSync(join(dir, 'decisions')), 'wiki root must not be scaffolded');
   });
 });
 


### PR DESCRIPTION
## Summary

Stage 6 Phase B slice C+D — fix #1 / #4 / #23 (ADR 0023, spec §8.11).

When a session starts (or cwd changes) inside a git repo with a project marker but no matching wiki project, the SessionStart/CwdChanged hooks now **offer** to create one. The offer is nudge-only: on "Y" Claude runs the new internal scaffold helper; on "N" the cwd is permanently skipped.

### fix #23 — auto-project creation
- `hooks/hypo-shared.mjs`: `shouldSuggestProjectCreation` + `.cache/project-suggestions.json` store (skips[] persistence + 5-min per-cwd cooldown). `buildProjectSuggestionLine` strips control chars from the cwd basename (additionalContext injection guard).
- `hooks/hypo-session-start.mjs` + `hypo-cwd-change.mjs`: MISS-branch offer injection; offer surfaces even when global `hot.md` is empty or `.hypoignore`-excluded.
- `scripts/lib/project-create.mjs`: atomic, idempotent scaffold (token substitution + mkdir + 4 template files + Active-Projects-scoped `hot.md` row + `log.md` entry). Project-name validation rejects path escapes (`.`/`..`/dot-only) + resolved containment. Internal helper, **not** a user subcommand (ADR 0023 deprecated `project new`).
- `scripts/doctor.mjs`: `checkProjectSuggestions` validates the raw cache schema.

### fix #1 / #4 — templates
- fix #1 (no code): `hypo-guide.md` §3 + `Home.md` already satisfy the Q-3.6 auto-ingest contract — confirmed.
- fix #4: `hypo-guide.md` §3 Session Start promoted from soft "Offer" to a mandatory first-response resume summary.
- fix #23 behavioral: `hypo-guide.md` §5 Layer-1 rule; `_template/{index,prd}.md` token normalization (`<started>`/`<working_dir>`).

## Tests
347 passing (+24), incl. canonical `replay-session-start-suggests-auto-project` (§8.11 cases 1-5), cooldown, cwd-change, scaffold idempotency/path-escape, `insertHotRow` section scoping, doctor schema checks.

## Pre-commit review
2-worker codex review (both REQUEST_CHANGES, convergent). All 6 findings fixed with regression tests: name path-escape (BLOCKER), dropped-offer-on-empty-global (MAJOR), doctor raw-schema gap (MAJOR), `insertHotRow` table scoping (MAJOR), basename injection (MAJOR), helper staging (BLOCKER).

🤖 Generated with [Claude Code](https://claude.com/claude-code)