### PR TITLE
feat(stage-6-e5): doctor extensions integrity — fix #33 (ADR 0024)

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -21,6 +21,15 @@ import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import { readSyncState, projectSuggestionsPath } from '../hooks/hypo-shared.mjs';
+import {
+  discoverExtensions,
+  parseManifest,
+  buildExpectedSettingsEntries,
+  readExtensionPkgStateNoMutate,
+  EXT_TYPES,
+  CODEX_TYPES,
+} from './lib/extensions.mjs';
+import { sha256, readFileIfRegular } from './lib/pkg-json.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -647,6 +656,190 @@ function checkCodexPaths() {
   }
 }
 
+// ── extensions integrity (fix #33 — ADR 0024, E5) ───────────────────────────
+
+// Detect drift between the user's `~/hypomnema/extensions/` source, the recorded
+// per-target SHA map (`hypo-pkg.json`), and the installed copies + settings.json
+// entries under `~/.claude` (or `~/.codex` with --codex). Reuses E2's read-only
+// helpers (plan §5 D4) — never re-derives discovery/manifest/SHA logic.
+//
+// Severity taxonomy (plan §5 #4 pins manifest; the rest mirror the slash-command
+// / settings-stale precedent that recoverable drift is a warn, not a ship blocker):
+//   manifest malformed (parse fail / unknown event) → FAIL (won't self-heal; §5 #4)
+//   manifest missing                                → warn (hook just won't register; §5 #4)
+//   installed copy SHA ≠ recorded (user-modified)   → warn (--force-extensions recovers)
+//   recorded entry but copy absent / non-regular    → warn (upgrade --apply recovers)
+//   expected settings entry missing                 → warn (upgrade --apply recovers)
+//   orphan settings entry (source removed)          → warn (uninstall recovers; boost #2)
+// A malformed manifest failing here is what makes the §5.1.3 `fails=0` ship gate
+// actually cover §8.12-7(c) — asserted by the doctor-extensions-integrity test.
+//
+// E5 is doctor SURFACE only. The settings.json mixed-group surgical *write*
+// (preserve sibling-plugin hooks, swap only ours) stays deferred — it is a
+// write-path change to registerSettings (extensions.mjs:488), not a doctor check.
+function checkExtensions(hypoDir, claudeHome, target = 'claude') {
+  const extDir = join(hypoDir, 'extensions');
+  // E1 baseline absent (e.g. --from-remote clone, plan §5 #8) → nothing to check.
+  if (!existsSync(extDir)) return;
+
+  const root = target === 'codex' ? join(HOME, '.codex') : claudeHome;
+  const label = target === 'codex' ? 'Codex extensions integrity' : 'Extensions integrity';
+  // The per-target SHA map lives in ~/.claude/hypo-pkg.json under
+  // `extensions.{claude,codex}` (sync writes both targets into the one file —
+  // upgrade.mjs:681), so the pkg path is always claude regardless of target.
+  const pkgPath = join(claudeHome, 'hypo-pkg.json');
+  const settingsPath = join(root, 'settings.json');
+  const hooksDir = join(root, 'hooks');
+  const types = target === 'codex' ? CODEX_TYPES : EXT_TYPES;
+
+  const patterns = loadHypoIgnore(hypoDir);
+  const discovered = discoverExtensions(extDir, patterns, hypoDir);
+
+  const problems = [];
+
+  // (c) manifest health — hooks only (plan §0 D3: non-hook manifests don't register).
+  for (const ext of discovered.hooks) {
+    if (!ext.manifestPath) {
+      problems.push({
+        severity: 'warn',
+        msg: `${ext.name}.manifest.json missing — hook will not auto-register`,
+      });
+      continue;
+    }
+    const parsed = parseManifest(ext.manifestPath);
+    if (!parsed.ok) {
+      problems.push({ severity: 'fail', msg: `${ext.manifestName} malformed (${parsed.error})` });
+    }
+  }
+
+  // (a) hard-copy SHA: recorded SHA vs the installed copy on disk.
+  const recorded = readExtensionPkgStateNoMutate(pkgPath, target);
+  for (const [key, recSHA] of Object.entries(recorded)) {
+    // Skip keys outside this target's covered types (defensive: a Claude run records
+    // skills/agents that a codex target never installs — don't false-flag them).
+    if (!types.includes(key.split('/')[0])) continue;
+    const destPath = join(root, key);
+    if (!existsSync(destPath)) {
+      problems.push({
+        severity: 'warn',
+        msg: `${key} recorded but not installed — run upgrade --apply`,
+      });
+      continue;
+    }
+    const onDisk = readFileIfRegular(destPath);
+    if (onDisk === null) {
+      problems.push({ severity: 'warn', msg: `${key} is not a regular file — left untouched` });
+      continue;
+    }
+    if (sha256(onDisk) !== recSHA) {
+      problems.push({
+        severity: 'warn',
+        msg: `${key} modified since install (drift) — use --force-extensions`,
+      });
+    }
+  }
+
+  // (b) settings.json entries. Distinguish three states:
+  //   - malformed JSON      → skip (checkSettingsJson / checkCodexPaths already FAILs it;
+  //                            piling on a misleading "not registered" warn helps no one)
+  //   - missing file / no `hooks` object → treat as an EMPTY hooks map, so a synced
+  //     extension whose registration is absent still surfaces as expected-but-missing
+  //     (§8.12-7(b)). A missing file alone with no extensions yields no problem (gate-safe).
+  let settingsParseFailed = false;
+  let hooksObj = {};
+  if (existsSync(settingsPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      if (
+        parsed &&
+        parsed.hooks &&
+        typeof parsed.hooks === 'object' &&
+        !Array.isArray(parsed.hooks)
+      ) {
+        hooksObj = parsed.hooks;
+      }
+    } catch {
+      settingsParseFailed = true;
+    }
+  }
+  if (!settingsParseFailed) {
+    const expected = buildExpectedSettingsEntries(discovered.hooks, hooksDir);
+
+    // (b) for each registrable hook: locate the single-hook group that owns its
+    // command (mirroring registerSettings' isOurGroup, extensions.mjs:512) and
+    // compare against the manifest-derived shape. Two drift kinds, both warn:
+    //   - not registered (no owning group under the right event) → run upgrade --apply
+    //   - registered but matcher/timeout differs from the manifest → run upgrade --apply
+    // The shape-differs branch is the settings-entry mismatch E3 deferred to E5
+    // (extensions.mjs:488); upgrade --apply silently self-heals it, so doctor is
+    // the only surface that reports it.
+    const ownsCommand = (g, command) =>
+      g &&
+      typeof g === 'object' &&
+      Array.isArray(g.hooks) &&
+      g.hooks.length === 1 &&
+      g.hooks[0] &&
+      g.hooks[0].command === command;
+    for (const entry of expected) {
+      const desiredHook = { type: 'command', command: entry.command };
+      if (entry.timeout) desiredHook.timeout = entry.timeout;
+      const desiredGroup = { hooks: [desiredHook] };
+      if (entry.matcher) desiredGroup.matcher = entry.matcher;
+
+      const groups = Array.isArray(hooksObj[entry.event]) ? hooksObj[entry.event] : [];
+      const owning = groups.find((g) => ownsCommand(g, entry.command));
+      if (!owning) {
+        problems.push({
+          severity: 'warn',
+          msg: `${entry.name} not registered under ${entry.event} — run upgrade --apply`,
+        });
+      } else if (JSON.stringify(owning) !== JSON.stringify(desiredGroup)) {
+        problems.push({
+          severity: 'warn',
+          msg: `${entry.name} settings entry differs from manifest (matcher/timeout) — run upgrade --apply`,
+        });
+      }
+    }
+
+    // orphan (boost #2): a hypo-ext-* command in settings with no source extension.
+    // E4 excluded hypo-ext-* from the core stale checker (doctor.mjs:302), so this
+    // is the ONLY place orphaned extension entries are caught.
+    const sourceCmds = new Set(
+      discovered.hooks.map((ext) => `node ${hooksDir.replace(HOME, '$HOME')}/${ext.file}`),
+    );
+    const seen = new Set();
+    for (const groups of Object.values(hooksObj)) {
+      if (!Array.isArray(groups)) continue;
+      for (const g of groups) {
+        if (!g || typeof g !== 'object') continue;
+        for (const h of g.hooks || []) {
+          if (typeof h.command !== 'string') continue;
+          if (!/(?:^|[/\s])hypo-ext-[^/\s]+\.mjs(?=$|["'\s])/.test(h.command)) continue;
+          if (sourceCmds.has(h.command) || seen.has(h.command)) continue;
+          seen.add(h.command);
+          problems.push({
+            severity: 'warn',
+            msg: `orphan settings entry (${h.command}) — source extension removed; run uninstall`,
+          });
+        }
+      }
+    }
+  }
+
+  if (problems.length === 0) {
+    pass(label, 'All extensions consistent');
+    return;
+  }
+  const hasFail = problems.some((p) => p.severity === 'fail');
+  const sample = problems
+    .slice(0, 4)
+    .map((p) => p.msg)
+    .join('; ');
+  const extra = problems.length > 4 ? ` (+${problems.length - 4} more)` : '';
+  if (hasFail) fail(label, `${sample}${extra}`);
+  else warn(label, `${sample}${extra}`);
+}
+
 // ── feedback projection (fix #37 #9 — ADR 0031) ──────────────────────────────
 
 // Spawn feedback-sync.mjs --check --json and map its drift report onto doctor's
@@ -752,6 +945,8 @@ if (rootOk) {
 checkHooks();
 checkSettingsJson();
 if (args.codex) checkCodexPaths();
+if (rootOk) checkExtensions(args.hypoDir, args.claudeHome, 'claude');
+if (rootOk && args.codex) checkExtensions(args.hypoDir, args.claudeHome, 'codex');
 if (rootOk) checkSyncState(args.hypoDir);
 if (rootOk) checkProjectSuggestions(args.hypoDir);
 if (rootOk) checkFeedbackProjection(args.hypoDir, args.claudeHome, args.projectId);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2768,6 +2768,202 @@ test('extensions-codex-sync: --force-extensions overwrites a drifted codex copy'
   });
 });
 
+// §8.12 (7) doctor extensions integrity (fix #33, ADR 0024 E5). Detects
+// (a) hard-copy SHA mismatch, (b) settings-entry mismatch + orphan, (c) manifest
+// missing (warn) / malformed (fail). Malformed = FAIL is what makes doctor's
+// `fails=0` ship gate (§5.1.3) actually cover §8.12-7(c).
+test('doctor-extensions-integrity', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const doctorLabel = 'Extensions integrity';
+      const findExt = (out) => out.find((c) => c.label === doctorLabel);
+
+      // Author + sync a healthy hook extension.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-watch.mjs', '#!/usr/bin/env node\n// v1\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+      });
+      const sync = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(sync.status, 0, `sync failed: ${sync.stderr}`);
+
+      // (clean) all consistent → pass.
+      let r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      let ext = findExt(JSON.parse(r.stdout));
+      assert.ok(ext, 'extensions integrity check not found');
+      assert.equal(ext.status, 'pass', `expected pass when consistent: ${ext.detail}`);
+
+      // (a) user edits the installed copy → recorded SHA ≠ on-disk → warn (not fail).
+      const installed = join(home, '.claude', 'hooks', 'hypo-ext-watch.mjs');
+      writeFileSync(installed, '#!/usr/bin/env node\n// hand-edited\n');
+      r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      ext = findExt(JSON.parse(r.stdout));
+      assert.equal(ext.status, 'warn', `SHA drift must warn: ${ext.detail}`);
+      assert.ok(/drift/i.test(ext.detail), `drift detail expected: ${ext.detail}`);
+      assert.notEqual(r.status, 1, 'a recoverable drift must not fail the doctor gate');
+
+      // (b) restore the copy, then strip the settings entry → expected-missing → warn.
+      const resync = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--force-extensions'],
+        home,
+      );
+      assert.equal(resync.status, 0, `resync failed: ${resync.stderr}`);
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      settings.hooks.PostToolUse = (settings.hooks.PostToolUse || []).filter(
+        (g) => !(g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-watch.mjs')),
+      );
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+      r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      ext = findExt(JSON.parse(r.stdout));
+      assert.equal(ext.status, 'warn', `missing settings entry must warn: ${ext.detail}`);
+      assert.ok(/not registered/i.test(ext.detail), `registration detail expected: ${ext.detail}`);
+
+      // (b-orphan) settings entry whose source extension was removed → warn.
+      // E4 excludes hypo-ext-* from the core stale checker, so checkExtensions is
+      // the only place this is caught.
+      withTmpHome((home2) => {
+        const hypoDir2 = join(dir, 'wiki2');
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir2}`, '--no-git-init'], home2);
+        const s2 = {
+          hooks: {
+            Stop: [
+              {
+                hooks: [{ type: 'command', command: 'node $HOME/.claude/hooks/hypo-ext-gone.mjs' }],
+              },
+            ],
+          },
+        };
+        writeFileSync(join(home2, '.claude', 'settings.json'), JSON.stringify(s2, null, 2));
+        const ro = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir2}`, '--json'], home2);
+        const eo = findExt(JSON.parse(ro.stdout));
+        assert.equal(eo.status, 'warn', `orphan entry must warn: ${eo.detail}`);
+        assert.ok(/orphan/i.test(eo.detail), `orphan detail expected: ${eo.detail}`);
+      });
+
+      // (c-warn) hook with no manifest → warn ("will not auto-register").
+      withTmpHome((home3) => {
+        const hypoDir3 = join(dir, 'wiki3');
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir3}`, '--no-git-init'], home3);
+        writeExt(hypoDir3, 'hooks', 'hypo-ext-nomani.mjs', '#!/usr/bin/env node\n'); // no manifest
+        runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir3}`, '--apply'], home3);
+        const rm = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir3}`, '--json'], home3);
+        const em = findExt(JSON.parse(rm.stdout));
+        assert.equal(em.status, 'warn', `missing manifest must warn: ${em.detail}`);
+        assert.ok(/missing/i.test(em.detail), `missing-manifest detail expected: ${em.detail}`);
+        assert.notEqual(rm.status, 1, 'a missing manifest must not fail the gate');
+      });
+
+      // (c-fail) malformed manifest → FAIL + non-zero exit (ship gate covers §8.12-7c).
+      withTmpHome((home4) => {
+        const hypoDir4 = join(dir, 'wiki4');
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir4}`, '--no-git-init'], home4);
+        const extHooks = join(hypoDir4, 'extensions', 'hooks');
+        mkdirSync(extHooks, { recursive: true });
+        writeFileSync(join(extHooks, 'hypo-ext-bad.mjs'), '#!/usr/bin/env node\n');
+        // Unknown event → parseManifest !ok → malformed → fail.
+        writeFileSync(
+          join(extHooks, 'hypo-ext-bad.manifest.json'),
+          JSON.stringify({ type: 'hook', event: 'NotARealEvent' }),
+        );
+        const rf = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir4}`, '--json'], home4);
+        const ef = findExt(JSON.parse(rf.stdout));
+        assert.equal(ef.status, 'fail', `malformed manifest must fail: ${ef.detail}`);
+        assert.equal(rf.status, 1, 'malformed manifest must fail the doctor gate (exit 1)');
+      });
+
+      // (b-shape) command registered but matcher/timeout differs from the manifest.
+      // upgrade --apply silently self-heals this (extensions.mjs:544), so doctor is
+      // the only surface that reports it (the mismatch E3 deferred to E5).
+      withTmpHome((home5) => {
+        const hypoDir5 = join(dir, 'wiki5');
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir5}`, '--no-git-init'], home5);
+        writeExt(hypoDir5, 'hooks', 'hypo-ext-shape.mjs', '#!/usr/bin/env node\n', {
+          type: 'hook',
+          event: 'PostToolUse',
+          matcher: 'Write',
+          timeout: 5000,
+        });
+        runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir5}`, '--apply'], home5);
+        // User hand-edits the matcher in settings.json (recorded SHA path untouched).
+        const sp = join(home5, '.claude', 'settings.json');
+        const s = JSON.parse(readFileSync(sp, 'utf-8'));
+        for (const g of s.hooks.PostToolUse) {
+          if ((g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-shape.mjs'))) {
+            g.matcher = 'Edit'; // diverge from manifest's "Write"
+          }
+        }
+        writeFileSync(sp, JSON.stringify(s, null, 2));
+        const r5 = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir5}`, '--json'], home5);
+        const e5 = findExt(JSON.parse(r5.stdout));
+        assert.equal(e5.status, 'warn', `settings shape drift must warn: ${e5.detail}`);
+        assert.ok(/differs from manifest/i.test(e5.detail), `shape-drift detail: ${e5.detail}`);
+      });
+
+      // (b-missing-file) codex 2-worker review: a synced hook whose settings.json was
+      // deleted (or has no hooks object) must still warn "not registered" — a matching
+      // SHA must not mask the absent registration (§8.12-7(b)). Regression for the
+      // pre-fix guard that skipped the entry check unless settings.hooks existed.
+      withTmpHome((home6) => {
+        const hypoDir6 = join(dir, 'wiki6');
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir6}`, '--no-git-init'], home6);
+        writeExt(hypoDir6, 'hooks', 'hypo-ext-noreg.mjs', '#!/usr/bin/env node\n', {
+          type: 'hook',
+          event: 'Stop',
+        });
+        runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir6}`, '--apply'], home6);
+        // Delete settings.json — the installed copy + recorded SHA still match.
+        rmSync(join(home6, '.claude', 'settings.json'), { force: true });
+        const r6 = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir6}`, '--json'], home6);
+        const e6 = findExt(JSON.parse(r6.stdout));
+        assert.equal(e6.status, 'warn', `missing settings.json must still warn: ${e6.detail}`);
+        assert.ok(
+          /not registered/i.test(e6.detail),
+          `not-registered detail expected: ${e6.detail}`,
+        );
+      });
+    });
+  });
+});
+
+// §8.12 (7) codex target: doctor --codex runs the same integrity check against
+// ~/.codex, and skills/agents recorded under claude do not false-flag there.
+test('doctor-extensions-integrity: --codex target', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-cdxdoc.mjs', '#!/usr/bin/env node\n// v1\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      const sync = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex'],
+        home,
+      );
+      assert.equal(sync.status, 0, `codex sync failed: ${sync.stderr}`);
+
+      // Clean → codex check passes.
+      let r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--codex', '--json'], home);
+      let ext = JSON.parse(r.stdout).find((c) => c.label === 'Codex extensions integrity');
+      assert.ok(ext, 'codex extensions integrity check not found');
+      assert.equal(ext.status, 'pass', `expected codex pass: ${ext.detail}`);
+
+      // Edit the installed codex copy → drift warn on the codex target.
+      writeFileSync(join(home, '.codex', 'hooks', 'hypo-ext-cdxdoc.mjs'), '// edited\n');
+      r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--codex', '--json'], home);
+      ext = JSON.parse(r.stdout).find((c) => c.label === 'Codex extensions integrity');
+      assert.equal(ext.status, 'warn', `codex drift must warn: ${ext.detail}`);
+    });
+  });
+});
+
 // ── lint.mjs --fix tests ─────────────────────────────────────────────────────
 
 suite('lint.mjs --fix');


### PR DESCRIPTION
## Summary

Stage 6 Phase B slice **E5** (fix #33, ADR 0024). Adds a read-only `checkExtensions(hypoDir, claudeHome, target)` to `doctor.mjs` that surfaces drift between the user's `~/hypomnema/extensions/` source, the recorded per-target SHA map, and the installed copies + `settings.json` entries.

Reuses E2's exported read-only helpers (`discoverExtensions` / `parseManifest` / `buildExpectedSettingsEntries` / `readExtensionPkgStateNoMutate`) — no re-derivation (plan §5 D4).

## Detects (spec §8.12-7)

- **(a) hard-copy SHA mismatch** — recorded SHA ≠ on-disk copy (drift), or a recorded entry whose copy is absent / non-regular → **warn**.
- **(b) settings entry** — not registered, **matcher/timeout shape drift** (the mismatch E3 explicitly deferred to E5), or **orphan** entry whose source was removed (E4 excludes `hypo-ext-*` from the core stale checker, so this is the only surface that catches it) → **warn**. A missing `settings.json` / no-`hooks` object is treated as an empty hooks map so an absent registration still surfaces; malformed JSON is left to `checkSettingsJson`'s fail.
- **(c) manifest** — missing → **warn**; malformed → **FAIL** (blocks the §5.1.3 `fails=0` ship gate; taxonomy pinned in plan §5 #4).

## Notes

- Per-target SHA map lives in `~/.claude/hypo-pkg.json` under `extensions.{claude,codex}`, so the codex target reads the claude pkg path and filters to `CODEX_TYPES` (hooks+commands) — skills/agents recorded under claude never false-flag.
- **Scope**: E5 is doctor *surface* only. The settings.json mixed-group surgical *write* (preserve sibling-plugin hooks, swap only ours) is a write-path change to `registerSettings` and stays deferred as a separate fix.

## Tests

362 → 364: `doctor-extensions-integrity` (clean→pass, SHA drift, missing entry, shape drift, orphan, missing-settings-file regression, manifest missing=warn / malformed=fail+exit1) + `doctor-extensions-integrity: --codex target`.

Pre-commit `/teams 2:codex` review converged on a false pass when `settings.json` was missing/no-hooks; fixed + regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)