### PR TITLE
fix(upgrade): --codex core hooks mirror — fix #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`hypomnema upgrade --codex` mirrors core hooks (fix #48).** `init --codex`
+  has always installed Hypomnema's core hooks into `~/.codex/hooks/` and
+  registered them in `~/.codex/settings.json`, but `upgrade` only mirrored
+  user extensions — so a v1.1.x → v1.2.0 codex user's core hooks stayed
+  stale until a fresh install. The flag now drives drift detection, hook-file
+  apply, settings.json registration, and the `wiki-*.mjs → hypo-*.mjs` rename
+  migration on both targets in one pass. The human-readable report labels
+  the two blocks ("Hook files (codex)", "settings.json (codex)") and JSON
+  output gains `hooksCodex` / `settingsCodex` / `oldHookRefsCodex` plus
+  matching `applied.*Codex` keys. Without `--codex` nothing under `~/.codex/`
+  is inspected (parity with the existing extensions behaviour).
 - **Auto-project creation on cwd match (ADR 0023).** When you start a session
   (or change directory) inside a git repository that carries a project marker
   (`package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`, `pom.xml`,

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -14,7 +14,10 @@
  *   --apply             Apply hook file updates and settings.json merges
  *   --force-commands    Overwrite user-modified slash command files (creates .bak)
  *   --force-extensions  Overwrite user-modified / conflicting extension copies (creates .bak)
- *   --codex             Also sync extensions into ~/.codex/{hooks,commands} + settings.json
+ *   --codex             Mirror to ~/.codex/{hooks,commands,settings.json} — core
+ *                       hook drift/apply, settings.json registration, the
+ *                       wiki-*.mjs → hypo-*.mjs rename migration (fix #48), and
+ *                       the user-extensions companion sync (E4 / fix #32).
  *   --json              Output results as JSON
  */
 
@@ -218,13 +221,15 @@ function checkSchemaVersion(hypoDir) {
   };
 }
 
-function checkHookFiles() {
-  const claudeHooks = join(HOME, '.claude', 'hooks');
+// Target-aware: the same core-hook integrity check runs against ~/.claude/hooks/
+// for the default claude target, and against ~/.codex/hooks/ when --codex is set
+// (fix #48, ADR 0024). The function reads only — apply happens in applyHookFiles.
+function checkHookFiles(hooksDir) {
   const results = [];
 
   const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
   for (const file of allFiles) {
-    const installedPath = join(claudeHooks, file);
+    const installedPath = join(hooksDir, file);
     const srcPath = join(HOOKS_SRC, file);
 
     if (!existsSync(installedPath)) {
@@ -246,9 +251,10 @@ function checkHookFiles() {
   return results;
 }
 
-function checkSettingsJson() {
-  const settingsPath = join(HOME, '.claude', 'settings.json');
-  const hooksDir = join(HOME, '.claude', 'hooks');
+// Same target-aware shape as checkHookFiles — the registered command string is
+// reconstructed from `hooksDir`, so a codex check verifies that ~/.codex/settings.json
+// references ~/.codex/hooks/<file>.mjs (not the claude path).
+function checkSettingsJson(settingsPath, hooksDir) {
   const results = [];
 
   let settings = {};
@@ -275,9 +281,11 @@ function checkSettingsJson() {
 
 // ── apply actions ────────────────────────────────────────────────────────────
 
-function applyHookFiles(hookResults) {
-  const claudeHooks = join(HOME, '.claude', 'hooks');
-  mkdirSync(claudeHooks, { recursive: true });
+// `hooksDir` is the target the stale/missing paths in `hookResults` already point
+// at (the check above embeds the absolute installedPath). The directory is created
+// up front so first-time codex installs (~/.codex/hooks/ absent) succeed.
+function applyHookFiles(hookResults, hooksDir) {
+  mkdirSync(hooksDir, { recursive: true });
 
   const applied = [];
   for (const h of hookResults) {
@@ -289,8 +297,7 @@ function applyHookFiles(hookResults) {
   return applied;
 }
 
-function applySettingsJson(settingsResults) {
-  const settingsPath = join(HOME, '.claude', 'settings.json');
+function applySettingsJson(settingsResults, settingsPath) {
   let settings = {};
   if (existsSync(settingsPath)) {
     try {
@@ -305,6 +312,17 @@ function applySettingsJson(settingsResults) {
   for (const s of settingsResults) {
     if (s.status !== 'missing') continue;
     if (!Array.isArray(settings.hooks[s.event])) settings.hooks[s.event] = [];
+    // fix #48 BLOCKER: re-check the current parsed settings before appending.
+    // applyHookNameMigration may have rewritten a legacy wiki-*.mjs command to
+    // exactly `s.cmd` between checkSettingsJson and now — appending without
+    // this guard creates a duplicate registration (codex 2-worker review
+    // reproduced 11 duplicate hypo-*.mjs entries on a wiki-only legacy settings
+    // file). The precheck list is allowed to be stale; the apply path must
+    // self-heal against the on-disk truth.
+    const alreadyPresent = settings.hooks[s.event]
+      .flatMap((g) => g.hooks || [])
+      .some((h) => h.command === s.cmd);
+    if (alreadyPresent) continue;
     settings.hooks[s.event].push({ hooks: [{ type: 'command', command: s.cmd }] });
     applied.push(`${s.event}: ${s.file}`);
   }
@@ -331,8 +349,9 @@ const HOOK_RENAMES = {
   'personal-wiki-check.mjs': 'hypo-personal-check.mjs',
 };
 
-function checkOldHookNames() {
-  const settingsPath = join(HOME, '.claude', 'settings.json');
+// Same target-aware shape: scans either ~/.claude/settings.json or ~/.codex/settings.json
+// for v1.0/v1.1 `wiki-*.mjs` references that need renaming to `hypo-*.mjs`.
+function checkOldHookNames(settingsPath) {
   if (!existsSync(settingsPath)) return [];
   let settings;
   try {
@@ -355,9 +374,7 @@ function checkOldHookNames() {
   return found;
 }
 
-function applyHookNameMigration(oldRefs) {
-  const settingsPath = join(HOME, '.claude', 'settings.json');
-  const hooksDir = join(HOME, '.claude', 'hooks');
+function applyHookNameMigration(oldRefs, settingsPath, hooksDir) {
   if (!existsSync(settingsPath)) return [];
 
   let settings;
@@ -383,7 +400,8 @@ function applyHookNameMigration(oldRefs) {
 
   if (applied.length > 0) {
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-    // Copy renamed hook files to ~/.claude/hooks/
+    // Copy renamed hook files to the target hooks dir (~/.claude/hooks or
+    // ~/.codex/hooks per the caller — fix #48 mirror).
     for (const [oldName, newName] of Object.entries(HOOK_RENAMES)) {
       const oldPath = join(hooksDir, oldName);
       const newPath = join(hooksDir, newName);
@@ -653,18 +671,32 @@ function applyCommands(commandResults, force) {
 
 const args = parseArgs(process.argv);
 
+// Target paths. Claude is always checked; codex is checked only when --codex is set
+// (fix #48, ADR 0024) so users without codex installed see no false drift.
+const claudeHooksDir = join(HOME, '.claude', 'hooks');
+const claudeSettingsPath = join(HOME, '.claude', 'settings.json');
+const codexHooksDir = join(HOME, '.codex', 'hooks');
+const codexSettingsPath = join(HOME, '.codex', 'settings.json');
+
 const schema = checkSchemaVersion(args.hypoDir);
-const hooks = checkHookFiles();
-const settings = checkSettingsJson();
+const hooks = checkHookFiles(claudeHooksDir);
+const settings = checkSettingsJson(claudeSettingsPath, claudeHooksDir);
 const pkgJson = checkPkgJson();
 const commands = checkCommands();
-const oldHookRefs = checkOldHookNames();
+const oldHookRefs = checkOldHookNames(claudeSettingsPath);
 const hypoignore = checkHypoignore(args.hypoDir);
+
+// fix #48: when --codex is set, mirror the same core-hook checks against ~/.codex/
+// so `hypomnema upgrade --codex` reports drift symmetrically and `--apply --codex`
+// updates both targets in one pass (matching init.mjs behaviour).
+const hooksCodex = args.codex ? checkHookFiles(codexHooksDir) : null;
+const settingsCodex = args.codex ? checkSettingsJson(codexSettingsPath, codexHooksDir) : null;
+const oldHookRefsCodex = args.codex ? checkOldHookNames(codexSettingsPath) : null;
 
 // Extensions companion (ADR 0024, fix #29 + #30). Read-only check; the apply
 // happens below, AFTER applyCommands, so the per-target SHA map merges into the
 // hypo-pkg.json that applyCommands writes (rather than being clobbered by it).
-const extSettingsPath = join(HOME, '.claude', 'settings.json');
+const extSettingsPath = claudeSettingsPath;
 const extDir = join(args.hypoDir, 'extensions');
 const extCheck = syncExtensions({
   extDir,
@@ -679,7 +711,7 @@ const extCheck = syncExtensions({
 // E4 (#32): --codex mirrors the extensions sync into ~/.codex (hooks + commands
 // only; skills/agents skipped with a notice). The per-target SHA map lives in the
 // same ~/.claude/hypo-pkg.json under extensions.codex, so pkgPath is unchanged.
-const extCodexSettingsPath = join(HOME, '.codex', 'settings.json');
+const extCodexSettingsPath = codexSettingsPath;
 const extCheckCodex = args.codex
   ? syncExtensions({
       extDir,
@@ -697,6 +729,17 @@ const staleHooks = hooks.filter(
 );
 const missingSettings = settings.filter((s) => s.status === 'missing');
 const invalidSettings = settings.some((s) => s.status === 'invalid-json');
+const staleHooksCodex = hooksCodex
+  ? hooksCodex.filter(
+      (h) => h.status === 'stale' || h.status === 'missing' || h.status === 'src-missing',
+    )
+  : [];
+const missingSettingsCodex = settingsCodex
+  ? settingsCodex.filter((s) => s.status === 'missing')
+  : [];
+const invalidSettingsCodex = settingsCodex
+  ? settingsCodex.some((s) => s.status === 'invalid-json')
+  : false;
 const schemaDrift = schema.bump !== 'none' && schema.bump !== 'unknown' && schema.bump !== 'ahead';
 const pkgJsonDrift = pkgJson.status !== 'up-to-date';
 const staleCommands = commands.filter((c) => c.status === 'stale' || c.status === 'missing');
@@ -711,6 +754,9 @@ let appliedHooks = [];
 let appliedSettings = [];
 let appliedPkgJson = false;
 let appliedHookNameRenames = [];
+let appliedHooksCodex = [];
+let appliedSettingsCodex = [];
+let appliedHookNameRenamesCodex = [];
 let appliedCommands = [];
 let appliedHypoignore = [];
 let appliedExtensions = null;
@@ -718,17 +764,34 @@ let appliedExtensionsCodex = null;
 
 if (args.apply) {
   if (oldHookRefs.length > 0) {
-    appliedHookNameRenames = applyHookNameMigration(oldHookRefs);
+    appliedHookNameRenames = applyHookNameMigration(
+      oldHookRefs,
+      claudeSettingsPath,
+      claudeHooksDir,
+    );
   }
   if (schema.bump === 'major' && schema.installed && schema.current && existsSync(args.hypoDir)) {
     migrationPath = writeMigrationReport(args.hypoDir, schema.installed, schema.current);
   }
-  appliedHooks = applyHookFiles(hooks);
-  appliedSettings = applySettingsJson(settings);
+  appliedHooks = applyHookFiles(hooks, claudeHooksDir);
+  appliedSettings = applySettingsJson(settings, claudeSettingsPath);
   // applyCommands handles the single atomic hypo-pkg.json write (pkgRoot, version, schema, commands map)
   appliedCommands = applyCommands(commands, args.forceCommands);
   appliedPkgJson = true;
   appliedHypoignore = applyHypoignoreMigration(hypoignore);
+  // fix #48: codex core hooks + settings + wiki-*→hypo-* rename mirror. Same order
+  // as the claude side (rename first so subsequent hook copy can find renamed targets).
+  if (args.codex) {
+    if (oldHookRefsCodex.length > 0) {
+      appliedHookNameRenamesCodex = applyHookNameMigration(
+        oldHookRefsCodex,
+        codexSettingsPath,
+        codexHooksDir,
+      );
+    }
+    appliedHooksCodex = applyHookFiles(hooksCodex, codexHooksDir);
+    appliedSettingsCodex = applySettingsJson(settingsCodex, codexSettingsPath);
+  }
   // After applyCommands wrote hypo-pkg.json — merges extensions.<target> alongside.
   appliedExtensions = syncExtensions({
     extDir,
@@ -759,6 +822,15 @@ if (args.apply) {
 
 const extDrift = extCheck.needsWork || (extCheckCodex?.needsWork ?? false);
 
+// fix #48: codex drift only counts when --codex is set — without the flag the codex
+// target is intentionally unobserved (parity with the existing extensions pattern).
+const codexCoreDrift =
+  args.codex &&
+  (staleHooksCodex.length > 0 ||
+    missingSettingsCodex.length > 0 ||
+    invalidSettingsCodex ||
+    (oldHookRefsCodex?.length ?? 0) > 0);
+
 const hasDrift =
   staleHooks.length > 0 ||
   missingSettings.length > 0 ||
@@ -771,7 +843,8 @@ const hasDrift =
   orphanedCommands.length > 0 ||
   nonRegularCommands.length > 0 ||
   hypoignore.status === 'needs-migration' ||
-  extDrift;
+  extDrift ||
+  codexCoreDrift;
 
 if (args.json) {
   console.log(
@@ -786,6 +859,10 @@ if (args.json) {
         hypoignore,
         extensions: extCheck,
         extensionsCodex: extCheckCodex,
+        // fix #48: codex core mirror (null when --codex absent).
+        hooksCodex,
+        settingsCodex,
+        oldHookRefsCodex,
         applied: {
           hooks: appliedHooks,
           settings: appliedSettings,
@@ -795,6 +872,9 @@ if (args.json) {
           hypoignore: appliedHypoignore,
           extensions: appliedExtensions,
           extensionsCodex: appliedExtensionsCodex,
+          hooksCodex: appliedHooksCodex,
+          settingsCodex: appliedSettingsCodex,
+          hookNameRenamesCodex: appliedHookNameRenamesCodex,
         },
         migrationReport: migrationPath,
       },
@@ -835,47 +915,51 @@ if (schema.bump === 'none') {
   );
 }
 
-// Hook files
-const upToDate = hooks.filter((h) => h.status === 'up-to-date').length;
-const staleCount = hooks.filter((h) => h.status === 'stale').length;
-const missCount = hooks.filter((h) => h.status === 'missing').length;
-const srcMiss = hooks.filter((h) => h.status === 'src-missing').length;
-
-if (staleCount === 0 && missCount === 0 && srcMiss === 0) {
-  lines.push(`✓ Hook files        ${upToDate}/${hooks.length} up to date`);
-} else {
-  lines.push(
-    `⚠ Hook files        ${upToDate} up to date, ${staleCount} stale, ${missCount} missing, ${srcMiss} src-missing:`,
-  );
-  for (const h of hooks) {
-    if (h.status === 'up-to-date') {
-      lines.push(`    ✓ ${h.file}`);
-    } else if (h.status === 'stale') {
-      lines.push(`    ⚠ ${h.file}  [stale — package has newer version]`);
-    } else if (h.status === 'missing') {
-      lines.push(`    ✗ ${h.file}  [not found in ~/.claude/hooks/]`);
-    } else if (h.status === 'src-missing') {
-      lines.push(`    ⚠ ${h.file}  [installed but missing from package — may be orphaned]`);
+// Hook files (target-aware so --codex can mirror the same block; fix #48).
+function pushHookSummary(hookList, label, targetPath) {
+  const colHook = `Hook files${label}`.padEnd(20);
+  const up = hookList.filter((h) => h.status === 'up-to-date').length;
+  const st = hookList.filter((h) => h.status === 'stale').length;
+  const mi = hookList.filter((h) => h.status === 'missing').length;
+  const sm = hookList.filter((h) => h.status === 'src-missing').length;
+  if (st === 0 && mi === 0 && sm === 0) {
+    lines.push(`✓ ${colHook}${up}/${hookList.length} up to date`);
+  } else {
+    lines.push(`⚠ ${colHook}${up} up to date, ${st} stale, ${mi} missing, ${sm} src-missing:`);
+    for (const h of hookList) {
+      if (h.status === 'up-to-date') {
+        lines.push(`    ✓ ${h.file}`);
+      } else if (h.status === 'stale') {
+        lines.push(`    ⚠ ${h.file}  [stale — package has newer version]`);
+      } else if (h.status === 'missing') {
+        lines.push(`    ✗ ${h.file}  [not found in ${targetPath}]`);
+      } else if (h.status === 'src-missing') {
+        lines.push(`    ⚠ ${h.file}  [installed but missing from package — may be orphaned]`);
+      }
     }
   }
 }
+pushHookSummary(hooks, '', '~/.claude/hooks/');
+if (hooksCodex) pushHookSummary(hooksCodex, ' (codex)', '~/.codex/hooks/');
 
-// settings.json
-const regCount = settings.filter((s) => s.status === 'registered').length;
-const missReg = settings.filter((s) => s.status === 'missing').length;
-
-if (invalidSettings) {
-  lines.push(`✗ settings.json     invalid JSON — fix or back it up before re-running`);
-} else if (missReg === 0) {
-  lines.push(`✓ settings.json     ${regCount}/${settings.length} hook registrations present`);
-} else {
-  lines.push(
-    `⚠ settings.json     ${regCount}/${settings.length} registrations present — ${missReg} missing:`,
-  );
-  for (const s of settings) {
-    if (s.status === 'missing') lines.push(`    + ${s.event}: ${s.file}`);
+// settings.json registrations (target-aware mirror; fix #48).
+function pushSettingsSummary(sList, label, invalidFlag) {
+  const colS = `settings.json${label}`.padEnd(20);
+  const reg = sList.filter((s) => s.status === 'registered').length;
+  const mr = sList.filter((s) => s.status === 'missing').length;
+  if (invalidFlag) {
+    lines.push(`✗ ${colS}invalid JSON — fix or back it up before re-running`);
+  } else if (mr === 0) {
+    lines.push(`✓ ${colS}${reg}/${sList.length} hook registrations present`);
+  } else {
+    lines.push(`⚠ ${colS}${reg}/${sList.length} registrations present — ${mr} missing:`);
+    for (const s of sList) {
+      if (s.status === 'missing') lines.push(`    + ${s.event}: ${s.file}`);
+    }
   }
 }
+pushSettingsSummary(settings, '', invalidSettings);
+if (settingsCodex) pushSettingsSummary(settingsCodex, ' (codex)', invalidSettingsCodex);
 
 // Package metadata
 if (pkgJson.status === 'up-to-date') {
@@ -929,16 +1013,21 @@ if (commands.length === 0) {
   }
 }
 
-// Old hook names (wiki-*.mjs → hypo-*.mjs rename migration)
-if (oldHookRefs.length > 0) {
-  lines.push(
-    `⚠ Hook name migration  ${oldHookRefs.length} old wiki-*.mjs reference(s) in settings.json — run --apply to rename:`,
-  );
-  for (const r of oldHookRefs)
-    lines.push(`    ${r.event}: ${r.oldName} → ${HOOK_RENAMES[r.oldName]}`);
-} else {
-  lines.push(`✓ Hook names        All hook references use current hypo-*.mjs names`);
+// Old hook names (wiki-*.mjs → hypo-*.mjs rename migration). Target-aware so
+// fix #48 surfaces codex settings.json that still references the v1.0/v1.1 names.
+function pushHookNameSummary(refs, label) {
+  if (refs.length > 0) {
+    lines.push(
+      `⚠ Hook name migration${label}  ${refs.length} old wiki-*.mjs reference(s) — run --apply to rename:`,
+    );
+    for (const r of refs) lines.push(`    ${r.event}: ${r.oldName} → ${HOOK_RENAMES[r.oldName]}`);
+  } else {
+    const colN = `Hook names${label}`.padEnd(20);
+    lines.push(`✓ ${colN}All hook references use current hypo-*.mjs names`);
+  }
 }
+pushHookNameSummary(oldHookRefs, '');
+if (oldHookRefsCodex) pushHookNameSummary(oldHookRefsCodex, ' (codex)');
 
 // .hypoignore migration (ensure required runtime patterns are present)
 if (hypoignore.status === 'no-file') {
@@ -1006,7 +1095,10 @@ if (
   appliedPkgJson ||
   appliedHookNameRenames.length > 0 ||
   appliedCommands.length > 0 ||
-  appliedHypoignore.length > 0
+  appliedHypoignore.length > 0 ||
+  appliedHooksCodex.length > 0 ||
+  appliedSettingsCodex.length > 0 ||
+  appliedHookNameRenamesCodex.length > 0
 ) {
   lines.push('');
   if (appliedHookNameRenames.length > 0) {
@@ -1031,6 +1123,19 @@ if (
   if (appliedHypoignore.length > 0) {
     lines.push(`✓ Appended .hypoignore entries (${appliedHypoignore.length}):`);
     for (const e of appliedHypoignore) lines.push(`    → ${e}`);
+  }
+  // fix #48: codex-target applied actions (mirrors claude blocks above).
+  if (appliedHookNameRenamesCodex.length > 0) {
+    lines.push(`✓ Renamed legacy hook references (codex) (${appliedHookNameRenamesCodex.length}):`);
+    for (const r of appliedHookNameRenamesCodex) lines.push(`    → ${r}`);
+  }
+  if (appliedHooksCodex.length > 0) {
+    lines.push(`✓ Updated hook files (codex) (${appliedHooksCodex.length}):`);
+    for (const f of appliedHooksCodex) lines.push(`    → ${f}`);
+  }
+  if (appliedSettingsCodex.length > 0) {
+    lines.push(`✓ Merged settings.json entries (codex) (${appliedSettingsCodex.length}):`);
+    for (const e of appliedSettingsCodex) lines.push(`    → ${e}`);
   }
 }
 
@@ -1083,7 +1188,12 @@ const totalDrift =
       ).length +
       extCheckCodex.conflicts.length +
       extCheckCodex.drifts.length
-    : 0);
+    : 0) +
+  // fix #48: codex core mirror counts the same way as the claude side.
+  staleHooksCodex.length +
+  missingSettingsCodex.length +
+  (invalidSettingsCodex ? 1 : 0) +
+  (oldHookRefsCodex?.length ?? 0);
 if (totalDrift === 0) {
   lines.push('Result: Hypomnema is up to date');
 } else if (args.apply) {
@@ -1100,7 +1210,10 @@ if (totalDrift === 0) {
     (appliedPkgJson ? 1 : 0) +
     appliedHookNameRenames.length +
     appliedHypoignore.length +
-    appliedExtCount;
+    appliedExtCount +
+    appliedHooksCodex.length +
+    appliedSettingsCodex.length +
+    appliedHookNameRenamesCodex.length;
   lines.push(`Result: ${total} update(s) applied. Run /hypo:doctor to verify.`);
 } else {
   lines.push(`Result: ${totalDrift} item(s) need updating — run with --apply to install`);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2768,6 +2768,409 @@ test('extensions-codex-sync: --force-extensions overwrites a drifted codex copy'
   });
 });
 
+// §5.1.2 fix #48 — `hypomnema upgrade --codex` must mirror the same core-hook
+// drift detection and apply that the claude side already does (init --codex
+// installs core hooks into ~/.codex/hooks + registers them in ~/.codex/settings.json
+// — upgrade had to catch up). Two cases:
+//   (a) init --codex then a stale codex hook → upgrade --apply --codex restores
+//   (b) init (no --codex) then upgrade --apply --codex installs codex from scratch
+// Both also assert that plain --apply (no --codex) never touches ~/.codex.
+test('upgrade-codex-core-hooks-mirror', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      // init --codex so ~/.codex/{hooks,settings.json} already exist.
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-git-init', '--codex'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init --codex failed: ${initR.stderr}`);
+
+      const cdxHooks = join(home, '.codex', 'hooks');
+      const cdxSettings = join(home, '.codex', 'settings.json');
+      const claudeHooks = join(home, '.claude', 'hooks');
+      const cdxHookFile = join(cdxHooks, 'hypo-shared.mjs');
+      const claudeHookFile = join(claudeHooks, 'hypo-shared.mjs');
+
+      // Both targets must have the hook installed by init.
+      assert.ok(existsSync(cdxHookFile), 'init --codex must install core hooks to ~/.codex/hooks');
+      assert.ok(existsSync(claudeHookFile), 'init must install core hooks to ~/.claude/hooks');
+
+      // Mutate the codex copy → introduce stale drift. Same byte change in claude
+      // would be detected too (regression for both sides).
+      writeFileSync(cdxHookFile, '// drifted codex hook\n');
+      writeFileSync(claudeHookFile, '// drifted claude hook\n');
+
+      // ── (1) plain --apply (no --codex) must NEVER touch ~/.codex ─────────────
+      const rNo = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(rNo.status, 0, `claude-only apply failed: ${rNo.stderr}`);
+      assert.equal(
+        readFileSync(cdxHookFile, 'utf-8'),
+        '// drifted codex hook\n',
+        'plain --apply (no --codex) must not update the codex hook',
+      );
+      assert.notEqual(
+        readFileSync(claudeHookFile, 'utf-8'),
+        '// drifted claude hook\n',
+        'plain --apply must update the claude hook (sanity)',
+      );
+
+      // ── (2) upgrade --codex (no --apply) must report codex drift in JSON ────
+      const rCheck = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--codex', '--json'],
+        home,
+      );
+      assert.equal(rCheck.status, 1, 'codex drift must exit 1 in dry-run');
+      const checkJson = JSON.parse(rCheck.stdout);
+      assert.ok(
+        Array.isArray(checkJson.hooksCodex),
+        'JSON output must include hooksCodex when --codex is set',
+      );
+      assert.ok(
+        checkJson.hooksCodex.some((h) => h.file === 'hypo-shared.mjs' && h.status === 'stale'),
+        'codex hook drift must be reported as stale',
+      );
+
+      // ── (3) upgrade --apply --codex restores the codex hook ─────────────────
+      const rApply = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex', '--json'],
+        home,
+      );
+      assert.equal(rApply.status, 0, `upgrade --apply --codex failed: ${rApply.stderr}`);
+      const applyJson = JSON.parse(rApply.stdout);
+      assert.ok(
+        applyJson.applied.hooksCodex.includes('hypo-shared.mjs'),
+        'codex hook must appear in applied.hooksCodex',
+      );
+      assert.notEqual(
+        readFileSync(cdxHookFile, 'utf-8'),
+        '// drifted codex hook\n',
+        'codex hook must be restored from the package source',
+      );
+
+      // ── (4) idempotency: a second --apply --codex syncs nothing new ─────────
+      const rAgain = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex', '--json'],
+        home,
+      );
+      assert.equal(rAgain.status, 0, `second --apply --codex failed: ${rAgain.stderr}`);
+      const againJson = JSON.parse(rAgain.stdout);
+      assert.equal(
+        againJson.applied.hooksCodex.length,
+        0,
+        'idempotent re-apply must not update any codex hook',
+      );
+      assert.equal(
+        againJson.applied.settingsCodex.length,
+        0,
+        'idempotent re-apply must not register any codex settings entry',
+      );
+    });
+  });
+});
+
+// fix #48 — from-scratch case: `init` was run WITHOUT --codex, so ~/.codex does
+// not yet exist. `upgrade --apply --codex` must create both ~/.codex/hooks/ and
+// register every core hook in ~/.codex/settings.json (mirrors init --codex).
+test('upgrade-codex-core-hooks-from-scratch', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      // Claude-only init: ~/.codex must NOT exist beforehand.
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      assert.ok(
+        !existsSync(join(home, '.codex', 'hooks')),
+        '~/.codex/hooks must not exist before upgrade --codex',
+      );
+
+      // upgrade --codex (no --apply) must surface every codex hook as missing.
+      const rCheck = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--codex', '--json'],
+        home,
+      );
+      assert.equal(rCheck.status, 1, 'missing codex hooks must exit 1 in dry-run');
+      const checkJson = JSON.parse(rCheck.stdout);
+      assert.ok(
+        checkJson.hooksCodex.length > 0 &&
+          checkJson.hooksCodex.every((h) => h.status === 'missing'),
+        'every codex hook must be reported as missing before from-scratch apply',
+      );
+      assert.ok(
+        checkJson.settingsCodex.every((s) => s.status === 'missing'),
+        'every codex settings registration must be reported as missing',
+      );
+
+      // apply: ~/.codex/hooks/ + settings.json get created and registered.
+      const rApply = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex', '--json'],
+        home,
+      );
+      assert.equal(rApply.status, 0, `upgrade --apply --codex failed: ${rApply.stderr}`);
+      const applyJson = JSON.parse(rApply.stdout);
+
+      const cdxHooks = join(home, '.codex', 'hooks');
+      assert.ok(existsSync(cdxHooks), '~/.codex/hooks must be created by upgrade --apply --codex');
+      assert.ok(
+        existsSync(join(cdxHooks, 'hypo-shared.mjs')),
+        'core hook must be hard-copied to ~/.codex/hooks',
+      );
+      assert.ok(
+        applyJson.applied.hooksCodex.length > 0,
+        'applied.hooksCodex must list the created hooks',
+      );
+
+      const cdxSettings = JSON.parse(readFileSync(join(home, '.codex', 'settings.json'), 'utf-8'));
+      // The registered command must point at ~/.codex (not ~/.claude) — the
+      // mergeSettingsJson path uses the codex hooksDir.
+      const allCmds = Object.values(cdxSettings.hooks || {})
+        .flatMap((groups) => groups)
+        .flatMap((g) => g.hooks || [])
+        .map((h) => h.command || '');
+      assert.ok(
+        allCmds.some((c) => c.includes('$HOME/.codex/hooks/')),
+        'codex settings entries must point at ~/.codex/hooks/, not ~/.claude/hooks/',
+      );
+      assert.ok(
+        !allCmds.some((c) => c.includes('$HOME/.claude/hooks/')),
+        'codex settings must NOT reference ~/.claude/hooks/',
+      );
+      assert.ok(
+        applyJson.applied.settingsCodex.length > 0,
+        'applied.settingsCodex must list the registered events',
+      );
+    });
+  });
+});
+
+// fix #48 — the wiki-*.mjs → hypo-*.mjs rename migration (§8.6 line 1103) must
+// mirror onto ~/.codex/settings.json too. Simulates a v1.0/v1.1 codex user whose
+// codex settings carries a legacy `wiki-shared.mjs` reference: `upgrade --apply
+// --codex` should rewrite the command and copy the renamed hook into ~/.codex/hooks/.
+test('upgrade-codex-core-hooks-mirror: wiki-*.mjs → hypo-*.mjs rename on codex side', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-git-init', '--codex'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init --codex failed: ${initR.stderr}`);
+
+      // Plant the legacy state: a wiki-shared.mjs file in ~/.codex/hooks/ AND a
+      // settings.json entry that still references it. The fresh init carried the
+      // new hypo-shared.mjs reference — we replace it with the legacy command so
+      // the rename detector has work to do.
+      const cdxHooks = join(home, '.codex', 'hooks');
+      const cdxSettingsPath = join(home, '.codex', 'settings.json');
+      writeFileSync(join(cdxHooks, 'wiki-shared.mjs'), '// legacy v1.1 codex hook\n');
+
+      const cfg = JSON.parse(readFileSync(cdxSettingsPath, 'utf-8'));
+      // Pick an event the legacy hook would actually have appeared in (any one is
+      // fine — the rename scan walks every event).
+      const eventName = Object.keys(cfg.hooks || {})[0] || 'SessionStart';
+      cfg.hooks = cfg.hooks || {};
+      cfg.hooks[eventName] = cfg.hooks[eventName] || [];
+      cfg.hooks[eventName].push({
+        hooks: [{ type: 'command', command: 'node $HOME/.codex/hooks/wiki-shared.mjs' }],
+      });
+      writeFileSync(cdxSettingsPath, JSON.stringify(cfg, null, 2) + '\n');
+
+      // dry-run --codex must surface the codex-side legacy reference.
+      const rCheck = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--codex', '--json'],
+        home,
+      );
+      assert.equal(rCheck.status, 1, 'codex legacy hook ref must exit 1 in dry-run');
+      const checkJson = JSON.parse(rCheck.stdout);
+      assert.ok(
+        Array.isArray(checkJson.oldHookRefsCodex) &&
+          checkJson.oldHookRefsCodex.some((r) => r.oldName === 'wiki-shared.mjs'),
+        'oldHookRefsCodex must include the legacy wiki-shared.mjs reference',
+      );
+
+      // apply: the rename rewrites the command AND the renamed hook file appears
+      // in ~/.codex/hooks/ (mirrors the claude-side behaviour at upgrade.mjs:386-394).
+      const rApply = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex', '--json'],
+        home,
+      );
+      assert.equal(rApply.status, 0, `upgrade --apply --codex failed: ${rApply.stderr}`);
+      const applyJson = JSON.parse(rApply.stdout);
+      assert.ok(
+        applyJson.applied.hookNameRenamesCodex.some((r) =>
+          r.includes('wiki-shared.mjs → hypo-shared.mjs'),
+        ),
+        'applied.hookNameRenamesCodex must list the rename',
+      );
+
+      const cfgAfter = JSON.parse(readFileSync(cdxSettingsPath, 'utf-8'));
+      const allCmds = Object.values(cfgAfter.hooks || {})
+        .flatMap((groups) => groups)
+        .flatMap((g) => g.hooks || [])
+        .map((h) => h.command || '');
+      assert.ok(
+        !allCmds.some((c) => c.includes('wiki-shared.mjs')),
+        'no codex settings entry must still reference wiki-shared.mjs after apply',
+      );
+      assert.ok(
+        allCmds.some((c) => c.includes('$HOME/.codex/hooks/hypo-shared.mjs')),
+        'codex settings must now reference $HOME/.codex/hooks/hypo-shared.mjs',
+      );
+      assert.ok(
+        existsSync(join(cdxHooks, 'hypo-shared.mjs')),
+        'renamed hypo-shared.mjs must exist in ~/.codex/hooks',
+      );
+    });
+  });
+});
+
+// fix #48 BLOCKER (codex 2-worker pre-commit review, 2026-05-23): the precheck
+// list from checkSettingsJson can become stale when applyHookNameMigration
+// rewrites a legacy `wiki-*.mjs` command to its modern `hypo-*.mjs` form between
+// the two passes. Without the per-entry re-check that applySettingsJson now
+// performs, the apply pass would append a duplicate hypo-*.mjs entry on top of
+// the just-renamed command. Both workers independently reproduced 11 duplicate
+// registrations on a wiki-only codex settings file — same silent-corruption
+// pattern as fix #47.
+test('upgrade-codex-core-hooks-mirror: legacy wiki-only settings yields no duplicate registrations', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-git-init', '--codex'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init --codex failed: ${initR.stderr}`);
+
+      const cdxSettingsPath = join(home, '.codex', 'settings.json');
+
+      // Force a fully-legacy codex state: rewrite every hypo-*.mjs command in
+      // codex settings to its wiki-*.mjs predecessor. After this step the codex
+      // settings file is in the shape a v1.0/v1.1 user upgrading to v1.2 would
+      // have (no hypo-* references at all).
+      const cfg = JSON.parse(readFileSync(cdxSettingsPath, 'utf-8'));
+      const rewriteMap = {
+        'hypo-session-start.mjs': 'wiki-session-start.mjs',
+        'hypo-first-prompt.mjs': 'wiki-first-prompt.mjs',
+        'hypo-lookup.mjs': 'wiki-lookup.mjs',
+        'hypo-compact-guard.mjs': 'wiki-compact-guard.mjs',
+        'hypo-auto-stage.mjs': 'wiki-auto-stage.mjs',
+        'hypo-hot-rebuild.mjs': 'wiki-hot-rebuild.mjs',
+        'hypo-auto-commit.mjs': 'wiki-auto-commit.mjs',
+        'hypo-cwd-change.mjs': 'wiki-cwd-change.mjs',
+        'hypo-file-watch.mjs': 'wiki-file-watch.mjs',
+        'hypo-personal-check.mjs': 'personal-wiki-check.mjs',
+      };
+      for (const groups of Object.values(cfg.hooks || {})) {
+        for (const g of Array.isArray(groups) ? groups : []) {
+          for (const h of g.hooks || []) {
+            for (const [modern, legacy] of Object.entries(rewriteMap)) {
+              if ((h.command || '').includes(modern)) {
+                h.command = h.command.replace(modern, legacy);
+              }
+            }
+          }
+        }
+      }
+      writeFileSync(cdxSettingsPath, JSON.stringify(cfg, null, 2) + '\n');
+
+      // dry-run --codex must report the legacy refs (the wiki-only state is
+      // genuine drift). checkSettingsJson may also report the modern names as
+      // "missing" — that is exactly the stale-precheck shape that needs to be
+      // self-healed at apply time.
+      const rCheck = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--codex', '--json'],
+        home,
+      );
+      assert.equal(rCheck.status, 1, 'wiki-only codex settings must exit 1 in dry-run');
+      const checkJson = JSON.parse(rCheck.stdout);
+      assert.ok(
+        checkJson.oldHookRefsCodex.length >= Object.keys(rewriteMap).length,
+        'every legacy ref must be detected in oldHookRefsCodex',
+      );
+
+      // apply --codex: the rename rewrites every wiki-* → hypo-*. Without the
+      // BLOCKER fix, applySettingsJson would then append a SECOND hypo-* entry
+      // for every event (its precheck saw "missing"). With the fix it must
+      // self-heal and produce exactly one entry per registration.
+      const rApply = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex', '--json'],
+        home,
+      );
+      assert.equal(rApply.status, 0, `upgrade --apply --codex failed: ${rApply.stderr}`);
+
+      const cfgAfter = JSON.parse(readFileSync(cdxSettingsPath, 'utf-8'));
+      const cmdCounts = new Map();
+      for (const groups of Object.values(cfgAfter.hooks || {})) {
+        for (const g of Array.isArray(groups) ? groups : []) {
+          for (const h of g.hooks || []) {
+            const cmd = h.command || '';
+            cmdCounts.set(cmd, (cmdCounts.get(cmd) || 0) + 1);
+          }
+        }
+      }
+      const duplicates = [...cmdCounts.entries()].filter(([, n]) => n > 1);
+      assert.equal(
+        duplicates.length,
+        0,
+        `no codex settings command must appear twice after apply — found duplicates: ${JSON.stringify(duplicates)}`,
+      );
+      // And every modern hook from rewriteMap must appear exactly once.
+      for (const modern of Object.keys(rewriteMap)) {
+        const count = [...cmdCounts.keys()].filter((c) => c.includes(modern)).length;
+        assert.equal(
+          count,
+          1,
+          `${modern} must appear exactly once in codex settings (saw ${count})`,
+        );
+      }
+      // No legacy wiki-*.mjs reference may survive (round-2 worker 1 NIT) — a
+      // mutation that drops one rename step would leave a legacy command in
+      // place AND append the modern one; the duplicate-only check misses that.
+      for (const legacy of Object.values(rewriteMap)) {
+        const lingering = [...cmdCounts.keys()].filter((c) => c.includes(legacy));
+        assert.equal(
+          lingering.length,
+          0,
+          `no legacy ${legacy} reference must survive apply (found: ${JSON.stringify(lingering)})`,
+        );
+      }
+
+      // Idempotency: a second --apply --codex syncs nothing new on top.
+      const rAgain = runWithHome(
+        'upgrade.mjs',
+        [`--hypo-dir=${hypoDir}`, '--apply', '--codex', '--json'],
+        home,
+      );
+      assert.equal(rAgain.status, 0, `second --apply --codex failed: ${rAgain.stderr}`);
+      const againJson = JSON.parse(rAgain.stdout);
+      assert.equal(
+        againJson.applied.settingsCodex.length,
+        0,
+        'idempotent re-apply must not add any codex settings entry',
+      );
+      assert.equal(
+        againJson.applied.hookNameRenamesCodex.length,
+        0,
+        'idempotent re-apply must not re-trigger any codex hook rename',
+      );
+    });
+  });
+});
+
 // §8.12 (7) doctor extensions integrity (fix #33, ADR 0024 E5). Detects
 // (a) hard-copy SHA mismatch, (b) settings-entry mismatch + orphan, (c) manifest
 // missing (warn) / malformed (fail). Malformed = FAIL is what makes doctor's
@@ -3003,11 +3406,7 @@ test('extensions-settings-mixed-group: foreign sibling preserved, our hook in-pl
         matcher: 'Write|Edit',
         timeout: 10000,
       });
-      const r1 = runWithHome(
-        'upgrade.mjs',
-        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
-        home,
-      );
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
       assert.equal(r1.status, 0, `first apply: ${r1.stderr}`);
 
       // Inject foreign sibling into our matcher group.
@@ -3024,11 +3423,7 @@ test('extensions-settings-mixed-group: foreign sibling preserved, our hook in-pl
         matcher: 'Write|Edit',
         timeout: 20000,
       });
-      const r2 = runWithHome(
-        'upgrade.mjs',
-        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
-        home,
-      );
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
       assert.equal(r2.status, 0, `second apply: ${r2.stderr}`);
 
       const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
@@ -3046,8 +3441,7 @@ test('extensions-settings-mixed-group: foreign sibling preserved, our hook in-pl
       assert.equal(ours.timeout, 20000, 'our hook timeout patched in-place');
 
       const ourSingles = groups.filter(
-        (g) =>
-          g.hooks.length === 1 && (g.hooks[0].command || '').includes('hypo-ext-mixed.mjs'),
+        (g) => g.hooks.length === 1 && (g.hooks[0].command || '').includes('hypo-ext-mixed.mjs'),
       );
       assert.equal(ourSingles.length, 0, 'no duplicate single-hook group appended');
     });
@@ -3086,8 +3480,7 @@ test('extensions-settings-mixed-group: matcher change extracts our hook, foreign
       const groups = after.hooks.PostToolUse || [];
 
       const foreignGroup = groups.find(
-        (g) =>
-          g.hooks.length === 1 && g.hooks[0].command === 'node /other/plugin/hook.mjs',
+        (g) => g.hooks.length === 1 && g.hooks[0].command === 'node /other/plugin/hook.mjs',
       );
       assert.ok(foreignGroup, 'foreign hook left behind in its own single-hook group');
       assert.equal(
@@ -3097,9 +3490,7 @@ test('extensions-settings-mixed-group: matcher change extracts our hook, foreign
       );
 
       const ourGroup = groups.find(
-        (g) =>
-          g.hooks.length === 1 &&
-          (g.hooks[0].command || '').includes('hypo-ext-matcher.mjs'),
+        (g) => g.hooks.length === 1 && (g.hooks[0].command || '').includes('hypo-ext-matcher.mjs'),
       );
       assert.ok(ourGroup, 'our hook extracted into new single-hook group');
       assert.equal(ourGroup.matcher, 'Edit', 'our new group adopts the manifest matcher');
@@ -3140,19 +3531,13 @@ test('extensions-settings-mixed-group: event change extracts our hook, foreign k
       const pre = after.hooks.PreToolUse || [];
 
       const foreignGroup = post.find(
-        (g) =>
-          g.hooks.length === 1 && g.hooks[0].command === 'node /other/plugin/hook.mjs',
+        (g) => g.hooks.length === 1 && g.hooks[0].command === 'node /other/plugin/hook.mjs',
       );
-      assert.ok(
-        foreignGroup,
-        'foreign hook stays under PostToolUse with the original matcher',
-      );
+      assert.ok(foreignGroup, 'foreign hook stays under PostToolUse with the original matcher');
       assert.equal(foreignGroup.matcher, 'Write');
 
       const ourGroup = pre.find(
-        (g) =>
-          g.hooks.length === 1 &&
-          (g.hooks[0].command || '').includes('hypo-ext-event.mjs'),
+        (g) => g.hooks.length === 1 && (g.hooks[0].command || '').includes('hypo-ext-event.mjs'),
       );
       assert.ok(ourGroup, 'our hook moved to PreToolUse single-hook group');
       assert.equal(ourGroup.matcher, 'Write');
@@ -3191,24 +3576,19 @@ test('extensions-settings-multi-occurrence-cleanup: duplicate single + mixed con
           { type: 'command', command: 'node /other/plugin/hook.mjs' },
           {
             type: 'command',
-            command: settings.hooks.PostToolUse[
-              settings.hooks.PostToolUse.findIndex((g) =>
-                (g.hooks || []).some((h) =>
-                  (h.command || '').includes('hypo-ext-dup.mjs'),
-                ),
-              )
-            ].hooks[0].command,
+            command:
+              settings.hooks.PostToolUse[
+                settings.hooks.PostToolUse.findIndex((g) =>
+                  (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-dup.mjs')),
+                )
+              ].hooks[0].command,
             timeout: 9999,
           },
         ],
       });
       writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 
-      const r = runWithHome(
-        'upgrade.mjs',
-        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
-        home,
-      );
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
       assert.equal(r.status, 0, `apply failed: ${r.stderr}`);
 
       const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
@@ -3255,11 +3635,7 @@ test('extensions-settings-mixed-group-idempotent: second --apply over a mixed-gr
       runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
       const before = readFileSync(settingsPath, 'utf-8');
 
-      const r2 = runWithHome(
-        'upgrade.mjs',
-        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
-        home,
-      );
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
       assert.equal(r2.status, 0, `idempotent apply: ${r2.stderr}`);
       const after = readFileSync(settingsPath, 'utf-8');
       assert.equal(after, before, 'second apply drifted the file (not byte-equal)');
@@ -3290,11 +3666,7 @@ test('extensions-settings-cleanup-shift: same-event lower-index duplicate remova
         matcher: 'Write',
         timeout: 10000,
       });
-      const r1 = runWithHome(
-        'upgrade.mjs',
-        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
-        home,
-      );
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
       assert.equal(r1.status, 0, `first apply: ${r1.stderr}`);
 
       // Hand-corrupt: build a settings.json with [corrupt-ours-mixed, canonical-
@@ -3334,11 +3706,7 @@ test('extensions-settings-cleanup-shift: same-event lower-index duplicate remova
       ];
       writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 
-      const r2 = runWithHome(
-        'upgrade.mjs',
-        [`--hypo-dir=${hypoDir}`, '--json', '--apply'],
-        home,
-      );
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
       assert.equal(r2.status, 0, `apply must not crash on cleanup-shift: ${r2.stderr}`);
 
       const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
@@ -3346,9 +3714,7 @@ test('extensions-settings-cleanup-shift: same-event lower-index duplicate remova
 
       // Foreign-only group survives, exactly as-is (no overwrite).
       const foreign = post.find(
-        (g) =>
-          g.hooks.length === 1 &&
-          g.hooks[0].command === 'node /foreign/keep.mjs',
+        (g) => g.hooks.length === 1 && g.hooks[0].command === 'node /foreign/keep.mjs',
       );
       assert.ok(foreign, 'foreign-only group must survive cleanup-shift');
       assert.equal(foreign.matcher, 'Read', 'foreign matcher untouched');


### PR DESCRIPTION
## Summary

- `init --codex` has always installed Hypomnema's core hooks into `~/.codex/hooks/` and registered them in `~/.codex/settings.json`, but `upgrade --codex` only mirrored user extensions (E4, fix #32). A v1.1.x → v1.2.0 codex user's core hooks therefore stayed stale until they re-ran `init`. fix #48 closes that gap so `upgrade --codex` covers core hooks + settings registration + the `wiki-*.mjs → hypo-*.mjs` rename migration on both targets in one pass.
- Six previously-claude-only helpers (`checkHookFiles` / `checkSettingsJson` / `applyHookFiles` / `applySettingsJson` / `checkOldHookNames` / `applyHookNameMigration`) take `(hooksDir, settingsPath)` arguments instead of hard-coding `~/.claude/{hooks,settings.json}`. JSON output gains `hooksCodex` / `settingsCodex` / `oldHookRefsCodex` plus `applied.{hooksCodex,settingsCodex,hookNameRenamesCodex}`. Human-readable report labels the new blocks `(codex)`. `hasDrift` and `totalDrift` only count the codex side when `--codex` is set (parity with the existing extensions pattern).
- **BLOCKER from codex 2-worker pre-commit review** (both workers independently reproduced 11 duplicate `hypo-*.mjs` entries on a wiki-only legacy codex settings file): the precheck list from `checkSettingsJson` can become stale by the time `applySettingsJson` runs, because `applyHookNameMigration` sits between the two and may have just rewritten a legacy `wiki-*.mjs` command to its modern `hypo-*.mjs` form. `applySettingsJson` now re-checks the current parsed settings for `s.cmd` before appending and skips if the entry is already present. The precheck list is allowed to be stale; the helper self-heals against on-disk truth. Same silent-corruption shape as fix #47.

## Test plan

- [x] `npm test` — 386 → 390 green, 4 new tests added (runner.mjs:2778/2879/2955/3037):
  - `upgrade-codex-core-hooks-mirror` — init --codex → stale codex hook → upgrade --apply --codex restores + idempotency.
  - `upgrade-codex-core-hooks-from-scratch` — init (no --codex) → upgrade --apply --codex installs `~/.codex/{hooks,settings.json}` from scratch.
  - `upgrade-codex-core-hooks-mirror: wiki-*.mjs → hypo-*.mjs rename on codex side` — codex settings ref rewrite + renamed file copy.
  - `upgrade-codex-core-hooks-mirror: legacy wiki-only settings yields no duplicate registrations` — the BLOCKER regression: a full wiki-only state through apply yields exactly one entry per modern hook AND no surviving legacy ref (round-2 worker 1 NIT).
- [x] `prettier --write scripts/upgrade.mjs tests/runner.mjs` clean.
- [x] codex 2-worker pre-commit review round 1: BLOCKER + CONCERN + 3 NIT — all addressed in this PR.
- [x] codex 2-worker pre-commit review round 2: BLOCKER 0, CONCERN 0, 1 NIT — addressed (post-apply legacy-ref absence assertion in test).
- [ ] Manual dogfood: simulate v1.1.x codex user → `hypomnema upgrade --apply --codex` → `hypomnema doctor` shows `fails:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)