### PR TITLE
fix(feedback-sync): MEMORY projection cross-project pollution (ADR 0031 §4)

### DIFF
--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -21,7 +21,7 @@ If the user did not provide them, ask. The classification fields are required so
 1. **Topic** (slug): "What topic does this feedback apply to? (e.g. `response-length`, `commit-style`)"
 2. **Rule** (entry): "State the rule or correction in one or two sentences."
 3. **Reason**: "What incident or reasoning prompted this?"
-4. **Scope**: "Does this apply globally (all projects) or to this project only?" → `global` | `project:<slug>`
+4. **Scope**: "Does this apply globally (all projects) or to this project only?" → `global` | `project:<project-id>` (project-id must exact-match the resolved id; see Step 3 note)
 5. **Tier**: "Is this a hard rule (L1) or a softer preference (L2)?" → `L1` | `L2`
 6. **Targets**: "Where should this project?" → `project-memory` (MEMORY.md) and/or `claude-learned` (global CLAUDE.md). Default `project-memory`.
 7. **Priority** (1–5, higher sorts first; default 3).
@@ -53,7 +53,7 @@ Run with `--dry-run` first to preview the generated page, then without it to wri
 node <package-root>/scripts/feedback.mjs \
   --topic="<slug>" \
   --entry="<one-line rule>" \
-  --scope="global|project:<slug>" \
+  --scope="global|project:<project-id>" \
   --tier="L1|L2" \
   --targets="project-memory[,claude-learned]" \
   --priority=<1-5> \
@@ -67,6 +67,8 @@ node <package-root>/scripts/feedback.mjs \
 ```
 
 When `--targets` includes `claude-learned`, `--global-summary` and `--promote-to-global` are required (and `--scope=global --tier=L1`).
+
+> **`scope: project:<project-id>` 주의 (v1.2.0).** `<project-id>`는 `feedback-sync`가 resolve한 project-id와 정확히 일치해야 한다 (default: cwd의 `/`,`.` → `-` 치환; `--project-id=<id>` 로 override). 일치하지 않으면 그 페이지는 해당 project의 MEMORY로 projection되지 **않는다** (silent skip — lint error 아님). 다만 현재 lint scope regex(`^project:[a-z0-9][a-z0-9-]*$`)는 cwd-derived id 형식(`-Users-...`)을 거부하므로, **`project:*` scope를 사용하려면 slug-safe id로 `--project-id=<slug>`를 override해서 wiki 디렉터리도 그 id에 맞추는 운영 패턴이 필요하다**. resolved-id ↔ slug 정합화는 v1.3.0 트랙에서 다룸.
 
 On a real (non-dry-run) write, the script automatically runs `feedback-sync --write` to refresh MEMORY.md / CLAUDE.md. If that post-step reports drift it prints a one-line warning — the page is still saved; reconcile with `hypomnema feedback-sync --check`.
 

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -219,7 +219,7 @@ function memoryTarget(args, projectId) {
     capKind: 'lines',
     filter: (p) =>
       p.fm.status === 'active' &&
-      (p.fm.scope === 'global' || (p.fm.scope || '').startsWith('project:')) &&
+      (p.fm.scope === 'global' || p.fm.scope === `project:${projectId}`) &&
       p.targets.includes('project-memory') &&
       PUBLIC_SENSITIVITY.has(p.fm.sensitivity),
     render: (p) =>

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -104,7 +104,12 @@ and `~/.claude/CLAUDE.md` `<learned_behaviors>`. They require:
 
 ```yaml
 status: active | superseded | archived
-scope: global | project:<slug>           # global → eligible for CLAUDE.md projection
+scope: global | project:<project-id>     # global → eligible for CLAUDE.md projection;
+                                         # <project-id> must exact-match the resolved
+                                         # project-id (default: cwd → `/`,`.` replaced
+                                         # with `-`; or pass `--project-id=<id>`).
+                                         # Mismatched scope = page is NOT projected
+                                         # into that project's MEMORY.md.
 tier: L1 | L2                            # L1 required for CLAUDE.md <learned_behaviors>
 targets: [project-memory, claude-learned] # which projection surfaces to derive
 sensitivity: public | sanitized          # `private` forbidden (wiki is git-pushed)

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -7395,7 +7395,7 @@ const FB_PROJECT_L2 = {
   title: 'Rule B',
   type: 'feedback',
   status: 'active',
-  scope: 'project:hypomnema',
+  scope: 'project:proj',
   tier: 'L2',
   targets: '[project-memory]',
   sensitivity: 'public',
@@ -7527,6 +7527,53 @@ test('feedback-sync-scope-project-rejected-from-claude: project scope only reach
     const rep = JSON.parse(runFb(['--check', '--json']).stdout);
     assert.equal(rep.targets.claude.candidates, 0, 'scope:project:* must be rejected from CLAUDE');
     assert.equal(rep.targets.memory.candidates, 1, 'project scope still projects to memory');
+  });
+});
+
+// Cross-project pollution guard (ADR 0031 cwd-scoped projection invariant):
+// memoryTarget.filter previously accepted any `scope: project:*` regardless of
+// the resolved project-id, so a `scope: project:other` page was silently
+// projected into `~/.claude/projects/<this-project>/memory/`. The fix tightens
+// the filter to an exact match against the resolved project-id, and renders /
+// sideFiles share the same desired set so MEMORY index + feedback_<slug>.md
+// stay consistent.
+test('feedback-sync-scope-project-mismatch-excluded: other-project scope never reaches this memory', () => {
+  const otherPage = { ...FB_PROJECT_L2, scope: 'project:other', memory_summary: 'do other' };
+  withFeedbackEnv({ 'mine': FB_PROJECT_L2, 'other': otherPage }, ({ memDir, runFb }) => {
+    const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+    assert.equal(
+      rep.targets.memory.candidates,
+      1,
+      `only the matching-project page should project to memory (got ${rep.targets.memory.candidates})`,
+    );
+    const w = runFb(['--write']);
+    assert.equal(w.status, 0, `--write should succeed: ${w.stderr}`);
+    const mem = readFileSync(join(memDir, 'MEMORY.md'), 'utf-8');
+    assert.ok(mem.includes('feedback_mine.md'), 'matching-project page must appear in MEMORY');
+    assert.ok(
+      !mem.includes('feedback_other.md'),
+      `other-project page must not appear in MEMORY: ${mem}`,
+    );
+    assert.ok(
+      existsSync(join(memDir, 'feedback_mine.md')),
+      'matching-project sideFile must be written',
+    );
+    assert.ok(
+      !existsSync(join(memDir, 'feedback_other.md')),
+      'other-project sideFile must NOT be written',
+    );
+  });
+});
+
+test('feedback-sync-scope-global-still-projects-to-memory: global scope is project-agnostic', () => {
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ memDir, runFb }) => {
+    const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+    assert.equal(rep.targets.memory.candidates, 1, 'global scope still reaches memory');
+    runFb(['--write']);
+    assert.ok(
+      readFileSync(join(memDir, 'MEMORY.md'), 'utf-8').includes('feedback_rule-a.md'),
+      'global page must appear in MEMORY index',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- `memoryTarget` filter at `scripts/feedback-sync.mjs:222` accepted any `scope: project:*` regardless of the resolved project-id, so a `scope: project:other` page was silently projected into `~/.claude/projects/<this-project>/memory/`. Discovered during v1.2.0 ship review (codex 1-worker).
- Fix tightens to exact match: `scope === 'global' || scope === \`project:${projectId}\``. `computeDesired()` is the single source for render / sideFiles / cap / report so MEMORY index and `feedback_<slug>.md` stay consistent.
- ADR 0031 §4 invariant ("MEMORY.md projection은 cwd-scoped") strengthened. Vault amendment in Review Log 2026-05-24 (`projects/hypomnema/decisions/0031-...`).

## Code

| File | Change |
|---|---|
| `scripts/feedback-sync.mjs` | 1-line filter tightening |
| `tests/runner.mjs` | +2 regression tests; `FB_PROJECT_L2.scope` `project:hypomnema` → `project:proj` (aligns with `withFeedbackEnv` default projectId — prior fixture was the exact case where cross-project pollution was developing) |
| `templates/SCHEMA.md` | `scope: project:<slug>` → `project:<project-id>` with exact-match + cwd-derived id semantics |
| `commands/feedback.md` | `--scope` flag clarified; new Step 3 caveat (line-continuation comment bug also fixed — bash copy-paste was breaking) |

## Tests

- `npm test` → **415 passed (413 + 2), 0 failed**
- New tests:
  - `feedback-sync-scope-project-mismatch-excluded` — `scope: project:other` excluded from `projectId='proj'` MEMORY/sideFile (assertions: `--check candidates`, `--write` MEMORY body, `feedback_other.md` absence + sideFile absence)
  - `feedback-sync-scope-global-still-projects-to-memory` — global scope guard

## Deferred to v1.3.0

The lint scope regex `^project:[a-z0-9][a-z0-9-]*$` and the default cwd-derived id (`-Users-...-Hypomnema`) have incompatible formats. To use `project:*` scope in v1.2.0 you must override with `--project-id=<slug>` so the resolved id matches the regex. The resolved-id ↔ wiki-slug reconciliation has a larger design surface (e.g., wiki project slug derivation from `working_dir`) and is tracked for v1.3.0. Both `templates/SCHEMA.md` and `commands/feedback.md` now state this caveat explicitly.

## Codex review (2-stage, /teams 1:codex)

- **Design (`prb-design`)** — verdict **CONCERN**: 1-line filter is correct; raised the scope identity / format conflict above. Addressed via doc updates + v1.3.0 deferral note.
- **Commit (`prb-commit`)** — verdict **CONCERN**: line-continuation `#` comment in `commands/feedback.md` Step 3 (bash copy-paste breakage) + `project:<slug>` leftover at Step 1. Both fixed before commit.

## Test plan
- [x] `npm test` green (415 passed)
- [x] `git diff --check` clean
- [x] Manual: `node -e` confirms cwd-derived id `-Users-...` does not satisfy lint regex (defer rationale verified)
- [x] Manual: existing dogfood wiki uses only `scope: global` → zero in-flight pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)