### PR TITLE
fix(close-gate): scope session-close lint to touched files + coherent marker gate

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -89,10 +89,14 @@ synthesis (no session-close intent) — the marker is then simply not written.
 | `--apply-session-close --payload=<path> --session-id=<id>` | Same as above, **plus** writes the per-session closed marker on success (clean git required). The Stop-chain Layer 3 path. |
 | `--apply-session-close --force` | Skips the probe early-exit. `--payload` still required for any actual apply work. |
 
-**Two lint gates run automatically (fix #40):**
+**Two lint gates run automatically (fix #40), scoped to the files this close writes:**
 
-1. **Preflight** — `lint.mjs --json` runs **before** any payload bytes are written. Errors in files this payload will overwrite (sessionState / projectHot / rootHot / openQuestions) are filtered (they're about to be replaced anyway). Errors in any other file → exit 1 with `stage='preflight-lint'`, no apply occurs.
-2. **Post-apply** — lint re-runs after the writes. Catches payloads that introduce a broken wikilink or malformed body. Surfaces as `stage='post-apply-lint'` (or `'post-apply-verification+lint'` if the freshness gate also fails).
+Both gates judge only the **payload files** (the 5 mandatory close files + `open-questions.md`). Lint debt in other projects or shared `pages/` this close did not author is reported as a non-blocking `notices[]` entry, never gated — so an unrelated broken page elsewhere cannot block your close.
+
+1. **Preflight** — `lint.mjs --json` runs **before** any payload bytes are written. Errors in overwrite targets (sessionState / projectHot / rootHot / openQuestions) are filtered (about to be replaced). Errors in an **append target** (session-log / log.md) still block (appending can't repair existing corruption) → exit 1 with `stage='preflight-lint'`. Errors outside the payload files → `notices[]`, apply proceeds.
+2. **Post-apply** — lint re-runs after the writes. Blocks only on **errors** in payload files (a payload-introduced malformed body / bad frontmatter); pre-existing errors elsewhere → `notices[]`. A lint crash (unparseable output) always blocks. Broken wikilinks are lint **warnings** (W4 — forward references to planned pages are normal) and are not gated here. Surfaces as `stage='post-apply-lint'` (or `'post-apply-verification+lint'` if freshness also fails).
+
+> **Manual close (direct Write tool calls)** clears the Stop-chain block via `--mark-session-closed --session-id=<id>`. Pass `--transcript-path=<path>` (the Stop hook surfaces it in its block message) so the marker is refused when a file **this session edited** still has lint errors — keeping the marker coherent with the PreCompact gate. Without `--transcript-path` it falls back to freshness + clean-git only (lint left to PreCompact).
 
 ---
 
@@ -102,9 +106,9 @@ The result JSON includes a `stage` field when `ok: false`. Branch on it:
 
 | `stage` | What broke | How to recover |
 |---|---|---|
-| `preflight-lint` | A non-payload file in the wiki has a blocking lint error. | Fix the lint error in that file (separate from session-close), then re-run. No payload bytes were written. |
+| `preflight-lint` | A payload file (append target — session-log / log.md) has a pre-existing blocking lint error. | Fix the lint error in that file, then re-run. No payload bytes were written. (Debt outside the payload files is a non-blocking notice, not this stage.) |
 | `post-apply-verification` | A mandatory file's `updated:` frontmatter is stale (≠ today) after apply. | Edit the payload's stale `content` (or supply correct `date`), then re-run. Writes are idempotent — re-applying a corrected payload is safe. |
-| `post-apply-lint` | The payload itself introduced a lint blocker (broken wikilink, bad frontmatter). | Fix the offending content in the payload, then re-run. |
+| `post-apply-lint` | The payload introduced an error-level lint blocker in a payload file (malformed body / bad frontmatter), or lint crashed. | Fix the offending content in the payload, then re-run. (Broken wikilinks are W4 warnings — not gated.) |
 | `post-apply-verification+lint` | Both above. | Fix both; re-run. |
 
 Once `ok: true`, report:

--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -54,12 +54,17 @@ function emitContinue() {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
 }
 
-function emitBlock(sessionId) {
+function emitBlock(sessionId, transcriptPath) {
   // One-line, skill-first. /hypo:crystallize is the documented session-close
   // alias; passing --session-id there writes the per-session marker that clears
   // this block. CLI fallback + bypass live in commands/crystallize.md, not here
   // — keep the Stop reason terse so the actionable instruction stands out.
-  const reason = `[WIKI_AUTOCLOSE] session-close 미완료 — /hypo:crystallize 실행으로 마무리 (session_id=${sessionId}).`;
+  // Surface the transcript path so the close can pass --transcript-path=<path>,
+  // which scopes the marker's lint gate to this session's own files (Bug A
+  // coherence: a marker written without lint would only let Stop pass for
+  // /compact to immediately re-block on the same errors).
+  const transcriptHint = transcriptPath ? ` --transcript-path=${transcriptPath}` : '';
+  const reason = `[WIKI_AUTOCLOSE] session-close 미완료 — /hypo:crystallize 실행으로 마무리 (session_id=${sessionId}${transcriptHint}).`;
   console.log(
     JSON.stringify({
       decision: 'block',
@@ -136,7 +141,7 @@ process.stdin.on('end', () => {
       return;
     }
 
-    emitBlock(sessionId);
+    emitBlock(sessionId, transcriptPath);
   } catch (err) {
     // Fail-open on any unexpected error.
     process.stderr.write(`[hypo-auto-minimal-crystallize] error: ${err?.message ?? String(err)}\n`);

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -33,6 +33,9 @@ import {
   isGateSkipped,
   isClosePattern,
   extractUserMessages,
+  extractTouchedWikiFiles,
+  closeFileTargets,
+  partitionLintScope,
 } from './hypo-shared.mjs';
 
 const WARNING_FILE = join(homedir(), '.claude', 'state', 'wiki-context-warning.json');
@@ -107,6 +110,7 @@ process.stdin.on('end', () => {
   const lintPath = PKG_ROOT ? join(PKG_ROOT, 'scripts', 'lint.mjs') : null;
   let lintBlockers = [];
   let lintW8 = [];
+  let lintNotices = []; // pre-existing debt in files this session did not touch
   let lintSkipped = false;
   if (!lintPath || !existsSync(lintPath)) {
     lintSkipped = true;
@@ -118,8 +122,35 @@ process.stdin.on('end', () => {
         timeout: 30000,
       });
       const parsed = JSON.parse(r.stdout || '{}');
-      lintBlockers = parsed.errors || [];
-      lintW8 = (parsed.warns || []).filter((w) => w.id === 'W8');
+      const allErrors = parsed.errors || [];
+      const allW8 = (parsed.warns || []).filter((w) => w.id === 'W8');
+      // Bug B: judge this session on the files IT touched, not the whole vault.
+      // A readable transcript lets us scope (edited files ∪ mandatory close
+      // files); a missing/unreadable transcript falls back to the conservative
+      // global gate (never weaker than before).
+      const haveTranscript = !!(transcriptPath && existsSync(transcriptPath));
+      if (haveTranscript) {
+        const scope = new Set([
+          ...extractTouchedWikiFiles(transcriptPath, HYPO_DIR),
+          ...closeFileTargets(HYPO_DIR),
+        ]);
+        const part = partitionLintScope(allErrors, scope);
+        lintBlockers = part.blocking;
+        lintNotices = part.notice;
+        // W8 (design-history stale) is the CURRENT project's close
+        // responsibility, not cross-project debt — block on the active
+        // project's, surface others' as notices.
+        if (closeFiles.project) {
+          const mine = `projects/${closeFiles.project}/design-history.md`;
+          lintW8 = allW8.filter((w) => w.file === mine);
+          lintNotices.push(...allW8.filter((w) => w.file !== mine));
+        } else {
+          lintW8 = allW8;
+        }
+      } else {
+        lintBlockers = allErrors;
+        lintW8 = allW8;
+      }
     } catch (err) {
       /* fail-open */
       process.stderr.write(`[hypo-personal-check] error: ${err?.message ?? String(err)}\n`);
@@ -128,6 +159,16 @@ process.stdin.on('end', () => {
 
   const lintOk = lintBlockers.length === 0;
   const designHistoryOk = lintW8.length === 0;
+  // Non-blocking heads-up about pre-existing lint debt in untouched files (other
+  // projects / shared pages). Surfaced so it is visible but never blocks compact.
+  const noticeText =
+    lintNotices.length > 0
+      ? `[WIKI CHECK] ${lintNotices.length} pre-existing lint issue(s) in files this session did not touch (not blocking): ${[
+          ...new Set(lintNotices.map((b) => b.file)),
+        ]
+          .slice(0, 5)
+          .join(', ')}${lintNotices.length > 5 ? ', …' : ''} — clean up when convenient.`
+      : '';
 
   // ── fix #37 Phase C: feedback projection drift (ADR 0031) ──
   // Single blocking gate invariant (spec §7.5): integrate into THIS hook, never
@@ -210,7 +251,13 @@ process.stdin.on('end', () => {
     closeFiles.ok &&
     feedbackOk
   ) {
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    console.log(
+      JSON.stringify(
+        noticeText
+          ? { continue: true, systemMessage: noticeText }
+          : { continue: true, suppressOutput: true },
+      ),
+    );
     return;
   }
 
@@ -267,7 +314,9 @@ process.stdin.on('end', () => {
       `  [ ] 9. hot.md    — update projects/<name>/hot.md (no exceptions)`,
       `  [ ] 10. root hot.md — update ~/hypomnema/hot.md active project table`,
       `  [ ] 11. updated: field — verify today's date on all touched .md files`,
-      `  [ ] 12. git commit & push`,
+      `  [ ] 12. lint — run scripts/lint.mjs; fix errors in files YOU touched`,
+      `           (other projects' / shared-page debt is reported as non-blocking notice)`,
+      `  [ ] 13. git commit & push`,
     ].join('\n');
 
   const closeIntentNote = hasCloseIntent
@@ -282,6 +331,7 @@ process.stdin.on('end', () => {
         `Run the checklist below in order, then retry /compact:`,
         ``,
         checklistText,
+        ...(noticeText ? ['', noticeText] : []),
         ``,
         `Trivial session? Bypass with HYPO_SKIP_GATE=1`,
       ].join('\n'),

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -801,6 +801,133 @@ export function hasMutatingTranscriptActivity(transcriptPath) {
   return false;
 }
 
+// ── session-scoped lint classification ──────────────────────────────────────
+// Bug A/B fix: the close gate must judge a session on the files IT touched, not
+// the whole vault. Lint debt from another project/session (often in shared
+// pages/) must not block this session's close/compact. Two scope builders feed
+// one shared classifier: transcript-derived (hooks + standalone marker) and
+// close-file/payload-derived (the documented apply path writes via Bash, so its
+// files never appear as Edit/Write file_paths and must be seeded explicitly).
+
+const MUTATING_FILE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+
+/** Pull file_path/notebook_path args from mutating tool_use blocks in one
+ *  transcript entry. Mirrors extractTranscriptToolNames' shape handling
+ *  (top-level tool_use + nested message.content[] blocks). */
+function extractTranscriptToolFilePaths(entry) {
+  const paths = [];
+  if (!entry || typeof entry !== 'object') return paths;
+  const pull = (name, input) => {
+    if (!name || !MUTATING_FILE_TOOLS.has(name) || !input || typeof input !== 'object') return;
+    const fp = input.file_path || input.notebook_path;
+    if (typeof fp === 'string' && fp) paths.push(fp);
+  };
+  if (entry.type === 'tool_use') pull(entry.name || entry.tool_name, entry.input);
+  const content = entry.message?.content ?? (Array.isArray(entry.content) ? entry.content : null);
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (block && typeof block === 'object' && block.type === 'tool_use') {
+        pull(block.name || block.tool_name, block.input);
+      }
+    }
+  }
+  return paths;
+}
+
+/** Normalize an absolute path to a repo-relative POSIX path under hypoDir, or
+ *  null if it resolves outside the wiki. */
+function toHypoRel(absPath, hypoDir) {
+  let rel;
+  try {
+    rel = relative(hypoDir, absPath);
+  } catch {
+    return null;
+  }
+  if (!rel || rel.startsWith('..') || rel.startsWith('/')) return null;
+  return rel.split('\\').join('/');
+}
+
+/**
+ * Repo-relative POSIX paths of wiki files this session edited via direct
+ * Edit/Write/MultiEdit/NotebookEdit tool_use. Returns a Set; empty when the
+ * transcript is missing/unreadable (callers decide the fallback). A per-line
+ * JSON parse error skips that line only (transcripts occasionally truncate).
+ */
+export function extractTouchedWikiFiles(transcriptPath, hypoDir) {
+  const out = new Set();
+  if (!transcriptPath || typeof transcriptPath !== 'string' || !existsSync(transcriptPath)) {
+    return out;
+  }
+  let raw;
+  try {
+    raw = readFileSync(transcriptPath, 'utf-8');
+  } catch {
+    return out;
+  }
+  for (const line of raw.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    let entry;
+    try {
+      entry = JSON.parse(t);
+    } catch {
+      continue;
+    }
+    for (const fp of extractTranscriptToolFilePaths(entry)) {
+      const rel = toHypoRel(fp, hypoDir);
+      if (rel) out.add(rel);
+    }
+  }
+  return out;
+}
+
+/**
+ * The mandatory session-close files (repo-relative POSIX). The documented close
+ * path `crystallize.mjs --apply-session-close` writes these from inside a Bash
+ * call, so they never surface as Edit/Write file_paths — they must seed the
+ * scoped-lint set explicitly or a close-introduced error would escape the gate.
+ * Mirrors the file list in sessionCloseFileStatus.
+ */
+export function closeFileTargets(hypoDir) {
+  const out = new Set(['hot.md', 'log.md']);
+  const project = resolveActiveProject(hypoDir);
+  if (project) {
+    out.add(`projects/${project}/session-state.md`);
+    out.add(`projects/${project}/hot.md`);
+    const month = freshDates()[0].slice(0, 7);
+    out.add(`projects/${project}/session-log/${month}.md`);
+  }
+  return out;
+}
+
+/** Normalize a path's separators to POSIX so scope membership is OS-independent.
+ *  lint.mjs emits `file` via path.relative (back-slashes on Windows) while the
+ *  scope builders produce forward-slash paths — normalize both sides. */
+function posixPath(p) {
+  return (p || '').split('\\').join('/');
+}
+
+/**
+ * Partition lint findings into `blocking` (a file this session is accountable
+ * for) vs `notice` (pre-existing debt elsewhere — surfaced, not blocking).
+ *
+ * `scope` = iterable of repo-relative paths the session is accountable for.
+ * Membership is exact on the normalized path. Only findings passed in are
+ * classified — callers pass lint ERRORS; broken wikilinks (lint W4 warnings) are
+ * intentionally warn-only (forward references to planned pages are normal in a
+ * wiki) and are NOT promoted to blocking by this gate.
+ */
+export function partitionLintScope(findings, scope) {
+  const normScope = new Set([...scope].map(posixPath));
+  const blocking = [];
+  const notice = [];
+  for (const f of findings || []) {
+    if (normScope.has(posixPath(f.file))) blocking.push(f);
+    else notice.push(f);
+  }
+  return { blocking, notice };
+}
+
 // ── session-close checklist ────────────────────────────────────────────────
 
 /**

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -55,7 +55,9 @@
  *     hypo-personal-check is still the final enforcement.
  *   • Post-apply — runs after the writes. Surfaces as stage='post-apply-lint'
  *     (or 'post-apply-verification+lint' if freshness also fails). Catches
- *     payloads that introduce a broken wikilink / malformed body.
+ *     payloads that introduce a malformed body / bad frontmatter (error-level);
+ *     broken wikilinks are lint W4 warnings and are not gated. A lint crash
+ *     hard-fails regardless of scope.
  */
 
 import {
@@ -77,6 +79,9 @@ import {
   writeSessionClosedMarker,
   sessionClosedMarkerPath,
   hypoIsClean,
+  extractTouchedWikiFiles,
+  closeFileTargets,
+  partitionLintScope,
 } from '../hooks/hypo-shared.mjs';
 
 const LINT_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'lint.mjs');
@@ -117,6 +122,7 @@ function parseArgs(argv) {
     sessionId: null,
     payload: null,
     force: false,
+    transcriptPath: null,
   };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
@@ -126,6 +132,7 @@ function parseArgs(argv) {
     else if (arg === '--mark-session-closed') args.markSessionClosed = true;
     else if (arg.startsWith('--session-id=')) args.sessionId = arg.slice(13);
     else if (arg.startsWith('--payload=')) args.payload = arg.slice(10);
+    else if (arg.startsWith('--transcript-path=')) args.transcriptPath = expandHome(arg.slice(18));
     else if (arg === '--force') args.force = true;
     else if (arg === '--json') args.json = true;
   }
@@ -359,6 +366,49 @@ function runMarkSessionClosed(args) {
     }
     process.exit(1);
   }
+  // Bug A coherence: the marker suppresses the Stop hook, but PreCompact blocks
+  // on lint. If a transcript is provided, refuse the marker when THIS session's
+  // own files (edited ∪ mandatory close files) carry lint errors — otherwise
+  // Stop would pass only for /compact to immediately re-block. No transcript →
+  // legacy freshness+git recovery path (lint left to PreCompact).
+  if (args.transcriptPath) {
+    let scopedLint = null;
+    try {
+      scopedLint = runLint(args.hypoDir);
+    } catch (err) {
+      // Lint crash → fail-open (never strand the marker writer on tooling), same
+      // posture as the PreCompact hook.
+      process.stderr.write(
+        `[crystallize] mark-session-closed lint skipped: ${err?.message ?? err}\n`,
+      );
+    }
+    if (scopedLint) {
+      const scope = new Set([
+        ...extractTouchedWikiFiles(args.transcriptPath, args.hypoDir),
+        ...closeFileTargets(args.hypoDir),
+      ]);
+      const { blocking } = partitionLintScope(scopedLint.errors || [], scope);
+      if (blocking.length > 0) {
+        const files = [...new Set(blocking.map((b) => b.file))];
+        const result = {
+          ok: false,
+          session_id: args.sessionId,
+          project: status.project,
+          lint_blockers: files,
+          error: "session-close gate not satisfied — lint errors in this session's files",
+        };
+        if (args.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(
+            `✗ lint errors in files this session touched — marker not written (fix then re-run):`,
+          );
+          for (const b of blocking) console.log(`  ✗ ${b.file}: ${b.message}`);
+        }
+        process.exit(1);
+      }
+    }
+  }
   writeSessionClosedMarker(args.hypoDir, args.sessionId, { project: status.project });
   // Marker writer swallows IO errors (best-effort, see hypo-shared.mjs). Verify
   // the file actually landed before claiming success — otherwise CLI exits 0
@@ -477,6 +527,19 @@ function applySessionClose(args) {
   if (payload.rootHot) overwriteTargets.add('hot.md');
   if (payload.openQuestions) overwriteTargets.add(join('pages', 'open-questions.md'));
 
+  // Bug B: the documented close path must not be blocked by lint debt OUTSIDE
+  // the files it writes (other projects, shared pages this close did not author).
+  // payloadScope = every file this apply writes or appends. Both lint passes are
+  // judged against it; errors elsewhere are surfaced as notices, never blocking.
+  const payloadScope = new Set([
+    join('projects', project, 'session-state.md'),
+    join('projects', project, 'hot.md'),
+    'hot.md',
+    join('projects', project, 'session-log', `${ym}.md`),
+    'log.md',
+    ...(payload.openQuestions ? [join('pages', 'open-questions.md')] : []),
+  ]);
+
   let preflightLint;
   try {
     preflightLint = runLint(args.hypoDir);
@@ -485,7 +548,13 @@ function applySessionClose(args) {
     console.log(args.json ? JSON.stringify(out, null, 2) : `✗ ${e.message}`);
     process.exit(1);
   }
-  const blockingErrors = preflightLint.errors.filter((e) => !overwriteTargets.has(e.file));
+  // Block only on errors in payload files we are NOT about to overwrite (append
+  // targets — session-log, log.md — can't be repaired by appending, so existing
+  // corruption there must block). Overwrite targets are about to be replaced;
+  // out-of-scope debt is not this close's concern (Bug B).
+  const blockingErrors = preflightLint.errors.filter(
+    (e) => payloadScope.has(e.file) && !overwriteTargets.has(e.file),
+  );
   if (blockingErrors.length > 0) {
     const out = {
       ok: false,
@@ -546,14 +615,19 @@ function applySessionClose(args) {
 
   const verification = sessionCloseFileStatus(args.hypoDir);
 
-  // Fix #40 post-apply lint: payload may have introduced a broken wikilink or
-  // a malformed session-state body. Surface as a distinct `stage` so caller can
-  // tell "lint broke" apart from "frontmatter stale". This runs even if the
-  // freshness gate also failed — both failure modes are useful to the caller.
+  // Fix #40 post-apply lint: payload may have introduced a malformed body or
+  // bad frontmatter. Surface as a distinct `stage` so caller can tell "lint
+  // broke" apart from "frontmatter stale". This runs even if the freshness gate
+  // also failed — both failure modes are useful to the caller.
   let postApplyLint;
+  let postApplyCrashed = false;
   try {
     postApplyLint = runLint(args.hypoDir);
   } catch (e) {
+    // A lint crash (unparseable output) after writes is NOT scopeable — there is
+    // no reliable `file` to classify — and must stay a HARD failure, exactly as
+    // before scoping was introduced.
+    postApplyCrashed = true;
     postApplyLint = {
       ok: false,
       errors: [{ file: '(lint crash)', message: e.message }],
@@ -561,7 +635,22 @@ function applySessionClose(args) {
     };
   }
 
-  const ok = verification.ok && postApplyLint.ok;
+  // Scope post-apply lint to payload files (Bug B): a payload-introduced error
+  // lands in a file this apply wrote, so it blocks; pre-existing debt elsewhere
+  // is a non-blocking notice. A lint crash bypasses scoping and blocks outright.
+  let postBlocking;
+  let postNotice;
+  if (postApplyCrashed) {
+    postBlocking = postApplyLint.errors;
+    postNotice = [];
+  } else {
+    ({ blocking: postBlocking, notice: postNotice } = partitionLintScope(
+      postApplyLint.errors || [],
+      payloadScope,
+    ));
+  }
+  const postLintOk = !postApplyCrashed && postBlocking.length === 0;
+  const ok = verification.ok && postLintOk;
 
   // ADR 0022 amendment 2026-05-19: auto-write the per-session
   // closed marker on a verified close. Hook authority is read-only; this is
@@ -581,7 +670,7 @@ function applySessionClose(args) {
   }
   const stage = ok
     ? null
-    : !verification.ok && !postApplyLint.ok
+    : !verification.ok && !postLintOk
       ? 'post-apply-verification+lint'
       : !verification.ok
         ? 'post-apply-verification'
@@ -595,6 +684,9 @@ function applySessionClose(args) {
     skipped,
     verification,
     lint: { preflight: preflightLint, postApply: postApplyLint },
+    // Pre-existing lint debt in files this close did not author (Bug B): surfaced
+    // for visibility, never gated. Empty on a clean vault.
+    notices: [...new Set(postNotice.map((e) => e.file))],
   };
 
   if (args.json) {
@@ -614,11 +706,20 @@ function applySessionClose(args) {
         console.log(`\n✗ session-close still incomplete after apply: ${bad}`);
         console.log('  Fix the payload (likely an `updated:` field) and retry.');
       }
-      if (!postApplyLint.ok) {
+      if (!postLintOk) {
         console.log('\n✗ post-apply lint failed:');
-        for (const e of postApplyLint.errors) console.log(`  ✗ ${e.file}: ${e.message}`);
+        for (const e of postBlocking) console.log(`  ✗ ${e.file}: ${e.message}`);
         console.log('  Payload introduced a lint blocker — fix the payload content and retry.');
       }
+    }
+    if (postNotice.length > 0) {
+      console.log(
+        `\n· ${postNotice.length} pre-existing lint issue(s) in untouched files (not blocking): ${[
+          ...new Set(postNotice.map((e) => e.file)),
+        ]
+          .slice(0, 5)
+          .join(', ')}${postNotice.length > 5 ? ', …' : ''}`,
+      );
     }
   }
   process.exit(ok ? 0 : 1);

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -11,7 +11,7 @@ When invoked at the end of a session (or with phrases like "세션 종료", "wra
 
 ## What this does
 
-- **Close mode**: walks the 6-step checklist (session-state, project hot.md, root hot.md, session-log, open-questions(변경 시), log.md) and verifies via `crystallize.mjs --check-session-close` — same gate the PreCompact hook runs.
+- **Close mode**: walks the checklist (session-state, project hot.md, root hot.md, session-log, open-questions(변경 시), log.md) plus a lint step, then writes via `crystallize.mjs --apply-session-close --payload=<path>` — which runs the lint gate automatically, **scoped to the files it writes** (debt elsewhere is a non-blocking notice). `--check-session-close` remains a read-only probe (freshness only). The PreCompact gate runs the same scoped lint, judging the session on the files it touched.
 - **Synthesis mode**: finds tag clusters (≥ N pages), orphan pages (no outbound `[[wikilinks]]`), and draft / stub pages, then guides consolidation into `pages/syntheses/<topic>.md` with back-links and `index.md` updates.
 
 ---

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -80,6 +80,10 @@ Ask: *"이 작업이 마무리되었나요? 세션을 정리(crystallize)할까�
 2. Update `projects/<name>/hot.md` (what was done, ≤500 words, overwrite)
 3. Append to `projects/<name>/session-log/YYYY-MM.md` (narrative entry, append-only)
 4. Update root `hot.md` pointer table + date
+5. Run `scripts/lint.mjs` and fix errors in files **you** touched — debt in other
+   projects / shared pages you did not author is reported as a non-blocking
+   notice, not a gate. (The documented `crystallize.mjs --apply-session-close`
+   path runs this lint automatically, scoped to the files it writes.)
 
 Skip session close for: single bug fix, single-file edit, Q&A only.
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -733,6 +733,9 @@ const {
   isGateSkipped,
   buildOutput,
   isClosePattern,
+  extractTouchedWikiFiles,
+  closeFileTargets,
+  partitionLintScope,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
@@ -951,6 +954,74 @@ test('merges extra fields alongside additionalContext', () => {
   const out = buildOutput('ctx', { continue: true });
   assert.equal(out.continue, true);
   assert.equal(out.additionalContext, 'ctx');
+});
+
+suite('hypo-shared.mjs — session-scoped lint (Bug A/B)');
+
+test('partitionLintScope: in-scope error blocks, out-of-scope error → notice', () => {
+  const findings = [
+    { file: 'projects/p/session-state.md', message: 'bad' },
+    { file: 'pages/feedback/other.md', message: 'Unknown tag: "x"' },
+  ];
+  const scope = new Set(['projects/p/session-state.md']);
+  const { blocking, notice } = partitionLintScope(findings, scope);
+  assert.equal(blocking.length, 1);
+  assert.equal(blocking[0].file, 'projects/p/session-state.md');
+  assert.equal(notice.length, 1);
+  assert.equal(notice[0].file, 'pages/feedback/other.md');
+});
+
+test('partitionLintScope: scope membership is separator-normalized (Windows path safety)', () => {
+  // lint.mjs emits `file` via path.relative — back-slashes on Windows — while the
+  // scope builders use forward slashes. Both sides are normalized so an in-scope
+  // error is never misclassified as out-of-scope (which would weaken the gate).
+  const findings = [{ file: 'projects\\p\\session-state.md', message: 'bad' }];
+  const scope = new Set(['projects/p/session-state.md']);
+  const { blocking, notice } = partitionLintScope(findings, scope);
+  assert.equal(blocking.length, 1);
+  assert.equal(notice.length, 0);
+});
+
+test('closeFileTargets: returns the 5 mandatory close files for the active project', () => {
+  withTmpDir((dir) => {
+    writeFileSync(join(dir, 'hot.md'), '| proj | 2026-06-07 | [[projects/proj/hot]] |\n');
+    const t = closeFileTargets(dir);
+    assert.ok(t.has('hot.md'));
+    assert.ok(t.has('log.md'));
+    assert.ok(t.has('projects/proj/session-state.md'));
+    assert.ok(t.has('projects/proj/hot.md'));
+    assert.ok([...t].some((f) => /^projects\/proj\/session-log\/\d{4}-\d{2}\.md$/.test(f)));
+  });
+});
+
+test('extractTouchedWikiFiles: pulls Edit/Write file_paths under hypoDir, ignores outside paths', () => {
+  withTmpDir((dir) => {
+    const inside = join(dir, 'projects', 'p', 'session-state.md');
+    const transcript = join(dir, 't.jsonl');
+    const lines = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Edit', input: { file_path: inside } },
+            { type: 'tool_use', name: 'Write', input: { file_path: '/etc/outside.md' } },
+            { type: 'tool_use', name: 'Bash', input: { command: 'echo hi' } },
+          ],
+        },
+      }),
+      'truncated-bad-json-line{',
+    ];
+    writeFileSync(transcript, lines.join('\n'));
+    const touched = extractTouchedWikiFiles(transcript, dir);
+    assert.ok(touched.has('projects/p/session-state.md'));
+    assert.equal(touched.has('/etc/outside.md'), false);
+    assert.equal(touched.size, 1);
+  });
+});
+
+test('extractTouchedWikiFiles: missing transcript → empty set (caller falls back)', () => {
+  assert.equal(extractTouchedWikiFiles('/no/such/transcript.jsonl', '/tmp').size, 0);
+  assert.equal(extractTouchedWikiFiles(null, '/tmp').size, 0);
 });
 
 suite('hypo-compact-guard.mjs — contract');
@@ -1815,11 +1886,10 @@ test('payload via stdin (`--payload=-`) works the same as a file', () => {
 
 // ── fix #40: helper lint preflight + post-apply check ───────────────────────
 
-test('preflight (#40): pre-existing lint blocker → exit 1 stage=preflight-lint, payload NOT applied', () => {
-  // Inject a malformed-frontmatter page (unclosed ---) under projects/. lint.mjs
-  // raises an 'error' for that, which must abort apply before any byte is
-  // written. Verify by checking session-state.md still carries the fixture's
-  // original "- next" body (payload sentinel did not land).
+test('preflight (Bug B): pre-existing blocker in a NON-payload file → does NOT abort, apply proceeds (scoped)', () => {
+  // Bug B fix: lint debt OUTSIDE the files this close writes (here a malformed
+  // page under projects/, not one of the 5 mandatory close files) must NOT block
+  // the documented apply path. It is surfaced as a notice and the payload lands.
   withWiki(
     (dir) => {
       writeFileSync(
@@ -1834,20 +1904,52 @@ test('preflight (#40): pre-existing lint blocker → exit 1 stage=preflight-lint
         content: `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n${sentinel}\n\n## 다음 작업\n\n- next\n`,
       };
       const r = runApply(dir, payload);
-      assert.equal(r.status, 1, `preflight must abort, got ${r.status}\n${r.stdout}`);
+      assert.equal(
+        r.status,
+        0,
+        `apply should proceed past out-of-scope debt, got ${r.status}\n${r.stdout}`,
+      );
       const out = JSON.parse(r.stdout);
-      assert.equal(out.ok, false);
-      assert.equal(out.stage, 'preflight-lint', `stage should be preflight-lint: ${r.stdout}`);
+      assert.equal(out.ok, true);
+      assert.ok(
+        out.notices.some((f) => f.endsWith('broken.md')),
+        `out-of-scope blocker should surface as a notice: ${r.stdout}`,
+      );
       const onDisk = readFileSync(
         join(dir, 'projects', 'test-project', 'session-state.md'),
         'utf-8',
       );
-      assert.ok(
-        !onDisk.includes(sentinel),
-        'preflight failure must NOT have written payload sentinel',
-      );
+      assert.ok(onDisk.includes(sentinel), 'apply should have written the payload sentinel');
     },
   );
+});
+
+test('preflight (#40 + Bug B): corrupt APPEND target (session-log) STILL blocks — appending cannot repair it', () => {
+  // The scoping carve-out preserves the #40 guarantee for append targets: a
+  // pre-existing malformed session-log file is in the payload scope and is NOT an
+  // overwrite target, so it must still abort preflight before any byte is written.
+  withWiki(null, (dir, today) => {
+    const ym = today.slice(0, 7);
+    writeFileSync(
+      join(dir, 'projects', 'test-project', 'session-log', `${ym}.md`),
+      '---\ntitle: sl\ntype: session-log\n\nbody (frontmatter never closes)\n',
+    );
+    const sentinel = `<!-- append-block-sentinel-${Date.now()} -->`;
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionState = {
+      content: `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n${sentinel}\n\n## 다음 작업\n\n- next\n`,
+    };
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `corrupt append target must abort, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(out.stage, 'preflight-lint', `stage should be preflight-lint: ${r.stdout}`);
+    const onDisk = readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8');
+    assert.ok(
+      !onDisk.includes(sentinel),
+      'preflight failure must NOT have written payload sentinel',
+    );
+  });
 });
 
 test('post-apply (#40): payload introduces lint blocker → exit 1 stage=post-apply-lint, bytes written', () => {
@@ -7669,6 +7771,90 @@ test('--mark-session-closed with ok gate + clean git → exit 0, marker created'
     assert.equal(marker.verification, 'session-close-file-status:ok');
     assert.ok(marker.closed_at, 'marker must carry closed_at timestamp');
   });
+});
+
+test('--mark-session-closed --transcript-path: lint error in a TOUCHED file → marker refused (Bug A)', () => {
+  withWiki(
+    (dir) => {
+      // committed in mutate (before git commit) so git stays clean while the
+      // lint error is present — the gate's freshness+git check passes and the
+      // new scoped-lint check is what must refuse.
+      writeFileSync(
+        join(dir, 'projects', 'test-project', 'note.md'),
+        '---\ntitle: note\ntype: concept\n\nbody never closes\n',
+      );
+    },
+    (dir) => {
+      const noteAbs = join(dir, 'projects', 'test-project', 'note.md');
+      const transcript = join(tmpdir(), `hypo-mark-touch-${process.pid}.jsonl`);
+      writeFileSync(
+        transcript,
+        JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: noteAbs } }] },
+        }) + '\n',
+      );
+      const r = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--mark-session-closed',
+        '--session-id=s-touch',
+        `--transcript-path=${transcript}`,
+        '--json',
+      ]);
+      rmSync(transcript, { force: true });
+      assert.equal(r.status, 1, `expected marker refused, got ${r.status}\n${r.stdout}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, false);
+      assert.ok(
+        (out.lint_blockers || []).some((f) => f.endsWith('note.md')),
+        `lint_blockers should name the touched file: ${r.stdout}`,
+      );
+      assert.ok(
+        !existsSync(join(dir, '.cache', 'session-closed-s-touch.marker')),
+        'marker must NOT be written when a touched file has lint errors',
+      );
+    },
+  );
+});
+
+test('--mark-session-closed --transcript-path: lint error only in an UNTOUCHED file → marker still written (Bug B)', () => {
+  withWiki(
+    (dir) => {
+      writeFileSync(
+        join(dir, 'projects', 'test-project', 'note.md'),
+        '---\ntitle: note\ntype: concept\n\nbody never closes\n',
+      );
+    },
+    (dir) => {
+      // transcript edited a clean close file, NOT the broken note.md
+      const cleanAbs = join(dir, 'projects', 'test-project', 'session-state.md');
+      const transcript = join(tmpdir(), `hypo-mark-untouch-${process.pid}.jsonl`);
+      writeFileSync(
+        transcript,
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', name: 'Edit', input: { file_path: cleanAbs } }],
+          },
+        }) + '\n',
+      );
+      const r = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--mark-session-closed',
+        '--session-id=s-untouch',
+        `--transcript-path=${transcript}`,
+        '--json',
+      ]);
+      rmSync(transcript, { force: true });
+      assert.equal(r.status, 0, `expected marker written, got ${r.status}\n${r.stdout}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, true);
+      assert.ok(
+        existsSync(join(dir, '.cache', 'session-closed-s-untouch.marker')),
+        "marker must be written — the lint error is out of this session's scope",
+      );
+    },
+  );
 });
 
 test('--apply-session-close --session-id leaves payload uncommitted → marker NOT written until git clean', () => {


### PR DESCRIPTION
## Why

The session-close gate had two structural bugs that surfaced when `/compact` was blocked by lint errors in files the session never created.

**Bug B — vault-global lint coupling.** `hypo-personal-check` (PreCompact) and the `crystallize.mjs` apply preflight/post-apply lint ran over the **whole vault** and blocked on **any** error anywhere. Lint debt from another project / shared `pages/` this session did not author blocked an unrelated session's compact. The offending files live in shared `pages/`, so project-directory scoping can't exclude them — only "what this session touched" can.

**Bug A — incoherent "closed".** `--mark-session-closed` wrote the Stop-clearing marker on freshness + clean-git only (**no lint**), while PreCompact blocks on lint → a session marked "closed" still failed `/compact`. The session-close checklist had no lint step, so a faithful executor never linted (`unknown-tag` is a hard error, yet committed pages carried unknown tags — direct evidence the lint-less path is habitual).

## What

- **Shared classifier** `partitionLintScope(findings, scope) → {blocking, notice}`, POSIX-normalized membership (Windows path safety). **Two scope builders**: `extractTouchedWikiFiles` (transcript Edit/Write file_paths) and `closeFileTargets` (the 5 mandatory close files — the apply path writes them via Bash, so they never appear as Edit/Write and must seed the scope).
- **PreCompact**: scope = touched ∪ close-files; W8 scoped to the **active project**; out-of-scope errors → non-blocking notice; no transcript → conservative **global fallback** (never weaker than before).
- **`runMarkSessionClosed`**: optional `--transcript-path` → scoped lint refuses the marker on this session's own errors; no transcript → legacy freshness+git recovery. The Stop hook surfaces the transcript path in its block message.
- **apply preflight/post-apply** scoped to payload files (overwrite-target exception kept; **append targets still block**; **lint crash hard-fails**; `result.notices[]` added).
- **Checklist lint step** added to all four sources: `templates/hypo-guide.md`, the inline hook checklist, `commands/crystallize.md`, `skills/crystallize/SKILL.md`.

Broken wikilinks stay lint **W4 warnings** (forward references to planned pages are normal) — intentionally **not** gated. The dependency-escape from the design draft was dropped after review confirmed gating warn-only findings would add close friction.

## Verification

- `npm test`: **528 → 535**. New coverage: `partitionLintScope` (scope + separator normalization), `extractTouchedWikiFiles`, `closeFileTargets`, apply scoped preflight (non-payload debt → notice / corrupt **append** target → still blocks), marker `--transcript-path` (touched error → marker refused / untouched error → marker written).

## Review trail

Two-stage codex cross-review via `/teams`:
- **Design** (2 workers) → `CONCERN`: scope-builder split (transcript vs payload), close-file seed (apply writes via Bash), payload scoping for apply, narrow dependency handling. All applied.
- **Pre-commit** (2 workers) → `BLOCKER ×2`: (1) post-apply lint **crash** passed as success; (2) broken-wikilink escape was **dead** (W4 is warn-only, gates consume errors); (3) Windows path separators weakened the gate. All fixed (crash hard-fails; escape dropped + docs aligned; both sides normalized).
- **Re-review** (1 worker) → `NIT` (stale comments) → fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)