### PR TITLE
feat(format): auto-format staged files via pre-commit hook

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -139,6 +139,34 @@ Some hook behavior is only observable inside a Claude Code session. Document the
 
 ---
 
+## Pre-commit auto-format hook
+
+`npm install` in this checkout installs a git `pre-commit` hook that runs `prettier --write` on staged files only. The hook is **non-blocking**: formatter failures print a notice but the commit still proceeds. The only block is when `git add` itself fails during restage (true index corruption).
+
+**Requirements**: Git ≥ 2.13 (uses `--absolute-git-dir`; `--git-common-dir` is 2.5+).
+
+**Path-locked to your checkout.** The shim embeds the absolute paths of your `HYPOMNEMA_ROOT` and `.git/` directory at install time. If you `mv` the checkout, re-run `npm install` to regenerate the shim — until then it safely no-ops.
+
+**Main worktree only.** `git worktree add` checkouts silently skip — the shared `.git/hooks/pre-commit` can only point at one embedded root at a time. Commit from the main worktree to get auto-format, or accept the no-op in linked worktrees.
+
+**CI is skipped.** `npm ci` runs `prepare`, but the installer detects `CI=true` and exits 0 without touching `.git/hooks/`. CI runs never mutate hooks.
+
+**Symlink-safe.** If `.git/hooks/` is a symlink, or an existing `pre-commit` is a symlink, the installer refuses to write through it.
+
+**Shared `core.hooksPath` safe.** The shim verifies both `--show-toplevel` and `--absolute-git-dir` against the embedded values before executing. Foreign repos that share your global `core.hooksPath` will silently no-op.
+
+**Env-override defense.** The Node side strips every `GIT_*` env from `git rev-parse --local-env-vars` (plus `GIT_NAMESPACE`, `GIT_CEILING_DIRECTORIES`, `GIT_CONFIG_*`) before its own git spawns. Inherited `GIT_INDEX_FILE` is preserved **only** when invoked from the installed shell shim (signalled via a sentinel env var). Direct `node scripts/pre-commit-format.mjs` invocation drops `GIT_INDEX_FILE` and falls back to the default `.git/index`, closing the class of attacks that try to drive the formatter against a crafted alternate index.
+
+**Existing non-marker pre-commit?** If you have your own `pre-commit` hook (no `# hypomnema-pre-commit-marker v1` on line 2), the installer logs a notice and never overwrites it.
+
+**Skip a single commit**: `git commit --no-verify`. AI agents must not use this without explicit user authorization.
+
+**Verbose install logs**: `HYPOMNEMA_HOOK_VERBOSE=1 npm install` prints skip/install reasons to stderr.
+
+**Distinction from `hooks/hypo-pre-commit.mjs`**: that file is the git pre-commit worker template that `scripts/init.mjs` installs into `<wiki>/.git/hooks/pre-commit` when a user runs `hypomnema init` in their own wiki repo. It lives in the *user's wiki* repo, not in this package repo. The two hooks never interact.
+
+---
+
 ## Branch and commit conventions
 
 - One logical change per branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypomnema",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypomnema",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "bin": {
         "hypomnema": "scripts/init.mjs"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "check:bilingual": "node scripts/check-bilingual.mjs --changelog",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "prepare": "node scripts/install-git-hooks.mjs",
     "prepublishOnly": "npm test && npm run lint && npm run smoke-pack && npm run check:bilingual"
   },
   "devDependencies": {

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -350,7 +350,9 @@ function runMarkSessionClosed(args) {
     if (args.json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
-      console.log(`✗ session-close gate not satisfied — marker not written (project: ${status.project || '(unresolved)'}):`);
+      console.log(
+        `✗ session-close gate not satisfied — marker not written (project: ${status.project || '(unresolved)'}):`,
+      );
       for (const f of status.missing) console.log(`  ✗ ${f} (missing)`);
       for (const f of status.stale) console.log(`  ✗ ${f} (stale)`);
       if (!git.clean) console.log(`  ✗ git: ${git.reason}`);
@@ -364,7 +366,11 @@ function runMarkSessionClosed(args) {
   // Codex Worker-2 CONCERN (pre-commit review).
   if (!existsSync(sessionClosedMarkerPath(args.hypoDir, args.sessionId))) {
     const err = 'marker file did not land after write (likely .cache permission/disk issue)';
-    console.log(args.json ? JSON.stringify({ ok: false, session_id: args.sessionId, error: err }, null, 2) : `✗ ${err}`);
+    console.log(
+      args.json
+        ? JSON.stringify({ ok: false, session_id: args.sessionId, error: err }, null, 2)
+        : `✗ ${err}`,
+    );
     process.exit(1);
   }
   const result = {
@@ -376,7 +382,9 @@ function runMarkSessionClosed(args) {
   if (args.json) {
     console.log(JSON.stringify(result, null, 2));
   } else {
-    console.log(`✓ session-closed marker written (session_id: ${args.sessionId}, project: ${status.project}).`);
+    console.log(
+      `✓ session-closed marker written (session_id: ${args.sessionId}, project: ${status.project}).`,
+    );
   }
   process.exit(0);
 }

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * scripts/install-git-hooks.mjs — idempotent git pre-commit hook installer.
+ *
+ * Wired into package.json as the `prepare` script so it runs after every
+ * `npm install` / `npm ci` in this checkout. The installer is FULLY fail-open:
+ * any filesystem or git error → silent exit 0. The CLAUDE.md formatter rule
+ * is best-effort; a failed install must never block contributor onboarding.
+ *
+ * Trust model:
+ *   - `expectedRoot` is derived from THIS script's filesystem location (via
+ *     `import.meta.url` → realpath), NOT from `git rev-parse`. Git probes
+ *     can be redirected by ambient GIT_DIR/GIT_WORK_TREE; the script's own
+ *     path cannot.
+ *   - All git probes use a scrubbed env (every name from `--local-env-vars`
+ *     plus GIT_NAMESPACE / GIT_CEILING_DIRECTORIES / GIT_CONFIG_*).
+ *   - Probes run with `cwd: expectedRoot` so npm `--prefix` invocations
+ *     can't redirect resolution either.
+ *   - Generated shim embeds `HYPOMNEMA_ROOT` + `HYPOMNEMA_GIT_DIR`. Runtime
+ *     shim refuses to exec unless both literals match the current values.
+ *
+ * Refusal conditions (all exit 0):
+ *   - `CI=true` env (npm ci on CI runs prepare; we must not touch hooks)
+ *   - `npm_command` in {pack, publish} or `npm_lifecycle_event=prepublishOnly`
+ *   - `.git/` absent (consumer install of the published tarball)
+ *   - linked worktree (--absolute-git-dir != --git-common-dir)
+ *   - toplevel != expectedRoot
+ *   - hooks dir / pre-commit file is a symlink
+ *   - existing non-marker pre-commit (don't clobber the user's own hook)
+ *   - any filesystem error (ENOENT, EPERM, EACCES, …)
+ *
+ * Verbose mode: set HYPOMNEMA_HOOK_VERBOSE=1 to see skip/install reasons.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+function exitSilent(msg) {
+  if (process.env.HYPOMNEMA_HOOK_VERBOSE === '1') {
+    process.stderr.write(`[install-git-hooks] ${msg}\n`);
+  }
+  process.exit(0);
+}
+
+// Static fallback list for `--local-env-vars`. Used when we don't yet have a
+// trusted git invocation (the installer is bootstrapping its own trust chain),
+// and also when git is too old to support `--local-env-vars`.
+const STATIC_LOCAL_ENV_VARS = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
+  'GIT_CONFIG',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_PREFIX',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_GRAFT_FILE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_SHALLOW_FILE',
+];
+
+function buildScrubbedEnv(localEnvList) {
+  const scrub = new Set([
+    ...(localEnvList || STATIC_LOCAL_ENV_VARS),
+    'GIT_NAMESPACE',
+    'GIT_CEILING_DIRECTORIES',
+    ...Object.keys(process.env).filter((k) => /^GIT_CONFIG_/.test(k)),
+  ]);
+  return Object.fromEntries(Object.entries(process.env).filter(([k]) => !scrub.has(k)));
+}
+
+function shellSingleQuote(s) {
+  // POSIX-safe: 'x' → 'x', x'y → 'x'\''y'
+  return `'` + s.replace(/'/g, `'\\''`) + `'`;
+}
+
+function shimBody(root, gitDir) {
+  return `#!/bin/sh
+# hypomnema-pre-commit-marker v1
+# Fail-open at every guard. Only the .mjs (after identity checks) can exit nonzero.
+set +e
+HYPOMNEMA_ROOT=${shellSingleQuote(root)}
+HYPOMNEMA_GIT_DIR=${shellSingleQuote(gitDir)}
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -z "$TOPLEVEL" ] && exit 0
+[ "$TOPLEVEL" = "$HYPOMNEMA_ROOT" ] || exit 0
+ABSGITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || exit 0
+[ "$ABSGITDIR" = "$HYPOMNEMA_GIT_DIR" ] || exit 0
+SCRIPT="$HYPOMNEMA_ROOT/scripts/pre-commit-format.mjs"
+[ -f "$SCRIPT" ] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
+# Sentinel: tells the .mjs it is running under our trusted shim (not direct
+# attacker invocation). The .mjs preserves inherited GIT_INDEX_FILE only when
+# this sentinel is present — direct invocation drops it and falls back to the
+# default \`.git/index\`. This closes prefix-matching attacks on the index
+# whitelist (e.g. attacker-crafted .git/next-index-attack.lock).
+HYPOMNEMA_HOOK_INVOCATION=1 exec node "$SCRIPT"
+`;
+}
+
+function writeShim(target, root, gitDir) {
+  try {
+    fs.writeFileSync(target, shimBody(root, gitDir), { mode: 0o755 });
+    try {
+      fs.chmodSync(target, 0o755);
+    } catch {}
+    return exitSilent(`installed pre-commit hook for ${root}`);
+  } catch (e) {
+    return exitSilent(`write hook failed: ${e.code || e.message}; skipping`);
+  }
+}
+
+async function main() {
+  try {
+    // (0) CI / lifecycle guards.
+    if (process.env.CI === 'true') return exitSilent('CI=true; skipping');
+    const lc = process.env.npm_command;
+    if (lc === 'pack' || lc === 'publish') {
+      return exitSilent(`npm_command=${lc}; skipping`);
+    }
+    if (process.env.npm_lifecycle_event === 'prepublishOnly') {
+      return exitSilent('prepublishOnly; skipping');
+    }
+
+    // (1) Derive expectedRoot from THIS script's location, not from git.
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    let expectedRoot;
+    try {
+      expectedRoot = fs.realpathSync(path.resolve(here, '..'));
+    } catch {
+      return exitSilent('cannot resolve script location; skipping');
+    }
+
+    // (2) Bootstrap scrubbed env with the static fallback list, just enough to
+    //     get a trusted git probe running. Then enrich from --local-env-vars at
+    //     runtime (modern git) so the scrub list always tracks git's own truth.
+    let cleanEnv = buildScrubbedEnv(null);
+    let run = (args) =>
+      execFileSync('git', args, {
+        encoding: 'utf-8',
+        env: cleanEnv,
+        cwd: expectedRoot,
+      }).trim();
+    try {
+      const list = run(['rev-parse', '--local-env-vars']).split(/\r?\n/).filter(Boolean);
+      cleanEnv = buildScrubbedEnv(list);
+      run = (args) =>
+        execFileSync('git', args, {
+          encoding: 'utf-8',
+          env: cleanEnv,
+          cwd: expectedRoot,
+        }).trim();
+    } catch {
+      // Old git without --local-env-vars; keep static-list cleanEnv.
+    }
+
+    // (3) Probe git with sanitized env.
+    let topR, absGitDir, commonDir;
+    try {
+      topR = fs.realpathSync(run(['rev-parse', '--show-toplevel']));
+      absGitDir = fs.realpathSync(run(['rev-parse', '--absolute-git-dir']));
+      const cd = run(['rev-parse', '--git-common-dir']);
+      commonDir = fs.realpathSync(path.isAbsolute(cd) ? cd : path.join(absGitDir, '..', cd));
+    } catch {
+      return exitSilent('git probe failed; skipping');
+    }
+
+    // (4) Identity + worktree + containment.
+    if (topR !== expectedRoot) {
+      return exitSilent('toplevel != expectedRoot; skipping');
+    }
+    if (absGitDir !== commonDir) {
+      return exitSilent('linked worktree; skipping');
+    }
+    if (!absGitDir.startsWith(expectedRoot + path.sep)) {
+      return exitSilent('gitDir outside expectedRoot; skipping');
+    }
+
+    // (5) Resolve hooks dir (still under sanitized env).
+    let rawHooksDir;
+    try {
+      rawHooksDir = run(['rev-parse', '--git-path', 'hooks']);
+    } catch {
+      return exitSilent('cannot resolve hooks dir; skipping');
+    }
+    if (!path.isAbsolute(rawHooksDir)) {
+      rawHooksDir = path.resolve(expectedRoot, rawHooksDir);
+    }
+
+    if (!fs.existsSync(rawHooksDir)) {
+      // Git creates .git/hooks lazily. Only create when it would land inside
+      // absGitDir — protects against `core.hooksPath=/elsewhere`.
+      if (!rawHooksDir.startsWith(absGitDir + path.sep)) {
+        return exitSilent('hooks dir outside gitDir; skipping');
+      }
+      try {
+        fs.mkdirSync(rawHooksDir, { recursive: true });
+      } catch {
+        return exitSilent('mkdir hooks dir failed; skipping');
+      }
+    }
+
+    let absHooksDir;
+    try {
+      absHooksDir = fs.realpathSync(rawHooksDir);
+    } catch {
+      return exitSilent('realpath hooks dir failed; skipping');
+    }
+
+    // (6) Symlink rejection + containment.
+    try {
+      if (fs.lstatSync(rawHooksDir).isSymbolicLink()) {
+        return exitSilent('hooks dir is symlink; skipping');
+      }
+    } catch {
+      return exitSilent('lstat hooks dir failed; skipping');
+    }
+    const rel = path.relative(absGitDir, absHooksDir);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      return exitSilent('hooks dir outside .git/; skipping');
+    }
+
+    // (7) Existing pre-commit logic.
+    const target = path.join(absHooksDir, 'pre-commit');
+    let existing;
+    try {
+      existing = fs.lstatSync(target);
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        return writeShim(target, expectedRoot, absGitDir);
+      }
+      return exitSilent(`stat target failed: ${e.code}; skipping`);
+    }
+    if (existing.isSymbolicLink()) {
+      return exitSilent('pre-commit is symlink; not overwriting');
+    }
+    let head;
+    try {
+      head = fs.readFileSync(target, 'utf-8').split('\n').slice(0, 3).join('\n');
+    } catch {
+      return exitSilent('read existing pre-commit failed; skipping');
+    }
+    if (head.includes('hypomnema-pre-commit-marker v1')) {
+      // Same marker — regenerate (refreshes embedded root if checkout moved).
+      return writeShim(target, expectedRoot, absGitDir);
+    }
+    return exitSilent('existing non-marker pre-commit; not overwriting');
+  } catch (e) {
+    return exitSilent(`unexpected: ${e.code || e.message}; skipping`);
+  }
+}
+
+main();

--- a/scripts/lib/pre-commit-format.mjs
+++ b/scripts/lib/pre-commit-format.mjs
@@ -1,0 +1,251 @@
+/**
+ * lib/pre-commit-format.mjs — pure logic for the auto-format-on-commit hook.
+ *
+ * Rule source: CLAUDE.md <formatting> directive. Pre-commit hook auto-runs the
+ * project formatter on STAGED files only. Formatter failure is non-blocking;
+ * only `git add` failure on restage is a true commit block.
+ *
+ * Why pure: lets tests construct synthetic staged sets without touching real
+ * git or invoking prettier. The CLI shim in scripts/pre-commit-format.mjs
+ * handles env resolution / repo-identity guards / process exit codes.
+ *
+ * Env discipline: every `git` spawn here MUST receive a caller-supplied `env`.
+ * The lib never reads `process.env` for git operations — that defence is what
+ * blocks GIT_DIR / GIT_WORK_TREE override attacks (see CONTRIBUTING.md).
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const STATUS_FILTER = 'ACMR';
+
+/**
+ * Parse the NUL-token stream emitted by `git diff --cached --name-status -z`.
+ *
+ * Token shape (verified live against git 2.50): records are NUL-separated.
+ *   A\0path\0          (added)
+ *   M\0path\0          (modified)
+ *   D\0path\0          (deleted — filtered out by --diff-filter)
+ *   T\0path\0          (type change — filtered out)
+ *   R<score>\0old\0new\0   (rename)
+ *   C<score>\0old\0new\0   (copy)
+ *
+ * Paths containing TAB are valid — TAB is not a separator here (it appears in
+ * the non-`-z` output, never in `-z`). Only NUL separates records.
+ *
+ * @param {string} buf  Raw stdout from `git diff --cached --name-status -z`.
+ * @returns {Array<{path: string, status: string}>}
+ */
+export function parseNameStatus(buf) {
+  const tokens = buf.split('\0');
+  // Trailing NUL leaves an empty token; drop it (and any stray empties).
+  while (tokens.length && tokens[tokens.length - 1] === '') tokens.pop();
+  const out = [];
+  for (let i = 0; i < tokens.length; ) {
+    const status = tokens[i++];
+    if (!status) continue;
+    const head = status[0];
+    if (head === 'R' || head === 'C') {
+      // Two-path record. Old is irrelevant for formatting — only the new path
+      // exists in the staged tree.
+      i++; // consume old
+      const next = tokens[i++];
+      if (next) out.push({ path: next, status: head });
+    } else if (head === 'A' || head === 'M') {
+      const p = tokens[i++];
+      if (p) out.push({ path: p, status: head });
+    } else {
+      // D, T, U, X — consume one path, drop. --diff-filter should exclude
+      // these but we defensively skip.
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse `git ls-files --stage -z` output to map paths → file mode strings.
+ * Output shape: `<mode> <hash> <stage>\t<path>\0`
+ */
+export function parseLsFilesStage(buf) {
+  const map = new Map();
+  const records = buf.split('\0');
+  for (const rec of records) {
+    if (!rec) continue;
+    const tabIdx = rec.indexOf('\t');
+    if (tabIdx < 0) continue;
+    const meta = rec.slice(0, tabIdx);
+    const path = rec.slice(tabIdx + 1);
+    const mode = meta.split(' ')[0];
+    map.set(path, mode);
+  }
+  return map;
+}
+
+/**
+ * Drop symlinks (120000) and gitlinks/submodules (160000). Regular file modes
+ * (100644, 100755) are kept.
+ */
+export function filterRegularFiles(entries, modeMap) {
+  return entries.filter((e) => {
+    const m = modeMap.get(e.path);
+    if (!m) return false; // not in index — defensively skip
+    return m !== '120000' && m !== '160000';
+  });
+}
+
+/**
+ * Partition staged paths into safe vs partial (also has unstaged hunks).
+ * Partial files are skipped to avoid swallowing unstaged work.
+ */
+export function partitionStagedFiles(entries, unstagedDirty) {
+  const safe = [];
+  const partial = [];
+  for (const e of entries) {
+    if (unstagedDirty.has(e.path)) partial.push(e);
+    else safe.push(e);
+  }
+  return { safe, partial };
+}
+
+/**
+ * Formatter dispatch table. Other entries (eslint, black, gofmt, cargo fmt)
+ * are placeholders — the table is data, not a branch tree. Activate by
+ * filling in an entry similar to `prettier`.
+ *
+ * Critically: NEVER use `npx` here. `npx prettier` may try a network install
+ * on a cold machine; we want a local-only binary or no-op.
+ */
+export function selectFormatter(repoRoot) {
+  const prettierBin = join(repoRoot, 'node_modules', '.bin', 'prettier');
+  if (existsSync(prettierBin)) {
+    return {
+      name: 'prettier',
+      bin: prettierBin,
+      buildArgs: (files) => ['--write', '--', ...files],
+    };
+  }
+  return null;
+}
+
+/**
+ * Run the formatter once with all safe files. Captures exit status; never
+ * throws.
+ */
+export function formatFiles(safe, formatter, { env, cwd } = {}) {
+  if (!safe.length || !formatter) {
+    return { ran: false, formatterFailed: false, reason: 'noop' };
+  }
+  const paths = safe.map((e) => e.path);
+  const res = spawnSync(formatter.bin, formatter.buildArgs(paths), {
+    cwd,
+    env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    ran: true,
+    formatterFailed: res.status !== 0,
+    exitCode: res.status,
+    stdout: res.stdout || '',
+    stderr: res.stderr || '',
+  };
+}
+
+/**
+ * Re-stage the formatted files. Returns `{gitAddFailed: bool, stderr}`.
+ * Prettier `--write` only writes on actual content change, so re-adding
+ * unchanged files is a cheap no-op. Doing it unconditionally avoids a
+ * before/after hash comparison.
+ */
+export function restageFormatted(files, { env, cwd } = {}) {
+  if (!files.length) return { gitAddFailed: false };
+  const res = spawnSync('git', ['add', '--', ...files], {
+    cwd,
+    env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    gitAddFailed: res.status !== 0,
+    stderr: res.stderr || '',
+  };
+}
+
+/**
+ * Top-level orchestrator used by the CLI shim. The caller supplies `cwd`
+ * (the Hypomnema toplevel) and a sanitized `env` (no inherited `GIT_*`
+ * except optionally a validated `GIT_INDEX_FILE`).
+ *
+ * @returns {{gitAddFailed: boolean, summary: string}}
+ */
+export async function runPreCommitFormat({ cwd, env }) {
+  const summary = [];
+  const stagedRes = spawnSync(
+    'git',
+    ['diff', '--cached', '--name-status', '-z', `--diff-filter=${STATUS_FILTER}`, '--'],
+    { cwd, env, encoding: 'utf-8' },
+  );
+  if (stagedRes.status !== 0) {
+    return { gitAddFailed: false, summary: 'git diff --cached failed; skipping' };
+  }
+  const staged = parseNameStatus(stagedRes.stdout || '');
+  if (!staged.length) return { gitAddFailed: false, summary: 'no staged files' };
+
+  // Filter out symlinks / submodules.
+  const lsRes = spawnSync(
+    'git',
+    ['ls-files', '--stage', '-z', '--', ...staged.map((e) => e.path)],
+    { cwd, env, encoding: 'utf-8' },
+  );
+  let regular = staged;
+  if (lsRes.status === 0) {
+    const modeMap = parseLsFilesStage(lsRes.stdout || '');
+    regular = filterRegularFiles(staged, modeMap);
+  }
+  if (!regular.length) return { gitAddFailed: false, summary: 'no regular staged files' };
+
+  // Unstaged-dirty set for partition.
+  const unstRes = spawnSync('git', ['diff', '--name-only', '-z', '--'], {
+    cwd,
+    env,
+    encoding: 'utf-8',
+  });
+  const unstaged = new Set();
+  if (unstRes.status === 0) {
+    for (const p of (unstRes.stdout || '').split('\0')) {
+      if (p) unstaged.add(p);
+    }
+  }
+  const { safe, partial } = partitionStagedFiles(regular, unstaged);
+  if (partial.length) {
+    summary.push(`skipped ${partial.length} partially-staged file(s)`);
+  }
+  if (!safe.length) return { gitAddFailed: false, summary: summary.join('; ') || 'no safe files' };
+
+  const formatter = selectFormatter(cwd);
+  if (!formatter) {
+    return {
+      gitAddFailed: false,
+      summary: [...summary, 'no formatter (node_modules/.bin/prettier missing)'].join('; '),
+    };
+  }
+  const fmt = formatFiles(safe, formatter, { env, cwd });
+  if (fmt.formatterFailed) {
+    summary.push(`${formatter.name} exit ${fmt.exitCode} (non-blocking)`);
+    return { gitAddFailed: false, summary: summary.join('; ') };
+  }
+  const restage = restageFormatted(
+    safe.map((e) => e.path),
+    { env, cwd },
+  );
+  if (restage.gitAddFailed) {
+    return {
+      gitAddFailed: true,
+      summary: `git add failed: ${restage.stderr.trim()}`,
+    };
+  }
+  summary.push(`formatted ${safe.length} file(s) via ${formatter.name}`);
+  return { gitAddFailed: false, summary: summary.join('; ') };
+}

--- a/scripts/pre-commit-format.mjs
+++ b/scripts/pre-commit-format.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * scripts/pre-commit-format.mjs — Node-side entry for the pre-commit hook.
+ *
+ * Invoked by the shell shim installed at <git-dir>/hooks/pre-commit. The shim
+ * already verifies HYPOMNEMA_ROOT + HYPOMNEMA_GIT_DIR; this script is the
+ * second layer of identity defence and the only place that may exit nonzero
+ * (only when `git add` fails on restage).
+ *
+ * Env discipline:
+ *   - probes git twice with ambient env to learn what Git thinks the repo is
+ *   - builds `cleanEnv` by stripping every name from `git rev-parse --local-env-vars`
+ *     plus GIT_NAMESPACE / GIT_CEILING_DIRECTORIES / GIT_CONFIG_* (belt-and-suspenders)
+ *   - validates inherited GIT_INDEX_FILE: preserve if inside HYPOMNEMA_GIT_DIR
+ *     (Git exports this for commit -am / commit -- path / commit --amend);
+ *     otherwise refuse — that's a foreign-index attack vector
+ *   - lib spawns get `cleanEnv` only; lib never touches process.env directly
+ *
+ * Why dynamic import: keeping the lib import behind every guard makes the
+ * fail-open story water-tight. A static import at file head would throw at
+ * module load if the lib were missing or syntactically broken, before any
+ * identity check could exit 0.
+ *
+ * Why pathToFileURL for the import: absolute filesystem paths fed to
+ * `import()` break when the checkout path contains URL-significant characters
+ * (#, %). pathToFileURL is the canonical Node way to bridge.
+ */
+
+try {
+  const { execFileSync } = await import('node:child_process');
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const { pathToFileURL, fileURLToPath } = await import('node:url');
+
+  const probe = (args, env) => execFileSync('git', args, { encoding: 'utf8', env }).trim();
+
+  // (0) Derive expectedRoot from THIS script's filesystem location. The shell
+  //     shim already verifies HYPOMNEMA_ROOT/HYPOMNEMA_GIT_DIR before exec'ing
+  //     us, but a direct `node scripts/pre-commit-format.mjs` invocation with
+  //     hostile GIT_DIR/GIT_WORK_TREE pointing at another repo that ALSO calls
+  //     itself "hypomnema" would bypass the package.json identity check unless
+  //     we anchor on the script's own location. import.meta.url cannot be
+  //     redirected by ambient env.
+  let expectedRoot;
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    expectedRoot = fs.realpathSync(path.resolve(here, '..'));
+  } catch {
+    process.exit(0);
+  }
+
+  // (1) Probe with ambient env to learn what Git thinks the repo is.
+  let toplevel, absGitDir, commonDir;
+  try {
+    toplevel = probe(['rev-parse', '--show-toplevel'], process.env);
+    absGitDir = probe(['rev-parse', '--absolute-git-dir'], process.env);
+    commonDir = probe(['rev-parse', '--git-common-dir'], process.env);
+  } catch {
+    process.exit(0);
+  }
+
+  // (2) Realpath-resolve for stable comparison.
+  let absGitDirR, commonDirR, toplevelR;
+  try {
+    absGitDirR = fs.realpathSync(absGitDir);
+    const cdAbs = path.isAbsolute(commonDir) ? commonDir : path.join(absGitDir, '..', commonDir);
+    commonDirR = fs.realpathSync(cdAbs);
+    toplevelR = fs.realpathSync(toplevel);
+  } catch {
+    process.exit(0);
+  }
+
+  // (3) Trust anchor — refuse to run against any toplevel other than this
+  //     script's own checkout. Closes the GIT_DIR/GIT_WORK_TREE attack where a
+  //     foreign hypomnema-named repo would otherwise pass the package.json check.
+  if (toplevelR !== expectedRoot) process.exit(0);
+
+  // (3a) Anchor the git dir to the expected location too. Without this, a
+  //      mixed-env attack — GIT_DIR=/foreign/.git + GIT_WORK_TREE=expectedRoot
+  //      + GIT_INDEX_FILE=/foreign/.git/index — would let `absGitDirR` point at
+  //      the foreign repo while `--show-toplevel` reports expectedRoot. The
+  //      subsequent GIT_INDEX_FILE check would then pass relative to the
+  //      foreign git dir, and the lib would operate on a foreign index while
+  //      mutating real files. (Live-verified by codex round 7.)
+  let expectedGitDirR;
+  try {
+    expectedGitDirR = fs.realpathSync(path.join(expectedRoot, '.git'));
+  } catch {
+    process.exit(0);
+  }
+  if (absGitDirR !== expectedGitDirR) process.exit(0);
+
+  // (4) Linked worktree → main-worktree only (documented limitation).
+  if (absGitDirR !== commonDirR) process.exit(0);
+
+  // (5) Repo identity check — package.json name must be "hypomnema" (defence in
+  //     depth alongside the expectedRoot anchor above).
+  const pkgPath = path.join(toplevelR, 'package.json');
+  if (!fs.existsSync(pkgPath)) process.exit(0);
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  } catch {
+    process.exit(0);
+  }
+  if (pkg?.name !== 'hypomnema') process.exit(0);
+
+  // (5) Build trusted env from --local-env-vars + GIT_CONFIG_* belt.
+  let localEnvList;
+  try {
+    localEnvList = probe(['rev-parse', '--local-env-vars'], process.env)
+      .split(/\r?\n/)
+      .filter(Boolean);
+  } catch {
+    // Static fallback (Git versions where --local-env-vars is unavailable).
+    localEnvList = [
+      'GIT_DIR',
+      'GIT_WORK_TREE',
+      'GIT_INDEX_FILE',
+      'GIT_OBJECT_DIRECTORY',
+      'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+      'GIT_COMMON_DIR',
+      'GIT_CONFIG',
+      'GIT_CONFIG_PARAMETERS',
+      'GIT_PREFIX',
+      'GIT_IMPLICIT_WORK_TREE',
+      'GIT_GRAFT_FILE',
+      'GIT_NO_REPLACE_OBJECTS',
+      'GIT_REPLACE_REF_BASE',
+      'GIT_SHALLOW_FILE',
+    ];
+  }
+  const scrub = new Set([
+    ...localEnvList,
+    'GIT_NAMESPACE',
+    'GIT_CEILING_DIRECTORIES',
+    ...Object.keys(process.env).filter((k) => /^GIT_CONFIG_/.test(k)),
+  ]);
+  const cleanEnv = Object.fromEntries(Object.entries(process.env).filter(([k]) => !scrub.has(k)));
+
+  // (6) GIT_INDEX_FILE preservation gated on shim invocation. Git legitimately
+  //     exports this for these commit shapes (verified live by codex round 5/9
+  //     on Git 2.50.1):
+  //       - .git/index             normal commit, commit --amend, merge commit
+  //       - .git/index.lock        commit -am, commit -p, commit --interactive
+  //       - .git/next-index-*.lock commit -- <pathspec>, rebase partial commit
+  //     The basename whitelist used in v8/v9 had a residual gap: a crafted
+  //     .git/next-index-attack.lock matches the `next-index-*` prefix even
+  //     though Git itself uses `next-index-<pid>.lock` (codex round 9 live
+  //     replay). Closing that prefix gap by tightening pattern just invites
+  //     more attacker iteration.
+  //
+  //     The cleaner defence: only honour inherited GIT_INDEX_FILE when we
+  //     were invoked from our own trusted shell shim (HYPOMNEMA_HOOK_INVOCATION
+  //     sentinel set there). Direct invocation — which is the only path an
+  //     attacker can use to plant a crafted index — drops the inherited value
+  //     and lets git fall back to the default `.git/index`, i.e. the real
+  //     staged set. The hook then either has nothing to do (no real stage) or
+  //     formats the real stage (correct behaviour). An attacker that can also
+  //     set HYPOMNEMA_HOOK_INVOCATION already has full env control and can
+  //     mutate files directly without going through the hook gadget.
+  const fromShim = process.env.HYPOMNEMA_HOOK_INVOCATION === '1';
+  if (fromShim && process.env.GIT_INDEX_FILE) {
+    // Even when trusted, sanity-check that the path lives inside our git dir.
+    // Belt-and-suspenders against shim invocation with an inherited but
+    // misdirected GIT_INDEX_FILE (e.g. by a wrapper that exec'd our shim).
+    const inherited = process.env.GIT_INDEX_FILE;
+    const lexical = path.isAbsolute(inherited) ? inherited : path.join(toplevelR, inherited);
+    let absIdx;
+    try {
+      absIdx = fs.realpathSync(lexical);
+    } catch {
+      absIdx = path.resolve(lexical);
+    }
+    if (path.dirname(absIdx) === absGitDirR) {
+      cleanEnv.GIT_INDEX_FILE = inherited;
+    }
+  }
+  // If !fromShim, GIT_INDEX_FILE stays scrubbed → lib uses default .git/index.
+
+  // (7) Dynamic-import the lib through a file:// URL so checkout paths with
+  //     URL-significant chars (#, %) don't break ESM resolution. We import
+  //     from expectedRoot, not toplevel — the script's own location is the
+  //     anchor of trust.
+  const libPath = path.join(expectedRoot, 'scripts/lib/pre-commit-format.mjs');
+  let lib;
+  try {
+    lib = await import(pathToFileURL(libPath).href);
+  } catch {
+    process.exit(0);
+  }
+
+  const result = await lib.runPreCommitFormat({ cwd: toplevelR, env: cleanEnv });
+  if (result.summary) process.stderr.write(`[pre-commit-format] ${result.summary}\n`);
+  process.exit(result.gitAddFailed ? 1 : 0);
+} catch {
+  process.exit(0);
+}

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -56,6 +56,13 @@ const wikiDir = join(work, 'wiki');
 let cleanupOk = false;
 
 try {
+  // Capture pre-commit hook contents (if any) BEFORE pack so we can prove
+  // `npm pack` didn't mutate it. The `prepare` lifecycle script runs during
+  // `npm pack` and could theoretically touch .git/hooks/pre-commit; the
+  // installer's CI/lifecycle guards must prevent that.
+  const preCommitPath = join(REPO, '.git', 'hooks', 'pre-commit');
+  const preCommitBefore = existsSync(preCommitPath) ? readFileSync(preCommitPath, 'utf-8') : null;
+
   step('npm pack');
   const pack = run('npm', ['pack', '--json'], { cwd: REPO });
   const meta = JSON.parse(pack.stdout)[0];
@@ -200,6 +207,15 @@ try {
   if (fbBootstrap.status !== 0 || !/would create draft/.test(fbBootstrap.stderr)) {
     throw new Error(
       `feedback-sync --bootstrap --dry-run did not announce drafts (exit ${fbBootstrap.status})`,
+    );
+  }
+
+  step('verify pre-commit hook was not mutated by npm pack');
+  const preCommitAfter = existsSync(preCommitPath) ? readFileSync(preCommitPath, 'utf-8') : null;
+  if (preCommitBefore !== preCommitAfter) {
+    throw new Error(
+      'npm pack mutated .git/hooks/pre-commit — the prepare lifecycle ' +
+        'guard (npm_command=pack) is not firing.',
     );
   }
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -10203,10 +10203,18 @@ test('shim: foreign hypomnema-named repo via GIT_DIR/GIT_WORK_TREE → does NOT 
 suite('pre-commit-format: installer');
 
 function runInstaller(dir, extraEnv = {}) {
+  // Drop CI/npm lifecycle envs from the parent process so the installer's
+  // skip guards (CI=true, npm_command=pack/publish, prepublishOnly) don't
+  // fire under GitHub Actions (where CI=true is always set). Tests that
+  // exercise those guards override via extraEnv explicitly.
+  const { CI, npm_command, npm_lifecycle_event, ...cleanParent } = process.env;
+  void CI;
+  void npm_command;
+  void npm_lifecycle_event;
   return spawnSync(process.execPath, [join(dir, 'scripts', 'install-git-hooks.mjs')], {
     cwd: dir,
     encoding: 'utf-8',
-    env: { ...process.env, ...extraEnv },
+    env: { ...cleanParent, ...extraEnv },
   });
 }
 
@@ -10318,13 +10326,19 @@ test('installer: linked worktree → skips', () => {
     // so its `import.meta.url` resolves to a valid file inside the worktree.
     mkdirSync(join(wt, 'scripts'), { recursive: true });
     cpSync(INSTALLER_PATH, join(wt, 'scripts', 'install-git-hooks.mjs'));
+    // Drop CI/lifecycle envs so the test exercises the linked-worktree guard,
+    // not the CI=true skip (always present on GitHub Actions).
+    const { CI, npm_command, npm_lifecycle_event, ...cleanParent } = process.env;
+    void CI;
+    void npm_command;
+    void npm_lifecycle_event;
     const r = spawnSync(process.execPath, [join(wt, 'scripts', 'install-git-hooks.mjs')], {
       cwd: wt,
       encoding: 'utf-8',
-      env: { ...process.env, HYPOMNEMA_HOOK_VERBOSE: '1' },
+      env: { ...cleanParent, HYPOMNEMA_HOOK_VERBOSE: '1' },
     });
     assert.equal(r.status, 0);
-    assert.match(r.stderr, /linked worktree|toplevel != expectedRoot|skipping/);
+    assert.match(r.stderr, /linked worktree|toplevel != expectedRoot/);
   } finally {
     if (wt) rmSync(wt, { recursive: true, force: true });
     rmSync(dir, { recursive: true, force: true });

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -9704,6 +9704,666 @@ test('check-bilingual: countHangul ignores non-Hangul Unicode (e.g. CJK, Hiragan
   assert.equal(countHangul('한글 + 漢字'), 2);
 });
 
+// ── pre-commit-format ────────────────────────────────────────────────────────
+
+const {
+  parseNameStatus,
+  parseLsFilesStage,
+  filterRegularFiles,
+  partitionStagedFiles,
+  selectFormatter,
+} = await import(`${SCRIPTS}/lib/pre-commit-format.mjs`);
+
+function makeGitRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-precommit-'));
+  const git = (args, opts = {}) => spawnSync('git', args, { cwd: dir, encoding: 'utf-8', ...opts });
+  git(['init', '-q', '-b', 'main']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'Test']);
+  return { dir, git };
+}
+
+suite('pre-commit-format: parseNameStatus (NUL token stream)');
+
+test('parser: A/M single-path records', () => {
+  const buf = 'A\0a.txt\0M\0b.txt\0';
+  assert.deepEqual(parseNameStatus(buf), [
+    { path: 'a.txt', status: 'A' },
+    { path: 'b.txt', status: 'M' },
+  ]);
+});
+
+test('parser: R<score> rename — only new path returned', () => {
+  const buf = 'R100\0old.txt\0new.txt\0';
+  assert.deepEqual(parseNameStatus(buf), [{ path: 'new.txt', status: 'R' }]);
+});
+
+test('parser: C<score> copy — only new path returned', () => {
+  const buf = 'C75\0src.txt\0copy.txt\0';
+  assert.deepEqual(parseNameStatus(buf), [{ path: 'copy.txt', status: 'C' }]);
+});
+
+test('parser: R000 (zero-score rename) handled', () => {
+  const buf = 'R000\0a.txt\0b.txt\0';
+  assert.deepEqual(parseNameStatus(buf), [{ path: 'b.txt', status: 'R' }]);
+});
+
+test('parser: paths starting with R or C do not collide with status tokens', () => {
+  // status and path are separate NUL tokens, so a path literally named "R100"
+  // never ambiguates against a rename status.
+  const buf = 'A\0R100\0A\0Cfile\0';
+  assert.deepEqual(parseNameStatus(buf), [
+    { path: 'R100', status: 'A' },
+    { path: 'Cfile', status: 'A' },
+  ]);
+});
+
+test('parser: D and T are skipped defensively', () => {
+  const buf = 'D\0deleted.txt\0A\0kept.txt\0T\0typechange.txt\0';
+  assert.deepEqual(parseNameStatus(buf), [{ path: 'kept.txt', status: 'A' }]);
+});
+
+test('parser: live git --name-status -z token shape (real repo)', () => {
+  const { dir, git } = makeGitRepo();
+  try {
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    git(['add', 'a.txt']);
+    git(['commit', '-q', '-m', 'init']);
+    git(['mv', 'a.txt', 'b space.txt']);
+    writeFileSync(join(dir, 'c.txt'), 'hello\n');
+    git(['add', 'c.txt']);
+    const r = git(['diff', '--cached', '--name-status', '-z', '--diff-filter=ACMR']);
+    assert.equal(r.status, 0);
+    const parsed = parseNameStatus(r.stdout);
+    // Expect one rename (a.txt -> "b space.txt") and one add (c.txt).
+    const paths = parsed.map((e) => e.path).sort();
+    assert.deepEqual(paths, ['b space.txt', 'c.txt']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('parser: filename with TAB (NUL is only separator)', () => {
+  const buf = 'A\0with\ttab.txt\0';
+  assert.deepEqual(parseNameStatus(buf), [{ path: 'with\ttab.txt', status: 'A' }]);
+});
+
+suite('pre-commit-format: ls-files mode filter');
+
+test('filter: drops symlink (120000) and gitlink (160000)', () => {
+  const entries = [
+    { path: 'reg.txt', status: 'A' },
+    { path: 'link.txt', status: 'A' },
+    { path: 'sub', status: 'A' },
+  ];
+  const modeMap = new Map([
+    ['reg.txt', '100644'],
+    ['link.txt', '120000'],
+    ['sub', '160000'],
+  ]);
+  const kept = filterRegularFiles(entries, modeMap);
+  assert.deepEqual(kept, [{ path: 'reg.txt', status: 'A' }]);
+});
+
+test('filter: missing from index → defensively excluded', () => {
+  const entries = [{ path: 'phantom.txt', status: 'A' }];
+  const kept = filterRegularFiles(entries, new Map());
+  assert.deepEqual(kept, []);
+});
+
+test('parseLsFilesStage: roundtrips mode for paths with spaces', () => {
+  const buf = '100644 hash 0\twith space.txt\x00120000 hash 0\tlink.txt\x00';
+  const m = parseLsFilesStage(buf);
+  assert.equal(m.get('with space.txt'), '100644');
+  assert.equal(m.get('link.txt'), '120000');
+});
+
+suite('pre-commit-format: partition (safe vs partial)');
+
+test('partition: file in both staged + unstaged dirty → partial', () => {
+  const staged = [
+    { path: 'a.txt', status: 'M' },
+    { path: 'b.txt', status: 'A' },
+  ];
+  const unstaged = new Set(['a.txt']);
+  const { safe, partial } = partitionStagedFiles(staged, unstaged);
+  assert.deepEqual(safe, [{ path: 'b.txt', status: 'A' }]);
+  assert.deepEqual(partial, [{ path: 'a.txt', status: 'M' }]);
+});
+
+test('partition: empty unstaged dirty → everything is safe', () => {
+  const staged = [{ path: 'a.txt', status: 'A' }];
+  const { safe, partial } = partitionStagedFiles(staged, new Set());
+  assert.equal(safe.length, 1);
+  assert.equal(partial.length, 0);
+});
+
+suite('pre-commit-format: selectFormatter dispatch');
+
+test('selectFormatter: returns null when node_modules/.bin/prettier absent', () => {
+  withTmpDir((dir) => {
+    assert.equal(selectFormatter(dir), null);
+  });
+});
+
+test('selectFormatter: returns prettier entry when bin exists', () => {
+  withTmpDir((dir) => {
+    const bin = join(dir, 'node_modules', '.bin');
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, 'prettier'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const f = selectFormatter(dir);
+    assert.ok(f, 'should detect prettier');
+    assert.equal(f.name, 'prettier');
+    assert.deepEqual(f.buildArgs(['x.js']), ['--write', '--', 'x.js']);
+  });
+});
+
+test('selectFormatter: NEVER uses npx (verify bin path is local)', () => {
+  withTmpDir((dir) => {
+    const bin = join(dir, 'node_modules', '.bin');
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(join(bin, 'prettier'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const f = selectFormatter(dir);
+    assert.equal(f.bin, join(bin, 'prettier'));
+    assert.ok(!/npx/.test(f.bin));
+  });
+});
+
+suite('pre-commit-format: end-to-end via shim');
+
+const SHIM_PATH = join(SCRIPTS, 'pre-commit-format.mjs');
+const INSTALLER_PATH = join(SCRIPTS, 'install-git-hooks.mjs');
+
+function setupHypomnemaFixture() {
+  const { dir, git } = makeGitRepo();
+  // Mirror Hypomnema layout: package.json + scripts/ + node_modules/.bin/prettier.
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: 'hypomnema', version: '0.0.0', type: 'module' }) + '\n',
+  );
+  mkdirSync(join(dir, 'scripts', 'lib'), { recursive: true });
+  cpSync(SHIM_PATH, join(dir, 'scripts', 'pre-commit-format.mjs'));
+  cpSync(INSTALLER_PATH, join(dir, 'scripts', 'install-git-hooks.mjs'));
+  cpSync(
+    join(SCRIPTS, 'lib', 'pre-commit-format.mjs'),
+    join(dir, 'scripts', 'lib', 'pre-commit-format.mjs'),
+  );
+  // Synthetic prettier that lowercases the file (deterministic, no real prettier).
+  const binDir = join(dir, 'node_modules', '.bin');
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    join(binDir, 'prettier'),
+    '#!/bin/sh\n# fake prettier: lowercase --write args\n' +
+      'while [ $# -gt 0 ]; do\n' +
+      '  case "$1" in\n' +
+      '    --write|--) shift; continue;;\n' +
+      '    *) f="$1"; tr "A-Z" "a-z" < "$f" > "$f.tmp" && mv "$f.tmp" "$f"; shift;;\n' +
+      '  esac\n' +
+      'done\nexit 0\n',
+    { mode: 0o755 },
+  );
+  git(['commit', '--allow-empty', '-q', '-m', 'init']);
+  return { dir, git };
+}
+
+function runShim(dir, extraEnv = {}) {
+  return spawnSync(process.execPath, [join(dir, 'scripts', 'pre-commit-format.mjs')], {
+    cwd: dir,
+    encoding: 'utf-8',
+    env: { ...process.env, ...extraEnv },
+  });
+}
+
+test('shim: no staged files → exit 0', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const r = runShim(dir);
+    assert.equal(r.status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shim: formats staged file + re-stages', () => {
+  const { dir, git } = setupHypomnemaFixture();
+  try {
+    writeFileSync(join(dir, 'sample.txt'), 'HELLO WORLD\n');
+    git(['add', 'sample.txt']);
+    const r = runShim(dir);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    // Staged content should now be lowercased (re-staged after format).
+    const showed = git(['show', ':sample.txt']);
+    assert.equal(showed.stdout, 'hello world\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shim: skips partially-staged file (preserves unstaged hunks)', () => {
+  const { dir, git } = setupHypomnemaFixture();
+  try {
+    writeFileSync(join(dir, 'sample.txt'), 'STAGED\n');
+    git(['add', 'sample.txt']);
+    // Add unstaged change on top.
+    writeFileSync(join(dir, 'sample.txt'), 'STAGED\nUNSTAGED\n');
+    const r = runShim(dir);
+    assert.equal(r.status, 0);
+    // Staged version should be unchanged (partial-staging guard).
+    const showed = git(['show', ':sample.txt']);
+    assert.equal(showed.stdout, 'STAGED\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shim: foreign repo (package.json name != "hypomnema") → exit 0, no format', () => {
+  const { dir, git } = makeGitRepo();
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'other' }) + '\n');
+    mkdirSync(join(dir, 'scripts', 'lib'), { recursive: true });
+    cpSync(SHIM_PATH, join(dir, 'scripts', 'pre-commit-format.mjs'));
+    cpSync(
+      join(SCRIPTS, 'lib', 'pre-commit-format.mjs'),
+      join(dir, 'scripts', 'lib', 'pre-commit-format.mjs'),
+    );
+    writeFileSync(join(dir, 'a.txt'), 'KEEP\n');
+    git(['commit', '--allow-empty', '-q', '-m', 'init']);
+    git(['add', 'a.txt']);
+    const r = runShim(dir);
+    assert.equal(r.status, 0);
+    // Confirm no format ran (no prettier in node_modules anyway, but identity
+    // guard should exit before lib even imports).
+    const showed = git(['show', ':a.txt']);
+    assert.equal(showed.stdout, 'KEEP\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shim: missing package.json → exit 0', () => {
+  const { dir, git } = makeGitRepo();
+  try {
+    git(['commit', '--allow-empty', '-q', '-m', 'init']);
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    cpSync(SHIM_PATH, join(dir, 'scripts', 'pre-commit-format.mjs'));
+    const r = runShim(dir);
+    assert.equal(r.status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shim: missing lib (scripts/lib/pre-commit-format.mjs) → exit 0 (fail-open)', () => {
+  const { dir, git } = makeGitRepo();
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'hypomnema' }) + '\n');
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    cpSync(SHIM_PATH, join(dir, 'scripts', 'pre-commit-format.mjs'));
+    git(['commit', '--allow-empty', '-q', '-m', 'init']);
+    const r = runShim(dir);
+    assert.equal(r.status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shim: GIT_INDEX_FILE pointing outside .git/ → exit 0 (foreign index attack)', () => {
+  const { dir } = setupHypomnemaFixture();
+  const foreignIdx = join(tmpdir(), `foreign-idx-${process.pid}`);
+  try {
+    writeFileSync(foreignIdx, '');
+    const r = runShim(dir, { GIT_INDEX_FILE: foreignIdx });
+    assert.equal(r.status, 0);
+  } finally {
+    rmSync(foreignIdx, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('shim: GIT_DIR=/foreign attack (different absolute-git-dir than ours) → exit 0', () => {
+  const { dir } = setupHypomnemaFixture();
+  const { dir: foreign } = makeGitRepo();
+  try {
+    const r = runShim(dir, {
+      GIT_DIR: join(foreign, '.git'),
+      GIT_WORK_TREE: dir,
+    });
+    // Either the guard catches mismatch (absGitDir != commonDir handled) or
+    // identity check fails. Either way exit 0, no formatting.
+    assert.equal(r.status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(foreign, { recursive: true, force: true });
+  }
+});
+
+test('shim: invocation WITH sentinel honours GIT_INDEX_FILE (legitimate commit -am path)', () => {
+  // Counterpart to the direct-invocation drop test: when the installed shim
+  // sets HYPOMNEMA_HOOK_INVOCATION=1, the .mjs preserves GIT_INDEX_FILE so
+  // that git's own commit-mode index files (index.lock, next-index-*.lock)
+  // continue to drive formatting. This protects the `commit -am` and
+  // `commit -- path` flows from accidentally losing inherited index state.
+  const { dir: real, git } = setupHypomnemaFixture();
+  try {
+    writeFileSync(join(real, 'sample.txt'), 'HELLO\n');
+    git(['add', 'sample.txt']);
+    // Snapshot the real index to next-index-12345.lock (mimicking git's
+    // commit -- path behaviour) and point GIT_INDEX_FILE at it.
+    const indexLock = join(real, '.git', 'next-index-12345.lock');
+    cpSync(join(real, '.git', 'index'), indexLock);
+    const r = spawnSync(process.execPath, [join(real, 'scripts', 'pre-commit-format.mjs')], {
+      cwd: real,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        GIT_INDEX_FILE: indexLock,
+        HYPOMNEMA_HOOK_INVOCATION: '1',
+      },
+    });
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    // The lib should have used the inherited index and formatted sample.txt.
+    const after = readFileSync(join(real, 'sample.txt'), 'utf-8');
+    assert.equal(after, 'hello\n', 'inherited index must be honoured under shim sentinel');
+  } finally {
+    rmSync(real, { recursive: true, force: true });
+  }
+});
+
+test('shim: direct invocation drops inherited GIT_INDEX_FILE (closes alternate-index attacks)', () => {
+  // Regression test for codex rounds 8 & 9. Both attacks (crafted .git/attack-
+  // index in round 8, .git/next-index-attack.lock prefix-bypass in round 9)
+  // worked by setting GIT_INDEX_FILE to an attacker-crafted alternate index and
+  // invoking the .mjs directly. The v10 defence is the HYPOMNEMA_HOOK_INVOCATION
+  // sentinel: only the installed shell shim sets it. Without it, .mjs drops
+  // GIT_INDEX_FILE and git falls back to the default `.git/index`.
+  //
+  // This test populates the attack-index with a victim file but leaves the
+  // real index empty. Direct invocation must NOT format the victim, because
+  // the default index has nothing staged.
+  const { dir: real, git } = setupHypomnemaFixture();
+  try {
+    writeFileSync(join(real, 'victim.txt'), 'VICTIM UPPER\n');
+    // Stage victim, snapshot index to attack file, then UNSTAGE — so the real
+    // .git/index is empty but the attack-index has victim staged.
+    git(['add', 'victim.txt']);
+    const attackIdx = join(real, '.git', 'next-index-attack.lock');
+    cpSync(join(real, '.git', 'index'), attackIdx);
+    git(['reset', 'HEAD', 'victim.txt']);
+    const before = readFileSync(join(real, 'victim.txt'), 'utf-8');
+    const r = spawnSync(process.execPath, [join(real, 'scripts', 'pre-commit-format.mjs')], {
+      cwd: real,
+      encoding: 'utf-8',
+      // Note: no HYPOMNEMA_HOOK_INVOCATION. Direct invocation must drop the
+      // attacker-controlled GIT_INDEX_FILE.
+      env: { ...process.env, GIT_INDEX_FILE: attackIdx },
+    });
+    assert.equal(r.status, 0);
+    const after = readFileSync(join(real, 'victim.txt'), 'utf-8');
+    assert.equal(after, before, 'victim must NOT be mutated — attacker-controlled index ignored');
+  } finally {
+    rmSync(real, { recursive: true, force: true });
+  }
+});
+
+test('shim: mixed-env (foreign GIT_DIR + real GIT_WORK_TREE + foreign GIT_INDEX_FILE) → no mutation', () => {
+  // Regression test for codex round-7 CONCERN. Attack shape:
+  //   GIT_DIR=/foreign/.git GIT_WORK_TREE=$expectedRoot
+  //   GIT_INDEX_FILE=/foreign/.git/index
+  // Without the (3a) expectedGitDirR guard, --show-toplevel returned
+  // expectedRoot (passing the anchor) while --absolute-git-dir resolved to
+  // foreign. The lib then ran with cwd=expectedRoot but using the foreign
+  // index, mutating real files (codex live-verified VICTIM UPPER → victim upper).
+  const { dir: real } = setupHypomnemaFixture();
+  const foreign = mkdtempSync(join(tmpdir(), 'hypo-mixed-env-'));
+  try {
+    spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: foreign });
+    spawnSync('git', ['config', 'user.email', 't@x'], { cwd: foreign });
+    spawnSync('git', ['config', 'user.name', 'T'], { cwd: foreign });
+    spawnSync('git', ['commit', '--allow-empty', '-q', '-m', 'init'], { cwd: foreign });
+    writeFileSync(join(real, 'victim.txt'), 'VICTIM UPPER\n');
+    spawnSync('git', ['add', 'victim.txt'], { cwd: real });
+    const before = readFileSync(join(real, 'victim.txt'), 'utf-8');
+    const r = spawnSync(process.execPath, [join(real, 'scripts', 'pre-commit-format.mjs')], {
+      cwd: real,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        GIT_DIR: join(foreign, '.git'),
+        GIT_WORK_TREE: real,
+        GIT_INDEX_FILE: join(foreign, '.git', 'index'),
+      },
+    });
+    assert.equal(r.status, 0);
+    const after = readFileSync(join(real, 'victim.txt'), 'utf-8');
+    assert.equal(after, before, 'victim file must NOT be mutated by foreign-index attack');
+  } finally {
+    rmSync(real, { recursive: true, force: true });
+    rmSync(foreign, { recursive: true, force: true });
+  }
+});
+
+test('shim: foreign hypomnema-named repo via GIT_DIR/GIT_WORK_TREE → does NOT run foreign lib', () => {
+  // Regression test for codex round-6 CONCERN: a malicious repo could claim to
+  // be "hypomnema" (matching package.json.name) and have its own
+  // scripts/lib/pre-commit-format.mjs. Without the expectedRoot anchor, the
+  // shim would execute that foreign lib. We assert that the shim refuses to
+  // run when toplevel != expectedRoot.
+  const { dir: real } = setupHypomnemaFixture();
+  // Build a fully-formed "foreign" hypomnema clone in another tmpdir with its
+  // own malicious lib (writes a sentinel file). The real shim lives at
+  // `real/scripts/pre-commit-format.mjs`; we invoke that directly with env
+  // pointing at the foreign repo.
+  const foreign = mkdtempSync(join(tmpdir(), 'hypo-foreign-fixture-'));
+  const sentinel = join(foreign, 'foreign-lib-ran.marker');
+  try {
+    spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: foreign });
+    spawnSync('git', ['config', 'user.email', 't@x'], { cwd: foreign });
+    spawnSync('git', ['config', 'user.name', 'T'], { cwd: foreign });
+    writeFileSync(
+      join(foreign, 'package.json'),
+      JSON.stringify({ name: 'hypomnema', version: '0.0.0', type: 'module' }) + '\n',
+    );
+    mkdirSync(join(foreign, 'scripts', 'lib'), { recursive: true });
+    writeFileSync(
+      join(foreign, 'scripts', 'lib', 'pre-commit-format.mjs'),
+      `import fs from 'node:fs';
+       export async function runPreCommitFormat() {
+         fs.writeFileSync(${JSON.stringify(sentinel)}, 'foreign lib ran\\n');
+         return { gitAddFailed: false, summary: 'foreign' };
+       }
+      `,
+    );
+    writeFileSync(join(foreign, 'a.txt'), 'X\n');
+    spawnSync('git', ['add', 'a.txt'], { cwd: foreign });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: foreign });
+    writeFileSync(join(foreign, 'b.txt'), 'Y\n');
+    spawnSync('git', ['add', 'b.txt'], { cwd: foreign });
+
+    // Direct invoke of the REAL shim with hostile env pointing at foreign.
+    const r = spawnSync(process.execPath, [join(real, 'scripts', 'pre-commit-format.mjs')], {
+      cwd: foreign,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        GIT_DIR: join(foreign, '.git'),
+        GIT_WORK_TREE: foreign,
+      },
+    });
+    assert.equal(r.status, 0);
+    assert.ok(
+      !existsSync(sentinel),
+      'foreign lib must NOT have run — expectedRoot anchor should block',
+    );
+  } finally {
+    rmSync(real, { recursive: true, force: true });
+    rmSync(foreign, { recursive: true, force: true });
+  }
+});
+
+suite('pre-commit-format: installer');
+
+function runInstaller(dir, extraEnv = {}) {
+  return spawnSync(process.execPath, [join(dir, 'scripts', 'install-git-hooks.mjs')], {
+    cwd: dir,
+    encoding: 'utf-8',
+    env: { ...process.env, ...extraEnv },
+  });
+}
+
+test('installer: fresh repo → installs shim with marker + 0755', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const r = runInstaller(dir);
+    assert.equal(r.status, 0);
+    const target = join(dir, '.git', 'hooks', 'pre-commit');
+    assert.ok(existsSync(target));
+    const content = readFileSync(target, 'utf-8');
+    assert.ok(content.includes('hypomnema-pre-commit-marker v1'));
+    assert.ok(content.includes('HYPOMNEMA_ROOT='));
+    assert.ok(content.includes('HYPOMNEMA_GIT_DIR='));
+    const mode = statSync(target).mode & 0o777;
+    assert.equal(mode & 0o100, 0o100, 'should be executable');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: existing non-marker pre-commit → does not overwrite', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const target = join(dir, '.git', 'hooks', 'pre-commit');
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, '#!/bin/sh\n# user hook\nexit 0\n');
+    const before = readFileSync(target, 'utf-8');
+    const r = runInstaller(dir);
+    assert.equal(r.status, 0);
+    const after = readFileSync(target, 'utf-8');
+    assert.equal(before, after, 'user hook preserved');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: marker file → regenerated (idempotent re-run safe)', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    runInstaller(dir);
+    const target = join(dir, '.git', 'hooks', 'pre-commit');
+    const first = readFileSync(target, 'utf-8');
+    const r = runInstaller(dir);
+    assert.equal(r.status, 0);
+    const second = readFileSync(target, 'utf-8');
+    assert.equal(first, second);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: existing symlinked pre-commit → not overwritten', () => {
+  const { dir } = setupHypomnemaFixture();
+  const tgt = mkdtempSync(join(tmpdir(), 'hypo-symlink-tgt-'));
+  const real = join(tgt, 'real-hook.sh');
+  try {
+    writeFileSync(real, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const hookFile = join(dir, '.git', 'hooks', 'pre-commit');
+    mkdirSync(dirname(hookFile), { recursive: true });
+    symlinkSync(real, hookFile);
+    runInstaller(dir);
+    // Should still be a symlink, pointing at the original target.
+    const st = statSync(hookFile);
+    assert.ok(st.isFile(), 'symlink resolves to file');
+    const lst = spawnSync('readlink', [hookFile], { encoding: 'utf-8' });
+    assert.equal(lst.stdout.trim(), real);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(tgt, { recursive: true, force: true });
+  }
+});
+
+test('installer: CI=true → skips, no hook written', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const r = runInstaller(dir, { CI: 'true' });
+    assert.equal(r.status, 0);
+    assert.ok(!existsSync(join(dir, '.git', 'hooks', 'pre-commit')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: npm_command=pack → skips', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const r = runInstaller(dir, { npm_command: 'pack', CI: '' });
+    assert.equal(r.status, 0);
+    assert.ok(!existsSync(join(dir, '.git', 'hooks', 'pre-commit')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: linked worktree → skips', () => {
+  const { dir, git } = setupHypomnemaFixture();
+  let wt = null;
+  try {
+    git(['branch', 'feat']);
+    wt = mkdtempSync(join(tmpdir(), 'hypo-wt-'));
+    // git worktree wants a path that does not yet exist; remove then add.
+    rmSync(wt, { recursive: true, force: true });
+    const wtAdd = spawnSync('git', ['-C', dir, 'worktree', 'add', wt, 'feat'], {
+      encoding: 'utf-8',
+    });
+    assert.equal(wtAdd.status, 0, `worktree add failed: ${wtAdd.stderr}`);
+    // Copy the installer into the linked worktree under the same scripts path
+    // so its `import.meta.url` resolves to a valid file inside the worktree.
+    mkdirSync(join(wt, 'scripts'), { recursive: true });
+    cpSync(INSTALLER_PATH, join(wt, 'scripts', 'install-git-hooks.mjs'));
+    const r = spawnSync(process.execPath, [join(wt, 'scripts', 'install-git-hooks.mjs')], {
+      cwd: wt,
+      encoding: 'utf-8',
+      env: { ...process.env, HYPOMNEMA_HOOK_VERBOSE: '1' },
+    });
+    assert.equal(r.status, 0);
+    assert.match(r.stderr, /linked worktree|toplevel != expectedRoot|skipping/);
+  } finally {
+    if (wt) rmSync(wt, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: foreign repo via GIT_DIR override → no hook written in foreign repo', () => {
+  const { dir } = setupHypomnemaFixture();
+  const foreign = mkdtempSync(join(tmpdir(), 'hypo-foreign-'));
+  try {
+    spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: foreign });
+    spawnSync('git', ['config', 'user.email', 't@x'], { cwd: foreign });
+    spawnSync('git', ['config', 'user.name', 'T'], { cwd: foreign });
+    spawnSync('git', ['commit', '--allow-empty', '-q', '-m', 'init'], { cwd: foreign });
+    // Run installer from Hypomnema cwd but with GIT_DIR pointing at foreign.
+    const r = runInstaller(dir, {
+      GIT_DIR: join(foreign, '.git'),
+      GIT_WORK_TREE: dir,
+      HYPOMNEMA_HOOK_VERBOSE: '1',
+    });
+    assert.equal(r.status, 0);
+    // Foreign repo must not have our hook.
+    assert.ok(!existsSync(join(foreign, '.git', 'hooks', 'pre-commit')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(foreign, { recursive: true, force: true });
+  }
+});
+
+test('installer: HYPOMNEMA_HOOK_VERBOSE=1 surfaces skip reason on stderr', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const r = runInstaller(dir, { CI: 'true', HYPOMNEMA_HOOK_VERBOSE: '1' });
+    assert.match(r.stderr, /CI=true|skipping/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
## Summary

- Adds a non-blocking git `pre-commit` hook that runs `prettier --write` on staged files only (CLAUDE.md `<formatting>` directive at repo level)
- Hook is installed automatically by `npm install` via the `prepare` lifecycle; uninstall by `git commit --no-verify` once or removing `.git/hooks/pre-commit`
- Hardened through **10 rounds of codex pre-commit review** — 6 BLOCKER + 18 CONCERN closed (5 design rounds + 5 implementation rounds; round 10 verdict: **CLEAR**)

## Files

**Added:**
- `scripts/lib/pre-commit-format.mjs` — pure logic (NUL-token parser, non-regular skip, partition, formatter dispatch)
- `scripts/pre-commit-format.mjs` — Node CLI shim (expectedRoot anchor, sanitized env, sentinel-gated GIT_INDEX_FILE)
- `scripts/install-git-hooks.mjs` — idempotent installer (fully fail-open, CI/pack/publish/linked-worktree skip)

**Modified:**
- `package.json` — wire `prepare` lifecycle
- `package-lock.json` — regenerated to align with `1.2.1` (pre-existing drift fixed as side effect)
- `docs/CONTRIBUTING.md` — Pre-commit hook section
- `scripts/smoke-pack.mjs` — assert no `.git/hooks/pre-commit` mutation during `npm pack`
- `tests/runner.mjs` — 33 new tests covering parser, partition, formatter, installer guards, env-attack regressions
- `scripts/crystallize.mjs` — pre-existing prettier line-wrap drift (14 lines, unrelated to feature; included because PR introduces the format pipeline)

## Security model

Closed through codex rounds 1–10:

| Attack vector | Defense |
|---|---|
| Foreign repo with shared `core.hooksPath` | Shim embeds `HYPOMNEMA_ROOT` + `HYPOMNEMA_GIT_DIR` at install time |
| `GIT_DIR` / `GIT_WORK_TREE` override | `.mjs` derives `expectedRoot` from `import.meta.url`; requires `realpath(--show-toplevel)===expectedRoot` AND `realpath(--absolute-git-dir)===realpath(expectedRoot/.git)` |
| Foreign `GIT_INDEX_FILE` (any path) | Preserved ONLY when shim sentinel `HYPOMNEMA_HOOK_INVOCATION=1` is set; direct invocation drops it and falls back to default `.git/index` |
| `--name-status -z` parser correctness | NUL-token stream parser tested against live `git diff --cached --name-status -z` output (A/M/D/T/R/C statuses) |
| Linked worktrees | Detected via `--git-common-dir != --absolute-git-dir`; silently skipped |
| `npm ci` / CI hook mutation | `CI=true` env skip + every fs op in try/catch |
| Symlink in `.git/hooks/` or `pre-commit` | `lstatSync` rejection; never writes through symlinks |
| Existing non-marker `pre-commit` | Preserved with stderr warn |

## Out of scope (documented)

- Linked worktrees (silent skip)
- Generic any-repo installer (script identity-locked)
- Attacker with full env control + `.git/` write (full compromise; hook is not net-new attack surface)

## Test plan

- [x] `npm test` — 479/479 passing (33 new tests)
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run smoke-pack` — passes, including new "no hook mutation during pack" assertion
- [x] Live-verified all commit shapes via installed shim: `commit`, `commit -am`, `commit -p`, `commit --interactive`, `commit --amend`, `commit -- <pathspec>`, merge commit
- [x] Live-verified env-override attacks all fail: foreign repo, mixed-env (`GIT_DIR=/foreign GIT_WORK_TREE=$real`), `.git/attack-index`, `.git/next-index-attack.lock`
- [x] Self-dogfood: this PR's own commit was processed by the newly-installed hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)