### PR TITLE
feat(stage-6-e4): extensions codex dual-cover — fix #32 (ADR 0024)

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -13,7 +13,7 @@
  *   --no-hooks             Skip hook installation
  *   --no-commands          Skip slash command installation to ~/.claude/commands/hypo/
  *   --force-commands       Overwrite user-modified slash command files (creates .bak)
- *   --codex                Also install Codex hooks (~/.codex/hooks/)
+ *   --codex                Also install Codex hooks + extensions (~/.codex/{hooks,commands}/)
  *   --git-remote=<url>     Git remote URL
  *   --no-git-init          Skip git initialization
  *   --from-remote=<url>    Clone existing Hypomnema wiki from remote and install hooks
@@ -130,7 +130,7 @@ Init options:
   --no-commands          Skip slash command installation to ~/.claude/commands/hypo/
   --force-commands       Overwrite user-modified slash command files (creates .bak)
   --force-extensions     Overwrite user-modified / conflicting extension copies (creates .bak)
-  --codex                Also install Codex hooks (~/.codex/hooks/)
+  --codex                Also install Codex hooks + extensions (~/.codex/{hooks,commands}/)
   --git-remote=<url>     Git remote URL
   --no-git-init          Skip git initialization
   --from-remote=<url>    Clone existing Hypomnema wiki from remote and install hooks
@@ -912,6 +912,37 @@ if (args.codex) {
   const codexHooks = join(HOME, '.codex', 'hooks');
   installHooks(codexHooks, args.dryRun);
   mergeSettingsJson(join(HOME, '.codex', 'settings.json'), codexHooks, args.dryRun, HOOK_MAP);
+
+  // 6b. user extensions companion → codex (E4, #32). Mirrors the claude sync above
+  // for the codex target: hooks + commands only (skills/agents are skipped with a
+  // notice). The per-target SHA map merges into the same ~/.claude/hypo-pkg.json
+  // under extensions.codex, alongside extensions.claude written in step 4b.
+  const extCodex = syncExtensions({
+    extDir: join(args.hypoDir, 'extensions'),
+    hypoDir: args.hypoDir,
+    target: 'codex',
+    settingsPath: join(HOME, '.codex', 'settings.json'),
+    pkgPath: pkgJsonPath(),
+    apply: !args.dryRun,
+    force: args.forceExtensions,
+  });
+  for (const a of extCodex.actions) {
+    if (a.action === 'create' || a.action === 'update' || a.action === 'force-update') {
+      log('created', `codex extension ${a.file} (${a.action})`);
+    }
+  }
+  for (const r of extCodex.registered) log('merged', `codex extension ${r}`);
+  for (const w of extCodex.warnings) log('skipped', `codex extension: ${w}`);
+  if (extCodex.conflicts.length > 0) {
+    log('errors', '[WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');
+    for (const c of extCodex.conflicts) log('errors', `codex extension ${c.file} (${c.action})`);
+  }
+  for (const d of extCodex.drifts) {
+    log(
+      'skipped',
+      `[WIKI: extension ${d.name} drift detected. Use --force-extensions to overwrite.]`,
+    );
+  }
 }
 
 // 7. git setup (skip when cloned from remote — already has .git + remote)

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -353,6 +353,18 @@ export function syncExtensions({
   const discovered = discoverExtensions(extDir, patterns, hypoDir);
   result.warnings.push(...discovered.warnings);
 
+  // E4 (#32): Codex supports hooks + commands only. If the user authored
+  // skills/agents extensions, surface a one-time notice that they are skipped
+  // for this target rather than silently dropping them (plan §2 E4).
+  if (target === 'codex') {
+    const skipped = discovered.skills.length + discovered.agents.length;
+    if (skipped > 0) {
+      result.warnings.push(
+        `${skipped} skill/agent extension(s) skipped for Codex — only hooks + commands are supported`,
+      );
+    }
+  }
+
   const recorded = readExtensionPkgStateNoMutate(pkgPath, target);
   const newSHAs = {};
   // Preserve recorded SHAs for types this target does not cover (e.g. codex skips

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -14,6 +14,7 @@
  *   --apply             Apply hook file updates and settings.json merges
  *   --force-commands    Overwrite user-modified slash command files (creates .bak)
  *   --force-extensions  Overwrite user-modified / conflicting extension copies (creates .bak)
+ *   --codex             Also sync extensions into ~/.codex/{hooks,commands} + settings.json
  *   --json              Output results as JSON
  */
 
@@ -71,12 +72,14 @@ function parseArgs(argv) {
     json: false,
     forceCommands: false,
     forceExtensions: false,
+    codex: false,
   };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--apply') args.apply = true;
     else if (arg === '--force-commands') args.forceCommands = true;
     else if (arg === '--force-extensions') args.forceExtensions = true;
+    else if (arg === '--codex') args.codex = true;
     else if (arg === '--json') args.json = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
@@ -673,6 +676,22 @@ const extCheck = syncExtensions({
   force: args.forceExtensions,
 });
 
+// E4 (#32): --codex mirrors the extensions sync into ~/.codex (hooks + commands
+// only; skills/agents skipped with a notice). The per-target SHA map lives in the
+// same ~/.claude/hypo-pkg.json under extensions.codex, so pkgPath is unchanged.
+const extCodexSettingsPath = join(HOME, '.codex', 'settings.json');
+const extCheckCodex = args.codex
+  ? syncExtensions({
+      extDir,
+      hypoDir: args.hypoDir,
+      target: 'codex',
+      settingsPath: extCodexSettingsPath,
+      pkgPath: pkgJsonPath(),
+      apply: false,
+      force: args.forceExtensions,
+    })
+  : null;
+
 const staleHooks = hooks.filter(
   (h) => h.status === 'stale' || h.status === 'missing' || h.status === 'src-missing',
 );
@@ -695,6 +714,7 @@ let appliedHookNameRenames = [];
 let appliedCommands = [];
 let appliedHypoignore = [];
 let appliedExtensions = null;
+let appliedExtensionsCodex = null;
 
 if (args.apply) {
   if (oldHookRefs.length > 0) {
@@ -719,11 +739,25 @@ if (args.apply) {
     apply: true,
     force: args.forceExtensions,
   });
+  // E4 (#32): codex apply runs AFTER the claude apply so it reads the freshly
+  // written hypo-pkg.json and merges extensions.codex alongside extensions.claude
+  // (the per-target spread in syncExtensions preserves the other target's map).
+  if (args.codex) {
+    appliedExtensionsCodex = syncExtensions({
+      extDir,
+      hypoDir: args.hypoDir,
+      target: 'codex',
+      settingsPath: extCodexSettingsPath,
+      pkgPath: pkgJsonPath(),
+      apply: true,
+      force: args.forceExtensions,
+    });
+  }
 }
 
 // ── output ───────────────────────────────────────────────────────────────────
 
-const extDrift = extCheck.needsWork;
+const extDrift = extCheck.needsWork || (extCheckCodex?.needsWork ?? false);
 
 const hasDrift =
   staleHooks.length > 0 ||
@@ -751,6 +785,7 @@ if (args.json) {
         oldHookRefs,
         hypoignore,
         extensions: extCheck,
+        extensionsCodex: extCheckCodex,
         applied: {
           hooks: appliedHooks,
           settings: appliedSettings,
@@ -759,6 +794,7 @@ if (args.json) {
           commands: appliedCommands,
           hypoignore: appliedHypoignore,
           extensions: appliedExtensions,
+          extensionsCodex: appliedExtensionsCodex,
         },
         migrationReport: migrationPath,
       },
@@ -766,7 +802,13 @@ if (args.json) {
       2,
     ),
   );
-  process.exit((hasDrift && !args.apply) || extCheck.conflicts.length > 0 ? 1 : 0);
+  process.exit(
+    (hasDrift && !args.apply) ||
+      extCheck.conflicts.length > 0 ||
+      (extCheckCodex?.conflicts.length ?? 0) > 0
+      ? 1
+      : 0,
+  );
 }
 
 // Human-readable report
@@ -910,41 +952,45 @@ if (hypoignore.status === 'no-file') {
   for (const e of hypoignore.missing) lines.push(`    + ${e.pattern}`);
 }
 
-// Extensions companion (ADR 0024; conflict/drift gating E3, #31)
-{
-  const pending = extCheck.actions.filter(
+// Extensions companion (ADR 0024; conflict/drift gating E3, #31). Shared by the
+// claude target and, under --codex, the codex target (E4, #32) — the label keeps
+// the two blocks distinguishable in the report.
+function pushExtSummary(check, label) {
+  // Pad to fit the longest label ("Extensions (codex)" = 18) plus a separating
+  // space so the count never glues onto the label.
+  const col = `Extensions${label}`.padEnd(20);
+  const pending = check.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
   );
-  const nConflicts = extCheck.conflicts.length;
-  const nDrifts = extCheck.drifts.length;
-  if (extCheck.actions.length === 0 && extCheck.warnings.length === 0) {
-    lines.push(`✓ Extensions        none found in ${extDir.replace(HOME, '~')}`);
+  const nConflicts = check.conflicts.length;
+  const nDrifts = check.drifts.length;
+  if (check.actions.length === 0 && check.warnings.length === 0) {
+    lines.push(`✓ ${col}none found in ${extDir.replace(HOME, '~')}`);
   } else if (pending.length === 0 && nConflicts === 0 && nDrifts === 0) {
-    const reg = extCheck.registered.length;
-    lines.push(
-      `✓ Extensions        ${extCheck.actions.length} synced${reg ? `, ${reg} hook(s) registered` : ''}`,
-    );
+    const reg = check.registered.length;
+    lines.push(`✓ ${col}${check.actions.length} synced${reg ? `, ${reg} hook(s) registered` : ''}`);
   } else {
     lines.push(
-      `⚠ Extensions        ${pending.length} to sync, ${nConflicts} conflict(s), ${nDrifts} drift(s):`,
+      `⚠ ${col}${pending.length} to sync, ${nConflicts} conflict(s), ${nDrifts} drift(s):`,
     );
     for (const a of pending) lines.push(`    + ${a.file}  [${a.action}]`);
-    for (const c of extCheck.conflicts)
-      lines.push(`    ✗ ${c.file}  [${c.action} — left untouched]`);
-    for (const d of extCheck.drifts) lines.push(`    ⚠ ${d.file}  [drift — left untouched]`);
+    for (const c of check.conflicts) lines.push(`    ✗ ${c.file}  [${c.action} — left untouched]`);
+    for (const d of check.drifts) lines.push(`    ⚠ ${d.file}  [drift — left untouched]`);
   }
   // E3 (#31): a hard conflict blocks install (exit 1, even under --apply); drift is
   // resolvable advisory. Emit the spec'd WIKI messages so the user knows the recovery.
   if (nConflicts > 0) {
     lines.push('  [WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');
   }
-  for (const d of extCheck.drifts) {
+  for (const d of check.drifts) {
     lines.push(
       `  [WIKI: extension ${d.name} drift detected. Use --force-extensions to overwrite.]`,
     );
   }
-  for (const w of extCheck.warnings) lines.push(`    ⚠ ${w}`);
+  for (const w of check.warnings) lines.push(`    ⚠ ${w}`);
 }
+pushExtSummary(extCheck, '');
+if (extCheckCodex) pushExtSummary(extCheckCodex, ' (codex)');
 
 // Migration report notice
 if (migrationPath) {
@@ -988,22 +1034,25 @@ if (
   }
 }
 
-if (appliedExtensions) {
-  const synced = appliedExtensions.actions.filter(
+function pushAppliedExt(applied, label) {
+  if (!applied) return;
+  const synced = applied.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
   );
-  if (synced.length > 0 || appliedExtensions.settingsChanged) {
+  if (synced.length > 0 || applied.settingsChanged) {
     lines.push('');
     if (synced.length > 0) {
-      lines.push(`✓ Synced extensions (${synced.length}):`);
+      lines.push(`✓ Synced extensions${label} (${synced.length}):`);
       for (const a of synced) lines.push(`    → ${a.file} (${a.action})`);
     }
-    if (appliedExtensions.settingsChanged) {
-      lines.push(`✓ Registered extension hooks (${appliedExtensions.registered.length}):`);
-      for (const r of appliedExtensions.registered) lines.push(`    → ${r}`);
+    if (applied.settingsChanged) {
+      lines.push(`✓ Registered extension hooks${label} (${applied.registered.length}):`);
+      for (const r of applied.registered) lines.push(`    → ${r}`);
     }
   }
 }
+pushAppliedExt(appliedExtensions, '');
+pushAppliedExt(appliedExtensionsCodex, ' (codex)');
 
 // Summary
 lines.push('');
@@ -1025,15 +1074,26 @@ const totalDrift =
   // E3 (#31): unresolved drift/conflict is pending work too — without these the
   // summary printed "up to date" while the exit code was 1 (codex review).
   extCheck.conflicts.length +
-  extCheck.drifts.length;
+  extCheck.drifts.length +
+  // E4 (#32): codex-target pending work counts identically (same message/exit
+  // consistency the E3 review caught — a codex conflict must not read "up to date").
+  (extCheckCodex
+    ? extCheckCodex.actions.filter(
+        (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
+      ).length +
+      extCheckCodex.conflicts.length +
+      extCheckCodex.drifts.length
+    : 0);
 if (totalDrift === 0) {
   lines.push('Result: Hypomnema is up to date');
 } else if (args.apply) {
-  const appliedExtCount = appliedExtensions
-    ? appliedExtensions.actions.filter(
-        (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
-      ).length + (appliedExtensions.settingsChanged ? 1 : 0)
-    : 0;
+  const countApplied = (r) =>
+    r
+      ? r.actions.filter(
+          (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
+        ).length + (r.settingsChanged ? 1 : 0)
+      : 0;
+  const appliedExtCount = countApplied(appliedExtensions) + countApplied(appliedExtensionsCodex);
   const total =
     appliedHooks.length +
     appliedSettings.length +
@@ -1051,5 +1111,5 @@ console.log(lines.join('\n'));
 // E3 (#31): a hard extension conflict blocks even under --apply (unlike ordinary
 // drift, which only fails check mode). --force-extensions clears the resolvable
 // cases; an unfollowable symlink/non-regular dest still counts and stays exit 1.
-const extBlocked = extCheck.conflicts.length > 0;
+const extBlocked = extCheck.conflicts.length > 0 || (extCheckCodex?.conflicts.length ?? 0) > 0;
 process.exit((hasDrift && !args.apply) || extBlocked ? 1 : 0);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2507,6 +2507,267 @@ test('extensions: .hypoignore-matched manifest is not copied or recorded', () =>
   });
 });
 
+// §8.12 (5) --codex mirrors the extensions sync into ~/.codex (hooks + commands
+// only; skills/agents skipped with a notice). Covers BOTH entry points (upgrade
+// here, init below) — the E3 review showed a shared sync fn can still leak
+// per-entry-point wiring bugs.
+test('extensions-codex-sync', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      // A hook (registrable), a command, and a skill (Codex-unsupported → skip).
+      writeExt(hypoDir, 'hooks', 'hypo-ext-cdxwatch.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 8000,
+      });
+      writeExt(hypoDir, 'commands', 'hypo-ext-cdxcmd.md', '# codex command\n');
+      writeExt(hypoDir, 'skills', 'hypo-ext-cdxskill.md', '# claude-only skill\n');
+
+      // (sanity) a plain --apply must NEVER touch ~/.codex.
+      const rNoCdx = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(rNoCdx.status, 0, `claude-only apply failed: ${rNoCdx.stderr}`);
+      assert.ok(
+        !existsSync(join(home, '.codex', 'hooks', 'hypo-ext-cdxwatch.mjs')),
+        'without --codex nothing must be written into ~/.codex',
+      );
+
+      // ── entry point 1: upgrade --codex --apply ──
+      const rUp = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply', '--codex'],
+        home,
+      );
+      assert.equal(rUp.status, 0, `upgrade --codex failed: ${rUp.stderr}`);
+      const up = JSON.parse(rUp.stdout);
+
+      const cdxHooks = join(home, '.codex', 'hooks');
+      const cdxCmds = join(home, '.codex', 'commands');
+      assert.ok(
+        existsSync(join(cdxHooks, 'hypo-ext-cdxwatch.mjs')),
+        'hook not hard-copied to ~/.codex/hooks',
+      );
+      assert.ok(
+        existsSync(join(cdxHooks, 'hypo-ext-cdxwatch.manifest.json')),
+        'manifest not hard-copied to ~/.codex/hooks',
+      );
+      assert.ok(
+        existsSync(join(cdxCmds, 'hypo-ext-cdxcmd.md')),
+        'command not hard-copied to ~/.codex/commands',
+      );
+      assert.ok(
+        !existsSync(join(home, '.codex', 'skills', 'hypo-ext-cdxskill.md')),
+        'skill extension must be skipped for the codex target',
+      );
+
+      // ~/.codex/settings.json entry uses a command WE constructed, pointing at ~/.codex.
+      const cdxSettings = JSON.parse(readFileSync(join(home, '.codex', 'settings.json'), 'utf-8'));
+      const grp = (cdxSettings.hooks?.PostToolUse || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-cdxwatch.mjs')),
+      );
+      assert.equal(grp.length, 1, 'exactly one codex PostToolUse entry expected');
+      assert.equal(
+        grp[0].hooks[0].command,
+        'node $HOME/.codex/hooks/hypo-ext-cdxwatch.mjs',
+        'codex command must point at ~/.codex and be constructed by us',
+      );
+      assert.equal(grp[0].matcher, 'Write', 'codex matcher from manifest not applied');
+
+      // per-target SHA: BOTH claude and codex maps must survive (regression guard).
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(
+        pkg.extensions?.claude?.['hooks/hypo-ext-cdxwatch.mjs'],
+        'claude per-target SHA was dropped by the codex sync',
+      );
+      assert.ok(
+        pkg.extensions?.codex?.['hooks/hypo-ext-cdxwatch.mjs'],
+        'codex hook SHA not recorded',
+      );
+      assert.ok(
+        pkg.extensions.codex['commands/hypo-ext-cdxcmd.md'],
+        'codex command SHA not recorded',
+      );
+      assert.ok(
+        !pkg.extensions.codex['skills/hypo-ext-cdxskill.md'],
+        'skipped skill must not be recorded under codex',
+      );
+
+      // skip notice surfaced on the codex result — and NOT on the claude result.
+      assert.ok(
+        up.extensionsCodex.warnings.some((w) => /skipped for Codex/i.test(w)),
+        'a skill/agent skip notice was expected for the codex target',
+      );
+      assert.ok(
+        !up.extensions.warnings.some((w) => /skipped for Codex/i.test(w)),
+        'the claude target must not emit a codex skip notice',
+      );
+
+      // idempotency: a second --codex --apply syncs nothing new.
+      const rUp2 = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply', '--codex'],
+        home,
+      );
+      assert.equal(rUp2.status, 0, `second --codex apply failed: ${rUp2.stderr}`);
+      const up2 = JSON.parse(rUp2.stdout);
+      const synced2 = up2.applied.extensionsCodex.actions.filter((a) =>
+        ['create', 'update', 'force-update'].includes(a.action),
+      );
+      assert.equal(synced2.length, 0, 'second --codex apply should sync nothing (idempotent)');
+    });
+  });
+});
+
+// §8.12 (5) the OTHER entry point: init --codex must run the same codex sync
+// (E3 lesson — wiring bugs surface per entry point even with a shared fn).
+test('extensions-codex-sync: init --codex entry point', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-icdx.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+
+      const r = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-git-init', '--codex'],
+        home,
+      );
+      assert.equal(r.status, 0, `init --codex failed: ${r.stderr}`);
+      assert.ok(
+        existsSync(join(home, '.codex', 'hooks', 'hypo-ext-icdx.mjs')),
+        'init --codex must hard-copy the extension into ~/.codex/hooks',
+      );
+      const cdxSettings = JSON.parse(readFileSync(join(home, '.codex', 'settings.json'), 'utf-8'));
+      assert.ok(
+        JSON.stringify(cdxSettings.hooks || {}).includes('hypo-ext-icdx.mjs'),
+        'init --codex must register the extension in ~/.codex/settings.json',
+      );
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(
+        pkg.extensions?.codex?.['hooks/hypo-ext-icdx.mjs'],
+        'init --codex must record the codex per-target SHA',
+      );
+      // init writes the claude target (step 4b) before the codex target (6b) — the
+      // codex write must not clobber the claude per-target SHA map.
+      assert.ok(
+        pkg.extensions?.claude?.['hooks/hypo-ext-icdx.mjs'],
+        'init --codex must preserve the claude per-target SHA',
+      );
+    });
+  });
+});
+
+// §8.12 (5) + (c): a codex hard conflict (foreign file at the ~/.codex target)
+// must block even under --apply (exit 1), leave the file untouched, and never
+// report "up to date" — the message/exit consistency the E3 review enforced.
+test('extensions-codex-sync: hard conflict blocks even under --apply', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-cdxconf.mjs', '#!/usr/bin/env node\n// source\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      // Pre-existing UNOWNED file occupying the codex target → hard conflict.
+      const cdxHooks = join(home, '.codex', 'hooks');
+      mkdirSync(cdxHooks, { recursive: true });
+      const target = join(cdxHooks, 'hypo-ext-cdxconf.mjs');
+      writeFileSync(target, '// foreign — not ours\n');
+
+      const r = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply', '--codex'],
+        home,
+      );
+      assert.equal(r.status, 1, 'a codex hard conflict must exit 1 even under --apply');
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        out.extensionsCodex.conflicts.some((c) => c.file === 'hooks/hypo-ext-cdxconf.mjs'),
+        'codex conflict must be reported in extensionsCodex.conflicts',
+      );
+      assert.equal(
+        readFileSync(target, 'utf-8'),
+        '// foreign — not ours\n',
+        'a conflicting codex file must be left untouched',
+      );
+
+      // The human-readable summary must not contradict the exit code (E3 review).
+      const rh = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply', '--codex'], home);
+      assert.equal(rh.status, 1, 'non-JSON codex conflict must also exit 1');
+      // The verdict line must not claim everything is settled (E3 message/exit
+      // consistency) — per-check "up to date" lines are fine, only the Result is.
+      assert.ok(
+        !/Result: Hypomnema is up to date/.test(rh.stdout),
+        'the summary verdict must not read "up to date" while a codex conflict exists',
+      );
+    });
+  });
+});
+
+// §8.12 (5) + 검증 4: --force-extensions resolves a drifted codex copy (backup +
+// overwrite). Both entry points forward the flag; this guards the codex wiring.
+test('extensions-codex-sync: --force-extensions overwrites a drifted codex copy', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-cdxforce.mjs', '#!/usr/bin/env node\n// v1\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply', '--codex'], home);
+      assert.equal(r1.status, 0, `initial codex sync failed: ${r1.stderr}`);
+      const installed = join(home, '.codex', 'hooks', 'hypo-ext-cdxforce.mjs');
+
+      // User edits the installed codex copy (drift) and the source advances to v2.
+      writeFileSync(installed, '#!/usr/bin/env node\n// user edit\n');
+      writeExt(hypoDir, 'hooks', 'hypo-ext-cdxforce.mjs', '#!/usr/bin/env node\n// v2\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+
+      // Plain --apply must NOT overwrite a drifted (owned-but-edited) codex copy.
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply', '--codex'], home);
+      assert.equal(
+        readFileSync(installed, 'utf-8'),
+        '#!/usr/bin/env node\n// user edit\n',
+        'apply without --force must not overwrite a drifted codex file',
+      );
+
+      // --force-extensions backs up (.bak) and overwrites from source.
+      const r3 = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex', '--force-extensions'],
+        home,
+      );
+      assert.equal(r3.status, 0, `--force-extensions codex apply failed: ${r3.stderr}`);
+      assert.equal(
+        readFileSync(installed, 'utf-8'),
+        '#!/usr/bin/env node\n// v2\n',
+        '--force-extensions must overwrite the codex copy with the source',
+      );
+      assert.ok(
+        existsSync(`${installed}.bak`),
+        '--force-extensions must back up the prior codex copy',
+      );
+    });
+  });
+});
+
 // ── lint.mjs --fix tests ─────────────────────────────────────────────────────
 
 suite('lint.mjs --fix');


### PR DESCRIPTION
## Summary

Slice E4 of Stage 6 Phase B. Wires the `--codex` flag through both extensions sync entry points so a user's `~/hypomnema/extensions/{hooks,commands}/` companions are mirrored into `~/.codex/{hooks,commands}/` + `~/.codex/settings.json`, alongside the existing `~/.claude` target.

The lib `syncExtensions(target='codex')` path was **already complete** (`CODEX_TYPES`, per-target SHA, `~/.codex` routing) — E4 is the entry-point wiring + a previously-missing skip notice.

## Changes

- **`lib/extensions.mjs`**: emit a one-time notice when skills/agents are skipped for the codex target (Codex supports hooks+commands only) — previously silent (plan §2 E4).
- **`upgrade.mjs`**: parse `--codex`; run a second `syncExtensions(target='codex')` for both check and apply (codex apply **after** claude apply so the per-target SHA map merges rather than clobbers); fold the codex result into `hasDrift`, `totalDrift`, `extBlocked`, the JSON report (`extensionsCodex`), and the human summary (labelled `(codex)`).
- **`init.mjs`**: run the codex extensions sync inside the existing `if (args.codex)` block, after the codex core hooks install.

Per-target SHA map (`extensions.claude` / `extensions.codex`) keeps the two targets independent. Security: the settings hook command is always constructed here as `node $HOME/.codex/hooks/<file>`, never sourced from the manifest.

## Tests (360 → 362)

- `extensions-codex-sync` (upgrade entry point) + `init --codex entry point`
- `codex hard-conflict blocks even under --apply` (exit 1 + conflict reported + verdict not "up to date")
- `codex --force-extensions overwrite` (backup + overwrite of a drifted codex copy)

Covers **both** entry points — the E3 lesson: a shared sync fn still leaks per-entry-point wiring bugs.

## Pre-commit review

`/teams 2:codex` — both workers **APPROVE_WITH_CHANGES, no correctness bug**. They confirmed: claude→codex apply ordering, per-target SHA preservation, codex conflict reflected in all exit/message paths, and manifest-independent command construction. The 3 MINOR test-coverage gaps they flagged are folded into the test list above.

## Deferred (out of #32 scope)

`upgrade --codex` does not yet mirror the **core** hooks (`checkSettingsJson`/`applySettingsJson`, hardcoded to `~/.claude`). spec §5.1.2 "apply: `~/.codex/` 동일 처리" → follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)