### PR TITLE
fix(feedback): accept cwd-derived project-ids in scope regex (OQ-34)

### DIFF
--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -68,7 +68,7 @@ node <package-root>/scripts/feedback.mjs \
 
 When `--targets` includes `claude-learned`, `--global-summary` and `--promote-to-global` are required (and `--scope=global --tier=L1`).
 
-> **`scope: project:<project-id>` 주의 (v1.2.0).** `<project-id>`는 `feedback-sync`가 resolve한 project-id와 정확히 일치해야 한다 (default: cwd의 `/`,`.` → `-` 치환; `--project-id=<id>` 로 override). 일치하지 않으면 그 페이지는 해당 project의 MEMORY로 projection되지 **않는다** (silent skip — lint error 아님). 다만 현재 lint scope regex(`^project:[a-z0-9][a-z0-9-]*$`)는 cwd-derived id 형식(`-Users-...`)을 거부하므로, **`project:*` scope를 사용하려면 slug-safe id로 `--project-id=<slug>`를 override해서 wiki 디렉터리도 그 id에 맞추는 운영 패턴이 필요하다**. resolved-id ↔ slug 정합화는 v1.3.0 트랙에서 다룸.
+> **`scope: project:<project-id>` 주의.** `<project-id>`는 `feedback-sync`가 resolve한 project-id와 정확히 일치해야 한다 (default: cwd의 `/`,`.` → `-` 치환; `--project-id=<id>` 로 override). 일치하지 않으면 그 페이지는 해당 project의 MEMORY로 projection되지 **않는다** (silent skip — lint error 아님). v1.3.0부터 scope regex(`^(global|project:[A-Za-z0-9_-]+)$`)가 cwd-derived id 형식(`-Users-...`)을 그대로 허용하므로 lint 통과를 위해 `--project-id=<slug>`를 override할 필요는 없다. 단 cwd에 공백 등 `[A-Za-z0-9_-]` 밖 문자가 있으면 그 id는 여전히 거부되니 그때만 `--project-id=<id>`로 override한다.
 
 On a real (non-dry-run) write, the script automatically runs `feedback-sync --write` to refresh MEMORY.md / CLAUDE.md. If that post-step reports drift it prints a one-line warning — the page is still saved; reconcile with `hypomnema feedback-sync --check`.
 

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -602,7 +602,7 @@ function bootstrapDraftContent({ title, summary, body, date, origin }) {
     `title: ${title}`,
     'type: feedback',
     'status: draft',
-    'scope: TODO              # global | project:<slug>',
+    'scope: TODO              # global | project:<project-id>',
     'tier: TODO               # L1 (CLAUDE.md <learned_behaviors> candidate) | L2',
     'targets: [project-memory]   # + claude-learned for a global L1 rule',
     'sensitivity: public      # public | sanitized (private is forbidden)',

--- a/scripts/feedback.mjs
+++ b/scripts/feedback.mjs
@@ -19,7 +19,7 @@
  *   --title=<text>          Frontmatter title (default: topic)
  *
  * Classification (lint #8 schema — required on create):
- *   --scope=<v>             global | project:<slug>           (required)
+ *   --scope=<v>             global | project:<project-id>     (required)
  *   --tier=<v>              L1 | L2                            (required)
  *   --targets=<list>        comma list of project-memory,claude-learned (default: project-memory)
  *   --sensitivity=<v>       public | sanitized                (default: public)
@@ -47,6 +47,7 @@ import { join } from 'path';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
 
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
 
@@ -120,7 +121,6 @@ function listTopics(hypoDir) {
 
 // ── classification validation (mirrors lint #8 / ADR 0031 §6) ──────────────────
 
-const SCOPE_RE = /^(global|project:[a-z0-9][a-z0-9-]*)$/;
 const TIER_ENUM = ['L1', 'L2'];
 const SENSITIVITY_ENUM = ['public', 'sanitized']; // private is forbidden (wiki is git-public)
 const TARGET_ENUM = ['project-memory', 'claude-learned'];
@@ -135,8 +135,8 @@ function parseTargets(raw) {
 // Validate the create-mode classification. Returns an array of error strings.
 function validateClassification(args, targets) {
   const errs = [];
-  if (!args.scope) errs.push('--scope is required (global | project:<slug>)');
-  else if (!SCOPE_RE.test(args.scope)) errs.push(`--scope invalid: "${args.scope}"`);
+  if (!args.scope) errs.push('--scope is required (global | project:<project-id>)');
+  else if (!FEEDBACK_SCOPE_RE.test(args.scope)) errs.push(`--scope invalid: "${args.scope}"`);
   if (!args.tier) errs.push('--tier is required (L1 | L2)');
   else if (!TIER_ENUM.includes(args.tier)) errs.push(`--tier invalid: "${args.tier}"`);
   if (!SENSITIVITY_ENUM.includes(args.sensitivity))

--- a/scripts/lib/feedback-scope.mjs
+++ b/scripts/lib/feedback-scope.mjs
@@ -1,0 +1,21 @@
+// Feedback page `scope:` field vocabulary — shared single source of truth.
+//
+// Consumed by:
+//   - scripts/lint.mjs      (lint-time validation of feedback page frontmatter)
+//   - scripts/feedback.mjs  (create-time --scope validation in /hypo:feedback)
+// Keep this the ONLY definition; both consumers import it so the two validators
+// never drift (ADR 0034 / OQ-34). feedback-sync.mjs matches scope by plain string
+// equality (not this regex), so it is intentionally not a consumer.
+//
+// Accepts `global` or `project:<id>`. The `<id>` charset matches what
+// deriveProjectId() (feedback-sync.mjs) emits from a cwd: `/` and `.` are both
+// replaced with `-`, producing leading-dash, mixed-case ids like
+// `-Users-you-Workspace-Project`. So the class allows a leading `-`, mixed case,
+// and `_`/`-` — but deliberately NOT `.`:
+//   - deriveProjectId never emits `.` (it is replaced), so excluding it loses
+//     nothing for the derived path; and
+//   - the resolved project-id is path-joined in feedback-sync.mjs:213, so keeping
+//     `.` out of the vocabulary avoids ever blessing `project:.` / `project:..`.
+// Known limit: a cwd containing spaces (or other path chars outside [A-Za-z0-9_-])
+// still derives an id this regex rejects; pass `--project-id=<id>` for those.
+export const FEEDBACK_SCOPE_RE = /^(global|project:[A-Za-z0-9_-]+)$/;

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -20,6 +20,7 @@ import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import { parseSchemaVocab, checkForbidden, parseSchemaPageDirs } from './lib/schema-vocab.mjs';
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
+import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -296,8 +297,12 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
   // feedback: scope vocabulary + conditional claude-learned fields (ADR 0031)
   if (fm.type === 'feedback') {
     const scope = fm.scope || '';
-    if (scope && scope !== 'global' && !/^project:[a-z0-9][a-z0-9-]*$/.test(scope)) {
-      issue('error', rel, `Invalid feedback scope: "${scope}" (allowed: global | project:<slug>)`);
+    if (scope && !FEEDBACK_SCOPE_RE.test(scope)) {
+      issue(
+        'error',
+        rel,
+        `Invalid feedback scope: "${scope}" (allowed: global | project:<project-id>)`,
+      );
     }
     const fbTargets = parseTagsField(fm.targets) || [];
     if (fbTargets.includes('claude-learned')) {

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -521,15 +521,16 @@ checklist below is manual:
 - [ ] **Re-run \`hypomnema lint\` after backfilling — confirm 0 feedback errors
       remain (including the conditional \`claude-learned\` fields above)**
 
-## Caveat — \`scope: project:<project-id>\` and slug regex
+## Note — \`scope: project:<project-id>\` and the scope regex
 
-The lint regex \`^project:[a-z0-9][a-z0-9-]*$\` accepts only short slugs, but
-\`feedback-sync\`'s default resolved project-id is cwd-derived (e.g.
-\`-Users-you-Workspace-Project\`), which the regex rejects. To use a
-\`scope: project:*\` page in v1.2.0 you must override with
-\`--project-id=<slug>\` so the resolved id is slug-safe. The full resolved-id
-↔ wiki-slug reconciliation is deferred to v1.3.0; \`commands/feedback.md\`
-documents the interim pattern.
+As of v1.3.0 the feedback scope regex \`^(global|project:[A-Za-z0-9_-]+)\$\`
+accepts cwd-derived project-ids directly (e.g.
+\`-Users-you-Workspace-Project\`), so a \`scope: project:*\` page no longer needs
+a \`--project-id=<slug>\` override just to pass \`lint\`. The resolved id must
+still exact-match \`feedback-sync\`'s project-id for projection (default: cwd
+with \`/\` and \`.\` replaced by \`-\`). Known limit: a cwd containing spaces or
+other characters outside \`[A-Za-z0-9_-]\` still derives an id the regex
+rejects — pass \`--project-id=<id>\` for those.
 `
     : `## What changed
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -5092,6 +5092,64 @@ test('feedback invalid scope → error', () => {
   );
 });
 
+// ── Track D (OQ-34): scope regex accepts cwd-derived project-ids ──────────────
+// deriveProjectId emits leading-dash, mixed-case ids (cwd `/`,`.` → `-`). The
+// v1.2 regex `^project:[a-z0-9][a-z0-9-]*$` rejected them, forcing a
+// `--project-id=<slug>` override; v1.3 relaxes the shared FEEDBACK_SCOPE_RE to
+// `^(global|project:[A-Za-z0-9_-]+)$`. These cover the lint stage of the
+// create → lint → projection consistency chain plus the hardening edges from
+// the codex design review (`.` excluded → no `project:.`/`project:..`; spaces
+// still rejected = documented limit).
+test('feedback scope: cwd-derived project-id (leading dash, mixed case) → no error', () => {
+  const { r } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('targets: [project-memory, claude-learned]', 'targets: [project-memory]')
+      .replace('global_summary: g\n', '')
+      .replace('promote_to_global: true\n', '')
+      .replace('scope: global', 'scope: project:-Users-you-Workspace-Project')
+      .replace('tier: L1', 'tier: L2'),
+  );
+  assert.equal(r.status, 0, `cwd-derived scope must lint clean: ${r.stdout}`);
+});
+
+test('feedback scope: existing short slug still accepted (backcompat regression)', () => {
+  const { r } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('targets: [project-memory, claude-learned]', 'targets: [project-memory]')
+      .replace('global_summary: g\n', '')
+      .replace('promote_to_global: true\n', '')
+      .replace('scope: global', 'scope: project:hypomnema')
+      .replace('tier: L1', 'tier: L2'),
+  );
+  assert.equal(r.status, 0, `short slug must remain clean: ${r.stdout}`);
+});
+
+test('feedback scope: dot-only project-id (project:. / project:..) → error', () => {
+  for (const bad of ['project:.', 'project:..']) {
+    const { r, out } = lintWithSchema(
+      'pages/feedback/x.md',
+      FB_FM_OK.replace('scope: global', `scope: ${bad}`),
+    );
+    assert.equal(r.status, 1, `${bad} must error`);
+    assert.ok(
+      out.errors.some((e) => e.message.includes('Invalid feedback scope')),
+      `${bad} must be rejected: ${r.stdout}`,
+    );
+  }
+});
+
+test('feedback scope: cwd-derived id with space still rejected (documented limit) → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('scope: global', 'scope: project:-Users-My Name-Proj'),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Invalid feedback scope')),
+    `space-bearing derived id must error: ${r.stdout}`,
+  );
+});
+
 test('feedback status:superseded + sensitivity:sanitized → no error (allowed enums)', () => {
   const { r } = lintWithSchema(
     'pages/feedback/x.md',
@@ -7668,11 +7726,10 @@ function fbPage(fields) {
 
 // Build a wiki + claude-home pair, seed feedback pages, run feedback-sync.
 // `pages` is { slug: fieldsObject }. Returns { dir, claudeHome, projectId, runFb(args) }.
-function withFeedbackEnv(pages, fn, { claudeMd, memoryMd } = {}) {
+function withFeedbackEnv(pages, fn, { claudeMd, memoryMd, projectId = 'proj' } = {}) {
   const base = mkdtempSync(join(tmpdir(), 'hypo-fb-'));
   const wiki = join(base, 'wiki');
   const claudeHome = join(base, 'claude');
-  const projectId = 'proj';
   const memDir = join(claudeHome, 'projects', projectId, 'memory');
   try {
     mkdirSync(join(wiki, 'pages', 'feedback'), { recursive: true });
@@ -7853,6 +7910,35 @@ test('feedback-sync-scope-project-rejected-from-claude: project scope only reach
     assert.equal(rep.targets.claude.candidates, 0, 'scope:project:* must be rejected from CLAUDE');
     assert.equal(rep.targets.memory.candidates, 1, 'project scope still projects to memory');
   });
+});
+
+// Track D 3rd stage (projection): a cwd-derived project-id round-trips through
+// projection. The page scope and the resolved project-id are matched by exact
+// string equality (feedback-sync.mjs:222 — unchanged by D), so a relaxed-lint
+// leading-dash id projects into the matching project's MEMORY exactly like a
+// short slug. Completes the create → lint → projection consistency chain.
+test('feedback-sync-scope-cwd-derived-id-projects: leading-dash mixed-case id reaches its MEMORY', () => {
+  const pid = '-Users-you-Workspace-Project';
+  const page = { ...FB_PROJECT_L2, scope: `project:${pid}`, memory_summary: 'do derived' };
+  withFeedbackEnv(
+    { derived: page },
+    ({ memDir, runFb }) => {
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(
+        rep.targets.memory.candidates,
+        1,
+        `cwd-derived scope must project to memory: got ${rep.targets.memory.candidates}`,
+      );
+      const w = runFb(['--write']);
+      assert.equal(w.status, 0, `--write should succeed: ${w.stderr}`);
+      const mem = readFileSync(join(memDir, 'MEMORY.md'), 'utf-8');
+      assert.ok(
+        mem.includes('feedback_derived.md'),
+        `derived-id page must appear in MEMORY: ${mem}`,
+      );
+    },
+    { projectId: pid },
+  );
 });
 
 // Cross-project pollution guard (ADR 0031 cwd-scoped projection invariant):
@@ -8807,6 +8893,53 @@ test('feedback.mjs create: full classification → page written + lint-clean', (
     const lint = run('lint.mjs', ['--json', `--hypo-dir=${dir}`]);
     const report = JSON.parse(lint.stdout);
     assert.equal(report.errors.length, 0, `lint errors on generated page: ${lint.stdout}`);
+  });
+});
+
+// Track D 1st stage (create): /hypo:feedback accepts a cwd-derived project scope
+// at create time (feedback.mjs --scope validation shares FEEDBACK_SCOPE_RE), and
+// the generated page lints clean — so create → lint is consistent end-to-end.
+test('feedback.mjs create: cwd-derived project scope → page written + lint-clean (Track D)', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [
+      '--topic=derived-scope-rule',
+      '--entry=프로젝트 한정 규칙.',
+      '--scope=project:-Users-you-Workspace-Project',
+      '--tier=L2',
+      '--targets=project-memory',
+      '--priority=2',
+      '--memory-summary=프로젝트 규칙 수행',
+      '--reason=정합 확인',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+    ]);
+    assert.equal(r.status, 0, `cwd-derived scope create failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'derived-scope-rule.md'), 'utf-8');
+    assert.ok(
+      page.includes('scope: project:-Users-you-Workspace-Project'),
+      `derived scope not written: ${page}`,
+    );
+    const lint = run('lint.mjs', ['--json', `--hypo-dir=${dir}`]);
+    const report = JSON.parse(lint.stdout);
+    assert.equal(report.errors.length, 0, `lint errors on generated page: ${lint.stdout}`);
+  });
+});
+
+test('feedback.mjs create: invalid scope vocabulary (project:.) → exit 1 (Track D edge)', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [
+      '--topic=bad-scope',
+      '--entry=x.',
+      '--scope=project:.',
+      '--tier=L2',
+      '--targets=project-memory',
+      '--priority=2',
+      '--memory-summary=x',
+      '--reason=x',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+    ]);
+    assert.equal(r.status, 1, `project:. must be rejected at create time: ${r.stdout}`);
   });
 });
 


### PR DESCRIPTION
## What & Why

The feedback `scope:` validators rejected cwd-derived project-ids (e.g. `-Users-you-Workspace-Project` — leading-dash + mixed-case) that `deriveProjectId` emits (`cwd.replace(/[/.]/g,'-')`), so authoring a `scope: project:*` page required a `--project-id=<slug>` override just to pass `lint`. The v1.2.0 `upgrade.mjs` Caveat flagged this as **deferred to v1.3.0** (real OQ-34, ADR 0034 carryover).

This is **v1.3.0 Track D**: relax the validators (Option 2 — `deriveProjectId` and on-disk project dirs **unchanged**). Backcompat was the deciding factor: changing the deriver would orphan every existing cwd-derived project directory and silently skip MEMORY projection for all dogfooders.

## Changes

- **New single source of truth** `scripts/lib/feedback-scope.mjs`:
  `export const FEEDBACK_SCOPE_RE = /^(global|project:[A-Za-z0-9_-]+)$/`
- `lint.mjs:299` + `feedback.mjs:123` both import it (byte-identical — no drift between lint-time and create-time validation). The old `scope !== 'global'` branch is absorbed by the `global|` alternation.
- **`.` deliberately excluded** from the charset: `deriveProjectId` replaces `.`→`-` so its output never contains a dot, and the resolved `projectId` is path-joined (`feedback-sync.mjs:213`) — excluding `.` loses nothing for derived ids while keeping `project:.` / `project:..` rejected.
- `feedback-sync` projection is **unchanged** — it matches scope by plain string equality (`feedback-sync.mjs:222`), not regex.
- Docs: `upgrade.mjs` Caveat (deferred → resolved) + `commands/feedback.md` (interim override no longer needed for lint); both document the spaces-in-cwd limit.

## Tests

`503 → 510 passed (+7)`, covering the full **create → lint → projection** consistency chain plus hardening edges:
- cwd-derived id (leading-dash, mixed-case) → lint clean
- existing short slug → still clean (backcompat regression)
- `project:.` / `project:..` → rejected (lint + create-time)
- space-bearing cwd-derived id → rejected (documented limit)
- cwd-derived id round-trips through projection into the matching MEMORY

## Backcompat

Old `[a-z0-9][a-z0-9-]*` is a strict subset of new `[A-Za-z0-9_-]+` — zero previously-valid value is now rejected.

## Verification

- `npm test`: 510 passed, 0 failed
- `npm run format:check`: clean
- `npm run fix:verify`: exit 0 (only pre-existing ORPHAN_ANCHOR warnings)
- dogfood: real `project:-Users-sangkyu-Workspace-Hypomnema` → accepted; `project:.` / `project:..` / space-id / `team` → rejected

## Review

Two-round codex cross-review via `/teams`:
- **Design** (round 1): verdict **CONCERN** → `.`-charset risk + spaces limit both resolved before implementation
- **Pre-commit** (round 2): verdict **NIT** → scaffold-comment terminology aligned; (a)–(e) review asks all confirmed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)