### PR TITLE
feat(stage-6-e2): extensions companion sync — fix #29/#30 (ADR 0024)

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -295,7 +295,11 @@ function checkSettingsJson() {
     fail('settings.json hook registrations', `0/${total} registered — run /hypo:init`);
   }
 
-  // fix #7: stale hypo-* entries (uninstall remnants)
+  // fix #7: stale hypo-* entries (uninstall remnants).
+  // hypo-ext-* commands are user-extension entries (ADR 0024) — not core hooks,
+  // so they are intentionally absent from HOOK_MAP. Excluded here; their
+  // integrity (SHA + manifest + entry match) is checked separately in E5 (#33).
+  const isExtCommand = (cmd) => /(?:^|[/\s])hypo-ext-[^/\s]+\.mjs(?=$|["'\s])/.test(cmd);
   const expectedCmds = new Set(
     Object.entries(HOOK_MAP).flatMap(([, files]) =>
       files.map((f) => `node ${hooksDir.replace(HOME, '$HOME')}/${f}`),
@@ -310,6 +314,7 @@ function checkSettingsJson() {
         if (
           typeof h.command === 'string' &&
           /hypo-[^/]+\.mjs/.test(h.command) &&
+          !isExtCommand(h.command) &&
           !expectedCmds.has(h.command)
         ) {
           stale.push(h.command);
@@ -335,6 +340,7 @@ function checkSettingsJson() {
       if (!g || typeof g !== 'object') continue;
       for (const h of g.hooks || []) {
         if (typeof h.command !== 'string' || !/hypo-[^/]+\.mjs/.test(h.command)) continue;
+        if (isExtCommand(h.command)) continue; // ext duplicates are E5's concern (#33)
         if (seen.has(h.command)) dupes.push(`${event}:${h.command}`);
         else seen.add(h.command);
       }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -45,6 +45,7 @@ import {
   isRegularFile,
   readFileIfRegular,
 } from './lib/pkg-json.mjs';
+import { syncExtensions } from './lib/extensions.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -861,6 +862,27 @@ if (args.hooks) {
 
 if (args.hooks || args.commands) {
   writePkgJson(args.dryRun, commandSHAs ? { commands: commandSHAs } : {});
+}
+
+// 4b. user extensions companion sync (ADR 0024, fix #29 + #30). Runs after
+// writePkgJson so the per-target SHA map is merged into the same hypo-pkg.json
+// (preserving the commands map) rather than racing it.
+if (args.hooks) {
+  const extResult = syncExtensions({
+    extDir: join(args.hypoDir, 'extensions'),
+    hypoDir: args.hypoDir,
+    target: 'claude',
+    settingsPath: join(HOME, '.claude', 'settings.json'),
+    pkgPath: pkgJsonPath(),
+    apply: !args.dryRun,
+  });
+  for (const a of extResult.actions) {
+    if (a.action === 'create' || a.action === 'update' || a.action === 'force-update') {
+      log('created', `extension ${a.file} (${a.action})`);
+    }
+  }
+  for (const r of extResult.registered) log('merged', `extension ${r}`);
+  for (const w of extResult.warnings) log('skipped', `extension: ${w}`);
 }
 
 // 5. shell function (claude wrapper)

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -1,0 +1,522 @@
+/**
+ * scripts/lib/extensions.mjs — User extensions companion sync (ADR 0024, fix #29 + #30).
+ *
+ * `~/hypomnema/extensions/{hooks,commands,skills,agents}/` holds user-authored
+ * extensions, git-tracked alongside the wiki. init/upgrade hard-copy them into
+ * `~/.claude/{type}/` (and, in E4, `~/.codex/{type}/`), track a per-target 3-way
+ * SHA in `~/.claude/hypo-pkg.json`, and auto-register hook-type extensions in
+ * settings.json from a sibling `<name>.manifest.json`.
+ *
+ * This module is the single source of sync logic — both init.mjs and
+ * upgrade.mjs --apply call `syncExtensions(...)` so the two flows can never
+ * drift (plan §5 D4). The read-only helpers (`discoverExtensions`,
+ * `parseManifest`, `buildExpectedSettingsEntries`, `readExtensionPkgStateNoMutate`)
+ * are exported for doctor (E5) and uninstall (E6) reuse without re-deriving them.
+ *
+ * Security (plan §5 #9): only files matching the `hypo-ext-<name>.<ext>` basename
+ * whitelist are discovered, and the settings.json command string is always
+ * constructed here as `node $HOME/.claude/hooks/<basename>` — never sourced from
+ * the manifest. A manifest cannot inject an arbitrary command path.
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  mkdirSync,
+} from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { sha256, isRegularFile, readFileIfRegular, writePkgJsonAtomic } from './pkg-json.mjs';
+import { loadHypoIgnore, isIgnored } from './hypo-ignore.mjs';
+
+const HOME = homedir();
+
+// Extension types and their on-disk target subdirectory under ~/.claude or ~/.codex.
+export const EXT_TYPES = ['hooks', 'commands', 'skills', 'agents'];
+
+// Required filename prefix (ADR 0024 §2 recommends; plan §5 #9 enforces). Files
+// without it are skipped so uninstall (which strips hypo-ext-*) can always reach
+// every file we install — and so a stray name cannot collide with core hooks.
+export const EXT_PREFIX = 'hypo-ext-';
+
+// Codex supports hooks + commands only; skills/agents are Claude-only (ADR 0024 §4).
+export const CODEX_TYPES = ['hooks', 'commands'];
+
+// Per-type expected file extension. Hooks are executable .mjs; the rest are .md.
+const TYPE_FILE_EXT = { hooks: '.mjs', commands: '.md', skills: '.md', agents: '.md' };
+
+// Claude Code hook events (D3 allowlist). A manifest with an event outside this
+// set is malformed → the whole extension is skipped (no copy, no registration).
+export const HOOK_EVENT_ALLOWLIST = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'UserPromptSubmit',
+  'Notification',
+  'Stop',
+  'SubagentStop',
+  'SessionStart',
+  'SessionEnd',
+  'PreCompact',
+]);
+
+// The <name> portion (filename minus extension) must match this. Rejects path
+// separators, traversal (..), and anything outside a conservative charset.
+const SAFE_EXT_STEM = /^hypo-ext-[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+// Hard-copy outcomes that mean "this file is ours" — safe to track its manifest
+// and register a settings entry. The skip-* outcomes mean we left a file we do
+// not own untouched, so we must not wire it up.
+const OWNED_ACTIONS = new Set(['create', 'update', 'force-update', 'up-to-date']);
+
+function pkgRootDir(target) {
+  return target === 'codex' ? join(HOME, '.codex') : join(HOME, '.claude');
+}
+
+// ── read-only helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Discover sync-eligible extensions under `extDir`. Returns a per-type map plus a
+ * `warnings` array. Applies the `.hypoignore` filter (#30), the basename
+ * whitelist (#9), and pairs each file with its optional `<name>.manifest.json`.
+ * No-ops gracefully when extDir is absent (e.g. --from-remote clones, plan §5 #8).
+ */
+export function discoverExtensions(extDir, hypoignorePatterns, hypoDir) {
+  const result = { hooks: [], commands: [], skills: [], agents: [], warnings: [] };
+  if (!extDir || !existsSync(extDir)) return result;
+
+  for (const type of EXT_TYPES) {
+    const typeDir = join(extDir, type);
+    if (!existsSync(typeDir)) continue;
+    let entries;
+    try {
+      entries = readdirSync(typeDir);
+    } catch {
+      continue;
+    }
+    const fileExt = TYPE_FILE_EXT[type];
+    for (const fname of entries) {
+      if (fname === '.gitkeep') continue;
+      // Manifests are paired with their sibling, not discovered standalone.
+      if (fname.endsWith('.manifest.json')) continue;
+      const srcPath = join(typeDir, fname);
+      if (isIgnored(srcPath, hypoDir, hypoignorePatterns)) continue;
+      if (!isRegularFile(srcPath)) continue;
+      if (!fname.endsWith(fileExt)) continue;
+      const stem = fname.slice(0, -fileExt.length);
+      if (!SAFE_EXT_STEM.test(stem)) {
+        result.warnings.push(
+          `${type}/${fname} skipped (extensions must use a 'hypo-ext-<name>' filename)`,
+        );
+        continue;
+      }
+      const manifestName = `${stem}.manifest.json`;
+      const manifestPath = join(typeDir, manifestName);
+      // The manifest is subject to the same .hypoignore filter as its sibling —
+      // an ignored manifest must not be copied or SHA-tracked.
+      const hasManifest =
+        existsSync(manifestPath) &&
+        isRegularFile(manifestPath) &&
+        !isIgnored(manifestPath, hypoDir, hypoignorePatterns);
+      result[type].push({
+        type,
+        name: stem,
+        file: fname,
+        srcPath,
+        manifestName,
+        manifestPath: hasManifest ? manifestPath : null,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Parse + validate an extension manifest. `registrable` is true only for a valid
+ * hook manifest (the kind that yields a settings.json entry). A non-hook manifest
+ * is `ok` but not registrable; a malformed one is `!ok` (caller skips the ext).
+ */
+export function parseManifest(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch {
+    return { ok: false, error: 'manifest unreadable' };
+  }
+  let m;
+  try {
+    m = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: 'manifest is not valid JSON' };
+  }
+  if (!m || typeof m !== 'object' || Array.isArray(m)) {
+    return { ok: false, error: 'manifest must be a JSON object' };
+  }
+  if (m.type !== 'hook') {
+    // skill/agent/command manifests carry no hook registration metadata.
+    return { ok: true, manifest: m, registrable: false };
+  }
+  if (typeof m.event !== 'string' || !HOOK_EVENT_ALLOWLIST.has(m.event)) {
+    return { ok: false, error: `unknown or missing hook event: ${m.event ?? '(none)'}` };
+  }
+  if (m.matcher !== undefined && typeof m.matcher !== 'string') {
+    return { ok: false, error: 'matcher must be a string' };
+  }
+  if (m.timeout !== undefined && (typeof m.timeout !== 'number' || m.timeout <= 0)) {
+    return { ok: false, error: 'timeout must be a positive number' };
+  }
+  return { ok: true, manifest: m, registrable: true };
+}
+
+/**
+ * Build the settings.json entries expected for the discovered hook extensions.
+ * The command string is constructed here (never from the manifest) as
+ * `node $HOME/.claude/hooks/<basename>`. Extensions whose manifest is missing or
+ * not registrable yield no entry.
+ */
+export function buildExpectedSettingsEntries(discoveredHooks, targetHooksDir) {
+  const entries = [];
+  for (const ext of discoveredHooks) {
+    if (!ext.manifestPath) continue;
+    const parsed = parseManifest(ext.manifestPath);
+    if (!parsed.ok || !parsed.registrable) continue;
+    const command = `node ${targetHooksDir.replace(HOME, '$HOME')}/${ext.file}`;
+    entries.push({
+      name: ext.name,
+      file: ext.file,
+      event: parsed.manifest.event,
+      matcher: parsed.manifest.matcher,
+      timeout: parsed.manifest.timeout,
+      command,
+    });
+  }
+  return entries;
+}
+
+/** Read the full hypo-pkg.json without any side effect (cf. pkg-json.readPkgJson,
+ * which renames a corrupt file — unsafe for read-only callers, plan §5 #3). */
+function readFullPkgNoMutate(pkgPath) {
+  if (!existsSync(pkgPath)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Read the recorded per-target extension SHA map without side effects. */
+export function readExtensionPkgStateNoMutate(pkgPath, target) {
+  const pkg = readFullPkgNoMutate(pkgPath);
+  const ext = pkg.extensions;
+  if (!ext || typeof ext !== 'object' || Array.isArray(ext)) return {};
+  const perTarget = ext[target];
+  return perTarget && typeof perTarget === 'object' && !Array.isArray(perTarget) ? perTarget : {};
+}
+
+// ── sync orchestration ─────────────────────────────────────────────────────────
+
+function writeFreshAtomic(dest, content) {
+  const tmp = `${dest}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, content);
+  try {
+    renameSync(tmp, dest);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {}
+    throw err;
+  }
+}
+
+/**
+ * Decide + (when apply) perform the hard-copy of one file, returning the SHA to
+ * record and an action label. Mirrors the slash-command 3-way SHA matrix
+ * (init.mjs:installCommands). `force` (E3) backs up + overwrites user-modified
+ * files; in E2 it is always false, so user-modified / unowned files are left
+ * untouched (E3 adds the conflict exit-code + --force-extensions semantics).
+ */
+function copyOne({ srcPath, destPath, key, recordedSHA, apply, force }) {
+  const srcContent = readFileSync(srcPath);
+  const srcSHA = sha256(srcContent);
+
+  if (!existsSync(destPath)) {
+    if (apply) writeFreshAtomic(destPath, srcContent);
+    return { action: 'create', sha: srcSHA };
+  }
+  if (!isRegularFile(destPath)) {
+    // Never overwrite symlinks/sockets; never claim ownership of them.
+    return { action: 'skip-non-regular', sha: recordedSHA ?? null };
+  }
+  const onDisk = readFileIfRegular(destPath);
+  if (onDisk === null) {
+    return { action: 'skip-unreadable', sha: recordedSHA ?? null };
+  }
+  const onDiskSHA = sha256(onDisk);
+  if (onDiskSHA === srcSHA) {
+    return { action: 'up-to-date', sha: srcSHA };
+  }
+  if (recordedSHA && onDiskSHA === recordedSHA) {
+    // Owned + unmodified by user → overwrite (edit-sync). CAS re-verify on apply.
+    if (apply) {
+      const verify = readFileIfRegular(destPath);
+      if (!verify || sha256(verify) !== recordedSHA) {
+        return { action: 'skip-changed', sha: recordedSHA };
+      }
+      writeFreshAtomic(destPath, srcContent);
+    }
+    return { action: 'update', sha: srcSHA };
+  }
+  // User-modified or pre-existing unowned file.
+  if (force) {
+    if (apply) {
+      writeFreshAtomic(`${destPath}.bak`, onDisk);
+      writeFreshAtomic(destPath, srcContent);
+    }
+    return { action: 'force-update', sha: srcSHA };
+  }
+  return {
+    action: recordedSHA ? 'skip-user-modified' : 'skip-conflict',
+    sha: recordedSHA ?? null,
+  };
+}
+
+/**
+ * Sync all discovered extensions for one target ('claude' | 'codex').
+ *
+ * Ordering (D2): per extension, the manifest is parsed + validated BEFORE any
+ * hard-copy, so a malformed manifest never leaves an orphaned, unregistered hook
+ * copy behind. settings.json is written once at the end (D2), and hypo-pkg.json's
+ * per-target SHA map is merged into the existing object (D2b) so the `commands`
+ * map and other fields survive.
+ *
+ * Returns a structured result; `needsWork` is true when a copy/registration is
+ * pending (drift), used by upgrade's check-mode exit code.
+ */
+export function syncExtensions({
+  extDir,
+  hypoDir,
+  target = 'claude',
+  settingsPath,
+  pkgPath,
+  apply = false,
+  force = false,
+}) {
+  const result = {
+    target,
+    actions: [],
+    registered: [],
+    warnings: [],
+    settingsChanged: false,
+    needsWork: false,
+  };
+
+  const types = target === 'codex' ? CODEX_TYPES : EXT_TYPES;
+  const targetRoot = pkgRootDir(target);
+  const patterns = loadHypoIgnore(hypoDir);
+  const discovered = discoverExtensions(extDir, patterns, hypoDir);
+  result.warnings.push(...discovered.warnings);
+
+  const recorded = readExtensionPkgStateNoMutate(pkgPath, target);
+  const newSHAs = {};
+  // Preserve recorded SHAs for types this target does not cover (e.g. codex skips
+  // skills/agents) so a Claude-then-Codex run does not drop Claude's records.
+  for (const [k, v] of Object.entries(recorded)) {
+    const t = k.split('/')[0];
+    if (!types.includes(t)) newSHAs[k] = v;
+  }
+
+  const expectedHookExts = [];
+
+  for (const type of types) {
+    const typeDir = join(targetRoot, type);
+    for (const ext of discovered[type]) {
+      // D3: validate the manifest before touching the filesystem.
+      let manifestParsed = null;
+      if (type === 'hooks') {
+        if (ext.manifestPath) {
+          manifestParsed = parseManifest(ext.manifestPath);
+          if (!manifestParsed.ok) {
+            result.warnings.push(
+              `${type}/${ext.manifestName} is malformed (${manifestParsed.error}) — skipping ${ext.name}`,
+            );
+            continue;
+          }
+        } else {
+          result.warnings.push(`${ext.name}.manifest.json missing — hook will not auto-register`);
+        }
+      }
+
+      if (apply) mkdirSync(typeDir, { recursive: true });
+
+      // (2) hard-copy the main file.
+      const fileKey = `${type}/${ext.file}`;
+      const fileRes = copyOne({
+        srcPath: ext.srcPath,
+        destPath: join(typeDir, ext.file),
+        key: fileKey,
+        recordedSHA: recorded[fileKey],
+        apply,
+        force,
+      });
+      if (fileRes.sha != null) newSHAs[fileKey] = fileRes.sha;
+      result.actions.push({ target, file: fileKey, action: fileRes.action });
+      if (
+        fileRes.action === 'create' ||
+        fileRes.action === 'update' ||
+        fileRes.action === 'force-update'
+      ) {
+        result.needsWork = result.needsWork || !apply;
+      } else if (fileRes.action === 'skip-user-modified' || fileRes.action === 'skip-conflict') {
+        result.warnings.push(`${fileKey} (${fileRes.action}) — left untouched`);
+      }
+
+      // If the main hook file was NOT written/owned by us (a pre-existing
+      // unowned file or a user-modified copy), we must not copy its manifest or
+      // register a settings entry — that would activate a file we refused to
+      // overwrite. Full conflict semantics (exit 1 + --force-extensions) land in
+      // E3 (#31); E2 just stays safe.
+      const ownedMainFile = OWNED_ACTIONS.has(fileRes.action);
+
+      // (2b) hard-copy the manifest alongside, when present + valid + owned, so
+      // its SHA is tracked and ~/.claude stays self-describing.
+      if (
+        type === 'hooks' &&
+        ownedMainFile &&
+        ext.manifestPath &&
+        manifestParsed &&
+        manifestParsed.ok
+      ) {
+        const mKey = `${type}/${ext.manifestName}`;
+        const mRes = copyOne({
+          srcPath: ext.manifestPath,
+          destPath: join(typeDir, ext.manifestName),
+          key: mKey,
+          recordedSHA: recorded[mKey],
+          apply,
+          force,
+        });
+        if (mRes.sha != null) newSHAs[mKey] = mRes.sha;
+        result.actions.push({ target, file: mKey, action: mRes.action });
+        if (
+          mRes.action === 'create' ||
+          mRes.action === 'update' ||
+          mRes.action === 'force-update'
+        ) {
+          result.needsWork = result.needsWork || !apply;
+        }
+        if (manifestParsed.registrable) expectedHookExts.push(ext);
+      }
+    }
+  }
+
+  // (3) settings.json registration — single write, path-based identity (D1).
+  const targetHooksDir = join(targetRoot, 'hooks');
+  const expectedEntries = buildExpectedSettingsEntries(expectedHookExts, targetHooksDir);
+  if (expectedEntries.length > 0) {
+    const reg = registerSettings(settingsPath, expectedEntries, apply);
+    result.registered = reg.registered;
+    result.settingsChanged = reg.changed;
+    if (reg.changed && !apply) result.needsWork = true;
+    if (reg.invalidJson) {
+      result.warnings.push(`${settingsPath} is not valid JSON — extension hooks not registered`);
+    }
+  }
+
+  // (4) persist per-target SHA map, merged into the existing pkg object (D2b).
+  if (apply) {
+    const existing = readFullPkgNoMutate(pkgPath);
+    const extObj =
+      existing.extensions &&
+      typeof existing.extensions === 'object' &&
+      !Array.isArray(existing.extensions)
+        ? { ...existing.extensions }
+        : {};
+    extObj[target] = newSHAs;
+    writePkgJsonAtomic(pkgPath, { ...existing, extensions: extObj });
+  }
+  result.newSHAs = newSHAs;
+
+  return result;
+}
+
+/**
+ * Reconcile the expected ext hook entries into settings.json (§8.12 b).
+ *
+ * For each entry we locate the single-hook group that owns its command (D1,
+ * path-based identity). If it already sits in the right event with the right
+ * matcher/timeout, it is left untouched — so a no-op run does not rewrite the
+ * file (idempotent). If the manifest changed matcher/timeout, the group is
+ * patched in place; if the event changed, the stale group is removed and a fresh
+ * one added under the new event. A pre-existing multi-hook group containing our
+ * command is treated as a manual edit and left alone (drift; E3 handles force).
+ */
+function registerSettings(settingsPath, expectedEntries, apply) {
+  let original = '';
+  let settings = {};
+  if (existsSync(settingsPath)) {
+    try {
+      original = readFileSync(settingsPath, 'utf-8');
+      settings = JSON.parse(original);
+    } catch {
+      return { registered: [], changed: false, invalidJson: true };
+    }
+  }
+  if (!settings.hooks || typeof settings.hooks !== 'object' || Array.isArray(settings.hooks)) {
+    settings.hooks = {};
+  }
+
+  const isOurGroup = (g, command) =>
+    g &&
+    typeof g === 'object' &&
+    Array.isArray(g.hooks) &&
+    g.hooks.length === 1 &&
+    g.hooks[0] &&
+    g.hooks[0].command === command;
+
+  const registered = [];
+  for (const entry of expectedEntries) {
+    registered.push(`${entry.event}: ${entry.name}`);
+
+    const desiredHook = { type: 'command', command: entry.command };
+    if (entry.timeout) desiredHook.timeout = entry.timeout;
+    const desiredGroup = { hooks: [desiredHook] };
+    if (entry.matcher) desiredGroup.matcher = entry.matcher;
+
+    // Locate the single-hook group that owns this command, in any event.
+    let foundEvent = null;
+    let foundIdx = -1;
+    for (const [event, groups] of Object.entries(settings.hooks)) {
+      if (!Array.isArray(groups)) continue;
+      const idx = groups.findIndex((g) => isOurGroup(g, entry.command));
+      if (idx !== -1) {
+        foundEvent = event;
+        foundIdx = idx;
+        break;
+      }
+    }
+
+    if (foundEvent === entry.event) {
+      // Same event — patch in place only if matcher/timeout drifted.
+      if (JSON.stringify(settings.hooks[entry.event][foundIdx]) !== JSON.stringify(desiredGroup)) {
+        settings.hooks[entry.event][foundIdx] = desiredGroup;
+      }
+    } else {
+      // Event migration or first registration.
+      if (foundEvent !== null) settings.hooks[foundEvent].splice(foundIdx, 1);
+      if (!Array.isArray(settings.hooks[entry.event])) settings.hooks[entry.event] = [];
+      settings.hooks[entry.event].push(desiredGroup);
+    }
+  }
+
+  const next = JSON.stringify(settings, null, 2) + '\n';
+  const changed = next !== original;
+  if (changed && apply) {
+    mkdirSync(join(settingsPath, '..'), { recursive: true });
+    writeFileSync(settingsPath, next);
+  }
+  return { registered, changed, invalidJson: false };
+}

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -38,6 +38,7 @@ import {
   isRegularFile,
   readFileIfRegular,
 } from './lib/pkg-json.mjs';
+import { syncExtensions } from './lib/extensions.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -648,6 +649,20 @@ const commands = checkCommands();
 const oldHookRefs = checkOldHookNames();
 const hypoignore = checkHypoignore(args.hypoDir);
 
+// Extensions companion (ADR 0024, fix #29 + #30). Read-only check; the apply
+// happens below, AFTER applyCommands, so the per-target SHA map merges into the
+// hypo-pkg.json that applyCommands writes (rather than being clobbered by it).
+const extSettingsPath = join(HOME, '.claude', 'settings.json');
+const extDir = join(args.hypoDir, 'extensions');
+const extCheck = syncExtensions({
+  extDir,
+  hypoDir: args.hypoDir,
+  target: 'claude',
+  settingsPath: extSettingsPath,
+  pkgPath: pkgJsonPath(),
+  apply: false,
+});
+
 const staleHooks = hooks.filter(
   (h) => h.status === 'stale' || h.status === 'missing' || h.status === 'src-missing',
 );
@@ -669,6 +684,7 @@ let appliedPkgJson = false;
 let appliedHookNameRenames = [];
 let appliedCommands = [];
 let appliedHypoignore = [];
+let appliedExtensions = null;
 
 if (args.apply) {
   if (oldHookRefs.length > 0) {
@@ -683,9 +699,20 @@ if (args.apply) {
   appliedCommands = applyCommands(commands, args.forceCommands);
   appliedPkgJson = true;
   appliedHypoignore = applyHypoignoreMigration(hypoignore);
+  // After applyCommands wrote hypo-pkg.json — merges extensions.<target> alongside.
+  appliedExtensions = syncExtensions({
+    extDir,
+    hypoDir: args.hypoDir,
+    target: 'claude',
+    settingsPath: extSettingsPath,
+    pkgPath: pkgJsonPath(),
+    apply: true,
+  });
 }
 
 // ── output ───────────────────────────────────────────────────────────────────
+
+const extDrift = extCheck.needsWork;
 
 const hasDrift =
   staleHooks.length > 0 ||
@@ -698,7 +725,8 @@ const hasDrift =
   userModifiedCommands.length > 0 ||
   orphanedCommands.length > 0 ||
   nonRegularCommands.length > 0 ||
-  hypoignore.status === 'needs-migration';
+  hypoignore.status === 'needs-migration' ||
+  extDrift;
 
 if (args.json) {
   console.log(
@@ -711,6 +739,7 @@ if (args.json) {
         commands,
         oldHookRefs,
         hypoignore,
+        extensions: extCheck,
         applied: {
           hooks: appliedHooks,
           settings: appliedSettings,
@@ -718,6 +747,7 @@ if (args.json) {
           hookNameRenames: appliedHookNameRenames,
           commands: appliedCommands,
           hypoignore: appliedHypoignore,
+          extensions: appliedExtensions,
         },
         migrationReport: migrationPath,
       },
@@ -869,6 +899,31 @@ if (hypoignore.status === 'no-file') {
   for (const e of hypoignore.missing) lines.push(`    + ${e.pattern}`);
 }
 
+// Extensions companion (ADR 0024)
+{
+  const pending = extCheck.actions.filter(
+    (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
+  );
+  const extConflicts = extCheck.actions.filter(
+    (a) => a.action === 'skip-user-modified' || a.action === 'skip-conflict',
+  );
+  if (extCheck.actions.length === 0 && extCheck.warnings.length === 0) {
+    lines.push(`✓ Extensions        none found in ${extDir.replace(HOME, '~')}`);
+  } else if (pending.length === 0 && extConflicts.length === 0) {
+    const reg = extCheck.registered.length;
+    lines.push(
+      `✓ Extensions        ${extCheck.actions.length} synced${reg ? `, ${reg} hook(s) registered` : ''}`,
+    );
+  } else {
+    lines.push(
+      `⚠ Extensions        ${pending.length} to sync, ${extConflicts.length} conflict(s):`,
+    );
+    for (const a of pending) lines.push(`    + ${a.file}  [${a.action}]`);
+    for (const a of extConflicts) lines.push(`    ⚠ ${a.file}  [${a.action} — left untouched]`);
+  }
+  for (const w of extCheck.warnings) lines.push(`    ⚠ ${w}`);
+}
+
 // Migration report notice
 if (migrationPath) {
   lines.push('');
@@ -911,6 +966,23 @@ if (
   }
 }
 
+if (appliedExtensions) {
+  const synced = appliedExtensions.actions.filter(
+    (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
+  );
+  if (synced.length > 0 || appliedExtensions.settingsChanged) {
+    lines.push('');
+    if (synced.length > 0) {
+      lines.push(`✓ Synced extensions (${synced.length}):`);
+      for (const a of synced) lines.push(`    → ${a.file} (${a.action})`);
+    }
+    if (appliedExtensions.settingsChanged) {
+      lines.push(`✓ Registered extension hooks (${appliedExtensions.registered.length}):`);
+      for (const r of appliedExtensions.registered) lines.push(`    → ${r}`);
+    }
+  }
+}
+
 // Summary
 lines.push('');
 const totalDrift =
@@ -924,16 +996,25 @@ const totalDrift =
   userModifiedCommands.length +
   orphanedCommands.length +
   nonRegularCommands.length +
-  (hypoignore.status === 'needs-migration' ? hypoignore.missing.length : 0);
+  (hypoignore.status === 'needs-migration' ? hypoignore.missing.length : 0) +
+  extCheck.actions.filter(
+    (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
+  ).length;
 if (totalDrift === 0) {
   lines.push('Result: Hypomnema is up to date');
 } else if (args.apply) {
+  const appliedExtCount = appliedExtensions
+    ? appliedExtensions.actions.filter(
+        (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
+      ).length + (appliedExtensions.settingsChanged ? 1 : 0)
+    : 0;
   const total =
     appliedHooks.length +
     appliedSettings.length +
     (appliedPkgJson ? 1 : 0) +
     appliedHookNameRenames.length +
-    appliedHypoignore.length;
+    appliedHypoignore.length +
+    appliedExtCount;
   lines.push(`Result: ${total} update(s) applied. Run /hypo:doctor to verify.`);
 } else {
   lines.push(`Result: ${totalDrift} item(s) need updating — run with --apply to install`);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2014,6 +2014,351 @@ test('--apply generates migration report for major SCHEMA bump', () => {
   });
 });
 
+// ── extensions companion sync (ADR 0024, fix #29 + #30) ──────────────────────
+
+suite('extensions companion sync (upgrade.mjs, ADR 0024)');
+
+function writeExt(hypoDir, type, name, content, manifest) {
+  const dir = join(hypoDir, 'extensions', type);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), content);
+  if (manifest !== undefined) {
+    const stem = name.replace(/\.[^.]+$/, '');
+    writeFileSync(join(dir, `${stem}.manifest.json`), JSON.stringify(manifest, null, 2));
+  }
+}
+
+// §8.12 (a) new extension → hard copy + manifest parse + settings.json entry +
+// 3-way SHA record; §8.12 (b) re-run is idempotent (no diff, settings stable).
+test('upgrade-extensions-hard-copy-and-manifest-register', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-mywatcher.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write|Edit',
+        timeout: 10000,
+      });
+
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r1.status, 0, `first --apply failed: ${r1.stderr}`);
+      const out1 = JSON.parse(r1.stdout);
+
+      // (a-1) hard copy of the hook AND its manifest into ~/.claude/hooks/
+      const copyDir = join(home, '.claude', 'hooks');
+      assert.ok(
+        existsSync(join(copyDir, 'hypo-ext-mywatcher.mjs')),
+        'extension hook not hard-copied to ~/.claude/hooks/',
+      );
+      assert.ok(
+        existsSync(join(copyDir, 'hypo-ext-mywatcher.manifest.json')),
+        'extension manifest not hard-copied alongside the hook',
+      );
+
+      // (a-2) settings.json registered the hook with a command WE constructed
+      // (never sourced from the manifest), plus matcher + timeout from manifest.
+      const settings = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      const groups = (settings.hooks?.PostToolUse || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-mywatcher.mjs')),
+      );
+      assert.equal(groups.length, 1, 'exactly one PostToolUse entry expected for the extension');
+      assert.equal(groups[0].matcher, 'Write|Edit', 'matcher from manifest not applied');
+      assert.equal(
+        groups[0].hooks[0].command,
+        'node $HOME/.claude/hooks/hypo-ext-mywatcher.mjs',
+        'command must be constructed by us, not sourced from manifest',
+      );
+      assert.equal(groups[0].hooks[0].timeout, 10000, 'timeout from manifest not applied');
+
+      // (a-3) per-target SHA recorded WITHOUT clobbering the commands map.
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(pkg.commands && Object.keys(pkg.commands).length > 0, 'commands map was dropped');
+      assert.ok(pkg.extensions?.claude, 'extensions.claude per-target map missing');
+      assert.ok(
+        pkg.extensions.claude['hooks/hypo-ext-mywatcher.mjs'],
+        'hook SHA not recorded under extensions.claude',
+      );
+      assert.ok(
+        pkg.extensions.claude['hooks/hypo-ext-mywatcher.manifest.json'],
+        'manifest SHA not recorded under extensions.claude',
+      );
+
+      // (b) idempotency — second --apply syncs nothing and leaves settings stable.
+      const settingsBefore = readFileSync(join(home, '.claude', 'settings.json'), 'utf-8');
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r2.status, 0, `second --apply failed: ${r2.stderr}`);
+      const out2 = JSON.parse(r2.stdout);
+      const synced2 = out2.applied.extensions.actions.filter((a) =>
+        ['create', 'update', 'force-update'].includes(a.action),
+      );
+      assert.equal(synced2.length, 0, 'second --apply should sync nothing (idempotent)');
+      assert.equal(
+        out2.applied.extensions.settingsChanged,
+        false,
+        'second --apply must not rewrite settings.json',
+      );
+      assert.equal(out2.extensions.needsWork, false, 'no drift expected on second check');
+      const settingsAfter = readFileSync(join(home, '.claude', 'settings.json'), 'utf-8');
+      assert.equal(
+        settingsAfter,
+        settingsBefore,
+        'settings.json drifted across idempotent --apply',
+      );
+    });
+  });
+});
+
+// §8.12 (6) .hypoignore-matched files are excluded from discovery/sync.
+test('extensions-respects-hypoignore', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      // One synced extension and one that .hypoignore must exclude.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-keep.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      writeExt(hypoDir, 'hooks', 'hypo-ext-skipme.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      const hypoignorePath = join(hypoDir, '.hypoignore');
+      writeFileSync(
+        hypoignorePath,
+        readFileSync(hypoignorePath, 'utf-8') + '\n# test exclusion\n*skipme*\n',
+      );
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+
+      const copyDir = join(home, '.claude', 'hooks');
+      assert.ok(
+        existsSync(join(copyDir, 'hypo-ext-keep.mjs')),
+        'non-ignored extension should be synced',
+      );
+      assert.ok(
+        !existsSync(join(copyDir, 'hypo-ext-skipme.mjs')),
+        '.hypoignore-matched extension must NOT be synced',
+      );
+      assert.ok(
+        !existsSync(join(copyDir, 'hypo-ext-skipme.manifest.json')),
+        '.hypoignore-matched extension manifest must NOT be synced',
+      );
+
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(
+        pkg.extensions.claude['hooks/hypo-ext-keep.mjs'],
+        'kept extension SHA should be recorded',
+      );
+      assert.ok(
+        !pkg.extensions.claude['hooks/hypo-ext-skipme.mjs'],
+        'ignored extension SHA must not be recorded',
+      );
+    });
+  });
+});
+
+// D2 ordering: a malformed manifest (unknown event) must skip the extension
+// entirely — no orphaned, unregistered hook copy left behind.
+test('extensions: malformed manifest leaves no orphan hard-copy', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-bad.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'BogusEvent',
+      });
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+      assert.ok(
+        !existsSync(join(home, '.claude', 'hooks', 'hypo-ext-bad.mjs')),
+        'malformed-manifest extension must NOT be hard-copied (D2: validate before copy)',
+      );
+      const settings = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      const registered = JSON.stringify(settings.hooks || {}).includes('hypo-ext-bad');
+      assert.ok(!registered, 'malformed-manifest extension must NOT be registered');
+    });
+  });
+});
+
+// Security #9: a hostile `command` field in the manifest must be ignored — the
+// settings entry command is always constructed locally.
+test('extensions: manifest command field cannot inject a command path', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-evil.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+        command: 'rm -rf /',
+      });
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+      const settings = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      const group = (settings.hooks?.Stop || []).find((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-evil.mjs')),
+      );
+      assert.ok(group, 'extension should still be registered');
+      assert.equal(
+        group.hooks[0].command,
+        'node $HOME/.claude/hooks/hypo-ext-evil.mjs',
+        'command must be constructed locally, never sourced from the manifest',
+      );
+      assert.ok(
+        !JSON.stringify(settings).includes('rm -rf'),
+        'manifest command field must never reach settings.json',
+      );
+    });
+  });
+});
+
+// HIGH (codex E2 review): a pre-existing unowned hook copy must NOT be wired up.
+// We refuse to overwrite it, so we must also refuse to copy its manifest or
+// register a settings entry that would activate a file we don't own.
+test('extensions: conflict on main file blocks manifest copy + registration', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      // A foreign, unowned file already sits where our extension would land.
+      const claudeHooks = join(home, '.claude', 'hooks');
+      mkdirSync(claudeHooks, { recursive: true });
+      writeFileSync(join(claudeHooks, 'hypo-ext-conflict.mjs'), '// not ours\n');
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-conflict.mjs', '#!/usr/bin/env node\n// ours\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+      });
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+
+      // Foreign file left untouched.
+      assert.equal(
+        readFileSync(join(claudeHooks, 'hypo-ext-conflict.mjs'), 'utf-8'),
+        '// not ours\n',
+        'foreign file must not be overwritten',
+      );
+      // Manifest NOT copied (we do not own the main file).
+      assert.ok(
+        !existsSync(join(claudeHooks, 'hypo-ext-conflict.manifest.json')),
+        'manifest must not be copied for an unowned/conflicted main file',
+      );
+      // NOT registered in settings.json.
+      const settings = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      assert.ok(
+        !JSON.stringify(settings.hooks || {}).includes('hypo-ext-conflict.mjs'),
+        'conflicted extension must NOT be registered in settings.json',
+      );
+    });
+  });
+});
+
+// MEDIUM (codex E2 review, §8.12 b): a manifest matcher/timeout change must be
+// reflected in the existing settings entry; an event change must migrate it
+// (no orphaned entry left in the old event).
+test('extensions: manifest change re-registers settings entry', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const manifestPath = join(hypoDir, 'extensions', 'hooks', 'hypo-ext-edit.manifest.json');
+      writeExt(hypoDir, 'hooks', 'hypo-ext-edit.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 5000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+
+      // Change matcher + timeout → expect the existing entry updated in place.
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({ type: 'hook', event: 'PostToolUse', matcher: 'Edit', timeout: 9000 }),
+      );
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r2.status, 0, `second --apply failed: ${r2.stderr}`);
+      const s2 = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      const post = (s2.hooks.PostToolUse || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-edit.mjs')),
+      );
+      assert.equal(post.length, 1, 'exactly one entry expected after matcher change');
+      assert.equal(post[0].matcher, 'Edit', 'matcher should be updated');
+      assert.equal(post[0].hooks[0].timeout, 9000, 'timeout should be updated');
+
+      // Change event → migrate (old event entry removed, new event entry added).
+      writeFileSync(manifestPath, JSON.stringify({ type: 'hook', event: 'Stop' }));
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      const s3 = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      const stillPost = (s3.hooks.PostToolUse || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-edit.mjs')),
+      );
+      const nowStop = (s3.hooks.Stop || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-edit.mjs')),
+      );
+      assert.equal(stillPost.length, 0, 'old-event entry must be removed on event migration');
+      assert.equal(nowStop.length, 1, 'entry must move to the new event');
+    });
+  });
+});
+
+// MEDIUM (codex E2 review): a .hypoignore-matched manifest must be excluded too
+// — the hook then has no manifest (warns, hard-copy proceeds, not registered).
+test('extensions: .hypoignore-matched manifest is not copied or recorded', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-partial.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      const hypoignorePath = join(hypoDir, '.hypoignore');
+      writeFileSync(hypoignorePath, readFileSync(hypoignorePath, 'utf-8') + '\n*.manifest.json\n');
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+      const claudeHooks = join(home, '.claude', 'hooks');
+      assert.ok(existsSync(join(claudeHooks, 'hypo-ext-partial.mjs')), 'hook should still copy');
+      assert.ok(
+        !existsSync(join(claudeHooks, 'hypo-ext-partial.manifest.json')),
+        'ignored manifest must not be copied',
+      );
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(
+        !pkg.extensions.claude['hooks/hypo-ext-partial.manifest.json'],
+        'ignored manifest SHA must not be recorded',
+      );
+      const settings = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      assert.ok(
+        !JSON.stringify(settings.hooks || {}).includes('hypo-ext-partial.mjs'),
+        'without a manifest the hook must not auto-register',
+      );
+    });
+  });
+});
+
 // ── lint.mjs --fix tests ─────────────────────────────────────────────────────
 
 suite('lint.mjs --fix');


### PR DESCRIPTION
## 슬라이스 E2 (#29 + #30) — User Extensions Companion Sync

ADR 0024 §8.12. `~/hypomnema/extensions/{hooks,commands,skills,agents}/`의 사용자 확장을 `~/.claude/{type}/`로 hard-copy + manifest 기반 settings.json 자동 등록 + per-target 3-way SHA 추적.

### 핵심 설계 (플랜 §0 반영)
- **D4 단일 sync**: `scripts/lib/extensions.mjs`의 `syncExtensions()`를 init과 upgrade `--apply`가 공유 — 두 흐름이 drift 불가.
- **D2 트랜잭션 순서**: manifest 검증 → hard-copy → settings 등록 → per-target SHA. malformed manifest는 고아 사본을 남기지 않음.
- **D2b per-target SHA**: `extensions.{claude,codex}` 스키마로 시작 (E4 dual-target false user-modified 방지). 기존 `commands` 맵 보존하며 머지.
- **D1 path-based 식별 + reconcile**: settings entry는 command path로 식별. manifest matcher/timeout 변경 시 in-place 갱신, event 변경 시 이전(§8.12 b).
- **보안 (#9)**: settings command는 항상 로컬 생성(`node $HOME/.claude/hooks/<basename>`), manifest에서 주입 불가. 파일명 `hypo-ext-<name>` whitelist 강제.
- 충돌/미소유 파일은 건드리지 않고 등록도 안 함 — 완전한 충돌 처리(exit 1 + `--force-extensions`)는 E3(#31).
- doctor: 정상 `hypo-ext-*` entry를 stale로 오탐하던 fix-#7 검사에서 제외 (무결성은 E5 #33).

### 테스트 (356 passed)
- `upgrade-extensions-hard-copy-and-manifest-register` (§8.12 a,b)
- `extensions-respects-hypoignore` (§8.12-6)
- 회귀: D2 순서 / command 주입 거부 / 충돌 격리 / manifest 변경 재등록 / 무시된 manifest 제외

### 사전 검토
commit 전 `/teams 1:codex` 선검토 → REQUEST_CHANGES 4건(HIGH 충돌 시 등록, MED settings 미갱신, MED manifest ignore, LOW regex 경계) 전부 교차검증 후 수정 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)