### PR TITLE
fix(extensions): doctor surface non-registrable orphan + matcher:"" drift — PR #53 follow-up

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -811,10 +811,23 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
         });
       } else if (picked.rank >= 3) {
         // ranks 3/4/5 — on target event, but hook or matcher drifted.
-        problems.push({
-          severity: 'warn',
-          msg: `${entry.name} settings entry differs from manifest (matcher/timeout) — run upgrade --apply`,
-        });
+        // PR #53 follow-up (codex CONCERN): the manifest boundary normalize
+        // (extensions.mjs:178) collapses `matcher: ""` → absent only on the
+        // manifest path. A hand-edited settings.json with `matcher: ""` still
+        // mismatches an absent manifest matcher (rankOccurrence treats "" vs
+        // undefined as non-equal). Surface this specific drift so the user
+        // sees the empty-string-vs-absent equivalence, not the generic blurb.
+        if (picked.occ.group.matcher === '' && entry.matcher === undefined) {
+          problems.push({
+            severity: 'warn',
+            msg: `${entry.name} settings has matcher: "" (equivalent to absent) — run upgrade --apply to normalize`,
+          });
+        } else {
+          problems.push({
+            severity: 'warn',
+            msg: `${entry.name} settings entry differs from manifest (matcher/timeout) — run upgrade --apply`,
+          });
+        }
       }
       // ext-aware duplicate surface: core duplicate-warn at checkSettingsJson
       // intentionally skips hypo-ext-* (line ~353 isExtCommand guard). With
@@ -832,9 +845,22 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
     // orphan (boost #2): a hypo-ext-* command in settings with no source extension.
     // E4 excluded hypo-ext-* from the core stale checker (doctor.mjs:302), so this
     // is the ONLY place orphaned extension entries are caught.
-    const sourceCmds = new Set(
-      discovered.hooks.map((ext) => `node ${hooksDir.replace(HOME, '$HOME')}/${ext.file}`),
-    );
+    //
+    // Two distinct orphan classes (PR #53 follow-up, codex Worker 2 NIT):
+    //   - source-removed: settings entry whose source file is gone → uninstall
+    //   - unregistrable : source file present but manifest malformed/non-hook,
+    //                     so (b) above skipped it and (c) only FAIL/warned the
+    //                     manifest itself, never naming the stale settings entry.
+    //                     Surfaced separately so the user knows the lingering
+    //                     entry needs cleanup independent of the manifest fix.
+    const cmdFor = (ext) => `node ${hooksDir.replace(HOME, '$HOME')}/${ext.file}`;
+    const sourceCmds = new Set(discovered.hooks.map(cmdFor));
+    const unregistrableCmds = new Set();
+    for (const ext of discovered.hooks) {
+      if (!ext.manifestPath) continue; // (c-warn) already names this case
+      const parsed = parseManifest(ext.manifestPath);
+      if (!parsed.ok || !parsed.registrable) unregistrableCmds.add(cmdFor(ext));
+    }
     const seen = new Set();
     for (const groups of Object.values(hooksObj)) {
       if (!Array.isArray(groups)) continue;
@@ -843,7 +869,16 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
         for (const h of g.hooks || []) {
           if (typeof h.command !== 'string') continue;
           if (!/(?:^|[/\s])hypo-ext-[^/\s]+\.mjs(?=$|["'\s])/.test(h.command)) continue;
-          if (sourceCmds.has(h.command) || seen.has(h.command)) continue;
+          if (seen.has(h.command)) continue;
+          if (unregistrableCmds.has(h.command)) {
+            seen.add(h.command);
+            problems.push({
+              severity: 'warn',
+              msg: `orphan settings entry (${h.command}) — manifest unregistrable; run uninstall`,
+            });
+            continue;
+          }
+          if (sourceCmds.has(h.command)) continue;
           seen.add(h.command);
           problems.push({
             severity: 'warn',

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3983,6 +3983,142 @@ test('parseManifest-empty-matcher: matcher:"" is normalized to undefined (CONCER
   });
 });
 
+// PR #53 follow-up (codex Worker 2 NIT, Concern A): doctor must surface a
+// hypo-ext-* settings.json entry whose source file is present but whose
+// manifest is malformed or non-hook (registrable:false). The pre-existing
+// orphan scan only matched source-removed cases — manifest-unregistrable
+// entries lingered silently because:
+//   - (b) `expected` loop skips them (no entry produced)
+//   - (c) manifest-health loop only FAILs/warns the manifest itself
+//   - orphan scan considered the source file presence sufficient
+// Distinct message ("manifest unregistrable") so the user knows it's the
+// manifest, not a missing file, that needs attention.
+test('doctor-extensions: malformed manifest + lingering settings entry → unregistrable orphan warn', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      // Healthy first, then break the manifest after the settings entry exists.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-broken.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+      });
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `apply: ${up.stderr}`);
+
+      // Now corrupt the manifest — unknown event ⇒ parseManifest !ok ⇒ malformed.
+      const extHooks = join(hypoDir, 'extensions', 'hooks');
+      writeFileSync(
+        join(extHooks, 'hypo-ext-broken.manifest.json'),
+        JSON.stringify({ type: 'hook', event: 'NotARealEvent' }),
+      );
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        /orphan settings entry .*hypo-ext-broken.*manifest unregistrable/i.test(detail),
+        `expected unregistrable-orphan warn naming settings entry: ${detail}`,
+      );
+      assert.ok(
+        !/orphan settings entry .*hypo-ext-broken.*source extension removed/i.test(detail),
+        `must not use source-removed phrasing when source is present: ${detail}`,
+      );
+    });
+  });
+});
+
+test('doctor-extensions: non-hook manifest + lingering settings entry → unregistrable orphan warn', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      // Hand-place source file + non-hook manifest (type:"skill" under hooks/) +
+      // pre-existing settings entry pointing at it. parseManifest returns
+      // ok:true, registrable:false — entry orphaned by manifest change.
+      const extHooks = join(hypoDir, 'extensions', 'hooks');
+      mkdirSync(extHooks, { recursive: true });
+      writeFileSync(join(extHooks, 'hypo-ext-skillish.mjs'), '#!/usr/bin/env node\n');
+      writeFileSync(
+        join(extHooks, 'hypo-ext-skillish.manifest.json'),
+        JSON.stringify({ type: 'skill' }),
+      );
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const seed = {
+        hooks: {
+          Stop: [
+            {
+              hooks: [
+                { type: 'command', command: 'node $HOME/.claude/hooks/hypo-ext-skillish.mjs' },
+              ],
+            },
+          ],
+        },
+      };
+      writeFileSync(settingsPath, JSON.stringify(seed, null, 2) + '\n');
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        /orphan settings entry .*hypo-ext-skillish.*manifest unregistrable/i.test(detail),
+        `expected unregistrable-orphan warn (non-hook manifest): ${detail}`,
+      );
+    });
+  });
+});
+
+// PR #53 follow-up (codex CONCERN, Concern B): hand-edited settings.json with
+// `matcher: ""` against a manifest with no matcher. extensions.mjs:178
+// normalizes only the manifest side; the settings side still mismatches at
+// rankOccurrence (rank 3). Pre-fix doctor lumped this into the generic
+// `differs (matcher/timeout)` warn — opaque since "" looks identical to
+// absent in casual reading. Fix: dedicated message naming the empty-string
+// equivalence so the user knows --apply will normalize it.
+test('doctor-extensions: hand-edited matcher:"" surfaces specific normalize-drift message', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      // Manifest has NO matcher.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-emptydrift.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PreToolUse',
+      });
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `apply: ${up.stderr}`);
+
+      // Hand-edit: set matcher to "" on our group (settings drift only).
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const s = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      for (const g of s.hooks.PreToolUse || []) {
+        if ((g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-emptydrift.mjs'))) {
+          g.matcher = '';
+        }
+      }
+      writeFileSync(settingsPath, JSON.stringify(s, null, 2) + '\n');
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        /hypo-ext-emptydrift settings has matcher: "" \(equivalent to absent\)/.test(detail),
+        `expected specific empty-matcher normalize msg: ${detail}`,
+      );
+      assert.ok(
+        !/hypo-ext-emptydrift settings entry differs from manifest/.test(detail),
+        `must NOT use the generic differs msg for this case: ${detail}`,
+      );
+    });
+  });
+});
+
 // ── extensions companion uninstall (ADR 0024, fix #34) ───────────────────────
 
 suite('extensions companion uninstall (uninstall.mjs, ADR 0024)');


### PR DESCRIPTION
fix #47 follow-up #2 / PR #53 codex review follow-up

## Concern A — non-registrable orphan surfaced in doctor

`scripts/doctor.mjs:checkExtensions` orphan scan previously only caught a `hypo-ext-*` settings entry whose **source file is gone**. Missing case (codex 2-worker pre-commit Worker 2 NIT on PR #53, deferred): source file is present but manifest is malformed (`parseManifest !ok`) OR non-hook (`registrable: false`). In that state:

- (c) manifest-health loop only FAILs/warns the manifest itself
- (b) expected loop skips it (no entry produced)
- orphan scan considered file presence sufficient

The user got no actionable signal about the lingering settings entry. The scan now adds a parallel "unregistrable" classification with a distinct message: `orphan settings entry (...) — manifest unregistrable; run uninstall`.

## Concern B — `matcher: ""` settings drift gets specific message

`scripts/lib/extensions.mjs:178` (PR #53) normalizes `matcher: ""` → absent only on the **manifest** path. A user who hand-edits `settings.json` with `matcher: ""` against a manifest that has no matcher still triggers rank 3 ("" vs undefined mismatch in `rankOccurrence`). Pre-fix doctor lumped this into the generic `differs (matcher/timeout)` blurb — confusing since `""` reads identical to absent in JSON. The rank≥3 branch now special-cases this and emits `settings has matcher: "" (equivalent to absent) — run upgrade --apply to normalize`. Other drift cases keep the original wording.

## Tests (3 new)

- malformed manifest + lingering settings entry → unregistrable orphan warn
- non-hook (`type: "skill"`) manifest under `hooks/` + settings entry → unregistrable orphan warn
- hand-edited `matcher: ""` settings vs manifest absent matcher → specific normalize-drift message (and NOT the generic differs blurb)

## Test plan

- [x] `npm test` → 408 passed, 0 failed (405 baseline + 3 new)
- [x] `npm run lint` → 0 errors, 258 warnings (wiki content baseline, unchanged)
- [x] No new lint errors/warnings on changed files
- [x] codex pre-commit review (W2): NIT (comment provenance style — keeps project convention) + CLEAR, no BLOCKER/CONCERN

🤖 Generated with [Claude Code](https://claude.com/claude-code)