### PR TITLE
fix(lint): emit W8 design-history-stale warning — fix #49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`lint` emits `W8` design-history-stale warning (fix #49).** The PreCompact
+  hook (`hypo-personal-check.mjs`) has filtered `lint --json` warns for
+  `id === 'W8'` since the initial OSS hook drop, but `scripts/lint.mjs` never
+  emitted that id — so `design-history.md` aging next to a fresher
+  `session-log.md` (or `session-log/YYYY-MM.md` directory layout) was silently
+  invisible to the gate. Lint now runs `findDesignHistoryStale()` once per
+  project (outside the page loop), and emits a `W8`-tagged warn per stale
+  project with a POSIX-separated `file` literal (`projects/<name>/design-history.md`)
+  so the consumer's `file.split('/')` contract stays portable. The JSON `warn`
+  shape gains an optional `id` field, omitted for legacy id-less warns.
 - **`hypomnema upgrade --codex` mirrors core hooks (fix #48).** `init --codex`
   has always installed Hypomnema's core hooks into `~/.codex/hooks/` and
   registered them in `~/.codex/settings.json`, but `upgrade` only mirrored

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -120,7 +120,7 @@ If you need to share new logic, prefer extending an existing helper over adding 
 
 ```bash
 npm test       # tests/runner.mjs — unit + smoke + contract tests
-npm run lint   # scripts/lint.mjs — frontmatter + wikilink validation
+npm run lint   # scripts/lint.mjs — frontmatter + wikilink validation + W8 (design-history stale vs session-log)
 ```
 
 The test runner uses only Node.js built-ins. Tests create scoped temp directories and clean up after themselves; you can run the suite without any environment setup.

--- a/scripts/lib/design-history-stale.mjs
+++ b/scripts/lib/design-history-stale.mjs
@@ -1,0 +1,83 @@
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+const SESSION_LOG_DATE_RE = /^## \[(\d{4}-\d{2}-\d{2})\]/gm;
+const DESIGN_HISTORY_DATE_RE = /^## (\d{4}-\d{2}-\d{2})/gm;
+
+function parseDates(text, pattern) {
+  const dates = [];
+  pattern.lastIndex = 0;
+  let m;
+  while ((m = pattern.exec(text)) !== null) {
+    // The regex matches digit-shaped YYYY-MM-DD literals but cannot reject
+    // semantically invalid ones like 2026-13-01 or 2026-02-30. JavaScript's
+    // Date constructor returns an Invalid Date for those, which would later
+    // crash `toISOString()` with RangeError and poison `>` comparisons inside
+    // maxDate. Filter at the parse boundary so callers never see one.
+    const d = new Date(m[1]);
+    if (!Number.isNaN(d.getTime())) dates.push(d);
+  }
+  return dates;
+}
+
+function maxDate(dates) {
+  if (dates.length === 0) return null;
+  return dates.reduce((a, b) => (a > b ? a : b));
+}
+
+// Returns stale findings: { project, lastSession, lastDesignHistory, diffDays }
+// Only includes projects where design-history.md exists AND is stale relative
+// to the latest session-log entry. Date source is body section headings
+// (## YYYY-MM-DD), not frontmatter `updated:` — auto-stage hooks bump the
+// frontmatter on unrelated edits, so it can't signal staleness on its own.
+export function findDesignHistoryStale(hypoDir) {
+  const stale = [];
+
+  const projectsDir = join(hypoDir, 'projects');
+  if (!existsSync(projectsDir)) return stale;
+
+  for (const name of readdirSync(projectsDir)) {
+    const projectDir = join(projectsDir, name);
+    if (!statSync(projectDir).isDirectory()) continue;
+
+    const dhPath = join(projectDir, 'design-history.md');
+    if (!existsSync(dhPath)) continue;
+
+    // session-log can live as a flat `session-log.md` (legacy) or a directory
+    // `session-log/YYYY-MM.md` (spec §5.2.7 canonical). Aggregate dates from
+    // whichever shape is present — both forms appear in the wild and the
+    // staleness check needs to see all of them.
+    const sessionDates = [];
+    const flatSlPath = join(projectDir, 'session-log.md');
+    if (existsSync(flatSlPath)) {
+      sessionDates.push(...parseDates(readFileSync(flatSlPath, 'utf-8'), SESSION_LOG_DATE_RE));
+    }
+    const dirSlPath = join(projectDir, 'session-log');
+    if (existsSync(dirSlPath) && statSync(dirSlPath).isDirectory()) {
+      for (const entry of readdirSync(dirSlPath)) {
+        if (!entry.endsWith('.md')) continue;
+        const text = readFileSync(join(dirSlPath, entry), 'utf-8');
+        sessionDates.push(...parseDates(text, SESSION_LOG_DATE_RE));
+      }
+    }
+    if (sessionDates.length === 0) continue;
+
+    const dhText = readFileSync(dhPath, 'utf-8');
+    const lastSession = maxDate(sessionDates);
+    const lastDH = maxDate(parseDates(dhText, DESIGN_HISTORY_DATE_RE));
+
+    if (!lastSession) continue;
+
+    if (!lastDH || lastSession > lastDH) {
+      const diffDays = lastDH ? Math.round((lastSession - lastDH) / (1000 * 60 * 60 * 24)) : null;
+      stale.push({
+        project: name,
+        lastSession: lastSession.toISOString().slice(0, 10),
+        lastDesignHistory: lastDH ? lastDH.toISOString().slice(0, 10) : '(없음)',
+        diffDays,
+      });
+    }
+  }
+
+  return stale;
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -19,6 +19,7 @@ import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import { parseSchemaVocab, checkForbidden, parseSchemaPageDirs } from './lib/schema-vocab.mjs';
+import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -197,8 +198,8 @@ const VALID_TYPES = [
 
 const issues = [];
 
-function issue(severity, rel, msg, fullPath = null) {
-  issues.push({ severity, file: rel, message: msg, path: fullPath });
+function issue(severity, rel, msg, fullPath = null, id = null) {
+  issues.push({ severity, file: rel, message: msg, path: fullPath, id });
 }
 
 function hasHeading(content, heading) {
@@ -349,6 +350,21 @@ const pageDirs = parseSchemaPageDirs(args.hypoDir);
 
 for (const page of pages) lintPage(page, slugMap, tagVocab, pageDirs);
 
+// W8: design-history.md stale relative to session-log.md. Emitted once per
+// project (not per page) — runs outside the page loop. POSIX-separated path
+// literal (not path.join) so consumers can rely on `file.split('/')` shape
+// regardless of host OS — `hooks/hypo-personal-check.mjs:246` depends on this.
+for (const s of findDesignHistoryStale(args.hypoDir)) {
+  const gap = s.diffDays != null ? ` (${s.diffDays}일 차이)` : '';
+  issue(
+    'warn',
+    `projects/${s.project}/design-history.md`,
+    `design-history stale: session-log 최신=${s.lastSession} > design-history 최신=${s.lastDesignHistory}${gap} — projects/${s.project}/design-history.md에 설계 변경 사항을 append 하세요`,
+    null,
+    'W8',
+  );
+}
+
 if (args.fix) {
   const today = new Date().toISOString().slice(0, 10);
   const fixed = new Set();
@@ -392,7 +408,8 @@ const errors = issues.filter((i) => i.severity === 'error');
 const warns = issues.filter((i) => i.severity === 'warn');
 
 if (args.json) {
-  const toOut = ({ severity, file, message }) => ({ severity, file, message });
+  const toOut = ({ severity, file, message, id }) =>
+    id ? { severity, file, message, id } : { severity, file, message };
   console.log(
     JSON.stringify(
       {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -8351,6 +8351,186 @@ test('replay-post-tool-use-rejects-non-http-schemes: file:// / ftp:// / data: �
   }
 });
 
+// ── fix #49: lint W8 design-history stale emit ───────────────────────────────
+
+const { findDesignHistoryStale } = await import(`${SCRIPTS}/lib/design-history-stale.mjs`);
+
+function setupDhProject(root, name, { dh, sessionLogMd, sessionLogDir }) {
+  const dir = join(root, 'projects', name);
+  mkdirSync(dir, { recursive: true });
+  if (dh != null) writeFileSync(join(dir, 'design-history.md'), dh);
+  if (sessionLogMd != null) writeFileSync(join(dir, 'session-log.md'), sessionLogMd);
+  if (sessionLogDir) {
+    const slDir = join(dir, 'session-log');
+    mkdirSync(slDir, { recursive: true });
+    for (const [fname, body] of Object.entries(sessionLogDir)) {
+      writeFileSync(join(slDir, fname), body);
+    }
+  }
+}
+
+suite('fix #49: findDesignHistoryStale()');
+
+test('w8-stale: flat session-log.md newer than design-history → stale', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'p1', {
+      dh: '---\ntitle: dh\n---\n\n## 2026-05-10\nfoo\n',
+      sessionLogMd: '## [2026-05-20] session\nbar\n',
+    });
+    const stale = findDesignHistoryStale(root);
+    assert.equal(stale.length, 1);
+    assert.equal(stale[0].project, 'p1');
+    assert.equal(stale[0].lastSession, '2026-05-20');
+    assert.equal(stale[0].lastDesignHistory, '2026-05-10');
+    assert.equal(stale[0].diffDays, 10);
+  });
+});
+
+test('w8-stale: directory session-log/YYYY-MM.md aggregated across files', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'p2', {
+      dh: '## 2026-04-01\nfoo\n',
+      sessionLogDir: {
+        '2026-04.md': '## [2026-04-15] s\n',
+        '2026-05.md': '## [2026-05-22] s\n',
+      },
+    });
+    const stale = findDesignHistoryStale(root);
+    assert.equal(stale.length, 1);
+    assert.equal(stale[0].lastSession, '2026-05-22');
+  });
+});
+
+test('w8-clean: session-log older than design-history → no emit', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'p3', {
+      dh: '## 2026-05-22\nfoo\n',
+      sessionLogMd: '## [2026-05-10] s\n',
+    });
+    assert.equal(findDesignHistoryStale(root).length, 0);
+  });
+});
+
+test('w8-skip: project without design-history.md is skipped', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'p4', { sessionLogMd: '## [2026-05-20] s\n' });
+    assert.equal(findDesignHistoryStale(root).length, 0);
+  });
+});
+
+test('w8-skip: project without any session-log (file or dir) is skipped', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'p5', { dh: '## 2026-05-10\nfoo\n' });
+    assert.equal(findDesignHistoryStale(root).length, 0);
+  });
+});
+
+test('w8-edge: design-history body has no date heading → stale, diffDays=null', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'p6', {
+      dh: '---\ntitle: dh\nupdated: 2026-05-22\n---\n\nNo date headings here.\n',
+      sessionLogMd: '## [2026-05-20] s\n',
+    });
+    const stale = findDesignHistoryStale(root);
+    assert.equal(stale.length, 1);
+    assert.equal(stale[0].lastDesignHistory, '(없음)');
+    assert.equal(stale[0].diffDays, null);
+  });
+});
+
+test('w8-edge: invalid date headings (## [2026-13-01]) are filtered, no Invalid Date crash', () => {
+  // codex 2-worker pre-commit review CONCERN: `new Date('2026-13-01')` is an
+  // Invalid Date and `toISOString()` on it throws RangeError. Guarantee the
+  // parser silently drops malformed dates instead of crashing all of lint.
+  withTmpDir((root) => {
+    setupDhProject(root, 'p8', {
+      dh: '## 2026-05-10\nfoo\n',
+      sessionLogMd: '## [2026-13-01] bogus\n## [2026-05-20] real\n',
+    });
+    const stale = findDesignHistoryStale(root);
+    assert.equal(stale.length, 1);
+    assert.equal(stale[0].lastSession, '2026-05-20');
+  });
+});
+
+test('w8-edge: design-history with only invalid dates → stale with diffDays=null', () => {
+  // Use month-out-of-range (truly Invalid Date in JS); JS auto-normalizes
+  // overflows in the day field (2026-02-30 → 2026-03-02) but ISO 8601 strict
+  // parsing rejects month > 12 with NaN — that is the path findDesignHistoryStale
+  // must filter to avoid poisoning maxDate.
+  withTmpDir((root) => {
+    setupDhProject(root, 'p9', {
+      dh: '## 2026-13-01\ninvalid only\n',
+      sessionLogMd: '## [2026-05-20] s\n',
+    });
+    const stale = findDesignHistoryStale(root);
+    assert.equal(stale.length, 1);
+    assert.equal(stale[0].lastDesignHistory, '(없음)');
+    assert.equal(stale[0].diffDays, null);
+  });
+});
+
+test('w8-edge: frontmatter updated newer than body date → still stale on body comparison', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'p7', {
+      dh: '---\nupdated: 2026-05-25\n---\n\n## 2026-05-10\nfoo\n',
+      sessionLogMd: '## [2026-05-20] s\n',
+    });
+    const stale = findDesignHistoryStale(root);
+    assert.equal(stale.length, 1);
+    assert.equal(stale[0].lastDesignHistory, '2026-05-10');
+  });
+});
+
+suite('fix #49: lint.mjs --json W8 wiring');
+
+test('w8-lint-emits-id-and-posix-file-in-json', () => {
+  withTmpDir((root) => {
+    setupDhProject(root, 'demo', {
+      dh: '## 2026-05-10\nfoo\n',
+      sessionLogMd: '## [2026-05-20] s\n',
+    });
+    // pages/ scan dir is required by lint.mjs even if empty
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${root}`, '--json'],
+      {
+        encoding: 'utf-8',
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    const parsed = JSON.parse(r.stdout);
+    const w8 = (parsed.warns || []).filter((w) => w.id === 'W8');
+    assert.equal(w8.length, 1, `expected one W8 warn, got: ${JSON.stringify(parsed.warns)}`);
+    assert.equal(w8[0].file, 'projects/demo/design-history.md');
+    assert.ok(w8[0].message.includes('design-history stale'));
+    assert.equal(w8[0].id, 'W8');
+  });
+});
+
+test('w8-lint-omits-id-for-other-warns', () => {
+  withTmpDir((root) => {
+    // page with frontmatter missing `updated` field → W warn without id
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(join(root, 'pages', 'a.md'), '---\ntitle: a\ntype: concept\n---\n\nbody\n');
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${root}`, '--json'],
+      {
+        encoding: 'utf-8',
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    const parsed = JSON.parse(r.stdout);
+    const nonId = (parsed.warns || []).filter((w) => !('id' in w));
+    assert.ok(
+      nonId.length >= 1,
+      `expected non-W8 warns to omit id field: ${JSON.stringify(parsed.warns)}`,
+    );
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
## Summary

- `hooks/hypo-personal-check.mjs` filtered `lint --json warns[].id==='W8'` since the initial OSS hook drop, but `scripts/lint.mjs` never produced that id — `design-history.md` aging next to a fresher session-log was silently invisible to the PreCompact gate.
- Port `findDesignHistoryStale()` into `scripts/lib/design-history-stale.mjs` (pure function, no CLI), wire it into `lint.mjs` outside the page loop, and emit one POSIX-pathed warn per stale project. `issue()`/`toOut` gain an optional `id` field — legacy id-less warns keep their three-key JSON shape.
- Supports both legacy `session-log.md` and the canonical `session-log/YYYY-MM.md` directory layout (spec §5.2.7). Filters syntactically-shaped but semantically-invalid dates (month > 12) at the parse boundary to avoid `toISOString()` RangeError — codex 2-worker pre-commit review convergence.

## Background

Discovered as a follow-up of fix #7 (vault DEFAULT_WIKI_ROOT drift): the vault's `session-close-guard.mjs` carried the staleness logic but its CLI mode had zero callers (vault has no `.git/hooks/pre-commit` installed), and the OSS consumer side has had a dead `w.id === 'W8'` filter the whole time. This PR makes the consumer path actually fire. Vault `session-close-guard.mjs` removal is intentionally out of scope (`~/.claude/settings.local.json` still names it in a permission allowlist — separate follow-up).

## Pre-implementation review (codex 1-worker)

OK with one CONCERN — POSIX `file` literal (reflected). Recommended adding "id survives JSON" and "frontmatter newer than body date" tests (both included).

## Pre-commit review (codex 2-worker)

OK with one CONCERN, both workers converged: `new Date('2026-13-01')` is Invalid Date and `toISOString()` throws RangeError — could crash all of lint if any malformed heading slipped in. Fixed at the parse boundary with `Number.isNaN(d.getTime())` filter; two regression tests added.

## Test plan

- [x] `npm test` — 400 passed (+11 from fix #49, baseline 389). The one unrelated failure (`probe (#39)`) is a hardcoded-date fixture on `main` and not caused by this change.
- [x] `npx prettier --check` — clean.
- [x] Vault smoke: `node scripts/lint.mjs --hypo-dir=$HOME/hypomnema --json` emits exactly one W8 warn matching the consumer contract (`{id:'W8', file:'projects/hypomnema/design-history.md', message:...}`).
- [ ] Reviewer: confirm `hooks/hypo-personal-check.mjs:122,246` consumer behaviour is unchanged once a W8 warn is observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)