### PR TITLE
fix(resume): strip HTML comments + skip _template fallback (placeholder leak)

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -243,7 +243,9 @@ export function resolveActiveProject(hypoDir) {
   if (!existsSync(hotPath)) return null;
   let content;
   try {
-    content = readFileSync(hotPath, 'utf-8');
+    // Strip HTML comments before parsing so the canonical-format example row
+    // in templates/hot.md (`<!-- Row format: ... -->`) is not picked up as data.
+    content = readFileSync(hotPath, 'utf-8').replace(/<!--[\s\S]*?-->/g, '');
   } catch {
     return null;
   }

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -37,7 +37,9 @@ function resolveActiveProject(hypoDir) {
   const hotPath = join(hypoDir, 'hot.md');
   if (!existsSync(hotPath)) return null;
 
-  const content = readFileSync(hotPath, 'utf-8');
+  // Strip HTML comments before parsing so the canonical-format example row
+  // in templates/hot.md (`<!-- Row format: ... -->`) is not picked up as data.
+  const content = readFileSync(hotPath, 'utf-8').replace(/<!--[\s\S]*?-->/g, '');
   // Canonical hot.md uses wikilinks: | name | date | [[projects/slug/hot]] |
   // Pick the most recent row by the date column when present.
   const wikiRows = [
@@ -60,6 +62,8 @@ function resolveActiveProject(hypoDir) {
   let latest = null;
   let latestMtime = 0;
   for (const p of readdirSync(projectsDir)) {
+    // Skip the scaffold project init.mjs writes — it isn't a real active project.
+    if (p === '_template') continue;
     const ssPath = join(projectsDir, p, 'session-state.md');
     if (!existsSync(ssPath)) continue;
     const mtime = statSync(ssPath).mtimeMs;

--- a/templates/hot.md
+++ b/templates/hot.md
@@ -14,7 +14,7 @@ tags: [wiki, operations]
 
 | Project | Last Session | Hot Cache |
 |---|---|---|
-<!-- Row format: | Project Name | YYYY-MM-DD | [[projects/slug/hot]] | -->
+<!-- Row format: | Project Name | YYYY-MM-DD | projects/<slug>/hot (wikilink) | -->
 <!-- col2 date is rebuilt from projects/<slug>/hot.md frontmatter on each session close -->
 
 ## Session Start Checklist

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -18,6 +18,7 @@ import {
   symlinkSync,
   statSync,
   unlinkSync,
+  utimesSync,
   cpSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -7144,6 +7145,103 @@ test('with results: ingest prompt not shown', () => {
     assert.ok(
       !r.stdout.includes('/hypo:ingest'),
       `ingest prompt should not appear when results exist: ${r.stdout}`,
+    );
+  });
+});
+
+// ── resume.mjs smoke tests ───────────────────────────────────────────────────
+
+suite('resume.mjs — fresh-init + commented-example hot.md');
+
+test('resume on fresh-init vault: graceful "no active project found" — no slug leak', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+    // Sanity: the template comment example IS present in the generated hot.md.
+    const hot = readFileSync(join(hypoDir, 'hot.md'), 'utf-8');
+    assert.ok(/<!--[\s\S]*?Row format[\s\S]*?-->/.test(hot), 'expected comment in hot.md');
+    const r = run('resume.mjs', [`--hypo-dir=${hypoDir}`]);
+    assert.equal(
+      r.status,
+      1,
+      `expected exit 1, got ${r.status}; stdout=${r.stdout} stderr=${r.stderr}`,
+    );
+    assert.ok(
+      r.stderr.includes('no active project found'),
+      `expected matrix message in stderr: ${r.stderr}`,
+    );
+    assert.ok(
+      !r.stdout.includes('slug') && !r.stderr.includes('"slug"'),
+      `slug placeholder must not leak: stdout=${r.stdout} stderr=${r.stderr}`,
+    );
+  });
+});
+
+test('resume picks real project over _template fallback (even when _template is newer)', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+    // Add a real project alongside the scaffold _template, then make
+    // _template's session-state.md NEWER than foo's so mtime alone would pick
+    // _template. The explicit skip in resolveActiveProject must override that.
+    mkdirSync(join(hypoDir, 'projects', 'foo'), { recursive: true });
+    writeFileSync(
+      join(hypoDir, 'projects', 'foo', 'session-state.md'),
+      '---\ntitle: session-state — foo\ntype: session-state\nupdated: 2026-05-26\n---\n\n## 다음 이어받기\n- task A\n',
+    );
+    // Touch _template/session-state.md to be 1 second newer than foo's.
+    const templateSS = join(hypoDir, 'projects', '_template', 'session-state.md');
+    assert.ok(existsSync(templateSS), 'fixture: _template/session-state.md must exist after init');
+    const fooSS = join(hypoDir, 'projects', 'foo', 'session-state.md');
+    const fooMtime = statSync(fooSS).mtimeMs;
+    const newer = new Date(fooMtime + 5000);
+    utimesSync(templateSS, newer, newer);
+    const r = run('resume.mjs', [`--hypo-dir=${hypoDir}`]);
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr=${r.stderr}`);
+    assert.ok(r.stdout.startsWith('Project: foo'), `expected 'Project: foo', got: ${r.stdout}`);
+  });
+});
+
+test('resume strips legacy [[projects/slug/hot]] HTML-comment example (back-compat with pre-fix vaults)', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+    // Simulate an older installed hot.md that still has the pre-fix wikilink-
+    // shaped comment example (the exact form that produced the original leak).
+    const legacyHot = `---
+title: Hot Cache — Pointer
+type: reference
+updated: 2026-05-26
+tags: [wiki, operations]
+---
+
+# Hot Cache
+
+## Active Projects
+
+| Project | Last Session | Hot Cache |
+|---|---|---|
+<!-- Row format: | Project Name | YYYY-MM-DD | [[projects/slug/hot]] | -->
+`;
+    writeFileSync(join(hypoDir, 'hot.md'), legacyHot);
+    // Also remove _template so the fallback can't mask the parse-result.
+    rmSync(join(hypoDir, 'projects', '_template'), { recursive: true, force: true });
+    const r = run('resume.mjs', [`--hypo-dir=${hypoDir}`]);
+    assert.equal(
+      r.status,
+      1,
+      `expected exit 1, got ${r.status}; stdout=${r.stdout} stderr=${r.stderr}`,
+    );
+    assert.ok(
+      r.stderr.includes('no active project found'),
+      `expected matrix message in stderr: ${r.stderr}`,
+    );
+    assert.ok(
+      !r.stdout.includes('slug') && !r.stderr.includes('"slug"'),
+      `slug placeholder must not leak: stdout=${r.stdout} stderr=${r.stderr}`,
     );
   });
 });


### PR DESCRIPTION
## Summary

- `/hypo:resume` on a fresh-from-`init` vault leaked the literal `"slug"` as active project — the wikilink-row regex picked up the example inside `templates/hot.md`'s HTML comment `<!-- Row format: | ... | [[projects/slug/hot]] | -->`.
- Pre-existing in v1.2.0 (confirmed via `git show v1.2.0:...`). Surfaced by v1.2.1 pre-ship QA matrix row 18 with guard D orchestrator-side live re-verification.
- Three-place defense-in-depth fix + 3 regression tests; 2-round codex review (BLOCKER → NIT → all addressed).

## Changes

- **`scripts/resume.mjs`**: strip HTML comments before the wikilink regex; skip `_template` scaffold in the mtime fallback (init.mjs creates `projects/_template/session-state.md`, which would otherwise win on a fresh vault).
- **`hooks/hypo-shared.mjs`**: apply the same comment strip in the hand-mirrored `resolveActiveProject` (no fallback loop → no `_template` skip needed).
- **`templates/hot.md`**: rewrite the example comment to no longer embed a real `[[...]]` shape — `projects/<slug>/hot (wikilink)` instead.
- **`tests/runner.mjs`**: 3 new regression tests under suite `resume.mjs — fresh-init + commented-example hot.md`.

## Codex review

- **Design review** (`/teams 1:codex` on the design proposal): verdict **BLOCKER**. Required: (a) HTML-strip in BOTH `scripts/resume.mjs` AND `hooks/hypo-shared.mjs`, (b) `_template` skip in resume.mjs fallback (init.mjs writes a session-state.md for `_template` so comment-strip alone would just shift the bug from `slug` to `_template`), (c) keep `templates/hot.md` date as `YYYY-MM-DD` placeholder, not a real date. All addressed.
- **Pre-commit review** (`/teams 1:codex` on the diff): verdict **NIT**. Asked for (a) a fixture exercising the legacy `[[projects/slug/hot]]` comment form directly (the post-fix template no longer triggers the regex), (b) `_template` skip test where `_template`'s session-state.md is mtime-newer so the skip is what makes `foo` win. Both addressed in the test suite.

## Test plan

- [x] `npm test`: 423 passed / 0 failed (420 prior + 3 new resume tests).
- [x] Manual live verify: `node scripts/init.mjs --hypo-dir=/tmp/v --no-hooks --no-git-init && node scripts/resume.mjs --hypo-dir=/tmp/v` → `Error: no active project found...` (rc=1), no `"slug"` anywhere.
- [x] Manual live verify: add `projects/foo/session-state.md` → `Project: foo` (rc=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)