### PR TITLE
feat: PostToolUse WebFetch/WebSearch auto-ingest signal — fix #2

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -71,6 +71,15 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/hypo-web-fetch-ingest.mjs",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [

--- a/hooks/hypo-web-fetch-ingest.mjs
+++ b/hooks/hypo-web-fetch-ingest.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * hypo-web-fetch-ingest.mjs — PostToolUse hook (fix #2)
+ *
+ * When the LLM uses WebFetch or WebSearch, nudge it to follow §8.4 path A:
+ * "external research → /hypo:ingest into sources/". This hook produces a
+ * *signal*, not an automatic ingest call — per spec §5.4.6 Q-5.4.6:
+ *   "WebFetch/WebSearch 자동 ingest 시그널은 별도 hook(fix #2)으로 분리."
+ *
+ * Why signal-only (not direct ingest):
+ *   - slug derivation is LLM-driven (commands/ingest.md), so a hook cannot
+ *     reliably write to the canonical sources/<slug>.* path.
+ *   - duplicate-ingest detection is delegated to /hypo:ingest itself; the
+ *     nudge text says "이미 반영 여부 확인 후" so the LLM checks the page
+ *     graph before adding a new source.
+ *
+ * Output contract — Claude Code docs, "Add context for Claude":
+ *   PostToolUse uses **nested** hookSpecificOutput.additionalContext, NOT
+ *   the top-level additionalContext that UserPromptSubmit hooks use.
+ *   buildOutput() in hypo-shared.mjs is the top-level helper used by
+ *   hypo-first-prompt / hypo-lookup; intentionally not reused here. See
+ *   commit 515458f for the per-event matrix this codebase follows.
+ *
+ * URL redaction:
+ *   additionalContext lands in the transcript. Query strings and
+ *   fragments may carry tokens (?token=…, #access_token=…), so we emit
+ *   origin + pathname only. Malformed URLs are dropped to avoid raw
+ *   echoes.
+ *
+ * matcher choice:
+ *   hooks/hooks.json does not (today) propagate matcher/timeout through
+ *   scripts/init.mjs:mergeSettingsJson — the installer rewrites groups
+ *   as {hooks:[{type,command}]}. So we filter on tool_name internally
+ *   instead of declaring a matcher. Per-tool spawn cost (~39ms node
+ *   startup, measured 2026-05-23) is the trade-off; switch to a matcher
+ *   when the installer learns to preserve it.
+ *
+ * Fail-safe (spec §5.4.3 (e)): silent fail + {continue:true,
+ * suppressOutput:true}. PostToolUse fires only on successful tool calls;
+ * failures arrive on a separate PostToolUseFailure event, so no
+ * in-hook failure branch is needed.
+ */
+
+import { isGateSkipped } from './hypo-shared.mjs';
+
+let input = {};
+try {
+  const raw = await new Promise((r) => {
+    let d = '';
+    process.stdin.on('data', (c) => (d += c));
+    process.stdin.on('end', () => r(d));
+  });
+  input = raw ? JSON.parse(raw) : {};
+} catch (err) {
+  process.stderr.write(`[hypo-web-fetch-ingest] error: ${err?.message ?? String(err)}\n`);
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  process.exit(0);
+}
+
+const context = buildContext(input);
+const output = { continue: true, suppressOutput: true };
+if (context) {
+  output.hookSpecificOutput = {
+    hookEventName: 'PostToolUse',
+    additionalContext: context,
+  };
+}
+console.log(JSON.stringify(output));
+
+function buildContext(data) {
+  if (isGateSkipped()) return null;
+  const tool = data?.tool_name ?? '';
+  if (tool === 'WebFetch') {
+    const url = redactUrl(data?.tool_input?.url);
+    if (!url) return null;
+    return (
+      `[WIKI AUTO-INGEST: WebFetch] ${url}\n` +
+      `Spec §8.4 path A: confirm this URL is not already represented in ` +
+      `sources/ or pages/, then call /hypo:ingest to capture it. ` +
+      `(URL redacted of query/hash for transcript safety.)`
+    );
+  }
+  if (tool === 'WebSearch') {
+    return (
+      `[WIKI AUTO-INGEST: WebSearch] external search performed.\n` +
+      `Spec §8.4 path A: any URL you fetch from these results should be ` +
+      `captured via /hypo:ingest — confirm it is not already in sources/ before ingesting.`
+    );
+  }
+  return null;
+}
+
+/**
+ * Reduce a URL to `origin + pathname` so query strings, fragments, and
+ * userinfo (`https://user:pass@host`) — which routinely carry
+ * credentials / session tokens — never reach the transcript via
+ * additionalContext. `new URL().origin` is protocol + host + port only,
+ * so userinfo is dropped for free.
+ *
+ * The protocol allow-list (http/https) is a defense-in-depth guard:
+ * non-web schemes like `file://`, `ftp://`, `data:` can produce
+ * surprising origins (e.g. `null/Users/...`) or pull a local path into
+ * the transcript, so they are rejected instead of redacted.
+ *
+ * Path-carried secrets (`https://host/path/<token>`) remain — keeping
+ * the path is the whole point of identifying *which* page to ingest, so
+ * full path redaction would defeat the nudge's purpose. The nudge text
+ * still tells the LLM to verify the URL before committing it.
+ *
+ * Returns null on malformed input or disallowed scheme.
+ */
+function redactUrl(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return null;
+  }
+}

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -7331,6 +7331,7 @@ const STDERR_LOG_HOOKS = [
   'hypo-personal-check',
   'hypo-auto-minimal-crystallize',
   'hypo-auto-stage',
+  'hypo-web-fetch-ingest',
 ];
 
 for (const name of STDERR_LOG_HOOKS) {
@@ -7369,6 +7370,174 @@ test('hooks-stderr-log-format: forced catch emits [hypo-auto-stage] error: + pre
   const out = JSON.parse(r.stdout);
   assert.equal(out.continue, true);
   assert.equal(r.status, 0);
+});
+
+// ── hypo-web-fetch-ingest.mjs — PostToolUse auto-ingest signal (fix #2) ──────
+//
+// Coverage Matrix id (spec §9.1.1): `hook replay (PostToolUse WebFetch)`.
+// PostToolUse uses **nested** hookSpecificOutput.additionalContext (Claude
+// Code docs "Add context for Claude" + 515458f per-event matrix), unlike the
+// UserPromptSubmit hooks that use top-level additionalContext via buildOutput().
+suite('hypo-web-fetch-ingest.mjs — PostToolUse auto-ingest signal (fix #2)');
+
+function runWebFetchHook(payload, env = {}) {
+  return spawnSync(process.execPath, [join(HOOKS, 'hypo-web-fetch-ingest.mjs')], {
+    input: typeof payload === 'string' ? payload : JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: { ...process.env, HYPO_DIR: '', ...env },
+  });
+}
+
+test('replay-post-tool-use-web-fetch-injects-nested-additional-context: nudge under hookSpecificOutput', () => {
+  const r = runWebFetchHook({
+    tool_name: 'WebFetch',
+    tool_input: { url: 'https://example.com/article' },
+    tool_response: { ok: true },
+  });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true);
+  assert.equal(out.suppressOutput, true);
+  // BLOCKER from codex review: PostToolUse requires nested shape, not top-level.
+  assert.equal(
+    out.additionalContext,
+    undefined,
+    'top-level additionalContext is wrong for PostToolUse',
+  );
+  assert.ok(out.hookSpecificOutput, 'missing hookSpecificOutput');
+  assert.equal(out.hookSpecificOutput.hookEventName, 'PostToolUse');
+  assert.match(out.hookSpecificOutput.additionalContext, /WebFetch/);
+  assert.match(out.hookSpecificOutput.additionalContext, /https:\/\/example\.com\/article/);
+  assert.match(out.hookSpecificOutput.additionalContext, /\/hypo:ingest/);
+});
+
+test('replay-post-tool-use-web-search-injects-weak-signal: WebSearch nudge without URL', () => {
+  const r = runWebFetchHook({
+    tool_name: 'WebSearch',
+    tool_input: { query: 'claude code hooks docs' },
+    tool_response: { ok: true },
+  });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  assert.ok(out.hookSpecificOutput, 'expected nested hookSpecificOutput for WebSearch');
+  assert.equal(out.hookSpecificOutput.hookEventName, 'PostToolUse');
+  assert.match(out.hookSpecificOutput.additionalContext, /WebSearch/);
+  // Weak nudge: no specific URL echoed (tool_response shape isn't a stable contract).
+  assert.ok(
+    !/https?:\/\//.test(out.hookSpecificOutput.additionalContext),
+    'weak nudge must not echo URLs from tool_response',
+  );
+});
+
+test('replay-post-tool-use-skips-non-web-tools: Write/Edit/Bash → no signal', () => {
+  for (const tool of ['Write', 'Edit', 'Bash', 'Read']) {
+    const r = runWebFetchHook({ tool_name: tool, tool_input: { file_path: '/tmp/x' } });
+    assert.equal(r.status, 0, `${tool} stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, `${tool}: continue must remain true`);
+    assert.equal(out.suppressOutput, true);
+    assert.equal(
+      out.hookSpecificOutput,
+      undefined,
+      `${tool} must not produce hookSpecificOutput (only WebFetch/WebSearch do)`,
+    );
+  }
+});
+
+test('replay-post-tool-use-redacts-url-query-tokens: query/hash stripped before context injection', () => {
+  const r = runWebFetchHook({
+    tool_name: 'WebFetch',
+    tool_input: {
+      url: 'https://api.example.com/v1/users?token=sk-leakedvalue&session=abc#access_token=xyz',
+    },
+  });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  const ctx = out.hookSpecificOutput?.additionalContext ?? '';
+  // origin + pathname only; query/hash MUST be absent.
+  assert.match(ctx, /https:\/\/api\.example\.com\/v1\/users/);
+  assert.ok(!/sk-leakedvalue/.test(ctx), `query token leaked into context: ${ctx}`);
+  assert.ok(!/access_token=xyz/.test(ctx), `hash token leaked into context: ${ctx}`);
+  assert.ok(!/session=abc/.test(ctx), `session param leaked into context: ${ctx}`);
+  // The full raw URL must never appear in stdout either (defense in depth).
+  assert.ok(!/sk-leakedvalue/.test(r.stdout), `stdout leaked secret: ${r.stdout}`);
+});
+
+test('replay-post-tool-use-respects-skip-gate: HYPO_SKIP_GATE=1 → silent pass-through', () => {
+  const r = runWebFetchHook(
+    { tool_name: 'WebFetch', tool_input: { url: 'https://example.com/page' } },
+    { HYPO_SKIP_GATE: '1' },
+  );
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true);
+  assert.equal(
+    out.hookSpecificOutput,
+    undefined,
+    'gate-skipped run must not inject any additionalContext',
+  );
+});
+
+// Robustness/edge-case suite (codex pre-commit review 2026-05-23 reinforcement).
+// These cover the failure modes the happy-path tests don't hit: malformed stdin,
+// missing fields, malformed URLs, userinfo leaks, and non-http schemes.
+
+test('replay-post-tool-use-invalid-json-stdin: fail-open, stderr tagged', () => {
+  const r = runWebFetchHook('not-json');
+  assert.equal(r.status, 0, 'malformed stdin must still exit 0');
+  assert.match(r.stderr, /^\[hypo-web-fetch-ingest\] error: /m);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true);
+  assert.equal(out.suppressOutput, true);
+  assert.equal(out.hookSpecificOutput, undefined, 'no signal on parse error');
+});
+
+test('replay-post-tool-use-web-fetch-missing-url: silent skip (no signal)', () => {
+  const r = runWebFetchHook({ tool_name: 'WebFetch', tool_input: {} });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.continue, true);
+  assert.equal(
+    out.hookSpecificOutput,
+    undefined,
+    'missing url must not produce a nudge (nothing meaningful to point at)',
+  );
+});
+
+test('replay-post-tool-use-redacts-userinfo: user:pass@host stripped from origin', () => {
+  const r = runWebFetchHook({
+    tool_name: 'WebFetch',
+    tool_input: { url: 'https://alice:s3cret@internal.example.com/dashboard' },
+  });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  const ctx = out.hookSpecificOutput?.additionalContext ?? '';
+  assert.match(ctx, /https:\/\/internal\.example\.com\/dashboard/);
+  assert.ok(!/alice/.test(ctx), `userinfo leaked into context: ${ctx}`);
+  assert.ok(!/s3cret/.test(ctx), `password leaked into context: ${ctx}`);
+  assert.ok(!/alice|s3cret/.test(r.stdout), `userinfo leaked in stdout: ${r.stdout}`);
+});
+
+test('replay-post-tool-use-rejects-non-http-schemes: file:// / ftp:// / data: → no signal', () => {
+  for (const url of [
+    'file:///Users/secret/data.txt',
+    'ftp://example.com/private.tar.gz',
+    'data:text/plain;base64,aGVsbG8=',
+    'javascript:alert(1)',
+  ]) {
+    const r = runWebFetchHook({ tool_name: 'WebFetch', tool_input: { url } });
+    assert.equal(r.status, 0, `${url} stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.hookSpecificOutput,
+      undefined,
+      `non-http scheme ${url} must be rejected (no transcript echo)`,
+    );
+    assert.ok(
+      !/Users\/secret|private\.tar\.gz|aGVsbG8|alert/.test(r.stdout),
+      `non-http URL contents leaked in stdout: ${r.stdout}`,
+    );
+  }
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `hooks/hypo-web-fetch-ingest.mjs` — a PostToolUse hook that nudges the LLM to follow **spec §8.4 path A** after WebFetch/WebSearch tool use: "external research → `/hypo:ingest` into `sources/`".

Closes spec-v1.2 §9.1 **fix #2** (the last single-issue v1.2.0 fix tracked at `hook 신규 / PostToolUse(WebFetch/WebSearch) auto-ingest 시그널`).

## Design

**Signal-only, not direct ingest** (spec §5.4.6 Q-5.4.6):
- Slug derivation stays LLM-driven (`commands/ingest.md` decides slug at ingest time).
- Duplicate detection delegated to `/hypo:ingest` itself — the nudge text says *"이미 반영 여부 확인 후"* so the LLM checks the page graph before adding a new source.

**Output shape** (Claude Code docs *Add context for Claude* + `515458f` per-event matrix):
PostToolUse uses **nested** `hookSpecificOutput.additionalContext` — not the top-level shape that UserPromptSubmit hooks use via `buildOutput()`. The helper is deliberately not reused here.

```json
{
  "continue": true,
  "suppressOutput": true,
  "hookSpecificOutput": {
    "hookEventName": "PostToolUse",
    "additionalContext": "…"
  }
}
```

**URL redaction** — `origin + pathname` only:
- Query strings and fragments stripped (`?token=…`, `#access_token=…`).
- Userinfo dropped via `new URL().origin` (which is protocol + host + port only).
- **http(s) protocol allow-list** rejects `file://`, `ftp://`, `data:`, `javascript:`.
- Path-carried tokens stay — the path is what identifies which page to ingest.

**Success-only**: PostToolUse fires only on successful tool calls. Failures arrive on a separate `PostToolUseFailure` event, so no in-hook failure branch is needed.

**matcher omitted**: `scripts/init.mjs:mergeSettingsJson` does not propagate `matcher`/`timeout` through to `~/.claude/settings.json`. The hook filters on `tool_name` internally instead. ~39 ms node-startup cost per non-web tool call is the trade-off (measured 2026-05-23).

## Files

| File | Change |
|---|---|
| `hooks/hypo-web-fetch-ingest.mjs` | **new** — 121 lines including header rationale |
| `hooks/hooks.json` | PostToolUse slot entry (single SoT — installer auto-applies) |
| `tests/runner.mjs` | +10 replay tests + `hypo-web-fetch-ingest` added to `STDERR_LOG_HOOKS` |

## Tests

- `replay-post-tool-use-web-fetch-injects-nested-additional-context`
- `replay-post-tool-use-web-search-injects-weak-signal`
- `replay-post-tool-use-skips-non-web-tools` (Write/Edit/Bash/Read)
- `replay-post-tool-use-redacts-url-query-tokens`
- `replay-post-tool-use-respects-skip-gate` (`HYPO_SKIP_GATE=1`)
- `replay-post-tool-use-invalid-json-stdin` (fail-open)
- `replay-post-tool-use-web-fetch-missing-url` (silent skip)
- `replay-post-tool-use-redacts-userinfo` (`user:pass@host` stripped)
- `replay-post-tool-use-rejects-non-http-schemes` (`file://`, `ftp://`, `data:`, `javascript:`)
- `hooks-stderr-log-format: hypo-web-fetch-ingest.mjs` regression

**369 → 379 green**, lint 0 errors.

## Review path

- **advisor**: 2 rounds — narrowed plan from 7+ changes to 3-file scope (cooldown removed, ADR skipped, scripts/{init,upgrade,doctor,uninstall} untouched per hooks.json SoT).
- **codex 2-worker plan-review**: surfaced the nested `hookSpecificOutput` BLOCKER (Plan v3 originally specified `buildOutput()` reuse, which would have used the wrong shape for PostToolUse).
- **codex 2-worker pre-commit review**: reinforced 4 CONCERN points → http(s) protocol guard added, non-http schemes test added, userinfo redaction test added, invalid-JSON / missing-url fail-open tests added, `STDERR_LOG_HOOKS` list extended.

## Spec compliance

| Clause | Status |
|---|---|
| §5.4.6 Q-5.4.6 "별도 hook 분리" | ✅ |
| §8.4 경로 A "60초 내 `sources/` 변경" | ✅ (LLM-driven, hook signals only) |
| §5.4.3 (e) silent fail + `continue:true` | ✅ |
| §9.1.1 "hook replay (PostToolUse WebFetch)" coverage matrix | ✅ |

## Test plan

- [x] `npm test` — 379 passed, 0 failed
- [x] `npm run lint` — 0 errors
- [x] `node --check hooks/hypo-web-fetch-ingest.mjs`
- [x] `hooks/hooks.json` JSON parse
- [x] codex 2-worker plan-review + pre-commit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
