### PR TITLE
fix(test): align withWiki() fixture date to local time — fix #39 flake

### DIFF
--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -737,6 +737,18 @@ function runHook(hookFile, stdinData, extraEnv = {}) {
   });
 }
 
+// Local-date "today" matching scripts/crystallize.mjs's todayLocal(). The
+// session-close fixture models files Claude writes (session-state, project
+// hot.md, root hot.md, session-log, log.md) — those are user-facing wiki
+// content keyed to the harness's local `currentDate`. Using toISOString()
+// (UTC) here flakes in KST early morning, where the fixture stamps yesterday
+// (UTC) but crystallize returns today (local). See learnings/hook-utc-date-
+// vs-local-file-dates.md and fix #39.
+function todayLocal() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
 // Build a fully session-closed wiki tree: root hot.md + log.md plus the 4
 // project memory files (session-state, project hot.md, session-log) all
 // carrying today's date. Mirrors the strict session-close gate (5 mandatory
@@ -774,7 +786,7 @@ function buildCleanWikiTree(dir, today) {
 function withWiki(mutate, fn) {
   const dir = mkdtempSync(join(tmpdir(), 'hypo-wiki-'));
   try {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayLocal();
     buildCleanWikiTree(dir, today);
     if (mutate) mutate(dir, today);
     spawnSync('git', ['init'], { cwd: dir, encoding: 'utf-8' });


### PR DESCRIPTION
## Root cause

`tests/runner.mjs:withWiki()` computed the fixture date with `new Date().toISOString().slice(0,10)` (UTC), while `scripts/crystallize.mjs` defaults `payload.date` via `todayLocal()` (local `getFullYear/getMonth/getDate`).

In KST early morning (UTC+9, local 00:00–09:00), UTC is still the previous day. The fixture files were stamped `2026-05-23` (UTC) but `crystallize.mjs` returned `out.date = '2026-05-24'` (local), causing `assert.equal(out.date, today)` to fail.

Prior art: `~/hypomnema/pages/learnings/hook-utc-date-vs-local-file-dates.md` documents this exact UTC/local schism — "Claude harness `currentDate` = local; `toISOString()` = UTC; files Claude writes use local date."

## Chosen approach

**Option A**: Align `withWiki()` test fixture to local date.

Rationale:
- The fixture models files **Claude writes** (session-state, hot.md, session-log, log.md) — user-facing wiki content keyed to the harness's local `currentDate`.
- `crystallize.mjs` is the production code under test; its `todayLocal()` is the contract. The fixture must match it, not the other way around.
- Changing `crystallize.mjs` to UTC would alter wiki frontmatter `updated:` fields — bigger blast radius, contradicts the documented convention.
- The `feedback.mjs` test at line 8112 is intentionally left UTC — `feedback.mjs` stamps UTC and its assertion must match.

## Change

- Add `todayLocal()` helper in `tests/runner.mjs` (byte-for-byte equivalent to `scripts/crystallize.mjs:todayLocal()`).
- Replace `new Date().toISOString().slice(0,10)` in `withWiki()` with `todayLocal()`.
- 2 codex pre-implementation reviews (both LGTM, no blocking concerns).

## Test plan

- [ ] `npm test` → 401 passed, 0 failed
- [ ] `npx prettier --check tests/runner.mjs` → clean
- [ ] Verify test `probe (#39): no payload + gate ok → exit 0 with alreadyComplete` passes
- [ ] Confirm `feedback.mjs` test still uses UTC (no regression in opposite direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)