### PR TITLE
fix(extensions): doctor canonical-pick mirror + parseManifest empty matcher — fix #47 follow-up

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -27,6 +27,7 @@ import {
   buildExpectedSettingsEntries,
   readExtensionPkgStateNoMutate,
   collectOurOccurrences,
+  pickCanonicalOccurrence,
   EXT_TYPES,
   CODEX_TYPES,
 } from './lib/extensions.mjs';
@@ -770,15 +771,21 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
   if (!settingsParseFailed) {
     const expected = buildExpectedSettingsEntries(discovered.hooks, hooksDir);
 
-    // (b) for each registrable hook: locate any occurrence of our command
-    // (single-hook OR mixed group, fix #47) and compare against the manifest-
-    // derived shape. Three outcomes:
-    //   - no occurrence in any event → warn `not registered` (run upgrade --apply)
-    //   - occurrence in wrong event → warn `not registered under <event>` (run upgrade --apply)
-    //   - occurrence in target event but our hook entry or group matcher drifts
-    //     from the manifest → warn `settings entry differs` (run upgrade --apply)
-    // upgrade --apply self-heals all three via registerSettings' 8-priority
-    // canonical pass, so doctor is the only surface that reports it.
+    // (b) for each registrable hook: locate every occurrence of our command
+    // (single-hook OR mixed group, fix #47) and pick the canonical via the
+    // SAME 8-rank logic registerSettings uses (fix #47 follow-up, CONCERN 1).
+    // Without this mirror, doctor picked the first traversal-order occurrence
+    // under the target event and warned "differs" even when a later
+    // occurrence was the rank-1 canonical that upgrade --apply silently
+    // accepts — a confusing gap between report and action.
+    //
+    // Outcomes:
+    //   - no occurrence in any event       → warn `not registered`
+    //   - canonical on a non-target event  → warn `not registered under <event>`
+    //   - canonical rank 1/2 (exact)       → no drift; pass through
+    //     (ext-command duplicates are surfaced separately below — core
+    //     duplicate-warn at line ~344 excludes hypo-ext-* on purpose)
+    //   - canonical rank 3/4/5 on target   → warn `settings entry differs`
     //
     // Mixed-group: a foreign sibling sharing our matcher group does NOT itself
     // count as drift — only our own hook fields ({type, command, timeout?}) and
@@ -787,27 +794,37 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
     for (const entry of expected) {
       const desiredHook = { type: 'command', command: entry.command };
       if (entry.timeout) desiredHook.timeout = entry.timeout;
-      const desiredMatcher = entry.matcher;
 
       const occurrences = collectOurOccurrences(hooksObj, entry.command);
-      const targetOccurrence = occurrences.find((o) => o.event === entry.event);
-      if (!targetOccurrence) {
+      const picked = pickCanonicalOccurrence(occurrences, entry, desiredHook);
+      if (!picked) {
         problems.push({
           severity: 'warn',
           msg: `${entry.name} not registered under ${entry.event} — run upgrade --apply`,
         });
         continue;
       }
-      const groupMatcher = targetOccurrence.group.matcher;
-      const matcherMatches =
-        (groupMatcher === undefined || groupMatcher === null ? undefined : groupMatcher) ===
-        (desiredMatcher === undefined || desiredMatcher === null ? undefined : desiredMatcher);
-      const hookExact =
-        JSON.stringify(targetOccurrence.hook) === JSON.stringify(desiredHook);
-      if (!matcherMatches || !hookExact) {
+      if (picked.occ.event !== entry.event) {
+        problems.push({
+          severity: 'warn',
+          msg: `${entry.name} not registered under ${entry.event} — run upgrade --apply`,
+        });
+      } else if (picked.rank >= 3) {
+        // ranks 3/4/5 — on target event, but hook or matcher drifted.
         problems.push({
           severity: 'warn',
           msg: `${entry.name} settings entry differs from manifest (matcher/timeout) — run upgrade --apply`,
+        });
+      }
+      // ext-aware duplicate surface: core duplicate-warn at checkSettingsJson
+      // intentionally skips hypo-ext-* (line ~353 isExtCommand guard). With
+      // the canonical-pick above, exact rank-1 duplicates would otherwise be
+      // invisible to doctor until upgrade --apply runs cleanup. Surface them
+      // here so the report still names the work that --apply will do.
+      if (occurrences.length > 1) {
+        problems.push({
+          severity: 'warn',
+          msg: `${entry.name} has ${occurrences.length} occurrences in settings — run upgrade --apply to clean up`,
         });
       }
     }

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -168,6 +168,17 @@ export function parseManifest(path) {
   if (m.timeout !== undefined && (typeof m.timeout !== 'number' || m.timeout <= 0)) {
     return { ok: false, error: 'timeout must be a positive number' };
   }
+  // Boundary normalization (fix #47 follow-up, CONCERN 2): `matcher: ""` is a
+  // valid string per the type check above, but every downstream call site
+  // disagrees on what it means — `if (entry.matcher)` (line ~641) silently
+  // drops it from desiredGroup, while rankOccurrence's null/undefined→undef
+  // coercion (line ~571) compares "" against undefined as mismatch. Normalize
+  // here so every consumer (rank, registerSettings, doctor) sees a single
+  // representation: empty matcher === absent matcher.
+  if (m.matcher === '') {
+    m = { ...m };
+    delete m.matcher;
+  }
   return { ok: true, manifest: m, registrable: true };
 }
 
@@ -563,7 +574,12 @@ export function collectOurOccurrences(hooks, command) {
 // Rank an occurrence against the desired entry. Lower = preferred canonical.
 // See registerSettings docstring for the 8-step table (ranks 1-7 here; 8 is
 // "no occurrence found" handled by the caller).
-function rankOccurrence(occ, entry, desiredHook) {
+//
+// Exported (fix #47 follow-up) so `scripts/doctor.mjs` can mirror the write-
+// path canonical selection rather than picking the first traversal-order
+// occurrence — otherwise doctor warns "differs" on a drifted earlier match
+// while upgrade --apply silently accepts a rank-1 later one.
+export function rankOccurrence(occ, entry, desiredHook) {
   const onTarget = occ.event === entry.event;
   const groupMatcher = occ.group.matcher;
   const matcherMatches =
@@ -577,6 +593,33 @@ function rankOccurrence(occ, entry, desiredHook) {
   if (matcherMatches && hookExact) return 2;
   if (matcherMatches) return 4;
   return 5;
+}
+
+/**
+ * Pick the canonical occurrence for `entry` from `occurrences`, mirroring the
+ * write-path selection in registerSettings (lowest rank wins; ties break by
+ * settings traversal order — assumes the caller passed `collectOurOccurrences`
+ * output, which traverses events + groups + hooks in JSON key/array order).
+ * Returns `{ occ, rank } | null`.
+ *
+ * Exported so doctor reports drift against the SAME occurrence that
+ * upgrade --apply will treat as canonical — otherwise an earlier drifted
+ * occurrence would be flagged "differs" while a later exact occurrence is the
+ * actual canonical. Note: rank 1/2 means the canonical SHAPE is accepted, but
+ * upgrade --apply may still rewrite settings.json to remove non-canonical
+ * duplicates (doctor also surfaces `occurrences.length > 1` for that reason).
+ */
+export function pickCanonicalOccurrence(occurrences, entry, desiredHook) {
+  let canonical = null;
+  let canonicalRank = Infinity;
+  for (const occ of occurrences) {
+    const r = rankOccurrence(occ, entry, desiredHook);
+    if (r < canonicalRank) {
+      canonicalRank = r;
+      canonical = occ;
+    }
+  }
+  return canonical ? { occ: canonical, rank: canonicalRank } : null;
 }
 
 // Locate a matcher-group object reference inside the settings.hooks tree.
@@ -649,16 +692,11 @@ function registerSettings(settingsPath, expectedEntries, apply) {
     const occurrences = collectOurOccurrences(settings.hooks, entry.command);
 
     // 2. rank + pick canonical (lowest rank; first occurrence in traversal
-    //    order wins on tie because `<` is strict).
-    let canonical = null;
-    let canonicalRank = Infinity;
-    for (const occ of occurrences) {
-      const r = rankOccurrence(occ, entry, desiredHook);
-      if (r < canonicalRank) {
-        canonicalRank = r;
-        canonical = occ;
-      }
-    }
+    //    order wins on tie because `<` is strict). Doctor uses the same
+    //    helper so its drift report matches what --apply will actually do.
+    const picked = pickCanonicalOccurrence(occurrences, entry, desiredHook);
+    const canonical = picked ? picked.occ : null;
+    const canonicalRank = picked ? picked.rank : Infinity;
 
     // 3. drop non-canonical occurrences (cleanup pre-existing duplicates).
     //    Removal is by (group ref, hook ref) — index shifts at any depth do

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3775,6 +3775,202 @@ test('doctor-extensions-mixed-group-ownership: doctor accepts mixed-group occurr
   });
 });
 
+// fix #47 follow-up (CONCERN 1, doctor canonical-pick mirror):
+// doctor used to `.find(o => o.event === entry.event)` — picks the FIRST
+// traversal-order occurrence under the target event. registerSettings picks
+// the LOWEST-RANK occurrence (across all events). When the target event has
+// a drifted occurrence FIRST and an exact occurrence LATER, pre-fix doctor
+// warned "differs" while upgrade --apply was a no-op for the canonical.
+// Post-fix doctor uses pickCanonicalOccurrence (same helper as the write
+// path) and pass-throughs rank 1/2.
+test('doctor-extensions-canonical-mirror: drifted-first + exact-later does NOT warn `differs` (CONCERN 1)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-canon.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      // Hand-corrupt: under PostToolUse keep the canonical exact-shape group
+      // (rank 1) AND prepend a drifted single-hook group of our command (rank
+      // 3 — wrong timeout). registerSettings picks the later rank-1; doctor
+      // must agree, not warn "differs" on the earlier rank-3.
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const exactGroup = settings.hooks.PostToolUse.find((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-canon.mjs')),
+      );
+      const ourCommand = exactGroup.hooks.find((h) =>
+        (h.command || '').includes('hypo-ext-canon.mjs'),
+      ).command;
+      // Drifted single-hook group FIRST (rank 3 — same matcher, wrong timeout)
+      settings.hooks.PostToolUse = [
+        {
+          matcher: 'Write',
+          hooks: [{ type: 'command', command: ourCommand, timeout: 5000 }],
+        },
+        // Exact canonical group SECOND (rank 1)
+        exactGroup,
+      ];
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      assert.ok(ext, 'extensions integrity check missing');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        !/hypo-ext-canon settings entry differs/.test(detail),
+        `doctor falsely reported differs against drifted earlier occurrence: ${detail}`,
+      );
+      // It should still surface the duplicate (rank-1 canonical + rank-3 dup
+      // = 2 occurrences) so the user is told to run upgrade --apply.
+      assert.ok(
+        /hypo-ext-canon has 2 occurrences/.test(detail),
+        `doctor must surface duplicate-occurrence cleanup work: ${detail}`,
+      );
+    });
+  });
+});
+
+test('doctor-extensions-canonical-mirror: target-drift beats non-target-exact (rank 3 < rank 6) → warn `differs`', () => {
+  // Cross-event reviewer convergence (codex 2-worker pre-commit): the
+  // rank-3 occurrence under the TARGET event must beat a rank-6 exact-shape
+  // occurrence under a NON-target event, and doctor must surface "differs"
+  // (not "not registered"). Locks the semantics doctor and registerSettings
+  // share.
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-xevent.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const exactGroup = settings.hooks.PostToolUse.find((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-xevent.mjs')),
+      );
+      const ourCommand = exactGroup.hooks.find((h) =>
+        (h.command || '').includes('hypo-ext-xevent.mjs'),
+      ).command;
+
+      // Replace target event with a DRIFTED single-hook (rank 3) and add the
+      // EXACT-shape group under PreToolUse (rank 6 — wrong event). Doctor must
+      // pick rank 3 as canonical and warn "differs", not "not registered".
+      settings.hooks.PostToolUse = [
+        {
+          matcher: 'Write',
+          hooks: [{ type: 'command', command: ourCommand, timeout: 5000 }],
+        },
+      ];
+      settings.hooks.PreToolUse = [exactGroup];
+      writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        /hypo-ext-xevent settings entry differs/.test(detail),
+        `doctor must warn "differs" on target-drift even with non-target exact: ${detail}`,
+      );
+      assert.ok(
+        !/hypo-ext-xevent not registered/.test(detail),
+        `doctor must NOT warn "not registered" — target-rank-3 outranks non-target-rank-6: ${detail}`,
+      );
+    });
+  });
+});
+
+test('doctor-extensions-canonical-mirror: rank-1 alone is silent (no false dup warn)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-clean.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        matcher: 'Write',
+        timeout: 10000,
+      });
+      runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        !/hypo-ext-clean/.test(detail),
+        `clean install must not surface any ext warn: ${detail}`,
+      );
+    });
+  });
+});
+
+// fix #47 follow-up (CONCERN 2, empty matcher normalization):
+// parseManifest accepted `matcher: ""` as valid, but downstream `if
+// (entry.matcher)` silently dropped it from desiredGroup — a semantic
+// collapse where the manifest's expressed-empty matcher was treated as
+// "absent". Fix: normalize `""` → undefined at the boundary (parseManifest)
+// so EVERY consumer (rankOccurrence, registerSettings, doctor) agrees.
+test('parseManifest-empty-matcher: matcher:"" is normalized to undefined (CONCERN 2)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-empty.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PreToolUse',
+        matcher: '',
+      });
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r1.status, 0, `first apply: ${r1.stderr}`);
+
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const ourGroup = (after.hooks.PreToolUse || []).find((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-empty.mjs')),
+      );
+      assert.ok(ourGroup, 'our hook must be registered');
+      assert.ok(
+        !('matcher' in ourGroup),
+        `matcher:"" should be normalized to absent, got: ${JSON.stringify(ourGroup.matcher)}`,
+      );
+
+      // Idempotent: byte-equal on a second --apply
+      const before = readFileSync(settingsPath, 'utf-8');
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r2.status, 0, `second apply: ${r2.stderr}`);
+      assert.equal(readFileSync(settingsPath, 'utf-8'), before, 'second apply byte-equal no-op');
+
+      // doctor must agree — no `differs` warn for the empty-matcher entry
+      const dr = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(dr.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        !/hypo-ext-empty/.test(detail),
+        `doctor falsely warned on empty-matcher entry: ${detail}`,
+      );
+    });
+  });
+});
+
 // ── extensions companion uninstall (ADR 0024, fix #34) ───────────────────────
 
 suite('extensions companion uninstall (uninstall.mjs, ADR 0024)');


### PR DESCRIPTION
## Summary

Resolves two CONCERNs deferred from fix #47 (PR #49) pre-commit codex 2-worker review. Both touch the same doctor/extensions surface — single PR, single commit, two distinct semantic fixes labeled CONCERN 1 / CONCERN 2 in the message.

### CONCERN 1 — doctor / registerSettings canonical-pick divergence

`scripts/doctor.mjs:checkExtensions` picked the FIRST traversal-order occurrence of our hook command under the target event. `registerSettings` picks the LOWEST-RANK occurrence across ALL events via the 8-step priority table. When settings.json had a drifted occurrence FIRST and an exact-shape occurrence LATER in the same event, doctor warned `settings entry differs` while `upgrade --apply` silently accepted the later rank-1 as canonical and the patched hook was a no-op — a confusing gap between report and action.

**Fix:** export `rankOccurrence` and a new `pickCanonicalOccurrence` helper from `scripts/lib/extensions.mjs`. Both `registerSettings` (write) and doctor (read) call the same helper so their canonical selection cannot drift.

Also adds an ext-aware duplicate warn (`occurrences.length > 1`). The existing core duplicate-warn intentionally skips `hypo-ext-*` (E5 boundary, fix #33). With the new canonical-pick, rank-1-exact duplicates would otherwise be invisible to doctor until `upgrade --apply` runs cleanup — parallel ext-aware warn keeps them surfaced.

### CONCERN 2 — parseManifest empty matcher boundary normalization

`parseManifest` accepted `matcher: \"\"` as a valid string, but every downstream call site disagreed on what it meant:
- `registerSettings`: `if (entry.matcher) ...` silently dropped `\"\"` (falsy guard).
- `rankOccurrence`: normalized null/undefined → undefined but compared `\"\"` against `undefined` as mismatch.
- doctor's old drift comparison used the same null/undefined coercion.

**Note:** the original \"churn / idempotency bug\" framing from fix #47 review did not reproduce in probes (the write path converged by coincidence — rank-3 replace produced byte-equal JSON since both old and new groups omitted matcher). The real defect is the silent semantic collapse. **Fix at the boundary:** `parseManifest` now strips an empty matcher before returning, so every consumer sees one representation.

## Test plan

- [x] `npm test`: 400 → 404 passed (+4 new tests); 1 pre-existing UTC/local probe #39 failure remains untouched
- [x] `npx prettier --check` on changed files: passes
- [x] Codex pre-commit 2-worker review on the diff: 0 BLOCKERs. Convergent CONCERN on cross-event test coverage addressed (added rank-3-beats-rank-6 cross-event test). Other notes (orphan duplicate scan for non-registrable manifests, docstring nits) deferred — not regressions introduced by this change.

New tests (`tests/runner.mjs`):
- `doctor-extensions-canonical-mirror: drifted-first + exact-later does NOT warn 'differs'` — primary CONCERN 1 case + duplicate-warn surface
- `doctor-extensions-canonical-mirror: target-drift beats non-target-exact (rank 3 < rank 6) → warn 'differs'` — cross-event semantics lock (reviewer convergence)
- `doctor-extensions-canonical-mirror: rank-1 alone is silent (no false dup warn)` — clean-install negative case
- `parseManifest-empty-matcher: matcher:\"\" is normalized to undefined` — Concern 2 end-to-end (write + idempotency + doctor agreement)

## Notes for reviewer

- Pre-existing probe #39 failure (UTC vs local-date in withWiki fixture) is unrelated and untouched. There is a separate branch (`fix-probe-39-utc-local-date`) addressing it.
- No spec/ADR changes — implements existing §8.12 contract more consistently across write/read paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)