### PR TITLE
feat(stage-6-e3): extensions conflict detection + --force-extensions — fix #31 (ADR 0024)

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -100,6 +100,7 @@ function parseArgs(argv) {
     hooks: true,
     commands: true,
     forceCommands: false,
+    forceExtensions: false,
     codex: false,
     gitRemote: null,
     gitInit: true,
@@ -128,6 +129,7 @@ Init options:
   --no-hooks             Skip hook installation
   --no-commands          Skip slash command installation to ~/.claude/commands/hypo/
   --force-commands       Overwrite user-modified slash command files (creates .bak)
+  --force-extensions     Overwrite user-modified / conflicting extension copies (creates .bak)
   --codex                Also install Codex hooks (~/.codex/hooks/)
   --git-remote=<url>     Git remote URL
   --no-git-init          Skip git initialization
@@ -144,6 +146,7 @@ docstring at the top of scripts/<command>.mjs.`);
     else if (arg === '--no-hooks') args.hooks = false;
     else if (arg === '--no-commands') args.commands = false;
     else if (arg === '--force-commands') args.forceCommands = true;
+    else if (arg === '--force-extensions') args.forceExtensions = true;
     else if (arg === '--codex') args.codex = true;
     else if (arg.startsWith('--git-remote=')) args.gitRemote = arg.slice(13);
     else if (arg === '--no-git-init') args.gitInit = false;
@@ -875,6 +878,7 @@ if (args.hooks) {
     settingsPath: join(HOME, '.claude', 'settings.json'),
     pkgPath: pkgJsonPath(),
     apply: !args.dryRun,
+    force: args.forceExtensions,
   });
   for (const a of extResult.actions) {
     if (a.action === 'create' || a.action === 'update' || a.action === 'force-update') {
@@ -883,6 +887,18 @@ if (args.hooks) {
   }
   for (const r of extResult.registered) log('merged', `extension ${r}`);
   for (const w of extResult.warnings) log('skipped', `extension: ${w}`);
+  // E3 (#31): a hard conflict (unowned/symlinked target) blocks install — surface
+  // the recovery and force a non-zero exit. Drift is advisory (resolvable, no block).
+  if (extResult.conflicts.length > 0) {
+    log('errors', '[WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');
+    for (const c of extResult.conflicts) log('errors', `extension ${c.file} (${c.action})`);
+  }
+  for (const d of extResult.drifts) {
+    log(
+      'skipped',
+      `[WIKI: extension ${d.name} drift detected. Use --force-extensions to overwrite.]`,
+    );
+  }
 }
 
 // 5. shell function (claude wrapper)

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -235,9 +235,10 @@ function writeFreshAtomic(dest, content) {
 /**
  * Decide + (when apply) perform the hard-copy of one file, returning the SHA to
  * record and an action label. Mirrors the slash-command 3-way SHA matrix
- * (init.mjs:installCommands). `force` (E3) backs up + overwrites user-modified
- * files; in E2 it is always false, so user-modified / unowned files are left
- * untouched (E3 adds the conflict exit-code + --force-extensions semantics).
+ * (init.mjs:installCommands). `force` (E3, --force-extensions) backs up (.bak) +
+ * overwrites user-modified / unowned files; without it those are left untouched and
+ * surface as drift/conflict. A symlink/non-regular dest is never followed even under
+ * force (the isRegularFile guard precedes the force branch).
  */
 function copyOne({ srcPath, destPath, key, recordedSHA, apply, force }) {
   const srcContent = readFileSync(srcPath);
@@ -285,6 +286,29 @@ function copyOne({ srcPath, destPath, key, recordedSHA, apply, force }) {
 }
 
 /**
+ * Classify one hard-copy outcome into the sync result (E3, #31). Owned writes mark
+ * pending work; an owned-but-edited file is drift (warn + check-mode work); an
+ * unowned or unsafe-to-overwrite file is a hard conflict (blocks even --apply).
+ */
+function recordCopyOutcome(result, name, key, action, apply) {
+  if (action === 'create' || action === 'update' || action === 'force-update') {
+    result.needsWork = result.needsWork || !apply;
+  } else if (action === 'skip-user-modified') {
+    result.drifts.push({ name, file: key });
+    // Drift is pending work; needsWork drives check-mode exit 1 (not --apply).
+    result.needsWork = true;
+    result.warnings.push(`${key} (drift — user-modified) — left untouched`);
+  } else if (
+    action === 'skip-conflict' ||
+    action === 'skip-non-regular' ||
+    action === 'skip-unreadable'
+  ) {
+    result.conflicts.push({ name, file: key, action });
+    result.warnings.push(`${key} (${action}) — left untouched`);
+  }
+}
+
+/**
  * Sync all discovered extensions for one target ('claude' | 'codex').
  *
  * Ordering (D2): per extension, the manifest is parsed + validated BEFORE any
@@ -310,6 +334,15 @@ export function syncExtensions({
     actions: [],
     registered: [],
     warnings: [],
+    // Hard conflicts (E3, #31): a file we do NOT own — or cannot safely overwrite
+    // (symlink/non-regular/unreadable) — already occupies the target path. These
+    // block install with exit 1 even under --apply; --force-extensions resolves the
+    // owned/unowned-file cases (backup + overwrite) but never follows a symlink.
+    conflicts: [],
+    // Drift (E3, #31): a file we own whose on-disk copy the user has since edited.
+    // Warned + counted as pending work (check-mode exit 1, mirroring slash commands)
+    // but NOT a hard block under --apply. --force-extensions overwrites it.
+    drifts: [],
     settingsChanged: false,
     needsWork: false,
   };
@@ -364,21 +397,13 @@ export function syncExtensions({
       });
       if (fileRes.sha != null) newSHAs[fileKey] = fileRes.sha;
       result.actions.push({ target, file: fileKey, action: fileRes.action });
-      if (
-        fileRes.action === 'create' ||
-        fileRes.action === 'update' ||
-        fileRes.action === 'force-update'
-      ) {
-        result.needsWork = result.needsWork || !apply;
-      } else if (fileRes.action === 'skip-user-modified' || fileRes.action === 'skip-conflict') {
-        result.warnings.push(`${fileKey} (${fileRes.action}) — left untouched`);
-      }
+      recordCopyOutcome(result, ext.name, fileKey, fileRes.action, apply);
 
       // If the main hook file was NOT written/owned by us (a pre-existing
       // unowned file or a user-modified copy), we must not copy its manifest or
       // register a settings entry — that would activate a file we refused to
-      // overwrite. Full conflict semantics (exit 1 + --force-extensions) land in
-      // E3 (#31); E2 just stays safe.
+      // overwrite. The conflict/drift is recorded above; init/upgrade turn a hard
+      // conflict into exit 1 (E3, #31) unless --force-extensions resolves it.
       const ownedMainFile = OWNED_ACTIONS.has(fileRes.action);
 
       // (2b) hard-copy the manifest alongside, when present + valid + owned, so
@@ -401,13 +426,7 @@ export function syncExtensions({
         });
         if (mRes.sha != null) newSHAs[mKey] = mRes.sha;
         result.actions.push({ target, file: mKey, action: mRes.action });
-        if (
-          mRes.action === 'create' ||
-          mRes.action === 'update' ||
-          mRes.action === 'force-update'
-        ) {
-          result.needsWork = result.needsWork || !apply;
-        }
+        recordCopyOutcome(result, ext.name, mKey, mRes.action, apply);
         if (manifestParsed.registrable) expectedHookExts.push(ext);
       }
     }
@@ -453,6 +472,15 @@ export function syncExtensions({
  * patched in place; if the event changed, the stale group is removed and a fresh
  * one added under the new event. A pre-existing multi-hook group containing our
  * command is treated as a manual edit and left alone (drift; E3 handles force).
+ *
+ * E3 scope note (#31): settings.json entry drift is NOT surfaced here. Without a
+ * recorded last-written entry we cannot tell a user edit apart from a manifest
+ * change (the latter must auto-update — see the "manifest change re-registers"
+ * test), so this reconcile silently self-heals a single-hook group back to the
+ * manifest-derived shape. Detecting + reporting settings-entry mismatch is E5's
+ * job (#33, doctor integrity §8.12-7). Mixed-group surgical replacement (preserve
+ * sibling plugins' hooks, swap only ours) is likewise deferred — today a foreign
+ * hook sharing our group is left untouched as drift.
  */
 function registerSettings(settingsPath, expectedEntries, apply) {
   let original = '';

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -12,6 +12,8 @@
  * Options:
  *   --hypo-dir=<path>   Hypomnema root directory (default: resolved via HYPO_DIR / hypo-config.md scan / ~/hypomnema)
  *   --apply             Apply hook file updates and settings.json merges
+ *   --force-commands    Overwrite user-modified slash command files (creates .bak)
+ *   --force-extensions  Overwrite user-modified / conflicting extension copies (creates .bak)
  *   --json              Output results as JSON
  */
 
@@ -63,11 +65,18 @@ function pkgJsonPath() {
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, apply: false, json: false, forceCommands: false };
+  const args = {
+    hypoDir: null,
+    apply: false,
+    json: false,
+    forceCommands: false,
+    forceExtensions: false,
+  };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--apply') args.apply = true;
     else if (arg === '--force-commands') args.forceCommands = true;
+    else if (arg === '--force-extensions') args.forceExtensions = true;
     else if (arg === '--json') args.json = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
@@ -661,6 +670,7 @@ const extCheck = syncExtensions({
   settingsPath: extSettingsPath,
   pkgPath: pkgJsonPath(),
   apply: false,
+  force: args.forceExtensions,
 });
 
 const staleHooks = hooks.filter(
@@ -707,6 +717,7 @@ if (args.apply) {
     settingsPath: extSettingsPath,
     pkgPath: pkgJsonPath(),
     apply: true,
+    force: args.forceExtensions,
   });
 }
 
@@ -755,7 +766,7 @@ if (args.json) {
       2,
     ),
   );
-  process.exit(hasDrift && !args.apply ? 1 : 0);
+  process.exit((hasDrift && !args.apply) || extCheck.conflicts.length > 0 ? 1 : 0);
 }
 
 // Human-readable report
@@ -899,27 +910,38 @@ if (hypoignore.status === 'no-file') {
   for (const e of hypoignore.missing) lines.push(`    + ${e.pattern}`);
 }
 
-// Extensions companion (ADR 0024)
+// Extensions companion (ADR 0024; conflict/drift gating E3, #31)
 {
   const pending = extCheck.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
   );
-  const extConflicts = extCheck.actions.filter(
-    (a) => a.action === 'skip-user-modified' || a.action === 'skip-conflict',
-  );
+  const nConflicts = extCheck.conflicts.length;
+  const nDrifts = extCheck.drifts.length;
   if (extCheck.actions.length === 0 && extCheck.warnings.length === 0) {
     lines.push(`✓ Extensions        none found in ${extDir.replace(HOME, '~')}`);
-  } else if (pending.length === 0 && extConflicts.length === 0) {
+  } else if (pending.length === 0 && nConflicts === 0 && nDrifts === 0) {
     const reg = extCheck.registered.length;
     lines.push(
       `✓ Extensions        ${extCheck.actions.length} synced${reg ? `, ${reg} hook(s) registered` : ''}`,
     );
   } else {
     lines.push(
-      `⚠ Extensions        ${pending.length} to sync, ${extConflicts.length} conflict(s):`,
+      `⚠ Extensions        ${pending.length} to sync, ${nConflicts} conflict(s), ${nDrifts} drift(s):`,
     );
     for (const a of pending) lines.push(`    + ${a.file}  [${a.action}]`);
-    for (const a of extConflicts) lines.push(`    ⚠ ${a.file}  [${a.action} — left untouched]`);
+    for (const c of extCheck.conflicts)
+      lines.push(`    ✗ ${c.file}  [${c.action} — left untouched]`);
+    for (const d of extCheck.drifts) lines.push(`    ⚠ ${d.file}  [drift — left untouched]`);
+  }
+  // E3 (#31): a hard conflict blocks install (exit 1, even under --apply); drift is
+  // resolvable advisory. Emit the spec'd WIKI messages so the user knows the recovery.
+  if (nConflicts > 0) {
+    lines.push('  [WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');
+  }
+  for (const d of extCheck.drifts) {
+    lines.push(
+      `  [WIKI: extension ${d.name} drift detected. Use --force-extensions to overwrite.]`,
+    );
   }
   for (const w of extCheck.warnings) lines.push(`    ⚠ ${w}`);
 }
@@ -999,7 +1021,11 @@ const totalDrift =
   (hypoignore.status === 'needs-migration' ? hypoignore.missing.length : 0) +
   extCheck.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
-  ).length;
+  ).length +
+  // E3 (#31): unresolved drift/conflict is pending work too — without these the
+  // summary printed "up to date" while the exit code was 1 (codex review).
+  extCheck.conflicts.length +
+  extCheck.drifts.length;
 if (totalDrift === 0) {
   lines.push('Result: Hypomnema is up to date');
 } else if (args.apply) {
@@ -1022,4 +1048,8 @@ if (totalDrift === 0) {
 
 console.log(lines.join('\n'));
 
-process.exit(hasDrift && !args.apply ? 1 : 0);
+// E3 (#31): a hard extension conflict blocks even under --apply (unlike ordinary
+// drift, which only fails check mode). --force-extensions clears the resolvable
+// cases; an unfollowable symlink/non-regular dest still counts and stays exit 1.
+const extBlocked = extCheck.conflicts.length > 0;
+process.exit((hasDrift && !args.apply) || extBlocked ? 1 : 0);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2248,7 +2248,13 @@ test('extensions: conflict on main file blocks manifest copy + registration', ()
       });
 
       const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
-      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+      // E3 (#31): a hard conflict blocks install with exit 1 even under --apply.
+      assert.equal(r.status, 1, `conflict must block with exit 1: ${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        out.extensions.conflicts.some((c) => c.file === 'hooks/hypo-ext-conflict.mjs'),
+        'conflict must be reported in extensions.conflicts',
+      );
 
       // Foreign file left untouched.
       assert.equal(
@@ -2267,6 +2273,148 @@ test('extensions: conflict on main file blocks manifest copy + registration', ()
         !JSON.stringify(settings.hooks || {}).includes('hypo-ext-conflict.mjs'),
         'conflicted extension must NOT be registered in settings.json',
       );
+    });
+  });
+});
+
+// fix #31: the init.mjs conflict path must also block (exit 1) and report the
+// recovery — not throw. (Guards against the errors-bucket name typo.)
+test('extensions: init blocks on a hard conflict (exit 1, no throw)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `first init failed: ${initR.stderr}`);
+
+      // A foreign, unowned file occupies the target; author the extension.
+      const claudeHooks = join(home, '.claude', 'hooks');
+      writeFileSync(join(claudeHooks, 'hypo-ext-foreign.mjs'), '// not ours\n');
+      writeExt(hypoDir, 'hooks', 'hypo-ext-foreign.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+      });
+
+      const r = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 1, 'init must exit 1 on a hard extension conflict');
+      const combined = `${r.stdout}\n${r.stderr}`;
+      assert.ok(
+        combined.includes('existing file conflicts'),
+        'init must surface the conflict recovery message',
+      );
+      assert.equal(
+        readFileSync(join(claudeHooks, 'hypo-ext-foreign.mjs'), 'utf-8'),
+        '// not ours\n',
+        'foreign file must remain untouched',
+      );
+    });
+  });
+});
+
+// §8.12 (c) — fix #31: a user-edited owned copy is DRIFT (warn + check-mode exit 1,
+// not a hard --apply block); --force-extensions backs it up (.bak) and overwrites.
+// A foreign symlink at the target is a conflict that --force-extensions never
+// follows (it stays exit 1).
+test('extensions-conflict-detected-blocks-without-force', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const claudeHooks = join(home, '.claude', 'hooks');
+      const installed = join(claudeHooks, 'hypo-ext-drift.mjs');
+
+      // Author + install an extension we own.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-drift.mjs', '#!/usr/bin/env node\n// v1\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+      });
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(r1.status, 0, `initial sync failed: ${r1.stderr}`);
+      assert.ok(existsSync(installed), 'extension should be installed');
+
+      // The user edits the installed copy → drift (we own it, recorded SHA ≠ disk).
+      writeFileSync(installed, '#!/usr/bin/env node\n// hand-edited\n');
+
+      // (a) --check (no apply) → exit 1, reported as drift, file untouched.
+      const rc = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      assert.equal(rc.status, 1, 'drift must fail check mode (exit 1)');
+      const checkOut = JSON.parse(rc.stdout);
+      assert.ok(
+        checkOut.extensions.drifts.some((d) => d.file === 'hooks/hypo-ext-drift.mjs'),
+        'drift must be reported in extensions.drifts',
+      );
+      assert.equal(checkOut.extensions.conflicts.length, 0, 'drift is not a hard conflict');
+      assert.equal(
+        readFileSync(installed, 'utf-8'),
+        '#!/usr/bin/env node\n// hand-edited\n',
+        'check mode must not overwrite a drifted file',
+      );
+
+      // Non-JSON summary must stay consistent with the exit code: drift is pending
+      // work, so the summary must NOT claim "up to date" while exiting 1.
+      const rcText = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`], home);
+      assert.equal(rcText.status, 1, 'drift must fail check mode (non-JSON)');
+      assert.ok(
+        !rcText.stdout.includes('Hypomnema is up to date'),
+        'summary must not say "up to date" when drift is pending',
+      );
+      assert.ok(
+        rcText.stdout.includes('drift detected'),
+        'summary must surface the drift recovery message',
+      );
+
+      // (b) --apply WITHOUT force → drift is advisory, NOT a hard block (exit 0),
+      // and the user's edit is preserved (mirrors slash-command drift semantics).
+      const ra = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(ra.status, 0, `drift must not hard-block --apply: ${ra.stderr}`);
+      assert.equal(
+        readFileSync(installed, 'utf-8'),
+        '#!/usr/bin/env node\n// hand-edited\n',
+        'apply without --force-extensions must not overwrite a drifted file',
+      );
+
+      // (c) --apply --force-extensions → backup (.bak) + overwrite from source.
+      const rf = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--force-extensions'],
+        home,
+      );
+      assert.equal(rf.status, 0, `force apply failed: ${rf.stderr}`);
+      assert.equal(
+        readFileSync(installed, 'utf-8'),
+        '#!/usr/bin/env node\n// v1\n',
+        '--force-extensions must overwrite with the source content',
+      );
+      assert.ok(existsSync(`${installed}.bak`), '--force-extensions must back up the prior file');
+      assert.equal(
+        readFileSync(`${installed}.bak`, 'utf-8'),
+        '#!/usr/bin/env node\n// hand-edited\n',
+        'backup must hold the user-edited content',
+      );
+
+      // (d) a symlink at the target is a conflict --force-extensions never follows.
+      const decoy = join(dir, 'decoy.mjs');
+      writeFileSync(decoy, '// decoy\n');
+      writeExt(hypoDir, 'hooks', 'hypo-ext-link.mjs', '#!/usr/bin/env node\n// linked\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      symlinkSync(decoy, join(claudeHooks, 'hypo-ext-link.mjs'));
+      const rl = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply', '--force-extensions'],
+        home,
+      );
+      assert.equal(rl.status, 1, 'a symlink target must stay a conflict even under --force');
+      const linkOut = JSON.parse(rl.stdout);
+      assert.ok(
+        linkOut.extensions.conflicts.some(
+          (c) => c.file === 'hooks/hypo-ext-link.mjs' && c.action === 'skip-non-regular',
+        ),
+        'symlink must be reported as a non-regular conflict',
+      );
+      assert.equal(readFileSync(decoy, 'utf-8'), '// decoy\n', 'symlink target must be untouched');
     });
   });
 });


### PR DESCRIPTION
## Summary

E3 (#31) of Stage 6 Phase B slice E. Promotes E2's silent skip+warn into explicit conflict/drift gating with a `--force-extensions` escape hatch.

- **Hard conflict** (a pre-existing unowned file at the target, or a symlink/non-regular dest) → **exit 1 even under `--apply`**, message `[WIKI: existing file conflicts. Backup and retry, or use --force-extensions]`.
- **Drift** (a file we own whose installed copy the user has edited) → warn `[WIKI: extension <name> drift detected. Use --force-extensions to overwrite.]` + counted as pending work (**check-mode exit 1 only**, mirroring slash-command drift) — not a hard `--apply` block.
- **`--force-extensions`** (init + upgrade) backs up the prior file to `.bak` then overwrites from source. A symlink/non-regular dest is **never followed** even under force (isRegularFile guard precedes the force branch, plan §5#5).

## Intentionally deferred (documented in `registerSettings`)
- **settings.json-entry drift detection** — without a recorded settings SHA we cannot distinguish a user edit from a manifest change (which must auto-update), so reconcile self-heals. → **E5 (#33)** doctor integrity (§8.12-7).
- **settings mixed-group surgical replacement** (preserve sibling plugins' hooks, swap only ours) — today a foreign hook sharing our group is left untouched as drift.

## Pre-commit codex review (1 worker) → 2 findings cross-verified + fixed
1. **init.mjs conflict path** logged to the wrong bucket (`log('error')` vs the `errors` array) → would `TypeError` at runtime; the init conflict path was untested. Fixed + regression test `extensions: init blocks on a hard conflict`.
2. **upgrade.mjs non-JSON summary** `totalDrift` omitted `conflicts`/`drifts` → printed "Result: Hypomnema is up to date" while exiting 1. Fixed + summary-consistency assertion.

## Tests
357→358 green. New `extensions-conflict-detected-blocks-without-force` (Coverage Matrix §8.12 c) covers drift check/apply/force/symlink + init hard-conflict path. Existing E2 conflict test exit code flipped 0→1 for the promoted contract. `npm test` green, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)