### PR TITLE
chore(ci): bump actions/checkout + actions/setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run tests
@@ -25,8 +25,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Run lint
@@ -36,8 +36,8 @@ jobs:
     name: Init snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Dry-run reports DRY RUN without writing files
@@ -62,8 +62,8 @@ jobs:
     name: Upgrade snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Init then upgrade — JSON output has required fields
@@ -87,8 +87,8 @@ jobs:
     name: Hook replay
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: compact-guard — non-compact prompt passes through
@@ -133,8 +133,8 @@ jobs:
     name: Uninstall smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Dry-run reports DRY RUN
@@ -155,8 +155,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run tests without hypo env vars

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,8 +13,8 @@ jobs:
     name: Verify pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Init wiki
@@ -48,8 +48,8 @@ jobs:
     name: Audit smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: Init wiki

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # fetch-depth: 0 fetches full history including annotated tag objects;
           # the default shallow clone leaves git unable to read the tag body
           # that `check-bilingual --tag` validates.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

- Bump `actions/checkout@v4 → @v5` and `actions/setup-node@v4 → @v5` across `ci.yml`, `nightly.yml`, `release.yml` (22 line changes, no logic change).
- GitHub Actions runner default switches to Node 24 on **2026-06-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)), after which `@v4` (Node 20-based) actions are deprecated. This is the pre-emptive mechanical bump.

## Verification

- Every `setup-node` step has explicit `node-version` pinned (matrix `[18, 20, 22]` for test jobs, hard-coded `20`/`18` for lint/snapshot/hook-replay/uninstall/release). Default-version drift does not affect job behavior.
- `setup-node@v5` enables auto package-manager caching only when `package.json` has a `packageManager` field. This repo does not, so cache behavior is unchanged.
- `checkout@v5` requires runner v2.327.1+; hosted runners already have it.
- Codex pre-commit review (1 worker): **CLEAR**.

## Test plan

- [ ] CI passes on this branch (Node 18/20/22 matrix + lint + init-snapshot + upgrade-snapshot + hook-replay + uninstall-smoke)
- [ ] Nightly workflow validates next scheduled run (or via `workflow_dispatch`)
- [ ] Release workflow remains green at next tag (no behavior change expected — `node-version: 18` still explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)