### PR TITLE
fix(hooks): PreCompact lint-blocker reason shows file paths, not empty commas

### DIFF
--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -241,7 +241,9 @@ process.stdin.on('end', () => {
     !gitStatus.clean ? gitStatus.reason : '',
     !hotStatus.clean ? hotStatus.reason : '',
     !closeFiles.ok ? closeFilesReason : '',
-    !lintOk ? `lint blockers: ${lintBlockers.map((b) => b.id).join(', ')}` : '',
+    !lintOk
+      ? `lint blockers: ${[...new Set(lintBlockers.map((b) => b.id || b.file))].join(', ')}`
+      : '',
     !designHistoryOk
       ? `design-history stale: ${lintW8.map((w) => w.file.split('/')[1]).join(', ')}`
       : '',

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1169,6 +1169,35 @@ test('session-log missing a today-dated heading → block', () => {
   );
 });
 
+test('lint blockers without id field → reason names files, no empty placeholders', () => {
+  // Regression: line 244 used `b.id` directly, but error-severity lint issues
+  // never carry an id (only W8 warns do). The result was a reason like
+  // `lint blockers: , , , , , , ,` — blocks correctly but tells the user
+  // nothing actionable. Fix: fall back to file path + dedupe.
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(
+        join(dir, 'pages', 'feedback', 'broken.md'),
+        '---\ntitle: broken\ntype: feedback\nstatus: active\nscope: INVALID-SCOPE\nsensitivity: public\nupdated: 2026-05-26\n---\n',
+      );
+    },
+    (dir) => {
+      const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.decision, 'block', `expected block: ${r.stdout}`);
+      assert.ok(
+        out.reason.includes('lint blockers: pages/feedback/broken.md'),
+        `lint blockers should name the file, got: ${out.reason}`,
+      );
+      assert.ok(
+        !/lint blockers:\s*,/.test(out.reason),
+        `lint blockers section must not start with empty commas: ${out.reason}`,
+      );
+    },
+  );
+});
+
 test('open-questions.md absent/stale → still passes (conditional, not gated)', () => {
   withWiki(
     (dir) => {


### PR DESCRIPTION
## Summary

- PreCompact block reason on lint failure rendered `lint blockers: , , , , , , ,` because lint *errors* (vs W8 *warns*) carry no `id` field — block worked but conveyed zero actionable info.
- Fix: fall back to `b.file` when `b.id` missing, dedupe so multiple errors in same file collapse. Result on 7-error fixture: `lint blockers: pages/feedback/broken.md`.

## Context

Discovered during verification-matrix follow-up (24 claims live-tested 2026-05-26). PreCompact gating semantics unchanged — purely cosmetic.

## Tests

- New regression test in tests/runner.mjs asserts (a) `decision: block`, (b) `reason` contains file path, (c) `reason` does NOT start lint-blockers segment with empty commas.
- `npm test` → **420 passed, 0 failed** (was 419).
- `npm run lint` → 0 errors. `prettier --check` → clean.

## Codex pre-commit review

`/teams 1:codex precompact-lint-fix` — verdict: **CLEAR**. Confirmed `b.id || b.file` correct against current lint.mjs:411 producer; dedupe-by-file appropriate for one-line PreCompact reason; no risk to existing close-intent, contract, or strict-gate test paths.

## Test plan

- [x] Live test on synthetic vault with broken feedback page → `lint blockers: pages/feedback/broken.md`
- [x] Full test suite green
- [ ] Merge → no further follow-up; hook self-installs via existing channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)