### PR TITLE
feat(fix-verify): reject stub/vacuous spec with STUB_SPEC (Track A-gate)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -122,10 +122,20 @@ If you need to share new logic, prefer extending an existing helper over adding 
 npm test           # tests/runner.mjs — unit + smoke + contract tests
 npm run lint       # scripts/lint.mjs — frontmatter + wikilink validation + W8 (design-history stale vs session-log)
 npm run fix:verify # Phase 1 of learned_behavior #6 — verifies fix #N status claims in
-                   # wiki spec-v1.2.md against `// @fix #N: <test-name>` anchors in
+                   # a wiki spec against `// @fix #N: <test-name>` anchors in
                    # tests/runner.mjs. Maintainer dogfood; needs a local wiki at
                    # $HYPO_DIR or ~/hypomnema. Does NOT grep ADR core decision lines.
 ```
+
+> **`fix:verify` needs an explicit `--spec`.** The default path
+> (`projects/hypomnema/spec-v1.2.md`) is now a `type: reference` redirect stub —
+> the real spec moved to `archive/`. Running the bare command fails with
+> `STUB_SPEC` by design (a stub carries zero status claims, so greening it would
+> be vacuous). Point it at the real spec:
+>
+> ```bash
+> npm run fix:verify -- --spec ~/hypomnema/projects/hypomnema/archive/spec-v1.2.md
+> ```
 
 ### `// @fix #N:` anchor convention
 
@@ -138,7 +148,7 @@ test('replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → 
 
 The anchor's body must be the EXACT test name (whole rest of the line; no comma splitting). Multiple anchor lines per fix # accumulate. For fixes whose verification is behavioral / prompt-driven (no automated test by design), use the sentinel `// @fix #N: NO_AUTO_TEST`.
 
-`npm run fix:verify` reads these anchors plus the spec status claims and reports any drift (`NO_ANCHOR`, `MISSING_TEST`, `FAILING_TEST`, `ORPHAN_ANCHOR`). Plain `// fix #N: …` comments without the `@` prefix are treated as prose and ignored by the verifier.
+`npm run fix:verify` reads these anchors plus the spec status claims and reports any drift (`NO_ANCHOR`, `MISSING_TEST`, `FAILING_TEST`, `ORPHAN_ANCHOR`, `STUB_SPEC`). Plain `// fix #N: …` comments without the `@` prefix are treated as prose and ignored by the verifier.
 
 The test runner uses only Node.js built-ins. Tests create scoped temp directories and clean up after themselves; you can run the suite without any environment setup.
 

--- a/scripts/fix-status-verify.mjs
+++ b/scripts/fix-status-verify.mjs
@@ -25,6 +25,7 @@ import {
   parseStatus,
   parseRunnerOutput,
   verifyMatrix,
+  isReferenceStub,
 } from './lib/fix-status-verify.mjs';
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -72,6 +73,10 @@ function printHelp() {
       '',
       'Exit 0 if no error findings, 1 otherwise.',
       '',
+      'NOTE: The default --spec is a `type: reference` redirect stub (the real',
+      'spec moved to archive/). Running without --spec fails with STUB_SPEC by',
+      'design — pass --spec <real spec> to verify against actual claims.',
+      '',
       'NOTE: This tool only verifies that mapped tests exist and pass.',
       'It does NOT grep ADR core decision lines — see Phase 2 / v1.3.0.',
     ].join('\n'),
@@ -98,11 +103,11 @@ function runTests(testCommand) {
 
 function formatFinding(f) {
   const icon = f.level === 'error' ? '✗' : '⚠';
-  return (
-    `  ${icon} [${f.class}] fix #${f.fixNum}` +
-    (f.testName ? ` (${f.testName})` : '') +
-    `: ${f.detail}`
-  );
+  // Some findings are not tied to a specific fix # (STUB_SPEC,
+  // TEST_RUN_NONZERO_EXIT). Only render the `fix #N` segment when present so
+  // they don't print `fix #undefined`.
+  const ref = f.fixNum != null ? ` fix #${f.fixNum}` : '';
+  return `  ${icon} [${f.class}]${ref}` + (f.testName ? ` (${f.testName})` : '') + `: ${f.detail}`;
 }
 
 function main() {
@@ -123,6 +128,7 @@ function main() {
 
   const anchors = parseAnchors(runnerText);
   const status = parseStatus(specText);
+  const specIsStub = isReferenceStub(specText);
 
   if (!opts.json) {
     console.log(`fix-status-verify (Phase 1)`);
@@ -141,7 +147,7 @@ function main() {
     console.log(`  test run: ${passes} pass, ${fails} fail (exit ${testRun.exitCode})`);
   }
 
-  const matrixResult = verifyMatrix({ anchors, status, testResults });
+  const matrixResult = verifyMatrix({ anchors, status, testResults, specIsStub });
   const findings = [...matrixResult.findings];
 
   // CLI-level error: if the test command itself exited nonzero, the test run

--- a/scripts/lib/fix-status-verify.mjs
+++ b/scripts/lib/fix-status-verify.mjs
@@ -16,6 +16,8 @@
  * retired are NOT matched as positive claims.
  */
 
+import { parseFrontmatter } from './frontmatter.mjs';
+
 const POSITIVE_STATUSES = new Set(['merged', 'TRUE_MERGED', 'resolved']);
 
 // Words that disqualify a line as a positive claim (case-sensitive).
@@ -49,6 +51,18 @@ export function parseAnchors(runnerText) {
     if (!list.includes(name)) list.push(name);
   }
   return out;
+}
+
+/**
+ * Detect a redirect-stub spec: a page whose frontmatter declares
+ * `type: reference`. These are placeholders left behind after an archive move
+ * (e.g. spec-v1.2.md → archive/spec-v1.2.md) and carry zero fix-status claims.
+ * Pointing the verifier at one yields a vacuous green, so verifyMatrix rejects
+ * it up front.
+ */
+export function isReferenceStub(specText) {
+  const fm = parseFrontmatter(specText);
+  return fm?.type === 'reference';
 }
 
 /**
@@ -137,11 +151,48 @@ export function parseRunnerOutput(stdout) {
  *   MISSING_TEST    — anchor names a test, runner output does not contain it.
  *   FAILING_TEST    — anchor names a test, runner output marks it failed.
  *   ORPHAN_ANCHOR   — anchor exists, no positive status claim in spec (warn).
+ *   STUB_SPEC       — spec is unusable: a `type: reference` redirect stub, or
+ *                     it parses zero positive status claims while anchors exist
+ *                     (the vacuous-gate the tool exists to prevent). Error.
  *
  * Returns { ok, findings: [...] }. ok=false if any ERROR-level finding.
  * ORPHAN_ANCHOR is WARN-only.
+ *
+ * STUB_SPEC is a precondition failure, so it short-circuits: when the spec is
+ * unusable there is nothing meaningful to cross-check, and the per-anchor
+ * ORPHAN noise would only bury the one decisive error.
  */
-export function verifyMatrix({ anchors, status, testResults }) {
+export function verifyMatrix({ anchors, status, testResults, specIsStub = false }) {
+  if (specIsStub) {
+    return {
+      ok: false,
+      findings: [
+        {
+          level: 'error',
+          class: 'STUB_SPEC',
+          detail:
+            'spec is a `type: reference` redirect stub (0 fix-status claims by design) — pass --spec pointing at the real spec',
+        },
+      ],
+    };
+  }
+  // Vacuous-gate invariant: anchors exist in the runner but the spec yields no
+  // positive status claim to verify them against. Greening here would defeat
+  // the tool's purpose. (No anchors + no claims is an empty/custom matrix, not
+  // a vacuous gate, so it is left to the normal path.)
+  if (status.size === 0 && anchors.size > 0) {
+    return {
+      ok: false,
+      findings: [
+        {
+          level: 'error',
+          class: 'STUB_SPEC',
+          detail: `${anchors.size} anchor(s) in runner but 0 positive status claims parsed from spec — gate would be vacuous`,
+        },
+      ],
+    };
+  }
+
   const findings = [];
 
   for (const [fixNum, statusValue] of status.entries()) {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -11039,6 +11039,7 @@ const {
   parseStatus: fsvParseStatus,
   parseRunnerOutput: fsvParseRunnerOutput,
   verifyMatrix: fsvVerifyMatrix,
+  isReferenceStub: fsvIsReferenceStub,
 } = await import(`${SCRIPTS}/lib/fix-status-verify.mjs`);
 
 suite('fix-status-verify — parseAnchors');
@@ -11073,6 +11074,30 @@ test('parseAnchors: accumulates multiple anchors per fix #, dedupes', () => {
 test('parseAnchors: NO_AUTO_TEST sentinel preserved as-is', () => {
   const a = fsvParseAnchors('// @fix #20: NO_AUTO_TEST');
   assert.deepEqual(a.get(20), ['NO_AUTO_TEST']);
+});
+
+suite('fix-status-verify — isReferenceStub');
+
+test('isReferenceStub: true for type: reference frontmatter', () => {
+  const spec = [
+    '---',
+    'title: moved',
+    'type: reference',
+    'status: archived',
+    '---',
+    '',
+    '# moved',
+  ].join('\n');
+  assert.equal(fsvIsReferenceStub(spec), true);
+});
+
+test('isReferenceStub: false for a normal spec (type: spec)', () => {
+  const spec = ['---', 'title: real spec', 'type: spec', '---', '', '| #1 | merged |'].join('\n');
+  assert.equal(fsvIsReferenceStub(spec), false);
+});
+
+test('isReferenceStub: false when no frontmatter at all', () => {
+  assert.equal(fsvIsReferenceStub('# just a body\n| #1 | merged |'), false);
 });
 
 suite('fix-status-verify — parseStatus');
@@ -11182,12 +11207,71 @@ test('verifyMatrix: NO_AUTO_TEST sentinel → info finding, not error', () => {
 });
 
 test('verifyMatrix: ORPHAN_ANCHOR is warn-only, does not break ok', () => {
-  const anchors = new Map([[99, ['orphan-test']]]);
-  const status = new Map();
-  const testResults = new Map([['orphan-test', 'pass']]);
+  // status must hold ≥1 positive claim — an empty status with anchors is now a
+  // STUB_SPEC error (vacuous gate), not a warn. #15 is claimed+green; #99 is the
+  // orphan whose warn-only semantics this test guards.
+  const anchors = new Map([
+    [15, ['real-test']],
+    [99, ['orphan-test']],
+  ]);
+  const status = new Map([[15, 'TRUE_MERGED']]);
+  const testResults = new Map([
+    ['real-test', 'pass'],
+    ['orphan-test', 'pass'],
+  ]);
   const { ok, findings } = fsvVerifyMatrix({ anchors, status, testResults });
   assert.equal(ok, true);
-  assert.ok(findings.some((f) => f.class === 'ORPHAN_ANCHOR' && f.level === 'warn'));
+  assert.ok(
+    findings.some((f) => f.class === 'ORPHAN_ANCHOR' && f.level === 'warn' && f.fixNum === 99),
+  );
+  assert.ok(!findings.some((f) => f.class === 'STUB_SPEC'));
+});
+
+test('verifyMatrix: STUB_SPEC error when spec is a type:reference stub', () => {
+  const anchors = new Map([[15, ['real-test']]]);
+  const status = new Map([[15, 'TRUE_MERGED']]);
+  const testResults = new Map([['real-test', 'pass']]);
+  // Even with otherwise-green inputs, a stub spec short-circuits to one error.
+  const { ok, findings } = fsvVerifyMatrix({
+    anchors,
+    status,
+    testResults,
+    specIsStub: true,
+  });
+  assert.equal(ok, false);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, 'STUB_SPEC');
+  assert.equal(findings[0].level, 'error');
+});
+
+test('verifyMatrix: STUB_SPEC error when anchors exist but 0 status claims (vacuous)', () => {
+  const anchors = new Map([[15, ['real-test']]]);
+  const status = new Map();
+  const testResults = new Map([['real-test', 'pass']]);
+  const { ok, findings } = fsvVerifyMatrix({ anchors, status, testResults });
+  assert.equal(ok, false);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, 'STUB_SPEC');
+  assert.match(findings[0].detail, /vacuous/);
+});
+
+test('verifyMatrix: no STUB_SPEC when status has ≥1 claim', () => {
+  const anchors = new Map([[15, ['real-test']]]);
+  const status = new Map([[15, 'TRUE_MERGED']]);
+  const testResults = new Map([['real-test', 'pass']]);
+  const { ok, findings } = fsvVerifyMatrix({ anchors, status, testResults });
+  assert.equal(ok, true);
+  assert.ok(!findings.some((f) => f.class === 'STUB_SPEC'));
+});
+
+test('verifyMatrix: no STUB_SPEC when both status and anchors empty (custom/empty matrix)', () => {
+  const { ok, findings } = fsvVerifyMatrix({
+    anchors: new Map(),
+    status: new Map(),
+    testResults: new Map(),
+  });
+  assert.equal(ok, true);
+  assert.ok(!findings.some((f) => f.class === 'STUB_SPEC'));
 });
 
 test('verifyMatrix: all-green case → ok:true with no error findings', () => {
@@ -11232,6 +11316,74 @@ test('CLI: green fixture → exit 0', () => {
     assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
     assert.match(r.stdout, /verified/);
     assert.match(r.stdout, /ADR core decision grep NOT checked/);
+  });
+});
+
+test('CLI: type:reference stub spec → exit 1 with STUB_SPEC', () => {
+  withTmpDir((wikiDir) => {
+    const specPath = join(wikiDir, 'spec.md');
+    writeFileSync(
+      specPath,
+      ['---', 'title: moved', 'type: reference', '---', '', '# moved to archive/'].join('\n'),
+    );
+    const runnerPath = join(wikiDir, 'fixture-runner.mjs');
+    // Anchor present so the stub is the only reason to fail.
+    writeFileSync(
+      runnerPath,
+      ['#!/usr/bin/env node', '// @fix #100: t', "console.log('  ✓ t');"].join('\n'),
+    );
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'fix-status-verify.mjs'),
+        '--spec',
+        specPath,
+        '--runner',
+        runnerPath,
+        '--test-command',
+        `${process.execPath} ${runnerPath}`,
+        '--json',
+      ],
+      { encoding: 'utf-8', cwd: REPO },
+    );
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+    const j = JSON.parse(r.stdout);
+    assert.equal(j.ok, false);
+    assert.ok(
+      j.findings.some((f) => f.class === 'STUB_SPEC'),
+      `expected STUB_SPEC finding: ${JSON.stringify(j.findings)}`,
+    );
+  });
+});
+
+test('CLI: vacuous spec (anchors but 0 claims) → exit 1 with STUB_SPEC', () => {
+  withTmpDir((wikiDir) => {
+    const specPath = join(wikiDir, 'spec.md');
+    // Real (non-stub) spec but no positive status claim → vacuous gate.
+    writeFileSync(specPath, '# spec with no merged/resolved claims\nsome prose\n');
+    const runnerPath = join(wikiDir, 'fixture-runner.mjs');
+    writeFileSync(
+      runnerPath,
+      ['#!/usr/bin/env node', '// @fix #100: t', "console.log('  ✓ t');"].join('\n'),
+    );
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'fix-status-verify.mjs'),
+        '--spec',
+        specPath,
+        '--runner',
+        runnerPath,
+        '--test-command',
+        `${process.execPath} ${runnerPath}`,
+        '--json',
+      ],
+      { encoding: 'utf-8', cwd: REPO },
+    );
+    assert.equal(r.status, 1);
+    const j = JSON.parse(r.stdout);
+    assert.equal(j.ok, false);
+    assert.ok(j.findings.some((f) => f.class === 'STUB_SPEC'));
   });
 });
 


### PR DESCRIPTION
## What & why

`fix-status-verify` verifies that fixes claimed `merged`/`resolved`/`TRUE_MERGED` in a wiki spec have a matching `// @fix #N:` anchor in `tests/runner.mjs` and that the anchored test passed.

**Bug (empirically confirmed):** the default spec path `projects/hypomnema/spec-v1.2.md` became a `type: reference` redirect stub after the v1.2 archive move. So the tool greened with `statusClaims: 0, anchorCount: 9, exit 0` — a **vacuous gate** that silently defeats its own purpose.

```
$ node scripts/fix-status-verify.mjs --json        # before
{ "ok": true, "statusClaims": 0, "anchorCount": 9, ... }   # 9 anchors, 0 claims, still green
```

## Change

New **`STUB_SPEC`** error finding, emitted when the spec is either:
- a `type: reference` redirect stub (new `isReferenceStub` helper), or
- parses **0 positive status claims while anchors exist** (`status.size === 0 && anchors.size > 0` — the vacuous invariant).

Both short-circuit `verifyMatrix` to one decisive error. The no-anchors-**and**-no-claims case (empty/custom matrix) is intentionally left on the normal path, preserving the existing `TEST_RUN_NONZERO_EXIT` empty-spec test.

Also: `formatFinding` now handles any finding without a `fix #` (`fixNum == null`) generally — fixing a latent `fix #undefined` print that also affected `TEST_RUN_NONZERO_EXIT`.

Default stays pointed at the stub so `npm run fix:verify` **fails loudly** (OQ-A1 confirmed no CI/pre-commit invokes it) rather than chasing a moving archive path. Help text + `docs/CONTRIBUTING.md` document the required `--spec <real spec>`.

## Verification

| spec | before | after |
|---|---|---|
| default stub | `ok:true exit 0` (vacuous) | `ok:false exit 1` STUB_SPEC |
| archive spec (8 claims) | n/a | no STUB_SPEC (gate live) |

- `npm test`: **518 → 527** (+9: isReferenceStub ×3, verifyMatrix STUB_SPEC ×4, CLI integration ×2; existing `ORPHAN_ANCHOR warn-only` test updated to a non-empty status so its semantics survive).
- Human output prints `[STUB_SPEC]: …`, not `fix #undefined`.

## Scope

Track **A-gate** only (#1 vacuous-gate). Manifest / ADR_LINE grep / bare-anchor promotion (#2/#3/#4) are deferred to **A-sot**, pending OQ-A2 (manifest location) + status-SoT decisions.

## Review

Two-stage codex cross-review (1 worker each, via `/teams`):
- **Design** → `NIT` (reflected: `formatFinding` generalized to any null `fixNum`; kept a single spec-sanctioned `STUB_SPEC` class with explicit per-case detail strings rather than splitting into a second class).
- **Pre-commit** → `CLEAR` (codex independently re-ran `npm test` + real default/archive path checks + human-output `fix #undefined` regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)