### PR TITLE
feat(release): enforce bilingual CHANGELOG + annotated tag at publish-time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 fetches full history including annotated tag objects;
+          # the default shallow clone leaves git unable to read the tag body
+          # that `check-bilingual --tag` validates.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -29,6 +34,11 @@ jobs:
             echo "Tag ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
             exit 1
           fi
+
+      - name: Validate bilingual release docs (CHANGELOG + annotated tag)
+        run: |
+          node scripts/check-bilingual.mjs --changelog
+          node scripts/check-bilingual.mjs --tag "${GITHUB_REF_NAME}"
 
       - name: Run tests
         run: npm test

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -177,27 +177,57 @@ Hypomnema uses semver. Releases are automated via `release.yml` on `v*` tag push
 
 ### Cutting a release
 
+Every Hypomnema release must carry a Korean summary alongside the English body
+in **both** the CHANGELOG section AND the git tag annotation. The release
+workflow enforces this with `scripts/check-bilingual.mjs`; lightweight tags or
+a missing `### 한글 요약` section will block `npm publish`.
+
 ```bash
-# 1. Bump the version (writes package.json + CHANGELOG.md)
-node scripts/bump-version.mjs <patch|minor|major>
+# 1. Bump the version across package.json, plugin.json, marketplace.json,
+#    and templates/hypo-config.md. Takes a concrete semver (not patch/minor/major).
+node scripts/bump-version.mjs <new-semver>   # e.g. 1.2.2 or 1.3.0-rc.1
 
-# 2. Review the diff and edit CHANGELOG.md if needed
-git diff
+# 2. Edit CHANGELOG.md — the new section MUST include a "### 한글 요약"
+#    sub-section with at least 10 Hangul characters of real summary text.
+$EDITOR CHANGELOG.md
 
-# 3. Commit
+# 3. Verify locally before tagging (same check that runs in CI)
+node scripts/check-bilingual.mjs --changelog
+
+# 4. Commit
 git add package.json CHANGELOG.md
 git commit -m "chore: release v<version>"
 
-# 4. Tag and push
-git tag v<version>
+# 5. Tag with an ANNOTATED tag — never a lightweight tag.
+#    Annotation body shape: English summary, then "---" on its own line,
+#    then a Korean summary block.
+git tag -a v<version> -m "$(cat <<'EOF'
+Hypomnema v<version> — <one-line English summary>
+
+<a few lines of English body — what shipped, links, etc.>
+
+---
+
+Hypomnema v<version> — <한 줄 한글 요약>
+
+<몇 줄의 한글 요약 본문.>
+EOF
+)"
+
+# 6. Verify the tag annotation locally (same check that runs in CI)
+node scripts/check-bilingual.mjs --tag v<version>
+
+# 7. Push
 git push origin main --tags
 ```
 
 The `release.yml` workflow then:
 
 1. Verifies the tag matches `package.json` version.
-2. Runs `npm test` and `npm run lint`.
-3. Publishes to npm with `npm publish --access public --provenance`.
+2. Validates the CHANGELOG section AND the tag annotation are bilingual
+   (`scripts/check-bilingual.mjs`).
+3. Runs `npm test` and `npm run lint`.
+4. Publishes to npm with `npm publish --access public --provenance`.
 
 `NPM_TOKEN` must be set as a repository secret.
 

--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "lint": "node scripts/lint.mjs",
     "graph": "node scripts/graph.mjs",
     "smoke-pack": "node scripts/smoke-pack.mjs",
+    "check:bilingual": "node scripts/check-bilingual.mjs --changelog",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepublishOnly": "npm test && npm run lint && npm run smoke-pack"
+    "prepublishOnly": "npm test && npm run lint && npm run smoke-pack && npm run check:bilingual"
   },
   "devDependencies": {
     "prettier": "^3.8.3"

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -52,6 +52,12 @@ for (const { path, pattern } of targets) {
 }
 
 console.log(`\nNext steps:`);
-console.log(`  git add -A && git commit -m "chore(release): v${next}"`);
-console.log(`  git tag v${next}`);
-console.log(`  git push origin <branch> --tags`);
+console.log(`  1. Edit CHANGELOG.md — ensure the "## [${next}]" section has a`);
+console.log(`     "### 한글 요약" sub-section (release.yml check-bilingual gate).`);
+console.log(`  2. node scripts/check-bilingual.mjs --changelog   # local pre-check`);
+console.log(`  3. git add -A && git commit -m "chore(release): v${next}"`);
+console.log(`  4. Create an ANNOTATED tag (lightweight tags are rejected by CI):`);
+console.log(`       git tag -a v${next} -m "<English body>\\n\\n---\\n\\n<한글 요약>"`);
+console.log(`     See docs/CONTRIBUTING.md "Cutting a release" for the full template.`);
+console.log(`  5. node scripts/check-bilingual.mjs --tag v${next}   # local pre-check`);
+console.log(`  6. git push origin <branch> --tags`);

--- a/scripts/check-bilingual.mjs
+++ b/scripts/check-bilingual.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * check-bilingual.mjs — CLI gate for the bilingual release-doc rule.
+ *
+ * Modes:
+ *   --changelog [version]   Validate CHANGELOG.md section for given version.
+ *                           Defaults to package.json's "version" field.
+ *                           Wired into npm `prepublishOnly` so publishes fail
+ *                           when the Korean summary is missing.
+ *
+ *   --tag <ref>             Validate annotated tag body for given ref.
+ *                           Wired into .github/workflows/release.yml so a
+ *                           lightweight tag or a missing Korean section
+ *                           blocks the npm publish step.
+ *
+ * Exits 0 on pass, 1 on fail with a stderr diagnostic.
+ */
+
+import { readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { validateChangelog, validateTagBody } from './lib/check-bilingual.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+
+const RULE_REF =
+  'Rule source: CLAUDE.md learned_behaviors (release-doc-bilingual, 2026-05-24). ' +
+  'OSS Hypomnema ships must carry English body + Korean summary in both CHANGELOG section and git tag annotation.';
+
+function fail(msg) {
+  process.stderr.write(`[check-bilingual] FAIL: ${msg}\n${RULE_REF}\n`);
+  process.exit(1);
+}
+
+function ok(msg) {
+  process.stdout.write(`[check-bilingual] OK: ${msg}\n`);
+  process.exit(0);
+}
+
+function usage(exitCode) {
+  process.stdout.write(
+    `Usage:\n` +
+      `  node scripts/check-bilingual.mjs --changelog [version]\n` +
+      `      Validate CHANGELOG.md "## [<version>]" section. Default version: package.json.\n` +
+      `  node scripts/check-bilingual.mjs --tag <ref>\n` +
+      `      Validate annotated tag body (lightweight tags are rejected).\n`,
+  );
+  process.exit(exitCode);
+}
+
+const args = process.argv.slice(2);
+const mode = args[0];
+
+if (mode === '--help' || mode === '-h') usage(0);
+if (!mode) usage(1);
+
+if (mode === '--changelog') {
+  let version = args[1];
+  if (!version) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8'));
+      version = pkg.version;
+    } catch (err) {
+      fail(`cannot read package.json: ${err.message}`);
+    }
+  }
+  if (!version) fail('no version (arg empty, package.json has no "version" field)');
+
+  let content;
+  try {
+    content = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf-8');
+  } catch (err) {
+    fail(`cannot read CHANGELOG.md: ${err.message}`);
+  }
+
+  const result = validateChangelog(content, version);
+  if (!result.ok) fail(result.reason);
+  ok(`CHANGELOG.md [${version}] — ${result.hangulCount} Hangul chars in "### 한글 요약".`);
+} else if (mode === '--tag') {
+  const ref = args[1];
+  if (!ref) fail('--tag requires a ref argument (e.g. v1.2.1)');
+
+  // Reject lightweight tags. `git rev-parse <ref>^{tag}` succeeds ONLY for
+  // annotated tags. For lightweight tags the ^{tag} peel fails because there
+  // is no tag object — the ref points straight at a commit.
+  const tagObj = spawnSync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{tag}`], {
+    encoding: 'utf-8',
+    cwd: REPO_ROOT,
+  });
+  if (tagObj.status !== 0) {
+    const exists = spawnSync('git', ['rev-parse', '--verify', '--quiet', ref], {
+      encoding: 'utf-8',
+      cwd: REPO_ROOT,
+    });
+    if (exists.status !== 0) fail(`tag ${ref} not found`);
+    fail(
+      `tag ${ref} is a lightweight tag, not annotated. ` +
+        `Re-create with: git tag -a ${ref} -m "<English body>\n\n---\n\n<Korean summary>"`,
+    );
+  }
+
+  const tagBody = spawnSync('git', ['tag', '-l', `--format=%(contents)`, ref], {
+    encoding: 'utf-8',
+    cwd: REPO_ROOT,
+  });
+  if (tagBody.status !== 0) fail(`failed to read tag ${ref}: ${tagBody.stderr}`);
+
+  const result = validateTagBody(tagBody.stdout || '');
+  if (!result.ok) fail(`tag ${ref} — ${result.reason}`);
+  ok(`tag ${ref} annotation — ${result.hangulCount} Hangul chars after last "---" separator.`);
+} else {
+  fail(`unknown mode: ${mode}. Use --changelog or --tag (see --help).`);
+}

--- a/scripts/lib/check-bilingual.mjs
+++ b/scripts/lib/check-bilingual.mjs
@@ -1,0 +1,141 @@
+/**
+ * lib/check-bilingual.mjs — pure validators for the bilingual release-doc rule.
+ *
+ * Rule source: CLAUDE.md learned_behaviors release-doc-bilingual (2026-05-24).
+ * Every Hypomnema OSS ship must carry an English body PLUS a Korean summary
+ * block in both the CHANGELOG section and the git tag annotation. This module
+ * exports the parsing/validation primitives; the CLI wrapper in
+ * scripts/check-bilingual.mjs handles I/O and exit codes.
+ *
+ * Scope (deliberate): this gate only enforces the KOREAN half. The English
+ * half has been historically present in every ship — the rule exists because
+ * the Korean half is what gets silently dropped under time pressure (see
+ * release-doc-bilingual feedback page). A tag body of "---" + Korean with an
+ * empty English section would technically pass these validators, but that's
+ * acceptable because such a body is not a realistic failure mode for a
+ * maintainer who already wrote the English release notes. If "English missing"
+ * ever becomes a real regression vector, add an English-half threshold.
+ *
+ * Why pure functions: lets tests/runner.mjs construct synthetic CHANGELOG /
+ * tag-body strings without touching real git or real CHANGELOG.md.
+ */
+
+// AC00–D7A3 covers all precomposed Hangul syllables. We NFC-normalize the
+// input before counting so jamo-only inputs (decomposed) still match after
+// composition.
+export const HANGUL_RE = /[가-힣]/g;
+export const HANGUL_BODY_THRESHOLD = 10;
+
+export function countHangul(text) {
+  return (text.normalize('NFC').match(HANGUL_RE) || []).length;
+}
+
+export function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Validate that CHANGELOG.md content has a "## [<version>]" section containing
+ * a "### 한글 요약" sub-section with >= HANGUL_BODY_THRESHOLD Hangul chars.
+ *
+ * @param {string} content  CHANGELOG.md raw content (CRLF tolerated).
+ * @param {string} version  Semver string to look up (e.g. "1.2.1").
+ * @returns {{ok: true, hangulCount: number} | {ok: false, reason: string}}
+ */
+export function validateChangelog(content, version) {
+  if (!version) return { ok: false, reason: 'no version supplied' };
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const versionEsc = escapeRegex(version);
+  // Anchor closing bracket so 1.2.1 does NOT match the prefix of 1.2.10.
+  // Allow trailing " - YYYY-MM-DD" or nothing.
+  const sectionRe = new RegExp(`^## \\[${versionEsc}\\](\\s.*)?$`);
+
+  const startIndices = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (sectionRe.test(lines[i])) startIndices.push(i);
+  }
+  if (startIndices.length === 0) {
+    return { ok: false, reason: `no "## [${version}]" section in CHANGELOG.md` };
+  }
+  if (startIndices.length > 1) {
+    return {
+      ok: false,
+      reason: `duplicate "## [${version}]" sections (${startIndices.length}) in CHANGELOG.md`,
+    };
+  }
+
+  const start = startIndices[0];
+  let sectionEnd = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+  const sectionLines = lines.slice(start, sectionEnd);
+
+  const koreanHeadIdx = sectionLines.findIndex((l) => l.trim() === '### 한글 요약');
+  if (koreanHeadIdx === -1) {
+    return { ok: false, reason: `section [${version}] missing "### 한글 요약" sub-section` };
+  }
+
+  // Bound the Korean block: stop at the next H2 OR H3. CHANGELOG.md has
+  // sibling H3s like "### Internal", "### Fixed" — Hangul in those sections
+  // does not count toward the "### 한글 요약" requirement.
+  let koreanEnd = sectionLines.length;
+  for (let i = koreanHeadIdx + 1; i < sectionLines.length; i++) {
+    if (/^(##|###) /.test(sectionLines[i])) {
+      koreanEnd = i;
+      break;
+    }
+  }
+  const body = sectionLines.slice(koreanHeadIdx + 1, koreanEnd).join('\n');
+  const count = countHangul(body);
+  if (count < HANGUL_BODY_THRESHOLD) {
+    return {
+      ok: false,
+      reason:
+        `section [${version}] "### 한글 요약" body has ${count} Hangul chars ` +
+        `(threshold: ${HANGUL_BODY_THRESHOLD}). Heading alone does not count — write real Korean summary.`,
+    };
+  }
+  return { ok: true, hangulCount: count };
+}
+
+/**
+ * Validate that a git tag annotation body has a "---" separator with Korean
+ * text after the LAST such separator. Tolerates earlier "---" markdown
+ * horizontal rules in the English body.
+ *
+ * @param {string} body  Tag annotation body, as returned by
+ *                       `git tag -l --format='%(contents)' <ref>`.
+ * @returns {{ok: true, hangulCount: number} | {ok: false, reason: string}}
+ */
+export function validateTagBody(body) {
+  const lines = body.replace(/\r\n/g, '\n').split('\n');
+  let lastSepIdx = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].trim() === '---') {
+      lastSepIdx = i;
+      break;
+    }
+  }
+  if (lastSepIdx === -1) {
+    return {
+      ok: false,
+      reason:
+        'tag annotation has no "---" separator line (expected: English body + "---" + Korean)',
+    };
+  }
+  const tail = lines.slice(lastSepIdx + 1).join('\n');
+  const count = countHangul(tail);
+  if (count < HANGUL_BODY_THRESHOLD) {
+    return {
+      ok: false,
+      reason:
+        `tag body after the last "---" has only ${count} Hangul chars ` +
+        `(threshold: ${HANGUL_BODY_THRESHOLD}). Write a real Korean summary after the separator.`,
+    };
+  }
+  return { ok: true, hangulCount: count };
+}

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -30,6 +30,12 @@ import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync
 import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
 import { buildProjectSuggestionLine } from '../hooks/hypo-shared.mjs';
 import { parseSchemaVocab } from '../scripts/lib/schema-vocab.mjs';
+import {
+  validateChangelog,
+  validateTagBody,
+  countHangul,
+  HANGUL_BODY_THRESHOLD,
+} from '../scripts/lib/check-bilingual.mjs';
 
 const HOME = homedir();
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -9469,6 +9475,233 @@ test('w8-lint-omits-id-for-other-warns', () => {
       `expected non-W8 warns to omit id field: ${JSON.stringify(parsed.warns)}`,
     );
   });
+});
+
+// ── check-bilingual: release-doc bilingual rule enforcement ─────────────────
+
+suite('check-bilingual — CHANGELOG section validator');
+
+const CHANGELOG_HEADER = `# Changelog
+
+All notable changes to Hypomnema are documented in this file.
+
+## [Unreleased]
+
+`;
+
+function makeChangelogFixture(sections) {
+  return CHANGELOG_HEADER + sections.join('\n');
+}
+
+const KOREAN_FILLER = '이번 릴리스에서는 새로운 기능을 추가했고 몇 가지 버그를 수정했습니다.';
+
+test('check-bilingual: valid section with 한글 요약 sub-section passes', () => {
+  const cl = makeChangelogFixture([
+    `## [1.2.1] - 2026-05-26
+
+### Fixed
+
+- some English fix
+
+### 한글 요약
+
+- ${KOREAN_FILLER}
+
+### Internal
+
+- some English internal note
+`,
+  ]);
+  const r = validateChangelog(cl, '1.2.1');
+  assert.equal(r.ok, true, JSON.stringify(r));
+  assert.ok(r.hangulCount >= HANGUL_BODY_THRESHOLD);
+});
+
+test('check-bilingual: 한글 요약 heading with English-only body fails', () => {
+  const cl = makeChangelogFixture([
+    `## [1.0.0] - 2026-01-01
+
+### 한글 요약
+
+- This body is only English with no Korean characters.
+`,
+  ]);
+  const r = validateChangelog(cl, '1.0.0');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /Hangul chars/);
+});
+
+test('check-bilingual: section without 한글 요약 sub-section fails', () => {
+  const cl = makeChangelogFixture([
+    `## [1.0.0] - 2026-01-01
+
+### Fixed
+
+- some English fix
+`,
+  ]);
+  const r = validateChangelog(cl, '1.0.0');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /missing "### 한글 요약"/);
+});
+
+test('check-bilingual: version not in CHANGELOG fails', () => {
+  const cl = makeChangelogFixture([`## [1.0.0] - 2026-01-01\n\n- stuff\n`]);
+  const r = validateChangelog(cl, '9.9.9');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /no "## \[9\.9\.9\]"/);
+});
+
+test('check-bilingual: [Unreleased] does NOT satisfy a version-target lookup', () => {
+  // The fixture's header contains "## [Unreleased]" but the lookup is for 1.2.0
+  // → must fail (no special-casing — codex BLOCKER fix).
+  const cl = makeChangelogFixture([]);
+  const r = validateChangelog(cl, '1.2.0');
+  assert.equal(r.ok, false);
+});
+
+test('check-bilingual: 1.2.1 does not match 1.2.10 (semver escape)', () => {
+  const cl = makeChangelogFixture([
+    `## [1.2.10] - 2026-06-01
+
+### 한글 요약
+
+- ${KOREAN_FILLER}
+`,
+  ]);
+  const r = validateChangelog(cl, '1.2.1');
+  assert.equal(r.ok, false, 'must not match 1.2.10 prefix as 1.2.1');
+});
+
+test('check-bilingual: prerelease (1.2.1-rc.1) is matched literally', () => {
+  const cl = makeChangelogFixture([
+    `## [1.2.1-rc.1] - 2026-05-20
+
+### 한글 요약
+
+- ${KOREAN_FILLER}
+`,
+  ]);
+  const r = validateChangelog(cl, '1.2.1-rc.1');
+  assert.equal(r.ok, true);
+});
+
+test('check-bilingual: duplicate version sections fail', () => {
+  const cl = makeChangelogFixture([
+    `## [1.0.0] - 2026-01-01
+
+### 한글 요약
+
+- ${KOREAN_FILLER}
+
+## [1.0.0] - 2026-01-02
+
+### 한글 요약
+
+- ${KOREAN_FILLER}
+`,
+  ]);
+  const r = validateChangelog(cl, '1.0.0');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /duplicate.*sections/);
+});
+
+test('check-bilingual: Korean block boundary stops at next H3 (Internal section)', () => {
+  // The 한글 요약 body itself has 0 Korean chars (a parser bug would leak Hangul
+  // from the next "### Internal" section back into the "### 한글 요약" body).
+  // The boundary must stop at the next ### to prevent that false pass.
+  const KOREAN_INTERNAL =
+    '내부 변경 사항 한국어 텍스트입니다 더 많은 한글 단어들로 임계값을 넘기게 합니다.';
+  const cl = makeChangelogFixture([
+    `## [1.0.0] - 2026-01-01
+
+### 한글 요약
+
+- only English body here, no Korean at all.
+
+### Internal
+
+- ${KOREAN_INTERNAL}
+`,
+  ]);
+  const r = validateChangelog(cl, '1.0.0');
+  assert.equal(r.ok, false, 'must fail — Korean lives in Internal, not in 한글 요약');
+});
+
+test('check-bilingual: CRLF line endings normalized', () => {
+  const ko = `## [1.0.0] - 2026-01-01\r\n\r\n### 한글 요약\r\n\r\n- ${KOREAN_FILLER}\r\n`;
+  const cl = CHANGELOG_HEADER.replace(/\n/g, '\r\n') + ko;
+  const r = validateChangelog(cl, '1.0.0');
+  assert.equal(r.ok, true);
+});
+
+test('check-bilingual: NFC normalizes decomposed Hangul jamo before counting', () => {
+  // "가나다라마바사아자차" precomposed = 10 syllables. Decomposed = jamo-only.
+  const decomposed = '가나다라마바사아자차'.normalize('NFD');
+  assert.notEqual(decomposed, '가나다라마바사아자차');
+  const cl = makeChangelogFixture([`## [1.0.0] - 2026-01-01\n\n### 한글 요약\n\n${decomposed}\n`]);
+  const r = validateChangelog(cl, '1.0.0');
+  assert.equal(r.ok, true, `decomposed input must NFC-normalize; got: ${JSON.stringify(r)}`);
+});
+
+suite('check-bilingual — git tag annotation body validator');
+
+test('check-bilingual tag: valid body with --- + Korean passes', () => {
+  const body = `Hypomnema v1.0.0 — initial release\n\nEnglish summary body.\n\n---\n\n한국어 요약 본문입니다 여러 단어를 포함한 실제 한글 요약.\n`;
+  const r = validateTagBody(body);
+  assert.equal(r.ok, true);
+});
+
+test('check-bilingual tag: body without --- separator fails', () => {
+  const body = `Hypomnema v1.0.0\n\nEnglish only, no separator, but has 한국어 요약 inline.\n`;
+  const r = validateTagBody(body);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /no "---" separator/);
+});
+
+test('check-bilingual tag: --- present but no Korean after fails', () => {
+  const body = `Hypomnema v1.0.0\n\nEnglish body.\n\n---\n\nMore English, no Korean here.\n`;
+  const r = validateTagBody(body);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /Hangul/);
+});
+
+test('check-bilingual tag: only the LAST --- counts (tolerates English markdown HR)', () => {
+  // Earlier --- is a legit horizontal rule inside the English body. The Korean
+  // summary block lives after the SECOND --- only.
+  const body =
+    `Hypomnema v1.0.0\n\n` +
+    `English section A.\n\n---\n\nEnglish section B (still English, after first ---).\n\n` +
+    `---\n\n한국어 요약 본문입니다 충분한 분량의 실제 한글 요약.\n`;
+  const r = validateTagBody(body);
+  assert.equal(r.ok, true);
+});
+
+test('check-bilingual tag: --- present, only Hangul before it (header-only Korean) fails', () => {
+  // Korean lives BEFORE the separator (mis-ordered). After-separator body is
+  // English-only — must fail.
+  const body = `한국어 요약 본문입니다 충분한 분량의 실제 한글 요약.\n\n---\n\nEnglish only after the separator.\n`;
+  const r = validateTagBody(body);
+  assert.equal(r.ok, false);
+});
+
+test('check-bilingual tag: multiple --- + Korean after last passes', () => {
+  const body = `A\n---\nB\n---\nC\n---\n한글 요약 본문 충분한 길이의 실제 한국어 요약입니다.\n`;
+  const r = validateTagBody(body);
+  assert.equal(r.ok, true);
+});
+
+test('check-bilingual tag: short Korean (under threshold) fails', () => {
+  const body = `English body.\n\n---\n\n한글.\n`;
+  const r = validateTagBody(body);
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /threshold: 10/);
+});
+
+test('check-bilingual: countHangul ignores non-Hangul Unicode (e.g. CJK, Hiragana)', () => {
+  // 漢字 (CJK Han, not Hangul), ひらがな (Hiragana) — both should be 0.
+  assert.equal(countHangul('漢字 ひらがな English'), 0);
+  assert.equal(countHangul('한글 + 漢字'), 2);
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add `scripts/check-bilingual.mjs` gating `npm publish` on the **release-doc-bilingual** rule (`~/.claude/CLAUDE.md` learned_behaviors, 2026-05-24). The rule has been honored manually since v1.2.0 but never enforced — this PR closes the gap so future ships cannot silently drop the Korean summary.

## What ships

- **`scripts/check-bilingual.mjs`** + **`scripts/lib/check-bilingual.mjs`** (pure validators + CLI wrapper)
  - `--changelog [version]` — validates `## [<version>]` section has a `### 한글 요약` sub-section with **≥10 NFC-normalized Hangul chars**. Block boundary stops at the next H2 **or** H3 so sibling sections (`### Internal`, `### Fixed`) cannot leak Hangul into the gate. Auto-detects version from `package.json` when no arg.
  - `--tag <ref>` — validates annotated-tag body has a `---` separator line with **≥10 Hangul chars after the LAST** `---` (tolerates English markdown horizontal rules earlier). **Lightweight tags rejected** via `git rev-parse <ref>^{tag}`.
- **`package.json`**: `prepublishOnly` chains `npm run check:bilingual` after `smoke-pack`.
- **`.github/workflows/release.yml`**: runs both modes before `npm publish`; checkout uses `fetch-depth: 0` so the annotated-tag object is reachable.
- **`scripts/bump-version.mjs`**: next-steps now point at `git tag -a` with the bilingual annotation template and the local pre-check commands.
- **`docs/CONTRIBUTING.md`**: "Cutting a release" rewritten with the annotated-tag template; `bump-version` invocation corrected from `<patch|minor|major>` to `<new-semver>` (matches script's actual signature).

## Scope (intentional)

Only the **Korean** half is gated. The English half has been historically present in every ship; the rule exists because Korean is what gets silently dropped under time pressure. Documented in `lib/check-bilingual.mjs` docstring.

## Tests (19 new, 442 total green)

**CHANGELOG validator**: valid pass · English-only body fail · missing sub-section fail · version-not-found fail · `[Unreleased]` does not satisfy version lookup · semver escape (`1.2.1` vs `1.2.10`) · prerelease literal match · duplicate-section fail · H3-boundary stop (Korean in `### Internal` does not count) · CRLF · NFC decomposed jamo composition.

**Tag-body validator**: valid · no separator · separator without Korean fail · last-of-multiple-separators wins · mis-ordered Korean (before separator) fail · multiple separators · short Korean under threshold fail.

**`countHangul`**: ignores CJK / Hiragana.

## Codex review (2 rounds via `/teams`)

- **Design** (1 worker, gpt-5.5 xhigh): 2 BLOCKER + 6 CONCERN + 1 NIT — all addressed before implementation.
- **Pre-commit** (1 worker, gpt-5.5 xhigh): 0 BLOCKER + 2 real CONCERN — both fixed:
  - `bump-version.mjs` printed `git tag v${next}` (lightweight) → rewrote next-steps with annotated-tag template + pre-checks.
  - Korean-half-only enforcement → documented as deliberate scope in lib docstring.
  - 2 NITs deferred (integration test for lightweight CLI path; tab vs single-space after `##`/`###` — current style matches Keep-a-Changelog).

## Test plan

- [x] `npm test` — 442 passed, 0 failed
- [x] `node scripts/check-bilingual.mjs --changelog` against current `1.2.1` — pass
- [x] `node scripts/check-bilingual.mjs --tag v1.2.1` (annotated) — pass
- [x] `node scripts/check-bilingual.mjs --tag v1.1.0` (lightweight) — rejects with actionable message
- [x] `npm run lint` — 0 errors
- [x] Prettier format applied to all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)