### PR TITLE
fix(doctor): gate matcher:"" specific message on hookExact — PR #54 follow-up

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -815,9 +815,19 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
         // (extensions.mjs:178) collapses `matcher: ""` → absent only on the
         // manifest path. A hand-edited settings.json with `matcher: ""` still
         // mismatches an absent manifest matcher (rankOccurrence treats "" vs
-        // undefined as non-equal). Surface this specific drift so the user
-        // sees the empty-string-vs-absent equivalence, not the generic blurb.
-        if (picked.occ.group.matcher === '' && entry.matcher === undefined) {
+        // undefined as non-equal). Surface the empty-string-vs-absent
+        // equivalence ONLY when the hook itself is otherwise exact —
+        // otherwise the specific message would hide a co-occurring hook /
+        // timeout drift (PR #54 follow-up, codex W1 CONCERN). The hookExact
+        // comparison mirrors rankOccurrence's own canonical check
+        // (extensions.mjs ~580) so doctor's report tracks --apply intent.
+        const hookExact =
+          JSON.stringify(picked.occ.hook) === JSON.stringify(desiredHook);
+        if (
+          picked.occ.group.matcher === '' &&
+          entry.matcher === undefined &&
+          hookExact
+        ) {
           problems.push({
             severity: 'warn',
             msg: `${entry.name} settings has matcher: "" (equivalent to absent) — run upgrade --apply to normalize`,
@@ -825,7 +835,7 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
         } else {
           problems.push({
             severity: 'warn',
-            msg: `${entry.name} settings entry differs from manifest (matcher/timeout) — run upgrade --apply`,
+            msg: `${entry.name} settings entry differs from manifest (matcher/hook/timeout) — run upgrade --apply`,
           });
         }
       }

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -4119,6 +4119,59 @@ test('doctor-extensions: hand-edited matcher:"" surfaces specific normalize-drif
   });
 });
 
+// PR #54 follow-up (codex W1 CONCERN): the matcher:"" specific message must
+// only fire when the hook itself is also exact — otherwise a co-occurring
+// timeout (or hook field) drift gets hidden behind the empty-matcher blurb.
+// Fix gates the specific message on hookExact; this test plants matcher:""
+// AND a wrong timeout, then asserts the generic differs message is used
+// (not the normalize-only one), so the user is told about the timeout drift.
+test('doctor-extensions: matcher:"" + wrong timeout falls back to generic differs (hookExact gate)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      // Manifest has NO matcher but DOES have a timeout (5s).
+      writeExt(hypoDir, 'hooks', 'hypo-ext-emptyplustimeout.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PreToolUse',
+        timeout: 5,
+      });
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `apply: ${up.stderr}`);
+
+      // Hand-edit settings: matcher:"" AND timeout wrong (99 vs manifest 5).
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const s = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      for (const g of s.hooks.PreToolUse || []) {
+        for (const h of g.hooks || []) {
+          if ((h.command || '').includes('hypo-ext-emptyplustimeout.mjs')) {
+            g.matcher = '';
+            h.timeout = 99;
+          }
+        }
+      }
+      writeFileSync(settingsPath, JSON.stringify(s, null, 2) + '\n');
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      // Generic differs message (now widened to matcher/hook/timeout) MUST fire.
+      assert.ok(
+        /hypo-ext-emptyplustimeout settings entry differs from manifest/.test(detail),
+        `expected generic differs msg when hook drifted too: ${detail}`,
+      );
+      // The specific normalize-only message MUST NOT fire — that would hide
+      // the timeout drift from the user.
+      assert.ok(
+        !/hypo-ext-emptyplustimeout settings has matcher: "" \(equivalent to absent\)/.test(detail),
+        `must NOT use normalize-only msg when hook also drifted: ${detail}`,
+      );
+    });
+  });
+});
+
 // ── extensions companion uninstall (ADR 0024, fix #34) ───────────────────────
 
 suite('extensions companion uninstall (uninstall.mjs, ADR 0024)');


### PR DESCRIPTION
## Summary

PR #54 codex W1 returned a CONCERN that was silent-dropped by the spawned agent before merge:

> Concern B's special case fires whenever `picked.occ.group.matcher === '' && entry.matcher === undefined`, but it does not verify that the hook object itself is otherwise exact. A settings group with `matcher: ""` plus a wrong/missing `timeout` or extra hook-field drift would now report only `settings has matcher: "" (equivalent to absent)` — the timeout/hook drift the old generic message covered gets hidden.

## Changes

- `scripts/doctor.mjs:812-841` — add `hookExact = JSON.stringify(picked.occ.hook) === JSON.stringify(desiredHook)` gate. Specific normalize-only message only fires when matcher is `""`, manifest matcher is absent, AND the hook itself is exact. Otherwise fall through to the generic differs message.
- `scripts/doctor.mjs:840` — widen generic message scope from `(matcher/timeout)` to `(matcher/hook/timeout)` for accuracy (design-stage codex NIT).
- `tests/runner.mjs` — 1 new regression test: `matcher:"" + wrong timeout` → generic differs message fires, normalize-only does NOT.

## Compatibility

PR #54's `hand-edited matcher:"" surfaces specific normalize-drift message` test (line 4082) still passes — `hookExact === true` there, so the specific path still fires.

## Test plan

- [x] `npm test` → 409 passed, 0 failed (408 baseline + 1 new)
- [x] `npm run lint` → 0 errors, 258 warnings (wiki content baseline)
- [x] codex 1-worker design-stage review → CLEAR (NIT widened generic msg)
- [x] codex 1-worker commit-stage review → CLEAR, no BLOCKER/CONCERN/NIT (ran full test suite, 409 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)