### PR TITLE
fix(extensions): settings.json mixed-group surgical write — fix #47 (ADR 0024 amendment)

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -26,6 +26,7 @@ import {
   parseManifest,
   buildExpectedSettingsEntries,
   readExtensionPkgStateNoMutate,
+  collectOurOccurrences,
   EXT_TYPES,
   CODEX_TYPES,
 } from './lib/extensions.mjs';
@@ -674,9 +675,13 @@ function checkCodexPaths() {
 // A malformed manifest failing here is what makes the §5.1.3 `fails=0` ship gate
 // actually cover §8.12-7(c) — asserted by the doctor-extensions-integrity test.
 //
-// E5 is doctor SURFACE only. The settings.json mixed-group surgical *write*
-// (preserve sibling-plugin hooks, swap only ours) stays deferred — it is a
-// write-path change to registerSettings (extensions.mjs:488), not a doctor check.
+// E5 is doctor SURFACE for extensions integrity. The mixed-group surgical
+// *write* (preserve sibling-plugin hooks, swap only ours) used to be deferred
+// here; fix #47 (ADR 0024 amendment 2026-05-23) lifted that deferral —
+// registerSettings (extensions.mjs:478 docstring) now does occurrence-first +
+// 8-rank canonical write, and the (b) loop below mirrors that read-path via
+// collectOurOccurrences so a valid mixed-group occurrence is no longer warned
+// as `not registered`.
 function checkExtensions(hypoDir, claudeHome, target = 'claude') {
   const extDir = join(hypoDir, 'extensions');
   // E1 baseline absent (e.g. --from-remote clone, plan §5 #8) → nothing to check.
@@ -765,35 +770,41 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
   if (!settingsParseFailed) {
     const expected = buildExpectedSettingsEntries(discovered.hooks, hooksDir);
 
-    // (b) for each registrable hook: locate the single-hook group that owns its
-    // command (mirroring registerSettings' isOurGroup, extensions.mjs:512) and
-    // compare against the manifest-derived shape. Two drift kinds, both warn:
-    //   - not registered (no owning group under the right event) → run upgrade --apply
-    //   - registered but matcher/timeout differs from the manifest → run upgrade --apply
-    // The shape-differs branch is the settings-entry mismatch E3 deferred to E5
-    // (extensions.mjs:488); upgrade --apply silently self-heals it, so doctor is
-    // the only surface that reports it.
-    const ownsCommand = (g, command) =>
-      g &&
-      typeof g === 'object' &&
-      Array.isArray(g.hooks) &&
-      g.hooks.length === 1 &&
-      g.hooks[0] &&
-      g.hooks[0].command === command;
+    // (b) for each registrable hook: locate any occurrence of our command
+    // (single-hook OR mixed group, fix #47) and compare against the manifest-
+    // derived shape. Three outcomes:
+    //   - no occurrence in any event → warn `not registered` (run upgrade --apply)
+    //   - occurrence in wrong event → warn `not registered under <event>` (run upgrade --apply)
+    //   - occurrence in target event but our hook entry or group matcher drifts
+    //     from the manifest → warn `settings entry differs` (run upgrade --apply)
+    // upgrade --apply self-heals all three via registerSettings' 8-priority
+    // canonical pass, so doctor is the only surface that reports it.
+    //
+    // Mixed-group: a foreign sibling sharing our matcher group does NOT itself
+    // count as drift — only our own hook fields ({type, command, timeout?}) and
+    // the group's matcher are compared. Doctor never inspects foreign hook
+    // shape (no peering into `if`/`args`/`async`/`statusMessage` etc.).
     for (const entry of expected) {
       const desiredHook = { type: 'command', command: entry.command };
       if (entry.timeout) desiredHook.timeout = entry.timeout;
-      const desiredGroup = { hooks: [desiredHook] };
-      if (entry.matcher) desiredGroup.matcher = entry.matcher;
+      const desiredMatcher = entry.matcher;
 
-      const groups = Array.isArray(hooksObj[entry.event]) ? hooksObj[entry.event] : [];
-      const owning = groups.find((g) => ownsCommand(g, entry.command));
-      if (!owning) {
+      const occurrences = collectOurOccurrences(hooksObj, entry.command);
+      const targetOccurrence = occurrences.find((o) => o.event === entry.event);
+      if (!targetOccurrence) {
         problems.push({
           severity: 'warn',
           msg: `${entry.name} not registered under ${entry.event} — run upgrade --apply`,
         });
-      } else if (JSON.stringify(owning) !== JSON.stringify(desiredGroup)) {
+        continue;
+      }
+      const groupMatcher = targetOccurrence.group.matcher;
+      const matcherMatches =
+        (groupMatcher === undefined || groupMatcher === null ? undefined : groupMatcher) ===
+        (desiredMatcher === undefined || desiredMatcher === null ? undefined : desiredMatcher);
+      const hookExact =
+        JSON.stringify(targetOccurrence.hook) === JSON.stringify(desiredHook);
+      if (!matcherMatches || !hookExact) {
         problems.push({
           severity: 'warn',
           msg: `${entry.name} settings entry differs from manifest (matcher/timeout) — run upgrade --apply`,

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -477,23 +477,145 @@ export function syncExtensions({
 /**
  * Reconcile the expected ext hook entries into settings.json (§8.12 b).
  *
- * For each entry we locate the single-hook group that owns its command (D1,
- * path-based identity). If it already sits in the right event with the right
- * matcher/timeout, it is left untouched — so a no-op run does not rewrite the
- * file (idempotent). If the manifest changed matcher/timeout, the group is
- * patched in place; if the event changed, the stale group is removed and a fresh
- * one added under the new event. A pre-existing multi-hook group containing our
- * command is treated as a manual edit and left alone (drift; E3 handles force).
+ * For each entry we locate any group whose hooks[] array contains our command
+ * (D1, path-based identity) — single-hook groups owned exclusively by us AND
+ * mixed groups where a sibling plugin's hook shares the matcher. We collect ALL
+ * occurrences, rank them by an 8-step priority, pick one canonical, drop the
+ * rest (cleanup pre-existing duplicates), and mutate the canonical with the
+ * lowest-disturbance edit that lands the manifest-derived shape.
  *
- * E3 scope note (#31): settings.json entry drift is NOT surfaced here. Without a
- * recorded last-written entry we cannot tell a user edit apart from a manifest
- * change (the latter must auto-update — see the "manifest change re-registers"
- * test), so this reconcile silently self-heals a single-hook group back to the
- * manifest-derived shape. Detecting + reporting settings-entry mismatch is E5's
- * job (#33, doctor integrity §8.12-7). Mixed-group surgical replacement (preserve
- * sibling plugins' hooks, swap only ours) is likewise deferred — today a foreign
- * hook sharing our group is left untouched as drift.
+ * Priority (lowest rank wins, ties break by settings traversal order):
+ *   1. target event · single-hook ours · exact desired shape          (no-op)
+ *   2. target event · mixed · matcher matches · our hook exact         (no-op)
+ *   3. target event · single-hook ours · drift                         (group patch)
+ *   4. target event · mixed · matcher matches · our hook drift         (in-place hook patch)
+ *   5. target event · mixed · matcher differs                          (extract + append new)
+ *   6. non-target event · single-hook ours                             (splice + append new)
+ *   7. non-target event · mixed                                        (extract + append new)
+ *   8. no occurrence                                                   (append new)
+ *
+ * Mixed-group invariant (fix #47, ADR 0024 amendment 2026-05-23): foreign hooks
+ * sharing the matcher group are NEVER read, modified, or reordered. The hosting
+ * group's matcher is also left exactly as-is once we extract — even when our
+ * extraction is the reason the group becomes single-foreign. Foreign handler-
+ * level fields (`if`, `args`, `async`, `statusMessage`, …) are not even
+ * inspected (path-identity on `command` is the sole match key). Empty groups
+ * left behind by extraction are removed.
+ *
+ * Our hook entry, however, is canonical-reset on any drift mutation (ranks 3
+ * and 4): the entire prior hook object — including any handler-level fields a
+ * user appended to our hypo-ext-* entry — is replaced by the manifest-derived
+ * `{ type, command, timeout? }` shape. This mirrors the ADR 0024 hard-copy
+ * ownership semantic for hypo-ext-* file copies. Users who want extra handler
+ * fields on a Hypomnema-managed extension must extend the manifest, not edit
+ * settings.json directly (manifest-as-SoT). registerSettings is honest about
+ * this in its rank-3/rank-4 mutation steps below.
+ *
+ * Idempotency: rank-1 and rank-2 are explicit no-ops (output JSON byte-matches
+ * input). Every other rank converges after one pass — a second registerSettings
+ * call sees the just-written single-hook or in-place hook, scores it rank-1 or
+ * rank-2, and writes nothing.
+ *
+ * Doctor mirror (#47 scope): `scripts/doctor.mjs:776-802` previously only
+ * recognised single-hook groups as "owning" our command — it warned `not
+ * registered` for a mixed-group occurrence this function now accepts as
+ * canonical. The doctor side was updated in lock-step using the
+ * `collectOurOccurrences` helper exported below, so write-path acceptance and
+ * read-path recognition stay aligned.
  */
+/**
+ * Find every occurrence of `command` across every matcher group in `hooks`.
+ * Returns an array of locators in settings traversal order — the canonical
+ * tie-breaker when ranking matches in registerSettings.
+ *
+ * Exported (#47 scope) so `scripts/doctor.mjs` can use the same locator and
+ * accept mixed-group ownership instead of warning `not registered`.
+ *
+ * @param {object} hooks - settings.json `hooks` object (event → group[])
+ * @param {string} command - the manifest-derived command string to match
+ * @returns {Array<{event: string, groupIdx: number, hookIdx: number,
+ *                  group: object, hook: object, isMixed: boolean}>}
+ */
+export function collectOurOccurrences(hooks, command) {
+  const out = [];
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) return out;
+  for (const [event, groups] of Object.entries(hooks)) {
+    if (!Array.isArray(groups)) continue;
+    groups.forEach((group, groupIdx) => {
+      if (!group || typeof group !== 'object' || !Array.isArray(group.hooks)) return;
+      group.hooks.forEach((hook, hookIdx) => {
+        if (hook && hook.command === command) {
+          out.push({
+            event,
+            groupIdx,
+            hookIdx,
+            group,
+            hook,
+            isMixed: group.hooks.length > 1,
+          });
+        }
+      });
+    });
+  }
+  return out;
+}
+
+// Rank an occurrence against the desired entry. Lower = preferred canonical.
+// See registerSettings docstring for the 8-step table (ranks 1-7 here; 8 is
+// "no occurrence found" handled by the caller).
+function rankOccurrence(occ, entry, desiredHook) {
+  const onTarget = occ.event === entry.event;
+  const groupMatcher = occ.group.matcher;
+  const matcherMatches =
+    (groupMatcher === undefined || groupMatcher === null ? undefined : groupMatcher) ===
+    (entry.matcher === undefined || entry.matcher === null ? undefined : entry.matcher);
+  const hookExact = JSON.stringify(occ.hook) === JSON.stringify(desiredHook);
+
+  if (!onTarget) return occ.isMixed ? 7 : 6;
+  if (!occ.isMixed) return hookExact && matcherMatches ? 1 : 3;
+  // mixed on target
+  if (matcherMatches && hookExact) return 2;
+  if (matcherMatches) return 4;
+  return 5;
+}
+
+// Locate a matcher-group object reference inside the settings.hooks tree.
+// Returns null if the object has already been removed.
+//
+// Reference-based locators (instead of recorded {event, groupIdx, hookIdx}
+// numeric paths) are mandatory for cleanup-then-mutate safety: cleanup may
+// splice arrays at lower indices than the canonical, which would invalidate
+// any recorded numeric path. Object identity survives the splice.
+function locateGroup(hooks, groupRef) {
+  for (const event of Object.keys(hooks)) {
+    const groups = hooks[event];
+    if (!Array.isArray(groups)) continue;
+    const gi = groups.indexOf(groupRef);
+    if (gi !== -1) return { event, groupIdx: gi };
+  }
+  return null;
+}
+
+// Remove a matcher-group from its hosting event. If the event is left with no
+// groups, delete the event key so downstream iteration doesn't see empty arrays.
+function removeGroup(hooks, groupRef) {
+  const loc = locateGroup(hooks, groupRef);
+  if (!loc) return;
+  hooks[loc.event].splice(loc.groupIdx, 1);
+  if (hooks[loc.event].length === 0) delete hooks[loc.event];
+}
+
+// Splice a single hook object out of its matcher-group. If the group becomes
+// empty as a result, also remove the group. Foreign hook entries sharing the
+// group AND the group-level matcher are NEVER read or modified — `indexOf` on
+// the explicit hook reference is the sole locator.
+function removeHook(hooks, groupRef, hookRef) {
+  const hi = groupRef.hooks.indexOf(hookRef);
+  if (hi === -1) return;
+  groupRef.hooks.splice(hi, 1);
+  if (groupRef.hooks.length === 0) removeGroup(hooks, groupRef);
+}
+
 function registerSettings(settingsPath, expectedEntries, apply) {
   let original = '';
   let settings = {};
@@ -509,14 +631,6 @@ function registerSettings(settingsPath, expectedEntries, apply) {
     settings.hooks = {};
   }
 
-  const isOurGroup = (g, command) =>
-    g &&
-    typeof g === 'object' &&
-    Array.isArray(g.hooks) &&
-    g.hooks.length === 1 &&
-    g.hooks[0] &&
-    g.hooks[0].command === command;
-
   const registered = [];
   for (const entry of expectedEntries) {
     registered.push(`${entry.event}: ${entry.name}`);
@@ -526,27 +640,62 @@ function registerSettings(settingsPath, expectedEntries, apply) {
     const desiredGroup = { hooks: [desiredHook] };
     if (entry.matcher) desiredGroup.matcher = entry.matcher;
 
-    // Locate the single-hook group that owns this command, in any event.
-    let foundEvent = null;
-    let foundIdx = -1;
-    for (const [event, groups] of Object.entries(settings.hooks)) {
-      if (!Array.isArray(groups)) continue;
-      const idx = groups.findIndex((g) => isOurGroup(g, entry.command));
-      if (idx !== -1) {
-        foundEvent = event;
-        foundIdx = idx;
-        break;
+    // 1. collect ALL occurrences (single + mixed across all events). Each
+    //    occurrence carries direct references to its container group and hook
+    //    objects — numeric (event, groupIdx, hookIdx) coordinates are recorded
+    //    only for ranking, never used for mutation (BLOCKER #1 fix from #47
+    //    pre-commit review: cleanup may invalidate numeric paths; object
+    //    identity is the only stable locator).
+    const occurrences = collectOurOccurrences(settings.hooks, entry.command);
+
+    // 2. rank + pick canonical (lowest rank; first occurrence in traversal
+    //    order wins on tie because `<` is strict).
+    let canonical = null;
+    let canonicalRank = Infinity;
+    for (const occ of occurrences) {
+      const r = rankOccurrence(occ, entry, desiredHook);
+      if (r < canonicalRank) {
+        canonicalRank = r;
+        canonical = occ;
       }
     }
 
-    if (foundEvent === entry.event) {
-      // Same event — patch in place only if matcher/timeout drifted.
-      if (JSON.stringify(settings.hooks[entry.event][foundIdx]) !== JSON.stringify(desiredGroup)) {
-        settings.hooks[entry.event][foundIdx] = desiredGroup;
-      }
+    // 3. drop non-canonical occurrences (cleanup pre-existing duplicates).
+    //    Removal is by (group ref, hook ref) — index shifts at any depth do
+    //    not corrupt the canonical's hook reference, which we still hold.
+    for (const occ of occurrences) {
+      if (occ === canonical) continue;
+      removeHook(settings.hooks, occ.group, occ.hook);
+    }
+
+    // 4. apply mutation to canonical OR create new. All locators are by
+    //    object identity; numeric indices from step 1 are no longer trusted.
+    if (!canonical) {
+      // rank 8 — no occurrence.
+      if (!Array.isArray(settings.hooks[entry.event])) settings.hooks[entry.event] = [];
+      settings.hooks[entry.event].push(desiredGroup);
+    } else if (canonicalRank === 1 || canonicalRank === 2) {
+      // exact — no-op (idempotent).
+    } else if (canonicalRank === 3) {
+      // target single-hook drift → replace the canonical group object with
+      // the manifest-derived shape. Our hook entry is canonical-reset on this
+      // path (any user-added handler fields are discarded — that mirrors the
+      // ADR 0024 hard-copy ownership semantic for hypo-ext-*).
+      const loc = locateGroup(settings.hooks, canonical.group);
+      if (loc) settings.hooks[loc.event][loc.groupIdx] = desiredGroup;
+    } else if (canonicalRank === 4) {
+      // target mixed, matcher matches, our hook drifted → replace OUR hook
+      // entry (looked up by identity) with the manifest-derived shape.
+      // Foreign hooks and the group-level matcher are untouched; our own
+      // hook is canonical-reset (handler-level user mods on the hypo-ext-*
+      // hook are not preserved — by the same ADR 0024 ownership semantic).
+      const hi = canonical.group.hooks.indexOf(canonical.hook);
+      if (hi !== -1) canonical.group.hooks[hi] = desiredHook;
     } else {
-      // Event migration or first registration.
-      if (foundEvent !== null) settings.hooks[foundEvent].splice(foundIdx, 1);
+      // ranks 5/6/7 — extract our hook from its current group (foreign
+      // siblings + matcher in the source group remain exactly as found) and
+      // append a fresh single-hook group under the target event.
+      removeHook(settings.hooks, canonical.group, canonical.hook);
       if (!Array.isArray(settings.hooks[entry.event])) settings.hooks[entry.event] = [];
       settings.hooks[entry.event].push(desiredGroup);
     }

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2964,6 +2964,451 @@ test('doctor-extensions-integrity: --codex target', () => {
   });
 });
 
+// ── extensions settings.json mixed-group surgical write (fix #47, ADR 0024 amend 2026-05-23) ──
+//
+// registerSettings used to ignore mixed-group occurrences of our command (any
+// group where g.hooks.length > 1) — leaving us either drifted in place or
+// duplicated as a fresh append. fix #47 makes the write-path surgical: locate
+// every occurrence (single + mixed across every event), rank by 8-step
+// priority, pick canonical, drop duplicates, mutate with the lowest-disturbance
+// edit. Foreign hooks and the hosting group's matcher are NEVER modified.
+
+suite('extensions settings.json mixed-group surgical write (lib/extensions.mjs, fix #47)');
+
+// Helper: inject a foreign sibling hook into the matcher group that already
+// owns our hypo-ext-* command. Returns the path so the test can re-read.
+function injectForeignSibling(home, event, ourCmdSubstr, foreignHook) {
+  const settingsPath = join(home, '.claude', 'settings.json');
+  const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  const groups = settings.hooks[event] || [];
+  const ourGroupIdx = groups.findIndex((g) =>
+    (g.hooks || []).some((h) => (h.command || '').includes(ourCmdSubstr)),
+  );
+  assert.ok(ourGroupIdx !== -1, `our hook not found in ${event} groups`);
+  groups[ourGroupIdx].hooks.push(foreignHook);
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  return settingsPath;
+}
+
+test('extensions-settings-mixed-group: foreign sibling preserved, our hook in-place patched on timeout drift (rank 4)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-mixed.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write|Edit',
+        timeout: 10000,
+      });
+      const r1 = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
+        home,
+      );
+      assert.equal(r1.status, 0, `first apply: ${r1.stderr}`);
+
+      // Inject foreign sibling into our matcher group.
+      const settingsPath = injectForeignSibling(home, 'PostToolUse', 'hypo-ext-mixed.mjs', {
+        type: 'command',
+        command: 'node /other/plugin/hook.mjs',
+        timeout: 5000,
+      });
+
+      // Drift the manifest timeout — same matcher, same event, our hook fields change.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-mixed.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write|Edit',
+        timeout: 20000,
+      });
+      const r2 = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
+        home,
+      );
+      assert.equal(r2.status, 0, `second apply: ${r2.stderr}`);
+
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const groups = after.hooks.PostToolUse || [];
+      const mixed = groups.find((g) => g.hooks.length === 2);
+      assert.ok(mixed, 'mixed group should still exist (foreign + ours)');
+      assert.equal(mixed.matcher, 'Write|Edit', 'group matcher untouched');
+
+      const foreign = mixed.hooks.find((h) => h.command === 'node /other/plugin/hook.mjs');
+      assert.ok(foreign, 'foreign hook preserved');
+      assert.equal(foreign.timeout, 5000, 'foreign timeout never modified');
+
+      const ours = mixed.hooks.find((h) => (h.command || '').includes('hypo-ext-mixed.mjs'));
+      assert.ok(ours, 'our hook still in-place inside mixed group');
+      assert.equal(ours.timeout, 20000, 'our hook timeout patched in-place');
+
+      const ourSingles = groups.filter(
+        (g) =>
+          g.hooks.length === 1 && (g.hooks[0].command || '').includes('hypo-ext-mixed.mjs'),
+      );
+      assert.equal(ourSingles.length, 0, 'no duplicate single-hook group appended');
+    });
+  });
+});
+
+test('extensions-settings-mixed-group: matcher change extracts our hook, foreign keeps original group + matcher (rank 5)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-matcher.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      const settingsPath = injectForeignSibling(home, 'PostToolUse', 'hypo-ext-matcher.mjs', {
+        type: 'command',
+        command: 'node /other/plugin/hook.mjs',
+      });
+
+      // Matcher changes: our hook must extract; foreign stays under 'Write'.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-matcher.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Edit',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const groups = after.hooks.PostToolUse || [];
+
+      const foreignGroup = groups.find(
+        (g) =>
+          g.hooks.length === 1 && g.hooks[0].command === 'node /other/plugin/hook.mjs',
+      );
+      assert.ok(foreignGroup, 'foreign hook left behind in its own single-hook group');
+      assert.equal(
+        foreignGroup.matcher,
+        'Write',
+        'foreign group keeps the ORIGINAL matcher (never edited by us)',
+      );
+
+      const ourGroup = groups.find(
+        (g) =>
+          g.hooks.length === 1 &&
+          (g.hooks[0].command || '').includes('hypo-ext-matcher.mjs'),
+      );
+      assert.ok(ourGroup, 'our hook extracted into new single-hook group');
+      assert.equal(ourGroup.matcher, 'Edit', 'our new group adopts the manifest matcher');
+    });
+  });
+});
+
+test('extensions-settings-mixed-group: event change extracts our hook, foreign keeps original event (rank 7)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-event.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      const settingsPath = injectForeignSibling(home, 'PostToolUse', 'hypo-ext-event.mjs', {
+        type: 'command',
+        command: 'node /other/plugin/hook.mjs',
+      });
+
+      // Event changes from PostToolUse → PreToolUse.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-event.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PreToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const post = after.hooks.PostToolUse || [];
+      const pre = after.hooks.PreToolUse || [];
+
+      const foreignGroup = post.find(
+        (g) =>
+          g.hooks.length === 1 && g.hooks[0].command === 'node /other/plugin/hook.mjs',
+      );
+      assert.ok(
+        foreignGroup,
+        'foreign hook stays under PostToolUse with the original matcher',
+      );
+      assert.equal(foreignGroup.matcher, 'Write');
+
+      const ourGroup = pre.find(
+        (g) =>
+          g.hooks.length === 1 &&
+          (g.hooks[0].command || '').includes('hypo-ext-event.mjs'),
+      );
+      assert.ok(ourGroup, 'our hook moved to PreToolUse single-hook group');
+      assert.equal(ourGroup.matcher, 'Write');
+
+      // Ours must NOT be in PostToolUse anymore.
+      const stillPost = post.find((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-event.mjs')),
+      );
+      assert.equal(stillPost, undefined, 'our hook fully removed from PostToolUse');
+    });
+  });
+});
+
+test('extensions-settings-multi-occurrence-cleanup: duplicate single + mixed converges to one canonical', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-dup.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      // Hand-corrupt settings: keep the canonical single-hook group AND add a
+      // stale mixed-group occurrence under PreToolUse (event drift + foreign).
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      settings.hooks.PreToolUse = settings.hooks.PreToolUse || [];
+      settings.hooks.PreToolUse.push({
+        matcher: 'Edit',
+        hooks: [
+          { type: 'command', command: 'node /other/plugin/hook.mjs' },
+          {
+            type: 'command',
+            command: settings.hooks.PostToolUse[
+              settings.hooks.PostToolUse.findIndex((g) =>
+                (g.hooks || []).some((h) =>
+                  (h.command || '').includes('hypo-ext-dup.mjs'),
+                ),
+              )
+            ].hooks[0].command,
+            timeout: 9999,
+          },
+        ],
+      });
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+      const r = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
+        home,
+      );
+      assert.equal(r.status, 0, `apply failed: ${r.stderr}`);
+
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      // After cleanup: exactly one occurrence of our command, under PostToolUse
+      // (the rank-1 canonical), foreign hook in PreToolUse preserved alone.
+      const allEvents = ['PreToolUse', 'PostToolUse', 'Stop', 'UserPromptSubmit', 'SessionStart'];
+      let ourCount = 0;
+      for (const ev of allEvents) {
+        for (const g of after.hooks[ev] || []) {
+          for (const h of g.hooks || []) {
+            if ((h.command || '').includes('hypo-ext-dup.mjs')) ourCount += 1;
+          }
+        }
+      }
+      assert.equal(ourCount, 1, 'exactly one canonical occurrence after cleanup');
+
+      const foreignSurvived = (after.hooks.PreToolUse || []).some((g) =>
+        (g.hooks || []).some((h) => h.command === 'node /other/plugin/hook.mjs'),
+      );
+      assert.ok(foreignSurvived, 'foreign hook in PreToolUse preserved');
+    });
+  });
+});
+
+test('extensions-settings-mixed-group-idempotent: second --apply over a mixed-group canonical is a byte-equal no-op', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-idem.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      const settingsPath = injectForeignSibling(home, 'PostToolUse', 'hypo-ext-idem.mjs', {
+        type: 'command',
+        command: 'node /other/plugin/hook.mjs',
+      });
+
+      // First apply over the now-mixed group: rank-2 exact (matcher+hook match).
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      const before = readFileSync(settingsPath, 'utf-8');
+
+      const r2 = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
+        home,
+      );
+      assert.equal(r2.status, 0, `idempotent apply: ${r2.stderr}`);
+      const after = readFileSync(settingsPath, 'utf-8');
+      assert.equal(after, before, 'second apply drifted the file (not byte-equal)');
+
+      const out2 = JSON.parse(r2.stdout);
+      assert.equal(
+        out2.applied.extensions.settingsChanged,
+        false,
+        'idempotent apply reports settingsChanged=false',
+      );
+    });
+  });
+});
+
+// BLOCKER #1 regression (pre-commit codex 2-worker convergence 2026-05-23):
+// reference-based locators must survive cleanup-then-mutate even when an
+// earlier same-event group is removed during cleanup. The numeric-index
+// locator used to silently overwrite a foreign-only group at the stale index.
+test('extensions-settings-cleanup-shift: same-event lower-index duplicate removal preserves foreign-only neighbour (BLOCKER #1)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-shift.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      const r1 = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
+        home,
+      );
+      assert.equal(r1.status, 0, `first apply: ${r1.stderr}`);
+
+      // Hand-corrupt: build a settings.json with [corrupt-ours-mixed, canonical-
+      // ours-single-drift, foreign-only-group] in that traversal order. cleanup
+      // will remove [0] (corrupt mixed has ONLY our hook duplicated), causing a
+      // same-event groupIdx shift; with numeric locators the canonical at idx 1
+      // would re-point to the foreign-only group at idx 2 (now idx 1 after shift)
+      // and silently overwrite it.
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const existing = settings.hooks.PostToolUse.find((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-shift.mjs')),
+      );
+      const ourCommand = existing.hooks.find((h) =>
+        (h.command || '').includes('hypo-ext-shift.mjs'),
+      ).command;
+      // Replace PostToolUse with the staged corrupt layout.
+      settings.hooks.PostToolUse = [
+        // [0] corrupt: two of our hook in one group (no foreign).
+        {
+          matcher: 'Edit',
+          hooks: [
+            { type: 'command', command: ourCommand },
+            { type: 'command', command: ourCommand, timeout: 9999 },
+          ],
+        },
+        // [1] canonical ours-single with timeout drift.
+        {
+          matcher: 'Write',
+          hooks: [{ type: 'command', command: ourCommand, timeout: 5000 }],
+        },
+        // [2] foreign-only group — must survive untouched.
+        {
+          matcher: 'Read',
+          hooks: [{ type: 'command', command: 'node /foreign/keep.mjs', timeout: 1234 }],
+        },
+      ];
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+      const r2 = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
+        home,
+      );
+      assert.equal(r2.status, 0, `apply must not crash on cleanup-shift: ${r2.stderr}`);
+
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const post = after.hooks.PostToolUse || [];
+
+      // Foreign-only group survives, exactly as-is (no overwrite).
+      const foreign = post.find(
+        (g) =>
+          g.hooks.length === 1 &&
+          g.hooks[0].command === 'node /foreign/keep.mjs',
+      );
+      assert.ok(foreign, 'foreign-only group must survive cleanup-shift');
+      assert.equal(foreign.matcher, 'Read', 'foreign matcher untouched');
+      assert.equal(foreign.hooks[0].timeout, 1234, 'foreign timeout untouched');
+
+      // Exactly one occurrence of our command remains, with manifest shape.
+      let ourCount = 0;
+      let ourEntry = null;
+      let ourGroup = null;
+      for (const g of post) {
+        for (const h of g.hooks || []) {
+          if (h.command === ourCommand) {
+            ourCount += 1;
+            ourEntry = h;
+            ourGroup = g;
+          }
+        }
+      }
+      assert.equal(ourCount, 1, `expected exactly 1 canonical, got ${ourCount}`);
+      assert.equal(ourEntry.timeout, 10000, 'canonical entry has manifest timeout');
+      assert.equal(ourGroup.matcher, 'Write', 'canonical group has manifest matcher');
+    });
+  });
+});
+
+test('doctor-extensions-mixed-group-ownership: doctor accepts mixed-group occurrence (no false "not registered")', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-doctor.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      injectForeignSibling(home, 'PostToolUse', 'hypo-ext-doctor.mjs', {
+        type: 'command',
+        command: 'node /other/plugin/hook.mjs',
+      });
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      assert.equal(r.status, 0, `doctor exit: ${r.stderr}`);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      assert.ok(ext, 'extensions integrity check missing');
+      // Doctor must NOT warn `hypo-ext-doctor.mjs not registered` — the
+      // mixed-group occurrence is valid ownership under fix #47.
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        !/hypo-ext-doctor\.mjs not registered/.test(detail),
+        `doctor falsely reported not-registered: ${detail}`,
+      );
+    });
+  });
+});
+
 // ── extensions companion uninstall (ADR 0024, fix #34) ───────────────────────
 
 suite('extensions companion uninstall (uninstall.mjs, ADR 0024)');


### PR DESCRIPTION
## Summary

`registerSettings` used to ignore mixed-group occurrences (`g.hooks.length > 1`) of our `hypo-ext-*` command — leaving us drifted in place or duplicated as a fresh append. fix #47 makes the write-path surgical and lifts the deferral in `scripts/lib/extensions.mjs:488`.

## Mechanism

For each manifest-derived entry:
1. **Collect** ALL occurrences (single + mixed across every event) via `collectOurOccurrences`.
2. **Rank** each by an 8-step priority (extensions.mjs:478 docstring):
   - 1: target single-hook exact (no-op)
   - 2: target mixed matcher-matches hook-exact (no-op)
   - 3: target single-hook drift (group patch)
   - 4: target mixed matcher-matches hook-drift (in-place hook patch)
   - 5: target mixed matcher-differs (extract + new single)
   - 6: non-target single (splice + new single)
   - 7: non-target mixed (extract + new single)
   - 8: none (append)
3. **Pick** lowest-rank canonical (traversal-order tie break, strict `<`).
4. **Drop** non-canonical occurrences (multi-occurrence cleanup, self-heals pre-existing duplicate-corrupt state).
5. **Mutate** canonical with the lowest-disturbance edit.

## Invariants

- **Foreign hooks**: never inspected, modified, or reordered. Group-level matcher never modified. Foreign handler-level fields (`if` / `args` / `async` / `statusMessage` …) not inspected at all — path-identity on `command` is the sole match key.
- **Our own hook entry**: rank-3/rank-4 mutations canonical-reset our hook to the manifest-derived `{ type, command, timeout? }` shape. Any handler fields a user added to our hypo-ext-* entry are silently overwritten — mirrors ADR 0024 hard-copy ownership for hypo-ext-* file copies (manifest-as-SoT). To extend a hypo-ext handler, extend the manifest, not settings.json.

## Doctor mirror

`scripts/doctor.mjs:776-802` `ownsCommand` polled only single-hook groups; a valid mixed-group occurrence was warned `not registered`. doctor now imports `collectOurOccurrences` so write-path acceptance and read-path recognition stay aligned.

## Pre-commit codex 2-worker review trail

Two codex workers independently flagged a silent-corruption BLOCKER:
> Cleanup using numeric `(event, groupIdx)` paths is stale-prone when an earlier same-event group is spliced out during cleanup — canonical mutation then overwrites a foreign-only neighbour at the shifted index.

**Fix**: switched to reference-based locators (group/hook object identity). Index shifts no longer corrupt the canonical's locator.

**Regression test**: `extensions-settings-cleanup-shift` covers the exact 2-worker repro (PostToolUse [corrupt-ours-mixed, canonical-ours-single-drift, foreign-only-group] → foreign group must survive).

Worker 1's second BLOCKER (docstring claim "manifest-managed fields only" vs implementation canonical-reset of our hook entry) was resolved by clarifying the docstring + ADR 0024 amendment to honestly document the canonical-reset semantic (the choice was intentional; the docstring was the drift).

## Tests

- Before fix #47: 379 passed
- After fix #47: **386 passed, 0 failed**

7 new tests:
- `extensions-settings-mixed-group-{rank-4-timeout-drift, rank-5-matcher-change, rank-7-event-change}`
- `extensions-settings-multi-occurrence-cleanup`
- `extensions-settings-mixed-group-idempotent`
- `extensions-settings-cleanup-shift` (BLOCKER #1 regression)
- `doctor-extensions-mixed-group-ownership`

## Out of scope (deferred follow-ups)

- doctor duplicate-blindness — if `collectOurOccurrences` returns a duplicate occurrence outside the target event, doctor's first-occurrence-match passes; meanwhile registerSettings cleans up. Documented but no doctor change here. Separate fix.
- empty matcher (`""`) handling inconsistency — `truthy` checks in rank ranking and desired-group construction treat `""` and `undefined` differently. Documented; either reject `""` in manifest validation or unify, separate fix.

## Files changed

- `scripts/lib/extensions.mjs` (+229/-64) — registerSettings rewrite + `collectOurOccurrences` exported + reference-based locator helpers.
- `scripts/doctor.mjs` (+34/-25) — `ownsCommand` → `collectOurOccurrences` mirror; stale `mixed-group … deferred` comment updated.
- `tests/runner.mjs` (+445) — 7 new tests covering ranks 4/5/7, idempotency, multi-occurrence cleanup, BLOCKER regression, doctor mixed-group ownership.

Refs: ADR 0024 amendment 2026-05-23 (extensions companion git management) — see personal wiki for amendment text + `extensions.mjs:478` updated docstring for the 8-priority table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)