### PR TITLE
fix(doctor): surface orphan duplicate counts — PR #53/#54 follow-up NIT

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -821,13 +821,8 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
         // timeout drift (PR #54 follow-up, codex W1 CONCERN). The hookExact
         // comparison mirrors rankOccurrence's own canonical check
         // (extensions.mjs ~580) so doctor's report tracks --apply intent.
-        const hookExact =
-          JSON.stringify(picked.occ.hook) === JSON.stringify(desiredHook);
-        if (
-          picked.occ.group.matcher === '' &&
-          entry.matcher === undefined &&
-          hookExact
-        ) {
+        const hookExact = JSON.stringify(picked.occ.hook) === JSON.stringify(desiredHook);
+        if (picked.occ.group.matcher === '' && entry.matcher === undefined && hookExact) {
           problems.push({
             severity: 'warn',
             msg: `${entry.name} settings has matcher: "" (equivalent to absent) — run upgrade --apply to normalize`,
@@ -871,31 +866,42 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
       const parsed = parseManifest(ext.manifestPath);
       if (!parsed.ok || !parsed.registrable) unregistrableCmds.add(cmdFor(ext));
     }
-    const seen = new Set();
+    // PR #53/#54 follow-up deferred NIT: a single hypo-ext-* command can appear
+    // in multiple groups/events when settings.json was hand-edited or migrated
+    // across events. The registrable-entry duplicate surface above
+    // (`occurrences.length > 1`) only iterates `expected`, so orphan-class
+    // duplicates were silently de-duped to a single warn. Count occurrences per
+    // orphan command and append `(N occurrences)` when count > 1.
+    //
+    // Order: check `unregistrableCmds` BEFORE `sourceCmds` — a malformed or
+    // non-hook manifest still has the source file present, so the
+    // `sourceCmds.has` check would otherwise misclassify them as non-orphan.
+    const orphanInfo = new Map(); // command → { kind, count }
     for (const groups of Object.values(hooksObj)) {
       if (!Array.isArray(groups)) continue;
       for (const g of groups) {
         if (!g || typeof g !== 'object') continue;
-        for (const h of g.hooks || []) {
+        if (!Array.isArray(g.hooks)) continue;
+        for (const h of g.hooks) {
           if (typeof h.command !== 'string') continue;
           if (!/(?:^|[/\s])hypo-ext-[^/\s]+\.mjs(?=$|["'\s])/.test(h.command)) continue;
-          if (seen.has(h.command)) continue;
-          if (unregistrableCmds.has(h.command)) {
-            seen.add(h.command);
-            problems.push({
-              severity: 'warn',
-              msg: `orphan settings entry (${h.command}) — manifest unregistrable; run uninstall`,
-            });
-            continue;
-          }
-          if (sourceCmds.has(h.command)) continue;
-          seen.add(h.command);
-          problems.push({
-            severity: 'warn',
-            msg: `orphan settings entry (${h.command}) — source extension removed; run uninstall`,
-          });
+          let kind = null;
+          if (unregistrableCmds.has(h.command)) kind = 'unregistrable';
+          else if (!sourceCmds.has(h.command)) kind = 'source-removed';
+          else continue;
+          const info = orphanInfo.get(h.command);
+          if (info) info.count += 1;
+          else orphanInfo.set(h.command, { kind, count: 1 });
         }
       }
+    }
+    for (const [cmd, { kind, count }] of orphanInfo) {
+      const suffix = count > 1 ? ` (${count} occurrences)` : '';
+      const msg =
+        kind === 'unregistrable'
+          ? `orphan settings entry (${cmd}) — manifest unregistrable${suffix}; run uninstall`
+          : `orphan settings entry (${cmd}) — source extension removed${suffix}; run uninstall`;
+      problems.push({ severity: 'warn', msg });
     }
   }
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -4072,6 +4072,122 @@ test('doctor-extensions: non-hook manifest + lingering settings entry → unregi
   });
 });
 
+// PR #53/#54 follow-up deferred NIT: orphan duplicate scan. A single
+// hypo-ext-* command can appear in multiple groups/events when settings.json
+// was hand-edited. Pre-fix the orphan loop deduped by command and emitted a
+// single warn, hiding the duplicate count from the user. The fix counts
+// occurrences and appends `(N occurrences)`.
+test('doctor-extensions: source-removed orphan with 2 occurrences reports count', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      // Healthy install, then delete the source so it becomes an orphan.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-dup.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+      });
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `apply: ${up.stderr}`);
+
+      // Hand-edit settings.json to also register the same command under Stop —
+      // simulates manual migration leaving a second copy behind.
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const s = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      let extHook = null;
+      for (const groups of Object.values(s.hooks || {})) {
+        if (!Array.isArray(groups)) continue;
+        for (const g of groups) {
+          for (const h of g.hooks || []) {
+            if (typeof h.command === 'string' && /hypo-ext-[^/\s]+\.mjs/.test(h.command)) {
+              extHook = h;
+              break;
+            }
+          }
+          if (extHook) break;
+        }
+        if (extHook) break;
+      }
+      assert.ok(extHook, 'ext hook must be registered before duplicating');
+      s.hooks.Stop = [{ hooks: [{ ...extHook }] }];
+      writeFileSync(settingsPath, JSON.stringify(s, null, 2) + '\n');
+
+      // Remove BOTH source file AND the extensions/ directory entry so the
+      // command becomes orphan everywhere.
+      const extHooks = join(hypoDir, 'extensions', 'hooks');
+      rmSync(join(extHooks, 'hypo-ext-dup.mjs'));
+      rmSync(join(extHooks, 'hypo-ext-dup.manifest.json'));
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        /orphan settings entry .*hypo-ext-dup.*source extension removed \(2 occurrences\)/i.test(
+          detail,
+        ),
+        `expected source-removed orphan warn with (2 occurrences): ${detail}`,
+      );
+    });
+  });
+});
+
+test('doctor-extensions: unregistrable orphan with 2 occurrences reports count', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-dupbad.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+      });
+      const up = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(up.status, 0, `apply: ${up.stderr}`);
+
+      // Duplicate the settings entry under Stop.
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const s = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      let extHook = null;
+      for (const groups of Object.values(s.hooks || {})) {
+        if (!Array.isArray(groups)) continue;
+        for (const g of groups) {
+          for (const h of g.hooks || []) {
+            if (typeof h.command === 'string' && /hypo-ext-[^/\s]+\.mjs/.test(h.command)) {
+              extHook = h;
+              break;
+            }
+          }
+          if (extHook) break;
+        }
+        if (extHook) break;
+      }
+      assert.ok(extHook, 'ext hook must be registered before duplicating');
+      s.hooks.Stop = [{ hooks: [{ ...extHook }] }];
+      writeFileSync(settingsPath, JSON.stringify(s, null, 2) + '\n');
+
+      // Corrupt the manifest — source still present but unregistrable.
+      const extHooks = join(hypoDir, 'extensions', 'hooks');
+      writeFileSync(
+        join(extHooks, 'hypo-ext-dupbad.manifest.json'),
+        JSON.stringify({ type: 'hook', event: 'NotARealEvent' }),
+      );
+
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const checks = JSON.parse(r.stdout);
+      const ext = checks.find((c) => c.label === 'Extensions integrity');
+      const detail = (ext.detail || '').toString();
+      assert.ok(
+        /orphan settings entry .*hypo-ext-dupbad.*manifest unregistrable \(2 occurrences\)/i.test(
+          detail,
+        ),
+        `expected unregistrable orphan warn with (2 occurrences): ${detail}`,
+      );
+    });
+  });
+});
+
 // PR #53 follow-up (codex CONCERN, Concern B): hand-edited settings.json with
 // `matcher: ""` against a manifest with no matcher. extensions.mjs:178
 // normalizes only the manifest side; the settings side still mismatches at


### PR DESCRIPTION
## Summary

PR #53/#54 codex 2-worker pre-commit review flagged a NIT (deferred at the time): the orphan scan at `scripts/doctor.mjs:874-899` de-duplicated per command via a `seen` Set + `continue`, so when the same hypo-ext-* command appeared in **multiple groups/events** for an orphan class (source-removed OR unregistrable manifest), only ONE warning fired. The registrable-entry duplicate surface at line 847 (`occurrences.length > 1`) only iterates `expected`, so orphan duplicates were silently dropped.

## Fix

Replace the `seen` Set with a `Map { command → { kind, count } }`. Iterate the full settings tree, classify each ext-* command as `unregistrable` / `source-removed` / non-orphan, and accumulate count for orphan classes. After the scan, emit one warn per orphan command with a `(N occurrences)` suffix when count > 1. Also adds a defensive `Array.isArray(g.hooks)` guard (codex design-stage NIT).

**Order:** check `unregistrableCmds` BEFORE `sourceCmds` — malformed/non-hook manifests still have the source file present, so the `sourceCmds.has` check would otherwise misclassify them as non-orphan.

## Tests (+2)

- `doctor-extensions: source-removed orphan with 2 occurrences reports count` — same hypo-ext-* command in PostToolUse + Stop groups, source file deleted → warn includes `(2 occurrences)`.
- `doctor-extensions: unregistrable orphan with 2 occurrences reports count` — malformed manifest, settings hand-edited with duplicate entry → warn includes `(2 occurrences)`.

## Test plan

- [x] `npm test` → 411 passed, 0 failed (409 baseline + 2 new)
- [x] `npx prettier --check scripts/doctor.mjs tests/runner.mjs` → passes after `--write`
- [x] codex design-stage review (1 worker via `/teams`): **CLEAR** + 1 NIT (defensive `Array.isArray` guard, addressed in the fix)
- [x] codex pre-commit review (1 worker via `/teams`): **CLEAR**, no findings, `node tests/runner.mjs` re-verified by reviewer → 411 passed

## Notes

- No spec/ADR change. Implements existing §8.12 contract more completely.
- Pre-existing lint baseline (1 error + 266 warnings in `~/hypomnema/` wiki content) untouched — addressed separately in fix #8 (v1.2.0 ship gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)