### PR TITLE
fix(upgrade): migration report tag regression + Option C verify (별도 잔여 #5)

### DIFF
--- a/commands/upgrade.md
+++ b/commands/upgrade.md
@@ -28,7 +28,7 @@ node <package-root>/scripts/upgrade.mjs [--hypo-dir="<path>"]
 
 Show the output verbatim.
 
-> **Note**: If a major SCHEMA bump is detected, this step generates a `MIGRATION-vX.Y.md` file in the Hypomnema root. This is a new informational file — no existing files are overwritten.
+> **Note**: A major SCHEMA bump is only **detected** in this step. The informational `MIGRATION-vX.Y.md` file is written later by `--apply` (Step 4) and only on a major bump. `SCHEMA.md` is never auto-overwritten.
 
 ---
 
@@ -38,7 +38,7 @@ Show the output verbatim.
 - `⚠` — minor update available (stale hook or missing settings entry)
 - `✗` — major version bump or missing hook files (action required)
 
-For a **major SCHEMA bump**: point the user to the generated `MIGRATION-vX.Y.md` file in their Hypomnema root and ask them to review it before applying.
+For a **major SCHEMA bump**: warn the user that `--apply` will additionally write a `MIGRATION-vX.Y.md` informational file in their Hypomnema root and that they must manually merge the SCHEMA diff after applying.
 
 ---
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -465,7 +465,7 @@ function writeMigrationReport(hypoDir, fromVersion, toVersion) {
 title: Migration Report — v${fromVersion} → v${toVersion}
 type: reference
 updated: ${today}
-tags: [hypomnema, migration, schema]
+tags: [schema]
 ---
 
 # Migration Report: v${fromVersion} → v${toVersion}
@@ -479,10 +479,14 @@ Review the SCHEMA diff and update your wiki pages accordingly.
 
 ## Action items
 
-- [ ] Compare your \`SCHEMA.md\` (v${fromVersion}) with the package template (v${toVersion}) and update manually
-- [ ] Run \`/hypo:upgrade --apply\` to install updated hook files and settings.json entries
-- [ ] Check all \`adr\` and \`learning\` pages for new required frontmatter fields
-- [ ] Run \`/hypo:doctor\` after applying updates to verify installation health
+This report was generated during \`/hypo:upgrade --apply\`. Hook files and settings.json
+entries were applied by that run (or skipped with a warning if the target was malformed —
+see the upgrade output). \`SCHEMA.md\` is intentionally **not** overwritten by upgrade — the
+remaining steps are manual:
+
+- [ ] Compare your \`SCHEMA.md\` (v${fromVersion}) with the package template (v${toVersion}) and merge changes manually
+- [ ] Re-check all \`adr\` and \`learning\` pages for new required frontmatter fields once SCHEMA is updated
+- [ ] Run \`/hypo:doctor\` to verify installation health
 
 ## Notes
 
@@ -907,7 +911,7 @@ if (schema.bump === 'none') {
   );
 } else if (schema.bump === 'major') {
   lines.push(
-    `✗ SCHEMA version    ${schema.installed} → ${schema.current}  [MAJOR — review MIGRATION report, update manually]`,
+    `✗ SCHEMA version    ${schema.installed} → ${schema.current}  [MAJOR — --apply writes MIGRATION report; SCHEMA must be merged manually]`,
   );
 } else {
   lines.push(

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -129,7 +129,7 @@ Use lowercase, hyphenated tags. Vocabulary is locked — `lint` blocks unknown t
 and forbidden patterns (PascalCase, plurals, whitespace, generic words).
 Extend this list (and `~/hypomnema/SCHEMA.md`) before introducing a new tag.
 
-**Meta**: `wiki`, `index`, `pages`, `home`, `overview`, `guide`, `operations`, `schema`, `reference`, `hypo`, `commands`, `hot-cache`
+**Meta**: `wiki`, `index`, `pages`, `home`, `overview`, `guide`, `operations`, `schema`, `reference`, `hypo`, `commands`, `hot-cache`, `migration`
 **Workflow**: `automation`, `hooks`, `observability`, `autonomy`, `wiki-health`, `weekly`
 **Project**: `project`, `prd`, `adr`, `session-state`
 **Domain**: `ai`, `dev`, `ops`, `security`, `data`, `design`, `management`

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync.mjs';
 import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
 import { buildProjectSuggestionLine } from '../hooks/hypo-shared.mjs';
+import { parseSchemaVocab } from '../scripts/lib/schema-vocab.mjs';
 
 const HOME = homedir();
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -2022,6 +2023,86 @@ test('--apply generates migration report for major SCHEMA bump', () => {
       const content = readFileSync(out.migrationReport, 'utf-8');
       assert.ok(content.includes('0.9'), 'migration report should reference old version');
       assert.ok(content.includes('1.0'), 'migration report should reference new version');
+    });
+  });
+});
+
+// User's SCHEMA.md must be byte-equal after --apply. SCHEMA is user vocabulary;
+// upgrade emits an informational migration report instead and the user merges
+// manually. Tests this invariant in the presence of an unrecognized user-added
+// vocab block (which would otherwise be the obvious thing to "clean up").
+test('--apply leaves user SCHEMA.md byte-equal', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      // Simulate a user who appended a custom Domain tag to their SCHEMA.md.
+      // Option C contract: upgrade must NOT discard or rewrite this edit.
+      const schemaPath = join(hypoDir, 'SCHEMA.md');
+      const customLine = '\n<!-- user-custom: -->\n**UserDomain**: `user-custom-domain`\n';
+      const modified = readFileSync(schemaPath, 'utf-8') + customLine;
+      writeFileSync(schemaPath, modified);
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+
+      const after = readFileSync(schemaPath, 'utf-8');
+      assert.equal(after, modified, 'user SCHEMA.md must be byte-equal after --apply (Option C)');
+    });
+  });
+});
+
+// Migration report tags must be a subset of the *installed* wiki's SCHEMA vocab,
+// not the package's current vocab — because upgrade deliberately leaves user
+// SCHEMA.md untouched, so a long-installed wiki keeps its old vocab line.
+// lint.mjs does not scan the hypoDir root where the report is written, so a
+// file-level lint would give false confidence; the assertion is vocab-direct.
+// Backdate the installed Meta vocab line to the oldest shipped set before running.
+test('--apply migration report tags are all in installed SCHEMA vocab', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const schemaPath = join(hypoDir, 'SCHEMA.md');
+      // Patch (a) version to trigger major bump, (b) Meta vocab to the oldest
+      // shipped set — emulates a wiki that was last linted against an older
+      // package vocab and has never had its SCHEMA.md rewritten.
+      writeFileSync(
+        schemaPath,
+        readFileSync(schemaPath, 'utf-8')
+          .replace(/^version: .+$/m, 'version: 0.9')
+          .replace(
+            /^\*\*Meta\*\*:.*$/m,
+            '**Meta**: `wiki`, `index`, `operations`, `guide`, `schema`',
+          ),
+      );
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.ok(out.migrationReport, 'migrationReport should be set on major bump');
+
+      const reportContent = readFileSync(out.migrationReport, 'utf-8');
+      const tagLine = reportContent.match(/^tags:\s*\[(.+?)\]/m);
+      assert.ok(tagLine, 'migration report must have tags: [...] frontmatter');
+      const tags = tagLine[1]
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean);
+      assert.ok(tags.length > 0, 'migration report must declare at least one tag');
+
+      const vocab = parseSchemaVocab(hypoDir);
+      assert.ok(vocab.size > 0, 'installed SCHEMA vocab must be loadable');
+      for (const tag of tags) {
+        assert.ok(
+          vocab.has(tag),
+          `migration report tag "${tag}" not in installed SCHEMA vocab — major-bump upgrade would create a lint-failing page`,
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- v1.2.0 ship gate에 별도 잔여 #5 (OSS upgrade migration gate) 포함.
- `scripts/upgrade.mjs:writeMigrationReport()`의 `tags: [hypomnema, migration, schema]` 회귀 수정 — historical v1.0/v1.1 사용자가 upgrade 시 out-of-vocab 태그로 lint-failing page 생성하던 문제. Option C(SCHEMA 미터치) 원칙 자체는 이미 코드에 구현되어 있어, 본 PR은 (a) 실제 회귀 태그 수정 + (b) Option C 회귀 테스트 추가 + (c) doc/wording 정합성 정리.

## 문제

`scripts/upgrade.mjs:writeMigrationReport()`이 major bump 시 wiki 루트에 `MIGRATION-vX.Y.md`를 쓰면서 `tags: [hypomnema, migration, schema]` 명시. 그러나 v1.0/v1.1 historical Meta vocab은 `wiki, index, operations, guide, schema`로 `hypomnema`/`migration` 모두 부재. Option C가 SCHEMA.md를 의도적으로 미터치하므로, 실제 historical upgrader가 upgrade 시 lint-failing 페이지가 wiki 루트에 생성됨.

또한 `scripts/lint.mjs:345`가 hypoDir 루트를 스캔하지 않아 file-level lint 회귀 테스트는 false confidence — vocab-level 직접 단언이 정확한 회귀 검사.

## 변경

- **코드 fix**: `scripts/upgrade.mjs:468` `tags: [hypomnema, migration, schema]` → `tags: [schema]`. `schema`는 v1.0.0부터 현 SCHEMA까지 모든 Meta vocab에 존재하는 유일 토큰.
- **Dry-run 출력 정정** (`upgrade.mjs:913`): "review MIGRATION report, update manually" → "--apply writes MIGRATION report; SCHEMA must be merged manually". Dry-run은 report 안 쓰므로 self-referential wording 제거.
- **Report action items 정정**: "Run /hypo:upgrade --apply" 자기참조 제거. settings.json apply가 malformed 시 skip 가능성 명시.
- **commands/upgrade.md 정합성**: Step 2/3 — dry-run은 detect만, --apply가 report write. SCHEMA.md 미터치 명시.
- **(선택) forward-looking vocab 확장**: `templates/SCHEMA.md` Meta vocab에 `migration` 토큰 추가. 본 fix와 무관하나 향후 manual adoption용.
- **회귀 테스트 2건** (`tests/runner.mjs`):
  1. `--apply leaves user SCHEMA.md byte-equal (Option C)` — custom user vocab을 SCHEMA.md에 append → upgrade --apply → byte-equality 단언.
  2. `--apply migration report tags are all in installed SCHEMA vocab` — installed SCHEMA Meta vocab을 v1.0/v1.1 historical set으로 backdate → upgrade --apply → 생성된 report 태그가 `parseSchemaVocab(hypoDir)` Set에 모두 속함을 직접 단언.

## codex 2-stage review

학습 룰(2026-05-24) 준수, `/teams` skill 사용:

| Stage | Team | Verdict | 적용 fix |
|---|---|---|---|
| Design | `v120-itema-design` | **CONCERN** | C1(vocab 추가) 부적합 → C2(report 태그 수정)로 전환. Test B(lint MIGRATION 파일) false confidence → vocab assertion으로 교체. doc/code mismatch 발견. |
| Pre-commit | `v120-itema-commit` | **BLOCKER** | `[hypo, schema]`도 historical v1.0/v1.1 vocab에서 `hypo` 부재. Test B fixture가 현 template 기반이라 historical case 못 잡음. |
| Pre-commit 재검 | `v120-itema-commit2` | **CLEAR** | `[schema]` historical 안전성 확정. Test B fixture 강화(v1.0/v1.1 Meta vocab backdate) 검증 완료. |

Manual verify: `[hypo, schema]`로 임시 revert 시 강화된 회귀 테스트 1건이 정확히 fail (`migration report tag "hypo" not in installed SCHEMA vocab`). `[schema]` 복귀 시 413/413 pass — 회귀 테스트가 실제로 historical 케이스를 잡음을 확인.

## Test plan

- [x] `npm test` → **413 passed, 0 failed** (411 baseline + 2 새 회귀 테스트).
- [x] `npm run lint` → **0 error, 281 warning** (fix #8 ship gate baseline 유지).
- [x] `npm run smoke-pack` → **passed**.
- [x] 회귀 테스트가 실제 historical regression을 잡는지 manual verify (`[hypo, schema]` revert 시 fail 확인 후 `[schema]` 복귀).

## Refs

- `~/hypomnema/projects/hypomnema/scope-briefs-2026-05-24.md` §#5
- `~/hypomnema/projects/hypomnema/fix-37-contract.md` §10 (Option C 결정 근거)
- `~/hypomnema/projects/hypomnema/session-state.md` (2026-05-24-5 — v1.2.0 scope 재정의)

🤖 Generated with [Claude Code](https://claude.com/claude-code)