### PR TITLE
feat(stage-6-e6): uninstall extensions companion cleanup — fix #34 (ADR 0024)

### DIFF
--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -10,8 +10,17 @@
  *
  * Options:
  *   --apply              Actually remove files / edit settings.json (default: dry-run)
- *   --codex              Also remove Codex hooks (~/.codex/hooks/)
+ *   --codex              Also remove Codex hooks/commands + ext hard-copies (~/.codex/)
+ *   --force-commands     Remove user-modified slash commands instead of preserving them
+ *   --force-extensions   Remove user-modified extension files (hypo-ext-*) instead of preserving them
  *   --hooks-dir=<path>   Override Claude hooks directory (default: ~/.claude/hooks)
+ *
+ * Extensions (ADR 0024 fix #34): hypo-ext-* hard-copies under
+ * ~/.claude/{hooks,commands,skills,agents}/ and ~/.codex/{hooks,commands}/ (with
+ * --codex) are removed when their on-disk SHA matches the recorded one in
+ * ~/.claude/hypo-pkg.json#extensions.<target>. User-modified copies are preserved
+ * unless --force-extensions; symlinks/non-regular files are NEVER removed (force
+ * does not follow them). The wiki source (~/hypomnema/extensions/) is preserved.
  */
 
 import { existsSync, readFileSync, writeFileSync, rmSync, rmdirSync, readdirSync } from 'fs';
@@ -24,6 +33,12 @@ import {
   isRegularFile,
   readFileIfRegular,
 } from './lib/pkg-json.mjs';
+import {
+  EXT_PREFIX,
+  EXT_TYPES,
+  CODEX_TYPES,
+  readExtensionPkgStateNoMutate,
+} from './lib/extensions.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -79,14 +94,201 @@ function removeCommands(apply, force) {
   return { removed, skippedUserModified, skippedNonRegular };
 }
 
+// ── extensions removal (ADR 0024, fix #34) ───────────────────────────────────
+
+// Strip per-target extension SHA records from ~/.claude/hypo-pkg.json. Surgical:
+// we only touch the entries for keys we actually removed, so a `--force-extensions`
+// run that leaves user-modified files behind keeps their recorded SHAs intact
+// (doctor still has something to compare against next time). When the per-target
+// map empties out, drop the target key; when the whole `extensions` object empties,
+// drop it too. Other targets' records (e.g. codex map during a Claude-only uninstall)
+// are never touched.
+function stripExtensionsFromPkg(pkgPath, target, removedKeys, apply) {
+  if (!existsSync(pkgPath) || removedKeys.length === 0) return false;
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  } catch {
+    return false;
+  }
+  if (!pkg || typeof pkg !== 'object' || Array.isArray(pkg)) return false;
+  const extensions = pkg.extensions;
+  if (!extensions || typeof extensions !== 'object' || Array.isArray(extensions)) return false;
+  const perTarget = extensions[target];
+  if (!perTarget || typeof perTarget !== 'object' || Array.isArray(perTarget)) return false;
+
+  let changed = false;
+  for (const key of removedKeys) {
+    if (key in perTarget) {
+      delete perTarget[key];
+      changed = true;
+    }
+  }
+  if (Object.keys(perTarget).length === 0) {
+    delete extensions[target];
+    changed = true;
+  }
+  if (Object.keys(extensions).length === 0) {
+    delete pkg.extensions;
+    changed = true;
+  }
+  if (changed && apply) {
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  }
+  return changed;
+}
+
+// Remove hypo-ext-* hard-copies for one target (claude | codex). Mirrors
+// removeCommands' 3-way model: filesystem scan + per-target recorded SHA from
+// hypo-pkg.json#extensions[target] decides ownership. A file we never installed
+// (no recorded SHA) is left alone — that may be a foreign hypo-ext-* file the
+// user created by hand, never ours to delete. A user-modified file is preserved
+// unless --force-extensions; a symlink/non-regular target is always preserved
+// (force does not follow them, matching install/upgrade E3's guard).
+function removeExtensions(target, apply, force) {
+  const targetRoot = target === 'codex' ? join(HOME, '.codex') : join(HOME, '.claude');
+  const types = target === 'codex' ? CODEX_TYPES : EXT_TYPES;
+  // Per-target SHAs live in ~/.claude/hypo-pkg.json regardless of target (the
+  // file is a single source of truth, with extensions: { claude: {}, codex: {} }).
+  const pkgPath = join(HOME, '.claude', 'hypo-pkg.json');
+  const recorded = readExtensionPkgStateNoMutate(pkgPath, target);
+
+  const removed = [];
+  const removedKeys = [];
+  const skippedUserModified = [];
+  const skippedNonRegular = [];
+
+  for (const type of types) {
+    const typeDir = join(targetRoot, type);
+    if (!existsSync(typeDir)) continue;
+    let entries;
+    try {
+      entries = readdirSync(typeDir);
+    } catch {
+      continue;
+    }
+    for (const fname of entries) {
+      if (!fname.startsWith(EXT_PREFIX)) continue;
+      const key = `${type}/${fname}`;
+      const recordedSHA = recorded[key];
+      if (!recordedSHA) continue; // not tracked by us → leave alone
+      const fullPath = join(typeDir, fname);
+
+      if (!isRegularFile(fullPath)) {
+        // Refuse to follow symlinks/sockets even under --force-extensions.
+        skippedNonRegular.push(fullPath);
+        continue;
+      }
+      const buf = readFileIfRegular(fullPath);
+      const sha = buf ? sha256(buf) : null;
+
+      if (sha === recordedSHA || force) {
+        if (apply) rmSync(fullPath);
+        removed.push(fullPath);
+        removedKeys.push(key);
+      } else {
+        skippedUserModified.push(fullPath);
+      }
+    }
+  }
+  return { target, removed, removedKeys, skippedUserModified, skippedNonRegular };
+}
+
+// True iff `pkg.json` still holds extensions state for a target the current
+// uninstall did NOT process. Without this guard, a Claude-only uninstall would
+// wholesale-rm pkg.json even when ~/.codex/hooks/hypo-ext-* hard-copies (and
+// their `extensions.codex` ownership baseline) are still live — silently
+// orphaning Codex's per-target SHA contract (plan D2b/E6).
+//
+// Scope is narrowed to unprocessed targets so the legacy clean-uninstall path
+// stands: when commands are removed in full (commandResult has no skipped
+// entries) the stale `pkg.commands` map still gets wholesale-removed, matching
+// pre-E6 behavior. A processed target whose own state is non-empty (e.g.
+// user-modified ext file held back) is already guarded by its skippedUserModified
+// / skippedNonRegular tally — so we don't double-count it here.
+function unprocessedExtensionTargetRemains(pkgPath, processedTargets) {
+  if (!existsSync(pkgPath)) return false;
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  } catch {
+    // Cannot reliably inspect — refuse to delete (fail-safe: keep the file).
+    return true;
+  }
+  const exts = pkg && typeof pkg === 'object' && !Array.isArray(pkg) ? pkg.extensions : null;
+  if (!exts || typeof exts !== 'object' || Array.isArray(exts)) return false;
+  for (const [target, m] of Object.entries(exts)) {
+    if (processedTargets.has(target)) continue;
+    if (m && typeof m === 'object' && !Array.isArray(m) && Object.keys(m).length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// settings.json: strip groups whose command points to a hypo-ext-* path under
+// the target's hooks dir. Identity is path-based (plan §0 D1) — no hookMap needed
+// because ext hooks are never enumerated there. Mixed groups (foreign hook +
+// ours) keep the foreign hook; ours-only groups are dropped entirely. Mirrors
+// stripSettingsJson's flatMap pattern so other-plugin invariants (§7.3) hold.
+function stripExtensionSettings(settingsPath, hooksDir, apply) {
+  if (!existsSync(settingsPath)) return { stripped: [] };
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    return { stripped: [], error: `${settingsPath} is not valid JSON — skipping` };
+  }
+  if (!settings.hooks || typeof settings.hooks !== 'object') return { stripped: [] };
+
+  const cmdPrefix = `node ${hooksDir.replace(HOME, '$HOME')}/${EXT_PREFIX}`;
+  const isExtHook = (h) =>
+    h && h.type === 'command' && typeof h.command === 'string' && h.command.startsWith(cmdPrefix);
+
+  const stripped = [];
+  let changed = false;
+
+  for (const [event, groups] of Object.entries(settings.hooks)) {
+    if (!Array.isArray(groups)) continue;
+
+    const filtered = groups.flatMap((group) => {
+      if (!Array.isArray(group.hooks)) return [group];
+
+      const extHooks = group.hooks.filter(isExtHook);
+      const others = group.hooks.filter((h) => !isExtHook(h));
+
+      for (const h of extHooks) stripped.push(`${event}: ${h.command}`);
+
+      if (extHooks.length === 0) return [group];
+      changed = true;
+      if (others.length === 0) return [];
+      return [{ ...group, hooks: others }];
+    });
+
+    settings.hooks[event] = filtered;
+  }
+
+  if (changed && apply) {
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  }
+  return { stripped };
+}
+
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { apply: false, codex: false, hooksDir: null, forceCommands: false };
+  const args = {
+    apply: false,
+    codex: false,
+    hooksDir: null,
+    forceCommands: false,
+    forceExtensions: false,
+  };
   for (const arg of argv.slice(2)) {
     if (arg === '--apply') args.apply = true;
     else if (arg === '--codex') args.codex = true;
     else if (arg === '--force-commands') args.forceCommands = true;
+    else if (arg === '--force-extensions') args.forceExtensions = true;
     else if (arg.startsWith('--hooks-dir=')) args.hooksDir = arg.slice(12);
   }
   return args;
@@ -222,24 +424,63 @@ const hookResult = removeHookFiles(claudeHooksDir, hookFiles, args.apply);
 const settingsResult = stripSettingsJson(claudeSettings, claudeHooksDir, hookMap, args.apply);
 const commandResult = removeCommands(args.apply, args.forceCommands);
 
-// pkg.json metadata file removal — only when no user-modified commands remain on disk.
+// Extensions (ADR 0024, fix #34). Order matters: remove files first, then strip
+// settings, then surgically clear the per-target SHA map. The SHA strip uses
+// removedKeys so a user-modified file we left in place keeps its recorded SHA
+// (doctor still has a baseline next run). Settings are path-based and run even
+// if no files were removed — a manifest could have registered entries that the
+// hook copy was deleted by hand (force-commands legacy state).
 const pkgJsonPath = join(HOME, '.claude', 'hypo-pkg.json');
-let pkgJsonRemoved = null;
-const keepPkgJson =
-  commandResult.skippedUserModified.length > 0 || commandResult.skippedNonRegular.length > 0;
-if (existsSync(pkgJsonPath) && !keepPkgJson) {
-  if (args.apply) rmSync(pkgJsonPath);
-  pkgJsonRemoved = pkgJsonPath;
-}
+const claudeExtResult = removeExtensions('claude', args.apply, args.forceExtensions);
+const claudeExtSettings = stripExtensionSettings(claudeSettings, claudeHooksDir, args.apply);
 
 let codexHookResult = { removed: [], missing: [] };
 let codexSettingsResult = { stripped: [] };
+let codexCommandResult = null;
+let codexExtResult = {
+  target: 'codex',
+  removed: [],
+  removedKeys: [],
+  skippedUserModified: [],
+  skippedNonRegular: [],
+};
+let codexExtSettings = { stripped: [] };
 
 if (args.codex) {
   const codexHooksDir = join(HOME, '.codex', 'hooks');
   const codexSettings = join(HOME, '.codex', 'settings.json');
   codexHookResult = removeHookFiles(codexHooksDir, hookFiles, args.apply);
   codexSettingsResult = stripSettingsJson(codexSettings, codexHooksDir, hookMap, args.apply);
+  codexExtResult = removeExtensions('codex', args.apply, args.forceExtensions);
+  codexExtSettings = stripExtensionSettings(codexSettings, codexHooksDir, args.apply);
+}
+
+// Surgical per-target ext SHA strip — only for files we actually removed.
+stripExtensionsFromPkg(pkgJsonPath, 'claude', claudeExtResult.removedKeys, args.apply);
+if (args.codex) {
+  stripExtensionsFromPkg(pkgJsonPath, 'codex', codexExtResult.removedKeys, args.apply);
+}
+
+// pkg.json metadata file removal — only when no user-tracked state remains.
+// Both command and extension preservation cases hold the file: doctor still
+// needs the recorded SHAs of files we left behind so the next sync compares
+// against truth, not nothing.
+let pkgJsonRemoved = null;
+const processedExtTargets = new Set(['claude']);
+if (args.codex) processedExtTargets.add('codex');
+const keepPkgJson =
+  commandResult.skippedUserModified.length > 0 ||
+  commandResult.skippedNonRegular.length > 0 ||
+  claudeExtResult.skippedUserModified.length > 0 ||
+  claudeExtResult.skippedNonRegular.length > 0 ||
+  codexExtResult.skippedUserModified.length > 0 ||
+  codexExtResult.skippedNonRegular.length > 0 ||
+  // Claude-only uninstall must not wholesale-rm pkg.json if extensions.codex
+  // (or any other unprocessed target) still tracks live Codex hard-copies.
+  unprocessedExtensionTargetRemains(pkgJsonPath, processedExtTargets);
+if (existsSync(pkgJsonPath) && !keepPkgJson) {
+  if (args.apply) rmSync(pkgJsonPath);
+  pkgJsonRemoved = pkgJsonPath;
 }
 
 // ── report ───────────────────────────────────────────────────────────────────
@@ -249,6 +490,16 @@ if (dryRun) lines.push('[DRY RUN — pass --apply to make changes]');
 
 const allRemoved = [...hookResult.removed, ...codexHookResult.removed];
 const allStripped = [...settingsResult.stripped, ...codexSettingsResult.stripped];
+const extRemoved = [...claudeExtResult.removed, ...codexExtResult.removed];
+const extSkippedUserModified = [
+  ...claudeExtResult.skippedUserModified,
+  ...codexExtResult.skippedUserModified,
+];
+const extSkippedNonRegular = [
+  ...claudeExtResult.skippedNonRegular,
+  ...codexExtResult.skippedNonRegular,
+];
+const extStripped = [...claudeExtSettings.stripped, ...codexExtSettings.stripped];
 
 if (allRemoved.length)
   lines.push(
@@ -266,6 +517,22 @@ if (commandResult.skippedNonRegular.length)
   lines.push(
     `⊘ Slash commands skipped (non-regular file, ${commandResult.skippedNonRegular.length}) — refusing to follow symlinks:\n${commandResult.skippedNonRegular.map((p) => `  ${p}`).join('\n')}`,
   );
+if (extRemoved.length)
+  lines.push(
+    `✓ Extension files ${dryRun ? 'to remove' : 'removed'} (${extRemoved.length}):\n${extRemoved.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (extSkippedUserModified.length)
+  lines.push(
+    `⊘ Extension files preserved (user-modified, ${extSkippedUserModified.length}) — pass --force-extensions to remove anyway:\n${extSkippedUserModified.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (extSkippedNonRegular.length)
+  lines.push(
+    `⊘ Extension files skipped (non-regular file, ${extSkippedNonRegular.length}) — refusing to follow symlinks:\n${extSkippedNonRegular.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (extStripped.length)
+  lines.push(
+    `✓ settings.json extension entries ${dryRun ? 'to remove' : 'removed'} (${extStripped.length}):\n${extStripped.map((p) => `  ${p}`).join('\n')}`,
+  );
 if (allStripped.length)
   lines.push(
     `✓ settings.json entries ${dryRun ? 'to remove' : 'removed'} (${allStripped.length}):\n${allStripped.map((p) => `  ${p}`).join('\n')}`,
@@ -274,21 +541,27 @@ if (pkgJsonRemoved)
   lines.push(`✓ Package metadata ${dryRun ? 'to remove' : 'removed'}: ${pkgJsonRemoved}`);
 if (keepPkgJson && !pkgJsonRemoved && existsSync(pkgJsonPath))
   lines.push(
-    `⊘ Package metadata preserved (${pkgJsonPath}) — user-modified or non-regular commands still tracked`,
+    `⊘ Package metadata preserved (${pkgJsonPath}) — user-modified or non-regular files still tracked`,
   );
 if (hookResult.missing.length)
   lines.push(
     `⊘ Already absent (${hookResult.missing.length}):\n${hookResult.missing.map((p) => `  ${p}`).join('\n')}`,
   );
 if (settingsResult.error) lines.push(`⚠ ${settingsResult.error}`);
+if (claudeExtSettings.error) lines.push(`⚠ ${claudeExtSettings.error}`);
+if (codexExtSettings.error) lines.push(`⚠ ${codexExtSettings.error}`);
 
 if (
   !allRemoved.length &&
   !allStripped.length &&
+  !extRemoved.length &&
+  !extStripped.length &&
   !hookResult.missing.length &&
   !commandResult.removed.length &&
   !pkgJsonRemoved &&
-  !commandResult.skippedUserModified.length
+  !commandResult.skippedUserModified.length &&
+  !extSkippedUserModified.length &&
+  !extSkippedNonRegular.length
 ) {
   lines.push('Nothing to uninstall — Hypomnema does not appear to be installed.');
 }

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2964,6 +2964,328 @@ test('doctor-extensions-integrity: --codex target', () => {
   });
 });
 
+// ── extensions companion uninstall (ADR 0024, fix #34) ───────────────────────
+
+suite('extensions companion uninstall (uninstall.mjs, ADR 0024)');
+
+// §8.12 (d): uninstall removes hard-copies + manifests + slash-command exts +
+// settings entries, while preserving the wiki source AND any foreign plugin
+// entries in settings.json (§7.3 invariant).
+test('uninstall-removes-extensions-copy-preserves-source', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-mywatcher.mjs', '#!/usr/bin/env node\n// ours\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write|Edit',
+      });
+      writeExt(hypoDir, 'commands', 'hypo-ext-mycmd.md', '# my command\n');
+
+      // Install: hard-copy + manifest + settings entry + pkg SHA.
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `upgrade --apply failed: ${up.stderr}`);
+
+      // Pre-inject a foreign plugin's PostToolUse entry — uninstall MUST preserve it.
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const seedSettings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      seedSettings.hooks ??= {};
+      seedSettings.hooks.PostToolUse ??= [];
+      seedSettings.hooks.PostToolUse.push({
+        hooks: [{ type: 'command', command: 'node /opt/other-plugin/foo.mjs' }],
+      });
+      writeFileSync(settingsPath, JSON.stringify(seedSettings, null, 2) + '\n');
+
+      const hookCopy = join(home, '.claude', 'hooks', 'hypo-ext-mywatcher.mjs');
+      const manifestCopy = join(home, '.claude', 'hooks', 'hypo-ext-mywatcher.manifest.json');
+      const commandCopy = join(home, '.claude', 'commands', 'hypo-ext-mycmd.md');
+      assert.ok(existsSync(hookCopy), 'pre-state: hook copy must exist');
+      assert.ok(existsSync(manifestCopy), 'pre-state: manifest copy must exist');
+      assert.ok(existsSync(commandCopy), 'pre-state: command copy must exist');
+
+      // Uninstall --apply (claude target only).
+      const un = runWithHome('uninstall.mjs', ['--apply'], home);
+      assert.equal(un.status, 0, `uninstall failed: ${un.stderr}\n${un.stdout}`);
+
+      // Hard-copies + manifest + slash-command ext are gone.
+      assert.ok(!existsSync(hookCopy), 'hook copy must be removed');
+      assert.ok(!existsSync(manifestCopy), 'manifest copy must be removed');
+      assert.ok(!existsSync(commandCopy), 'command copy must be removed');
+
+      // Wiki source (~/hypomnema/extensions/) is preserved end-to-end.
+      assert.ok(
+        existsSync(join(hypoDir, 'extensions', 'hooks', 'hypo-ext-mywatcher.mjs')),
+        'wiki source hook must be preserved',
+      );
+      assert.ok(
+        existsSync(join(hypoDir, 'extensions', 'hooks', 'hypo-ext-mywatcher.manifest.json')),
+        'wiki source manifest must be preserved',
+      );
+      assert.ok(
+        existsSync(join(hypoDir, 'extensions', 'commands', 'hypo-ext-mycmd.md')),
+        'wiki source command must be preserved',
+      );
+
+      // settings.json: hypo-ext-* entries stripped; foreign plugin entry preserved.
+      const post = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const flat = JSON.stringify(post.hooks || {});
+      assert.ok(!flat.includes('hypo-ext-mywatcher'), 'hypo-ext settings entry must be stripped');
+      assert.ok(
+        flat.includes('/opt/other-plugin/foo.mjs'),
+        'foreign plugin entry must be preserved (§7.3 invariant)',
+      );
+
+      // pkg.json: per-target ext map either dropped or has no entries for the removed files.
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        const m = (pkg.extensions && pkg.extensions.claude) || {};
+        assert.ok(
+          !('hooks/hypo-ext-mywatcher.mjs' in m),
+          'hook SHA must be stripped from pkg.extensions.claude',
+        );
+        assert.ok(
+          !('hooks/hypo-ext-mywatcher.manifest.json' in m),
+          'manifest SHA must be stripped from pkg.extensions.claude',
+        );
+        assert.ok(
+          !('commands/hypo-ext-mycmd.md' in m),
+          'command SHA must be stripped from pkg.extensions.claude',
+        );
+      }
+    });
+  });
+});
+
+// Boost #6 (plan §5 PR-E6): pre-E6 the codex uninstall branch only stripped
+// ~/.codex/hooks + settings, leaving ~/.codex/commands/hypo-ext-*.md orphaned.
+// E6 must clean BOTH directories in one --codex pass.
+test('uninstall-extensions-codex-removes-both-hooks-and-commands', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-cdxun.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      writeExt(hypoDir, 'commands', 'hypo-ext-cdxuncmd.md', '# codex cmd\n');
+
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply', '--codex'], home);
+      assert.equal(up.status, 0, `upgrade --apply --codex failed: ${up.stderr}`);
+
+      const cdxHook = join(home, '.codex', 'hooks', 'hypo-ext-cdxun.mjs');
+      const cdxCmd = join(home, '.codex', 'commands', 'hypo-ext-cdxuncmd.md');
+      const claudeHook = join(home, '.claude', 'hooks', 'hypo-ext-cdxun.mjs');
+      const claudeCmd = join(home, '.claude', 'commands', 'hypo-ext-cdxuncmd.md');
+      assert.ok(existsSync(cdxHook), 'pre-state: codex hook copy must exist');
+      assert.ok(existsSync(cdxCmd), 'pre-state: codex command copy must exist');
+      assert.ok(existsSync(claudeHook), 'pre-state: claude hook copy must exist');
+      assert.ok(existsSync(claudeCmd), 'pre-state: claude command copy must exist');
+
+      const un = runWithHome('uninstall.mjs', ['--apply', '--codex'], home);
+      assert.equal(un.status, 0, `uninstall failed: ${un.stderr}\n${un.stdout}`);
+
+      // The boost #6 assertion: BOTH codex hooks AND codex commands cleaned.
+      assert.ok(!existsSync(cdxHook), 'codex hook copy must be removed');
+      assert.ok(!existsSync(cdxCmd), 'codex command copy must be removed (boost #6 gap)');
+      assert.ok(!existsSync(claudeHook), 'claude hook copy must be removed');
+      assert.ok(!existsSync(claudeCmd), 'claude command copy must be removed');
+
+      // ~/.codex/settings.json must no longer carry the ext entry.
+      const cdxSettingsPath = join(home, '.codex', 'settings.json');
+      if (existsSync(cdxSettingsPath)) {
+        const cdxSettings = JSON.parse(readFileSync(cdxSettingsPath, 'utf-8'));
+        const flat = JSON.stringify(cdxSettings.hooks || {});
+        assert.ok(!flat.includes('hypo-ext-cdxun'), 'codex settings ext entry must be stripped');
+      }
+
+      // pkg.json: per-target maps for both claude AND codex must be cleared.
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      if (existsSync(pkgPath)) {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        const claude = (pkg.extensions && pkg.extensions.claude) || {};
+        const codex = (pkg.extensions && pkg.extensions.codex) || {};
+        assert.ok(!('hooks/hypo-ext-cdxun.mjs' in codex), 'codex hook SHA must be stripped');
+        assert.ok(
+          !('commands/hypo-ext-cdxuncmd.md' in codex),
+          'codex command SHA must be stripped',
+        );
+        assert.ok(!('hooks/hypo-ext-cdxun.mjs' in claude), 'claude hook SHA must be stripped');
+      }
+    });
+  });
+});
+
+// Parity with --force-commands: a user-modified hypo-ext-* file is preserved
+// (with a `skippedUserModified` report) unless --force-extensions is passed.
+// pkg.json keeps the recorded SHA for the preserved file so doctor still has
+// a baseline next run.
+test('uninstall-extensions-preserves-user-modified-without-force', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      writeExt(hypoDir, 'hooks', 'hypo-ext-edited.mjs', '#!/usr/bin/env node\n// v1\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `upgrade failed: ${up.stderr}`);
+
+      // Locally edit the installed copy so the on-disk SHA diverges from the recorded one.
+      const target = join(home, '.claude', 'hooks', 'hypo-ext-edited.mjs');
+      writeFileSync(target, '// user-edited locally — must be preserved\n');
+
+      // No --force-extensions → preserved + report mentions preservation.
+      const un1 = runWithHome('uninstall.mjs', ['--apply'], home);
+      assert.equal(un1.status, 0, `uninstall failed: ${un1.stderr}\n${un1.stdout}`);
+      assert.ok(
+        existsSync(target),
+        'user-modified ext file must be preserved without --force-extensions',
+      );
+      assert.ok(
+        un1.stdout.includes('--force-extensions'),
+        `report must mention --force-extensions guidance: ${un1.stdout}`,
+      );
+
+      // pkg.json keeps the SHA for the preserved file (doctor needs a baseline).
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      const pkg1 = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      assert.ok(
+        pkg1.extensions?.claude?.['hooks/hypo-ext-edited.mjs'],
+        'pkg SHA must be retained for the preserved file',
+      );
+
+      // With --force-extensions → file removed + pkg entry cleared.
+      const un2 = runWithHome('uninstall.mjs', ['--apply', '--force-extensions'], home);
+      assert.equal(un2.status, 0, `force uninstall failed: ${un2.stderr}\n${un2.stdout}`);
+      assert.ok(!existsSync(target), '--force-extensions must remove the user-modified file');
+      if (existsSync(pkgPath)) {
+        const pkg2 = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        assert.ok(
+          !pkg2.extensions?.claude?.['hooks/hypo-ext-edited.mjs'],
+          '--force-extensions must clear the pkg SHA after removal',
+        );
+      }
+    });
+  });
+});
+
+// Per-target SHA contract (plan D2b): a Claude-only uninstall MUST NOT wipe
+// ~/.claude/hypo-pkg.json when ~/.codex/hooks/hypo-ext-*.mjs is still in place
+// (its ownership baseline lives in `extensions.codex` and must survive).
+// Regression cited by the codex pre-commit reviewer: without the
+// unprocessed-target guard, a claude-only uninstall would wholesale-rm pkg.json
+// and orphan the Codex copies.
+test('uninstall-extensions-claude-only-preserves-codex-state', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      writeExt(hypoDir, 'hooks', 'hypo-ext-cdxonly.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      writeExt(hypoDir, 'commands', 'hypo-ext-cdxcmd.md', '# codex cmd\n');
+
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply', '--codex'], home);
+      assert.equal(up.status, 0, `upgrade --apply --codex failed: ${up.stderr}`);
+
+      const codexHook = join(home, '.codex', 'hooks', 'hypo-ext-cdxonly.mjs');
+      const codexCmd = join(home, '.codex', 'commands', 'hypo-ext-cdxcmd.md');
+      assert.ok(existsSync(codexHook), 'pre-state: codex hook copy must exist');
+      assert.ok(existsSync(codexCmd), 'pre-state: codex command copy must exist');
+
+      // Claude-only uninstall — MUST leave Codex state intact.
+      const un = runWithHome('uninstall.mjs', ['--apply'], home);
+      assert.equal(un.status, 0, `claude-only uninstall failed: ${un.stderr}\n${un.stdout}`);
+
+      // Claude target stripped.
+      assert.ok(
+        !existsSync(join(home, '.claude', 'hooks', 'hypo-ext-cdxonly.mjs')),
+        'claude hook copy must be removed',
+      );
+
+      // Codex hard-copies survive the claude-only uninstall.
+      assert.ok(existsSync(codexHook), 'codex hook copy must survive claude-only uninstall');
+      assert.ok(existsSync(codexCmd), 'codex command copy must survive claude-only uninstall');
+
+      // pkg.json must NOT be wholesale-deleted — codex baseline must remain.
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      assert.ok(
+        existsSync(pkgPath),
+        'pkg.json must be preserved while extensions.codex still tracks live copies',
+      );
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      assert.ok(
+        pkg.extensions?.codex?.['hooks/hypo-ext-cdxonly.mjs'],
+        'codex hook SHA baseline must survive (per-target contract D2b)',
+      );
+      assert.ok(
+        pkg.extensions?.codex?.['commands/hypo-ext-cdxcmd.md'],
+        'codex command SHA baseline must survive',
+      );
+      // Claude target either dropped or cleared.
+      const claudeMap = pkg.extensions?.claude;
+      assert.ok(
+        claudeMap === undefined || Object.keys(claudeMap).length === 0,
+        'claude per-target map must be cleared by the uninstall',
+      );
+    });
+  });
+});
+
+// Plan §5 #6 (boost #6): non-regular destinations (symlink/socket/etc.) are
+// always preserved — `--force-extensions` does NOT follow them. Mirrors the
+// install/upgrade E3 guard so uninstall cannot delete a foreign target via a
+// dangling symlink in ~/.claude/hooks/.
+test('uninstall-extensions-skips-non-regular-symlink', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      writeExt(hypoDir, 'hooks', 'hypo-ext-symwatch.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `upgrade failed: ${up.stderr}`);
+
+      // Replace the regular hard-copy with a symlink to a decoy.
+      const target = join(home, '.claude', 'hooks', 'hypo-ext-symwatch.mjs');
+      const decoy = join(dir, 'decoy.mjs');
+      writeFileSync(decoy, '// decoy — must remain untouched\n');
+      rmSync(target);
+      symlinkSync(decoy, target);
+
+      // Without force → skip + report.
+      const un1 = runWithHome('uninstall.mjs', ['--apply'], home);
+      assert.equal(un1.status, 0, `uninstall failed: ${un1.stderr}\n${un1.stdout}`);
+      assert.ok(existsSync(target), 'symlink must not be removed without force');
+      assert.ok(existsSync(decoy), 'decoy target of symlink must remain untouched');
+      assert.ok(
+        un1.stdout.includes('non-regular'),
+        `report must mention non-regular skip: ${un1.stdout}`,
+      );
+
+      // --force-extensions must STILL refuse to follow non-regular destinations.
+      const un2 = runWithHome('uninstall.mjs', ['--apply', '--force-extensions'], home);
+      assert.equal(un2.status, 0, `force uninstall failed: ${un2.stderr}\n${un2.stdout}`);
+      assert.ok(existsSync(target), '--force-extensions must NOT follow symlinks');
+      assert.ok(existsSync(decoy), 'decoy must remain untouched under --force-extensions');
+    });
+  });
+});
+
 // ── lint.mjs --fix tests ─────────────────────────────────────────────────────
 
 suite('lint.mjs --fix');


### PR DESCRIPTION
## Summary

Stage 6 Phase B slice E6 — wire user-extension teardown into `uninstall.mjs`.
Closes the Extensions Companion lifecycle (ADR 0024) by removing hard-copies +
settings entries + per-target SHA records while preserving the wiki source
and foreign-plugin settings entries.

Fixes #34. Refs ADR 0024 §2 E6, plan §2 + §5 boost #6, spec §8.12 (d).

## Changes

### `scripts/uninstall.mjs` (+285/-12)

Reuses `lib/extensions.mjs` read-only helpers (E2's contract) — zero
re-implementation:
- `removeExtensions(target, apply, force)` — filesystem walk under
  `~/.{target}/{type}/` + per-target recorded SHA from
  `pkg.extensions[target]` decides ownership. Mirrors `removeCommands`' 3-way
  model: untracked files are left alone, user-modified files preserved unless
  `--force-extensions`, symlinks/non-regular **never** followed (force does not
  bypass the `isRegularFile` guard).
- `stripExtensionSettings(settingsPath, hooksDir, apply)` — path-based identity
  (plan D1). Matches `node $HOME/{hooksDir}/hypo-ext-*` prefix only; mixed
  groups keep foreign hooks while dropping ours (§7.3 invariant).
- `stripExtensionsFromPkg(pkgPath, target, removedKeys, apply)` — surgical
  per-target SHA strip. Files we left in place keep their SHA so doctor's next
  run has a baseline. Empty target maps dropped; empty `extensions` object
  dropped entirely.
- `unprocessedExtensionTargetRemains(pkgPath, processedTargets)` — guards
  wholesale pkg.json deletion. Found by the codex pre-commit review (1
  worker): without this, a Claude-only uninstall would `rm pkg.json` even when
  `~/.codex/hooks/hypo-ext-*` hard-copies are still live, orphaning their
  `extensions.codex` ownership baseline (per-target SHA contract D2b).

Other:
- `--force-extensions` flag (parity with `--force-commands`).
- Report: distinct sections for Extension files (removed/preserved/skipped)
  + settings.json extension entries; Nothing-to-uninstall guard updated.
- Docstring documents the full extension cleanup contract.

### `tests/runner.mjs` (+322/-0)

5 new tests in a new suite (the runner had no uninstall coverage pre-E6):

1. **`uninstall-removes-extensions-copy-preserves-source`** (§8.12 d) —
   end-to-end happy path. Foreign plugin entry preserved (§7.3 invariant);
   wiki source intact (§8.12 d).
2. **`uninstall-extensions-codex-removes-both-hooks-and-commands`** —
   plan §5 boost #6. Pre-E6 left `~/.codex/commands/hypo-ext-*.md` orphaned;
   now both `~/.codex/hooks` and `~/.codex/commands` cleaned in one pass.
3. **`uninstall-extensions-preserves-user-modified-without-force`** —
   `--force-commands` parity. User-edited file preserved (with guidance);
   SHA retained for doctor baseline; `--force-extensions` overrides.
4. **`uninstall-extensions-claude-only-preserves-codex-state`** —
   per-target SHA contract regression. Codex extensions installed +
   claude-only uninstall: `pkg.json` survives, `extensions.codex` intact,
   `~/.codex/` hard-copies untouched. Cited by codex pre-commit review.
5. **`uninstall-extensions-skips-non-regular-symlink`** —
   plan §5 boost #6 non-regular sub-clause. Symlink preserved + decoy
   untouched even under `--force-extensions`.

## Verification

- `npm test`: 364 → 369 passed, 0 failed.
- `HYPO_DIR=. npm run lint`: ✓ No lint issues found.
- Prettier applied (`scripts/uninstall.mjs`, `tests/runner.mjs`).
- Pre-commit `/teams 1:codex` review: returned **REQUEST_CHANGES** flagging
  the per-target SHA contract bug (claude-only uninstall wholesale-rm'ing
  `pkg.json` while codex copies were still live). Fixed via
  `unprocessedExtensionTargetRemains` + regression test #4 above; re-verified
  green. Reviewer note: 1-worker run = reduced cross-check vs the standard
  2-worker pre-commit lane.

## Out of scope (E6 boundaries)

- `settings.json` mixed-group surgical *write* (preserving foreign plugin
  hooks while replacing only ours when manifest changes) — separate fix.
  E5 already surfaces the mismatch in `doctor`; E6 only handles teardown.
- `upgrade --codex` core hooks mirror — pre-existing deferred item from E4,
  not part of E6.

## Cumulative Stage 6 Phase B status

Slice E: E1 #28 ✅ · E2 #29+#30 ✅ · E3 #31 ✅ · E4 #32 ✅ · E5 #33 ✅ ·
**E6 #34 (this PR)** → Stage 6 Phase B slice E complete after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)