### PR TITLE
chore(comments): normalize inline (#N) issue-refs to (fix #N)

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -170,7 +170,7 @@ function gitPull(dir) {
 
 /**
  * fix #10: surface unresolved sync failures recorded by a prior session's
- * Stop hook (#9). The entry is cleared only once this session's pull has
+ * Stop hook (fix #9). The entry is cleared only once this session's pull has
  * succeeded AND there is no unpushed commit left behind by a failed push
  * (`[ahead N]`).
  *

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -358,9 +358,9 @@ export function sessionCloseFileStatus(hypoDir) {
 
 // ── sync-state ────────────────────────────────────────────
 // `.cache/sync-state.json` is JSONL: one {timestamp, op, error, host} entry per
-// line. hypo-auto-commit (#9) appends on pull/push failure; hypo-session-start
-// (#10) surfaces open entries and clears them once sync is healthy again;
-// doctor (#11) warns while entries remain. Keep the schema defined here only.
+// line. hypo-auto-commit (fix #9) appends on pull/push failure; hypo-session-start
+// (fix #10) surfaces open entries and clears them once sync is healthy again;
+// doctor (fix #11) warns while entries remain. Keep the schema defined here only.
 
 /** @returns {string} path to the sync-state JSONL file for a wiki root. */
 function syncStatePath(hypoDir) {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -221,7 +221,7 @@ function checkDirectories(hypoDir) {
     'projects',
     'sources',
     // Extensions baseline (ADR 0024). Existence only — SHA / settings /
-    // manifest integrity is E5 (#33).
+    // manifest integrity is E5 (fix #33).
     'extensions/hooks',
     'extensions/commands',
     'extensions/skills',
@@ -309,7 +309,7 @@ function checkSettingsJson() {
   // stale hypo-* entries (uninstall remnants).
   // hypo-ext-* commands are user-extension entries (ADR 0024) — not core hooks,
   // so they are intentionally absent from HOOK_MAP. Excluded here; their
-  // integrity (SHA + manifest + entry match) is checked separately in E5 (#33).
+  // integrity (SHA + manifest + entry match) is checked separately in E5 (fix #33).
   const isExtCommand = (cmd) => /(?:^|[/\s])hypo-ext-[^/\s]+\.mjs(?=$|["'\s])/.test(cmd);
   const expectedCmds = new Set(
     Object.entries(HOOK_MAP).flatMap(([, files]) =>
@@ -351,7 +351,7 @@ function checkSettingsJson() {
       if (!g || typeof g !== 'object') continue;
       for (const h of g.hooks || []) {
         if (typeof h.command !== 'string' || !/hypo-[^/]+\.mjs/.test(h.command)) continue;
-        if (isExtCommand(h.command)) continue; // ext duplicates are E5's concern (#33)
+        if (isExtCommand(h.command)) continue; // ext duplicates are E5's concern (fix #33)
         if (seen.has(h.command)) dupes.push(`${event}:${h.command}`);
         else seen.add(h.command);
       }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -887,7 +887,7 @@ if (args.hooks) {
   }
   for (const r of extResult.registered) log('merged', `extension ${r}`);
   for (const w of extResult.warnings) log('skipped', `extension: ${w}`);
-  // E3 (#31): a hard conflict (unowned/symlinked target) blocks install — surface
+  // E3 (fix #31): a hard conflict (unowned/symlinked target) blocks install — surface
   // the recovery and force a non-zero exit. Drift is advisory (resolvable, no block).
   if (extResult.conflicts.length > 0) {
     log('errors', '[WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -80,8 +80,8 @@ function pkgRootDir(target) {
 
 /**
  * Discover sync-eligible extensions under `extDir`. Returns a per-type map plus a
- * `warnings` array. Applies the `.hypoignore` filter (#30), the basename
- * whitelist (#9), and pairs each file with its optional `<name>.manifest.json`.
+ * `warnings` array. Applies the `.hypoignore` filter (fix #30), the basename
+ * whitelist (plan §5 #9), and pairs each file with its optional `<name>.manifest.json`.
  * No-ops gracefully when extDir is absent (e.g. --from-remote clones, plan §5 #8).
  */
 export function discoverExtensions(extDir, hypoignorePatterns, hypoDir) {
@@ -364,7 +364,7 @@ export function syncExtensions({
   const discovered = discoverExtensions(extDir, patterns, hypoDir);
   result.warnings.push(...discovered.warnings);
 
-  // E4 (#32): Codex supports hooks + commands only. If the user authored
+  // E4 (fix #32): Codex supports hooks + commands only. If the user authored
   // skills/agents extensions, surface a one-time notice that they are skipped
   // for this target rather than silently dropping them (plan §2 E4).
   if (target === 'codex') {

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -784,7 +784,7 @@ const extCheck = syncExtensions({
   force: args.forceExtensions,
 });
 
-// E4 (#32): --codex mirrors the extensions sync into ~/.codex (hooks + commands
+// E4 (fix #32): --codex mirrors the extensions sync into ~/.codex (hooks + commands
 // only; skills/agents skipped with a notice). The per-target SHA map lives in the
 // same ~/.claude/hypo-pkg.json under extensions.codex, so pkgPath is unchanged.
 const extCodexSettingsPath = codexSettingsPath;
@@ -878,7 +878,7 @@ if (args.apply) {
     apply: true,
     force: args.forceExtensions,
   });
-  // E4 (#32): codex apply runs AFTER the claude apply so it reads the freshly
+  // E4 (fix #32): codex apply runs AFTER the claude apply so it reads the freshly
   // written hypo-pkg.json and merges extensions.codex alongside extensions.claude
   // (the per-target spread in syncExtensions preserves the other target's map).
   if (args.codex) {
@@ -1142,7 +1142,7 @@ function pushExtSummary(check, label) {
     for (const c of check.conflicts) lines.push(`    ✗ ${c.file}  [${c.action} — left untouched]`);
     for (const d of check.drifts) lines.push(`    ⚠ ${d.file}  [drift — left untouched]`);
   }
-  // E3 (#31): a hard conflict blocks install (exit 1, even under --apply); drift is
+  // E3 (fix #31): a hard conflict blocks install (exit 1, even under --apply); drift is
   // resolvable advisory. Emit the spec'd WIKI messages so the user knows the recovery.
   if (nConflicts > 0) {
     lines.push('  [WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');
@@ -1252,11 +1252,11 @@ const totalDrift =
   extCheck.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
   ).length +
-  // E3 (#31): unresolved drift/conflict is pending work too — without these the
+  // E3 (fix #31): unresolved drift/conflict is pending work too — without these the
   // summary printed "up to date" while the exit code was 1.
   extCheck.conflicts.length +
   extCheck.drifts.length +
-  // E4 (#32): codex-target pending work counts identically (same message/exit
+  // E4 (fix #32): codex-target pending work counts identically (same message/exit
   // consistency the E3 review caught — a codex conflict must not read "up to date").
   (extCheckCodex
     ? extCheckCodex.actions.filter(
@@ -1297,7 +1297,7 @@ if (totalDrift === 0) {
 
 console.log(lines.join('\n'));
 
-// E3 (#31): a hard extension conflict blocks even under --apply (unlike ordinary
+// E3 (fix #31): a hard extension conflict blocks even under --apply (unlike ordinary
 // drift, which only fails check mode). --force-extensions clears the resolvable
 // cases; an unfollowable symlink/non-regular dest still counts and stays exit 1.
 const extBlocked = extCheck.conflicts.length > 0 || (extCheckCodex?.conflicts.length ?? 0) > 0;

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2477,7 +2477,7 @@ test('extensions: conflict on main file blocks manifest copy + registration', ()
       });
 
       const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
-      // E3 (#31): a hard conflict blocks install with exit 1 even under --apply.
+      // E3 (fix #31): a hard conflict blocks install with exit 1 even under --apply.
       assert.equal(r.status, 1, `conflict must block with exit 1: ${r.stderr}`);
       const out = JSON.parse(r.stdout);
       assert.ok(
@@ -5023,7 +5023,7 @@ test('weekly-journal under journal/weekly missing week → error (scanDirs cover
   );
 });
 
-// feedback type — ADR 0031 / fix #37 conditional schema (#8)
+// feedback type — ADR 0031 / fix #37 conditional schema
 const FB_FM_OK =
   '---\ntitle: T\ntype: feedback\nstatus: active\nscope: global\ntier: L1\n' +
   'targets: [project-memory, claude-learned]\nsensitivity: public\npriority: 3\n' +
@@ -5945,7 +5945,7 @@ test('createProject rejects path-escape dot names (.., ., ...)', () => {
   });
 });
 
-// ── first-prompt forced resume summary + cwd-change re-trigger (#13) ──
+// ── first-prompt forced resume summary + cwd-change re-trigger (fix #13) ──
 suite('hypo-first-prompt.mjs — forced resume summary (fix #3 / #13)');
 
 // first-prompt reads its marker from os.tmpdir(), independent of HOME/HYPO_DIR.


### PR DESCRIPTION
## Summary

Low-priority comment-notation sweep (session-state 잔여 🐢 항목). Spec §9.1 internal fix-IDs were written as bare `(#N)` in code comments, which reads like a GitHub issue/PR number. Standardize to `(fix #N)` — the form already used elsewhere in the codebase (`crystallize.mjs`, `hypo-web-fetch-ingest.mjs`, `doctor.mjs:403`).

- **19 comment lines** converted `(#N)` → `(fix #N)` across 7 files, preserving E-labels (`E3/E4/E5 (fix #31/#32/#33)`).
- **`tests/runner.mjs:5026`** — dangling `(#8)` **removed** (not converted): spec fix #8 = `doctor-codex-paths`, unrelated to the feedback-schema fixture; `ADR 0031 / fix #37` already anchor the WHY.
- **`extensions.mjs:84`** — `basename whitelist` ref is `plan §5 #9` (per `extensions.mjs:16/41`), **not** spec fix #9 (`auto-commit sync-state`); written as `(plan §5 #9)` to match the file's own convention.
- **Out of scope (intentionally untouched):** `suite()`/`test()` string-literal names containing `(#N)` — those are identifiers the `fix-status-verify` `@fix` anchor parser links against; renaming would break linkage. User-facing docs (CHANGELOG/README/spec) use GitHub PR/issue numbers, a different convention.

Comment-only; **no code behavior change**.

## Review trail

- **codex 설계 리뷰** (1-worker, pre-implementation): **CLEAR** — `(fix #N)` target confirmed, `(#8)` removal confirmed, all 20 lines in scope.
- **codex pre-commit 리뷰** (1-worker): **CONCERN** → `extensions.mjs:84 (#9)` was a wrong namespace (plan §5, not spec fix). Reconciled by Claude (verified against `extensions.mjs:16/41`) and corrected to `(plan §5 #9)`.

## Test plan

- [x] `npm test` — 503 passed, 0 failed
- [x] `npm run lint` — 0 errors
- [x] `npm run fix:verify` — exit 0 (no anchor linkage regression)
- [x] committed diff is comment-only (20 insertions / 20 deletions, 7 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)