### PR TITLE
feat(lint): add --strict warning→error promotion with stable IDs (Track E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`hypomnema lint --strict` promotes selected warnings to errors (spec-v1.3.0 Track E).** A new opt-in `--strict` flag promotes a frozen set of warning classes to errors so they exit 1 — a general gate for release-checklists and opt-in pre-commit hooks. Stable warning IDs were introduced (`W1` no-frontmatter, `W2` unknown-type, `W3` missing-`updated`, `W4` broken-wikilink) alongside the pre-existing `W8` (design-history stale). `--strict` promotes `STRICT_PROMOTE_IDS = {W1, W2, W4}` — confirmed content defects — while leaving `W3` (auto-repaired by `--fix`) and `W8` (handled separately by the pre-compact hook) as warnings. Default `hypomnema lint` is **byte-identical**: only `W8` exposes an `id` in `--json` output, so existing consumers (`hooks/hypo-personal-check.mjs`) are unaffected. `npm run lint` and `prepublishOnly` keep using the default mode — `--strict` is never auto-wired into CI.
+
+### 한글 요약
+
+- **`hypomnema lint --strict` warning→error 승격 (spec-v1.3.0 Track E).** opt-in `--strict` 플래그 추가 — 동결된 warning 클래스 집합을 error로 승격해 exit 1로 만든다. release-checklist / opt-in pre-commit용 범용 게이트. 안정 warning ID(`W1` no-frontmatter, `W2` unknown-type, `W3` missing-`updated`, `W4` broken-wikilink)를 기존 `W8`(design-history stale)에 더해 부여했다. `--strict`는 `STRICT_PROMOTE_IDS = {W1, W2, W4}`(확정적 콘텐츠 결함)만 승격하고, `W3`(`--fix`로 자동복구)·`W8`(pre-compact 훅이 별도 처리)은 warning으로 유지한다. 기본 `hypomnema lint`는 **byte-identical** — `--json`에서 `W8`만 `id`를 노출하므로 기존 소비자(`hooks/hypo-personal-check.mjs`)는 무영향. `npm run lint`·`prepublishOnly`는 기본 모드를 그대로 사용 — `--strict`는 CI에 자동 배선되지 않는다.
+
 ## [1.2.1] - 2026-05-26
 
 ### Fixed

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -11,6 +11,9 @@
  *   --hypo-dir=<path>   Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
  *   --json              Output results as JSON
  *   --fix               Auto-add missing `updated` field (safe repairs only)
+ *   --strict            Promote selected warnings (STRICT_PROMOTE_IDS) to errors
+ *                       so they exit 1. Opt-in gate for release-checklist /
+ *                       pre-commit; default mode stays byte-identical.
  */
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
@@ -25,11 +28,12 @@ import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { hypoDir: null, json: false, fix: false };
+  const args = { hypoDir: null, json: false, fix: false, strict: false };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--json') args.json = true;
     else if (arg === '--fix') args.fix = true;
+    else if (arg === '--strict') args.strict = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;
@@ -199,6 +203,20 @@ const VALID_TYPES = [
 
 const issues = [];
 
+// Stable warning class IDs (W1..Wn). `--strict` promotes a frozen subset to
+// errors by ID — never by brittle message-text matching. W8 (design-history
+// stale) predates this scheme; hooks/hypo-personal-check.mjs filters `w.id ===
+// 'W8'`, so it must keep that number — the W5..W7 gap is honest history, not a
+// bug. (spec-v1.3.0 Track E)
+//
+// STRICT_PROMOTE_IDS (OQ-E1, frozen as a code constant): confirmed content
+// defects only.
+//   W1 no-frontmatter / W2 unknown-type / W4 broken-wikilink → promote.
+//   W3 missing-updated  → excluded (auto-repaired by --fix).
+//   W8 design-history-stale → excluded (hypo-personal-check handles it; would
+//                             double-gate).
+const STRICT_PROMOTE_IDS = new Set(['W1', 'W2', 'W4']);
+
 function issue(severity, rel, msg, fullPath = null, id = null) {
   issues.push({ severity, file: rel, message: msg, path: fullPath, id });
 }
@@ -250,7 +268,7 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
   }
 
   if (!content.match(/^---\r?\n/)) {
-    issue('warn', rel, 'No frontmatter found');
+    issue('warn', rel, 'No frontmatter found', null, 'W1');
     return;
   }
 
@@ -265,11 +283,11 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
   }
 
   if (fm.type && !VALID_TYPES.includes(fm.type)) {
-    issue('warn', rel, `Unknown type: "${fm.type}"`);
+    issue('warn', rel, `Unknown type: "${fm.type}"`, null, 'W2');
   }
 
   if (!fm.updated) {
-    issue('warn', rel, 'Missing frontmatter field: updated', path);
+    issue('warn', rel, 'Missing frontmatter field: updated', path, 'W3');
   }
 
   // type-conditional required fields
@@ -337,7 +355,7 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
 
   for (const link of extractWikilinks(content)) {
     if (!slugMap.has(link)) {
-      issue('warn', rel, `Broken wikilink: [[${link}]]`);
+      issue('warn', rel, `Broken wikilink: [[${link}]]`, null, 'W4');
     }
   }
 }
@@ -409,12 +427,29 @@ if (args.fix) {
   }
 }
 
+// --strict: promote selected warnings (by stable ID) to errors *before* the
+// errors/warns split, so exit code, counts, plain-text icons, and --json `ok`
+// all derive from the post-promotion severities through the existing paths.
+if (args.strict) {
+  for (const iss of issues) {
+    if (iss.severity === 'warn' && iss.id && STRICT_PROMOTE_IDS.has(iss.id)) {
+      iss.severity = 'error';
+    }
+  }
+}
+
 const errors = issues.filter((i) => i.severity === 'error');
 const warns = issues.filter((i) => i.severity === 'warn');
 
 if (args.json) {
+  // Default mode is byte-identical: only W8 carries an `id` in the JSON payload
+  // (hooks/hypo-personal-check.mjs filters on it). All other IDs stay internal
+  // unless `--strict` is set, where the full ID set is exposed so promoted
+  // findings are traceable to their warning class.
   const toOut = ({ severity, file, message, id }) =>
-    id ? { severity, file, message, id } : { severity, file, message };
+    id && (id === 'W8' || args.strict)
+      ? { severity, file, message, id }
+      : { severity, file, message };
   console.log(
     JSON.stringify(
       {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -10020,6 +10020,117 @@ test('w8-lint-omits-id-for-other-warns', () => {
   });
 });
 
+// ── Track E: lint --strict warning→error promotion ──────────────────────────
+// spec-v1.3.0 Track E. Stable warning IDs (W1 no-frontmatter / W2 unknown-type
+// / W3 missing-updated / W4 broken-wikilink; W8 design-history-stale predates).
+// `--strict` promotes STRICT_PROMOTE_IDS = {W1,W2,W4} to errors (exit 1).
+// Default mode must stay byte-identical (only W8 exposes `id` in --json).
+
+suite('Track E: lint --strict warning ID promotion');
+
+function runLintE(root, extraArgs = []) {
+  return spawnSync(
+    process.execPath,
+    [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${root}`, '--json', ...extraArgs],
+    { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+  );
+}
+
+// page that triggers W2 (unknown-type) + W3 (missing-updated) + W4 (broken-wikilink)
+function setupStrictFixture(root) {
+  mkdirSync(join(root, 'pages'), { recursive: true });
+  writeFileSync(
+    join(root, 'pages', 'a.md'),
+    '---\ntitle: a\ntype: notarealtype\n---\n\nbody with [[nonexistent-page]] link\n',
+  );
+}
+
+test('strict: default --json keeps W1/W2/W4 ids internal (byte-identical guard)', () => {
+  withTmpDir((root) => {
+    setupStrictFixture(root);
+    const r = runLintE(root);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, 'default mode: warnings do not change exit code');
+    assert.equal(parsed.ok, true);
+    // every warn in this fixture is W2/W3/W4 (no W8) → none may expose `id`
+    const withId = (parsed.warns || []).filter((w) => 'id' in w);
+    assert.equal(
+      withId.length,
+      0,
+      `default --json must not leak non-W8 ids: ${JSON.stringify(parsed.warns)}`,
+    );
+    assert.equal((parsed.warns || []).length, 3);
+  });
+});
+
+test('strict: --strict promotes W2 + W4 to errors and exits 1', () => {
+  withTmpDir((root) => {
+    setupStrictFixture(root);
+    const r = runLintE(root, ['--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 1, 'promoted warnings exit 1');
+    assert.equal(parsed.ok, false);
+    const errIds = (parsed.errors || []).map((e) => e.id).sort();
+    assert.deepEqual(errIds, ['W2', 'W4'], `expected W2+W4 promoted: ${JSON.stringify(parsed)}`);
+    // W3 (missing-updated) is NOT in STRICT_PROMOTE_IDS → stays a warn
+    const warnIds = (parsed.warns || []).map((w) => w.id);
+    assert.deepEqual(warnIds, ['W3'], `W3 must stay a warn: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
+test('strict: W3-only fixture is not promoted (exit 0)', () => {
+  withTmpDir((root) => {
+    // valid type + valid links → only W3 (missing `updated`) remains
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(join(root, 'pages', 'a.md'), '---\ntitle: a\ntype: concept\n---\n\nbody\n');
+    const r = runLintE(root, ['--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, 'W3 is excluded from STRICT_PROMOTE_IDS → exit 0');
+    assert.equal(parsed.ok, true);
+    assert.equal((parsed.errors || []).length, 0);
+    assert.deepEqual(
+      (parsed.warns || []).map((w) => w.id),
+      ['W3'],
+    );
+  });
+});
+
+test('strict: W8 design-history-stale is not promoted (exit 0)', () => {
+  withTmpDir((root) => {
+    // valid frontmatter on both files so the *only* finding is W8 (stale) —
+    // otherwise the bare design-history.md/session-log.md trip W1 (no-frontmatter)
+    // which --strict would promote, masking what this test asserts.
+    setupDhProject(root, 'demo', {
+      dh: '---\ntitle: dh\ntype: reference\nupdated: 2026-05-10\n---\n\n## 2026-05-10\nfoo\n',
+      sessionLogMd:
+        '---\ntitle: sl\ntype: session-log\nupdated: 2026-05-20\n---\n\n## [2026-05-20] s\n',
+    });
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    const r = runLintE(root, ['--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, 'W8 is excluded from STRICT_PROMOTE_IDS → exit 0');
+    assert.equal(parsed.ok, true);
+    const w8 = (parsed.warns || []).filter((w) => w.id === 'W8');
+    assert.equal(w8.length, 1, `W8 stays a warn under --strict: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
+test('strict: W1 no-frontmatter promotes and preserves early-return skip', () => {
+  withTmpDir((root) => {
+    // no frontmatter at all → W1 fires and lintPage returns early, so no
+    // "Missing required frontmatter field" errors are also emitted for this page
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(join(root, 'pages', 'a.md'), 'plain body, no frontmatter\n');
+    const r = runLintE(root, ['--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 1);
+    assert.equal(parsed.ok, false);
+    const errs = parsed.errors || [];
+    assert.equal(errs.length, 1, `early-return preserved → only W1: ${JSON.stringify(errs)}`);
+    assert.equal(errs[0].id, 'W1');
+  });
+});
+
 // ── check-bilingual: release-doc bilingual rule enforcement ─────────────────
 
 suite('check-bilingual — CHANGELOG section validator');


### PR DESCRIPTION
## Summary

spec-v1.3.0 **Track E**. Adds an opt-in `hypomnema lint --strict` gate that promotes a frozen set of warning classes to errors (exit 1), for release-checklists and opt-in pre-commit hooks. Default `lint` stays **byte-identical**.

## What changed

- **Stable warning IDs** (`scripts/lint.mjs`): `W1` no-frontmatter, `W2` unknown-type, `W3` missing-`updated`, `W4` broken-wikilink. `W8` (design-history-stale) predates this scheme; the `W5..W7` gap is honest history — `hooks/hypo-personal-check.mjs` hardcodes `'W8'`, so **no renumbering**.
- **`STRICT_PROMOTE_IDS = {W1, W2, W4}`** (OQ-E1, frozen as a code constant): confirmed content defects. `W3` excluded (auto-repaired by `--fix`); `W8` excluded (pre-compact hook handles it — would double-gate).
- **Promotion = severity reclassification *before* the errors/warns split**, so exit code, counts, plain-text icons, and `--json` `ok` all derive through the existing paths.
- **Mode-aware `--json` serialization**: default exposes only `W8`'s `id` (preserving the prior shape that `hypo-personal-check` filters on); `--strict` exposes all IDs.
- `--strict` is **never auto-wired** into `npm run lint` / `prepublishOnly` / CI — opt-in only.

## Observable contract (spec L181-184)

| invocation | result |
|---|---|
| `lint` (no flag) | byte-identical output + same exit (error→1, else 0) |
| `lint --strict` + promotable warns 0 + errors 0 | exit 0 |
| `lint --strict` + promotable warns ≥1 | exit 1 |

## Verification

- **`npm test`: 518 passed, 0 failed** (513→518; 5 new Track E tests covering default byte-identical id-hiding, W2+W4 promotion/exit, W3 non-promotion, W8 non-promotion, W1 early-return preservation).
- **byte-identical proven against `main`** on the real vault — default `--json` and plain-text both produce an IDENTICAL diff with unchanged exit code.
- **Two-stage codex cross-review** (`/teams`): design → **CONCERN** (byte-identical guard too weak + `issue()` positional-arg trap) → applied; pre-commit → **CLEAR** (codex re-ran `npm test`).

## OQ-E1 resolution

`STRICT_PROMOTE_IDS = {W1, W2, W4}` frozen as a code constant (user-confirmed). Decision rule: promote confirmed content defects; hold auto-repairable (`W3`) and hook-handled (`W8`) classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)