### PR TITLE
feat(fix-verify): fix-manifest SoT + ADR-line grep + bare-anchor gate (Track A-sot, ADR 0036)

### DIFF
--- a/scripts/fix-status-verify.mjs
+++ b/scripts/fix-status-verify.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 /**
- * fix-status-verify (CLI) — verify fix→test linkage against wiki spec claims.
+ * fix-status-verify (CLI) — verify fix→test linkage + ADR-line evidence
+ * against wiki spec claims.
  *
- * Phase 1 (test-green half only). ADR core decision grep is out of scope —
- * see scripts/lib/fix-status-verify.mjs header.
+ * Phase 1: test-green half (anchors × spec status × runner results).
+ * Phase 2 (A-sot): manifest validation + manifest↔anchor drift + ADR core
+ * decision grep against the production corpus. See scripts/lib/fix-manifest.mjs
+ * and scripts/lib/fix-status-verify.mjs headers.
  *
  * Usage:
  *   node scripts/fix-status-verify.mjs [--hypo-dir <path>]
@@ -19,16 +22,29 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   parseAnchors,
   parseStatus,
   parseRunnerOutput,
   verifyMatrix,
   isReferenceStub,
+  validateManifest,
+  checkManifestCoverage,
+  checkAdrLines,
+  FIX_MANIFEST,
+  NO_ADR,
 } from './lib/fix-status-verify.mjs';
+import { buildCorpusSearch } from './lib/adr-corpus.mjs';
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Production-code corpus for the ADR-line grep (spec §A amendment 2026-06-07:
+// templates/ ships via npm `files`, so prompt-driven fixes are verifiable).
+const CORPUS_DIRS = ['scripts', 'hooks', 'commands', 'skills', 'templates'];
+// MUST exclude the manifest itself — it holds every adrKeyLine as a literal and
+// would self-match, making ADR_LINE_MISSING impossible to ever fire.
+const CORPUS_EXCLUDE = ['scripts/lib/fix-manifest.mjs'];
 
 function parseArgs(argv) {
   const out = {
@@ -37,6 +53,7 @@ function parseArgs(argv) {
     runner: join(REPO, 'tests/runner.mjs'),
     testCommand: 'npm test',
     json: false,
+    manifest: null,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -44,6 +61,7 @@ function parseArgs(argv) {
     else if (a === '--spec') out.spec = argv[++i];
     else if (a === '--runner') out.runner = argv[++i];
     else if (a === '--test-command') out.testCommand = argv[++i];
+    else if (a === '--manifest') out.manifest = argv[++i];
     else if (a === '--json') out.json = true;
     else if (a === '--help' || a === '-h') {
       printHelp();
@@ -77,8 +95,9 @@ function printHelp() {
       'spec moved to archive/). Running without --spec fails with STUB_SPEC by',
       'design — pass --spec <real spec> to verify against actual claims.',
       '',
-      'NOTE: This tool only verifies that mapped tests exist and pass.',
-      'It does NOT grep ADR core decision lines — see Phase 2 / v1.3.0.',
+      'Phase 2 (A-sot): also greps each manifest adrKeyLine against the',
+      'production corpus (scripts/ hooks/ commands/ skills/ templates/) and',
+      'checks manifest↔anchor drift. NO_ADR rows skip the grep (test-green only).',
     ].join('\n'),
   );
 }
@@ -110,8 +129,21 @@ function formatFinding(f) {
   return `  ${icon} [${f.class}]${ref}` + (f.testName ? ` (${f.testName})` : '') + `: ${f.detail}`;
 }
 
-function main() {
+async function main() {
   const opts = parseArgs(process.argv.slice(2));
+
+  // Manifest source: built-in code constant by default (ADR 0036). --manifest
+  // <path.mjs> overrides for tests, which inject a fixture manifest matching
+  // their synthetic fixes so the real manifest does not couple to fixtures.
+  let manifest = FIX_MANIFEST;
+  if (opts.manifest) {
+    if (!existsSync(opts.manifest)) {
+      console.error(`manifest not found: ${opts.manifest}`);
+      process.exit(2);
+    }
+    const mod = await import(pathToFileURL(resolve(opts.manifest)).href);
+    manifest = mod.FIX_MANIFEST;
+  }
 
   if (!existsSync(opts.spec)) {
     console.error(`spec not found: ${opts.spec}`);
@@ -150,6 +182,19 @@ function main() {
   const matrixResult = verifyMatrix({ anchors, status, testResults, specIsStub });
   const findings = [...matrixResult.findings];
 
+  // Phase 2 (A-sot): manifest validation + ADR-line grep. validateManifest and
+  // checkAdrLines are spec-independent (manifest/code health) and run always;
+  // checkManifestCoverage keys off the spec status (a no-op under STUB_SPEC,
+  // where status is empty).
+  const needsCorpus = manifest.some((r) => r.adrKeyLine !== NO_ADR);
+  const adrSearch = needsCorpus
+    ? buildCorpusSearch({ repoRoot: REPO, includeDirs: CORPUS_DIRS, excludePaths: CORPUS_EXCLUDE })
+    : () => false;
+  const adrExists = (adrPath) => existsSync(join(opts.hypoDir, 'projects/hypomnema', adrPath));
+  findings.push(...validateManifest(manifest));
+  findings.push(...checkManifestCoverage({ manifest, anchors, status }));
+  findings.push(...checkAdrLines({ manifest, searchFn: adrSearch, adrExistsFn: adrExists }));
+
   // CLI-level error: if the test command itself exited nonzero, the test run
   // is not green even if the anchored tests happen to all pass in the parsed
   // output. Surface as a synthetic error finding so `ok` flips false.
@@ -161,10 +206,10 @@ function main() {
       exitCode: testRun.exitCode,
     });
   }
-  const ok = matrixResult.ok && testRun.exitCode === 0;
+  const ok = !findings.some((f) => f.level === 'error') && testRun.exitCode === 0;
 
   const MANDATORY_NOTE =
-    'test-linkage + green only — ADR core decision grep NOT checked, see Phase 2 / v1.3.0';
+    'test-linkage + green + ADR-line grep (Phase 2): manifest evidence checked against production corpus';
 
   if (opts.json) {
     console.log(
@@ -205,4 +250,7 @@ function main() {
   process.exit(ok ? 0 : 1);
 }
 
-main();
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/scripts/lib/adr-corpus.mjs
+++ b/scripts/lib/adr-corpus.mjs
@@ -1,0 +1,79 @@
+/**
+ * adr-corpus — fs-backed production-code corpus search for the ADR-line grep.
+ *
+ * Kept separate from the pure verifier (scripts/lib/fix-status-verify.mjs) so
+ * that layer stays IO-free and unit-testable with injected searchFns. This
+ * module is itself testable against real temp directories.
+ *
+ * CRITICAL (self-match): the manifest module (scripts/lib/fix-manifest.mjs)
+ * lives *inside* the scripts/ corpus and holds every adrKeyLine as a literal.
+ * If it were scanned, every line would self-match and ADR_LINE_MISSING could
+ * never fire — the gate would be silently vacuous. The builder therefore
+ * excludes caller-supplied paths, resolved absolute, BEFORE reading any file.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DEFAULT_EXTENSIONS = ['.mjs', '.js', '.md', '.json', '.cjs'];
+
+function* walk(dir, excludeAbs, extensions) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return; // missing corpus dir is not fatal — other dirs may exist
+  }
+  for (const ent of entries) {
+    const full = join(dir, ent.name);
+    if (excludeAbs.has(resolve(full))) continue;
+    if (ent.isDirectory()) {
+      if (ent.name === 'node_modules' || ent.name === '.git') continue;
+      yield* walk(full, excludeAbs, extensions);
+    } else if (ent.isFile()) {
+      if (extensions.some((e) => ent.name.endsWith(e))) yield full;
+    }
+  }
+}
+
+/**
+ * Build a fixed-string corpus search function.
+ *
+ *   buildCorpusSearch({ repoRoot, includeDirs, excludePaths, extensions })
+ *     → (literal:string) => boolean
+ *
+ * - includeDirs / excludePaths are resolved relative to repoRoot.
+ * - excludePaths are matched by resolved absolute path (handles symlinks of the
+ *   caller-supplied path consistently with the walk's resolve()).
+ * - search is case-sensitive String.includes (fixed string, not regex).
+ *
+ * Files are read once and cached so repeated searches (one per manifest row)
+ * do not re-walk the tree.
+ */
+export function buildCorpusSearch({
+  repoRoot,
+  includeDirs,
+  excludePaths = [],
+  extensions = DEFAULT_EXTENSIONS,
+}) {
+  const excludeAbs = new Set(excludePaths.map((p) => resolve(repoRoot, p)));
+  const contents = [];
+  for (const dir of includeDirs) {
+    const abs = resolve(repoRoot, dir);
+    let isDir = false;
+    try {
+      isDir = statSync(abs).isDirectory();
+    } catch {
+      isDir = false;
+    }
+    if (!isDir) continue;
+    for (const file of walk(abs, excludeAbs, extensions)) {
+      try {
+        contents.push(readFileSync(file, 'utf-8'));
+      } catch {
+        /* unreadable file — skip */
+      }
+    }
+  }
+  return (literal) => contents.some((text) => text.includes(literal));
+}

--- a/scripts/lib/fix-manifest.mjs
+++ b/scripts/lib/fix-manifest.mjs
@@ -1,0 +1,109 @@
+/**
+ * fix-manifest — evidence mapping for claimed-merged fixes (Phase 2, A-sot).
+ *
+ * ADR 0036: this module is the *evidence* SoT (fix → test + ADR-line), NOT the
+ * *status* SoT. "Is fix N merged?" is answered solely by the wiki spec
+ * (parseStatus). A manifest row says "if the spec claims N merged, here is the
+ * test that proves the behavior and the production-code line that proves the
+ * ADR's core decision shipped."
+ *
+ * Shape (ADR 0036 decision 2 — NO `status` field):
+ *   { fixId:number, testNames:string[], adrPath:string|null, adrKeyLine:string }
+ *
+ *  - testNames: MUST set-equal the `// @fix #N:` anchors in tests/runner.mjs
+ *    (drift is an error — MANIFEST_TEST_DRIFT). Multiple anchors → multiple
+ *    names. The NO_AUTO_TEST sentinel is the ONLY allowed lone entry; it may
+ *    not be mixed with real test names.
+ *  - adrPath: path (relative to the wiki root) of the ADR whose core decision
+ *    this fix implements. `null` iff adrKeyLine is the NO_ADR sentinel.
+ *  - adrKeyLine: a maintainer-curated literal that embodies the fix's shipped
+ *    decision and exists verbatim in production code (scripts/ hooks/ commands/
+ *    skills/ templates/). Verified by fixed-string grep — 0 hits is
+ *    ADR_LINE_MISSING. The NO_ADR sentinel exempts a fix that has no ADR (small
+ *    / doctor fixes); the test-green check still applies. NO_ADR is NOT for
+ *    fixes that have an ADR but whose evidence lives outside the corpus.
+ *
+ * Coverage contract: every fix that is BOTH claimed-merged in the spec AND
+ * anchored in the runner must have exactly one row here (MANIFEST_MISSING_ROW
+ * is an error). Fixes anchored but not claimed (e.g. #18) are ORPHAN_ANCHOR
+ * warnings and need no row.
+ *
+ * Corpus note (spec §A amendment, 2026-06-07): the ADR-line grep corpus is
+ * scripts/ hooks/ commands/ skills/ AND templates/. templates/ ships via npm
+ * `files`, so prompt-driven fixes whose decision is installed as template text
+ * (e.g. #20 proactive close offer) are honestly verifiable there.
+ */
+
+export const NO_ADR = 'NO_ADR';
+export const NO_AUTO_TEST = 'NO_AUTO_TEST';
+
+export const FIX_MANIFEST = [
+  {
+    fixId: 15,
+    testNames: ['all type-conditional fields present → green'],
+    adrPath: 'decisions/0030-hypoignore-enforce-all-injection-hooks.md',
+    adrKeyLine: 'isIgnored(path, HYPO_DIR, patterns)',
+  },
+  {
+    fixId: 17,
+    testNames: [
+      '5 mandatory memory files fresh → suppressOutput:true',
+      'project hot.md not updated today → block, reason names the file',
+      'open-questions.md absent/stale → still passes (conditional, not gated)',
+    ],
+    adrPath: 'decisions/0022-session-close-ux-automation.md',
+    adrKeyLine: 'sessionCloseFileStatus',
+  },
+  {
+    // Behavioral / prompt-driven: no automated test, evidence is the installed
+    // template prompt (templates/hypo-guide.md). Has an ADR (0022), so NOT
+    // NO_ADR — the adrKeyLine greps the shipped template text.
+    fixId: 20,
+    testNames: [NO_AUTO_TEST],
+    adrPath: 'decisions/0022-session-close-ux-automation.md',
+    adrKeyLine: '이 작업이 마무리되었나요? 세션을 정리(crystallize)할까요?',
+  },
+  {
+    fixId: 25,
+    testNames: [
+      'replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE',
+    ],
+    adrPath: 'decisions/0022-session-close-ux-automation.md',
+    adrKeyLine: '[WIKI_AUTOCLOSE]',
+  },
+  {
+    // Removal fix (capacity bypass deleted). The shipped evidence is the
+    // deliberate removal-marker comment + the negative-control test.
+    fixId: 26,
+    testNames: [
+      'replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (fix #26 negative control)',
+    ],
+    adrPath: 'decisions/0022-session-close-ux-automation.md',
+    adrKeyLine: 'Capacity bypass (≥90%) REMOVED — fix #26',
+  },
+  {
+    fixId: 27,
+    testNames: [
+      'replay-auto-minimal-crystallize-on-incomplete-close: mutating + no marker + close-intent → block',
+      'replay-auto-minimal-crystallize-on-incomplete-close: valid marker → continue (even with close-intent)',
+    ],
+    adrPath: 'decisions/0022-session-close-ux-automation.md',
+    adrKeyLine: 'The hook NEVER writes the marker',
+  },
+  {
+    // No dedicated ADR (schema-vocab tag validation); test-green only.
+    fixId: 36,
+    testNames: ['PascalCase tag → error', 'unknown tag (not in vocab) → error'],
+    adrPath: null,
+    adrKeyLine: NO_ADR,
+  },
+  {
+    fixId: 38,
+    testNames: [
+      'clean-wiki payload → ok:true, new entries appended (apply dedup is exact-entry, not date-based)',
+      'idempotent: re-running same payload produces no new bytes (file mtimes unchanged)',
+    ],
+    adrPath: 'decisions/0029-crystallize-session-close-depth-expansion.md',
+    adrKeyLine: 'exact-entry append dedup',
+  },
+];

--- a/scripts/lib/fix-status-verify.mjs
+++ b/scripts/lib/fix-status-verify.mjs
@@ -260,4 +260,179 @@ export function verifyMatrix({ anchors, status, testResults, specIsStub = false 
   return { ok, findings };
 }
 
-export { POSITIVE_STATUSES, NEGATIVE_STATUS_TOKENS };
+// ── Phase 2 (A-sot) — manifest validation, coverage/drift, ADR-line grep ─────
+// ADR 0036: manifest is the evidence SoT (fix → test + ADR-line). status SoT
+// stays in the spec. These are pure functions; the CLI injects fs-backed
+// searchFn / adrExistsFn so the corpus walk stays out of the pure layer.
+
+import { FIX_MANIFEST, NO_ADR, NO_AUTO_TEST } from './fix-manifest.mjs';
+
+/** Order-insensitive set equality over string arrays (deduped). */
+function sameStringSet(a, b) {
+  const sa = new Set(a);
+  const sb = new Set(b);
+  if (sa.size !== sb.size) return false;
+  for (const x of sa) if (!sb.has(x)) return false;
+  return true;
+}
+
+/**
+ * Structural validation of the manifest shape (ADR 0036).
+ *
+ * Findings (all error):
+ *   MANIFEST_DUP_FIXID       — two rows share a fixId.
+ *   MANIFEST_EMPTY_TESTS     — testNames is empty.
+ *   MANIFEST_SENTINEL_MIX    — NO_AUTO_TEST mixed with real test names.
+ *   MANIFEST_EMPTY_KEYLINE   — adrKeyLine missing/blank.
+ *   MANIFEST_NO_ADR_SHAPE    — NO_ADR row with non-null adrPath, or a non-NO_ADR
+ *                              row with null adrPath.
+ */
+export function validateManifest(manifest = FIX_MANIFEST) {
+  const findings = [];
+  const seen = new Set();
+  for (const row of manifest) {
+    const fixNum = row.fixId;
+    if (seen.has(fixNum)) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_DUP_FIXID',
+        fixNum,
+        detail: `duplicate manifest row for fix #${fixNum}`,
+      });
+    }
+    seen.add(fixNum);
+
+    const names = Array.isArray(row.testNames) ? row.testNames : [];
+    if (names.length === 0) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_EMPTY_TESTS',
+        fixNum,
+        detail: `fix #${fixNum} manifest row has empty testNames`,
+      });
+    }
+    if (names.includes(NO_AUTO_TEST) && names.length > 1) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_SENTINEL_MIX',
+        fixNum,
+        detail: `fix #${fixNum} mixes NO_AUTO_TEST sentinel with real test names`,
+      });
+    }
+
+    const keyLine = typeof row.adrKeyLine === 'string' ? row.adrKeyLine.trim() : '';
+    if (!keyLine) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_EMPTY_KEYLINE',
+        fixNum,
+        detail: `fix #${fixNum} manifest row has empty adrKeyLine`,
+      });
+      continue;
+    }
+    const isNoAdr = row.adrKeyLine === NO_ADR;
+    if (isNoAdr && row.adrPath != null) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_NO_ADR_SHAPE',
+        fixNum,
+        detail: `fix #${fixNum} is NO_ADR but adrPath is not null`,
+      });
+    }
+    if (!isNoAdr && row.adrPath == null) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_NO_ADR_SHAPE',
+        fixNum,
+        detail: `fix #${fixNum} has a real adrKeyLine but null adrPath`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Coverage + drift between manifest, runner anchors, and spec status claims.
+ *
+ *   MANIFEST_MISSING_ROW  — a fix claimed-merged AND anchored has no manifest
+ *                           row (its ADR-line check would be silently skipped).
+ *                           Error: a missing row bypasses the whole gate.
+ *   MANIFEST_TEST_DRIFT   — a manifest row's testNames do not set-equal the
+ *                           runner anchors for that fix (stale evidence).
+ *
+ * Both error-level. The claimed∩anchored requirement mirrors the manifest
+ * scope (ADR 0036): rows exist to prove claims; anchors-without-claims are
+ * ORPHAN_ANCHOR (handled in verifyMatrix), not manifest gaps.
+ */
+export function checkManifestCoverage({ manifest = FIX_MANIFEST, anchors, status }) {
+  const findings = [];
+  const byFix = new Map(manifest.map((r) => [r.fixId, r]));
+
+  for (const fixNum of status.keys()) {
+    if (!anchors.has(fixNum)) continue; // claimed but unanchored → NO_ANCHOR (verifyMatrix)
+    if (!byFix.has(fixNum)) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_MISSING_ROW',
+        fixNum,
+        detail: `fix #${fixNum} is claimed-merged and anchored but has no manifest row`,
+      });
+    }
+  }
+
+  for (const row of manifest) {
+    const fixNum = row.fixId;
+    const anchored = anchors.get(fixNum) || [];
+    const names = Array.isArray(row.testNames) ? row.testNames : [];
+    if (!sameStringSet(names, anchored)) {
+      findings.push({
+        level: 'error',
+        class: 'MANIFEST_TEST_DRIFT',
+        fixNum,
+        detail:
+          `fix #${fixNum} manifest testNames ${JSON.stringify(names)} ` +
+          `≠ runner anchors ${JSON.stringify(anchored)}`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * ADR-line grep: each non-NO_ADR manifest row must point at an existing ADR
+ * file and its adrKeyLine must exist verbatim in the production-code corpus.
+ *
+ *   ADR_PATH_MISSING   — adrPath does not resolve to a file.
+ *   ADR_LINE_MISSING   — adrKeyLine not found in the corpus (fixed-string).
+ *
+ * searchFn(literal) → boolean: true iff the literal appears in the corpus
+ * (the corpus MUST exclude scripts/lib/fix-manifest.mjs, else every line
+ * self-matches and the gate is vacuous — see the CLI corpus builder).
+ * adrExistsFn(adrPath) → boolean. NO_ADR rows are skipped (test-green only).
+ */
+export function checkAdrLines({ manifest = FIX_MANIFEST, searchFn, adrExistsFn }) {
+  const findings = [];
+  for (const row of manifest) {
+    if (row.adrKeyLine === NO_ADR) continue;
+    const fixNum = row.fixId;
+    if (row.adrPath != null && !adrExistsFn(row.adrPath)) {
+      findings.push({
+        level: 'error',
+        class: 'ADR_PATH_MISSING',
+        fixNum,
+        detail: `fix #${fixNum} adrPath does not resolve: ${row.adrPath}`,
+      });
+    }
+    if (!searchFn(row.adrKeyLine)) {
+      findings.push({
+        level: 'error',
+        class: 'ADR_LINE_MISSING',
+        fixNum,
+        detail: `fix #${fixNum} adrKeyLine not found in production corpus: "${row.adrKeyLine}"`,
+      });
+    }
+  }
+  return findings;
+}
+
+export { POSITIVE_STATUSES, NEGATIVE_STATUS_TOKENS, FIX_MANIFEST, NO_ADR, NO_AUTO_TEST };

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -11700,7 +11700,14 @@ const {
   parseRunnerOutput: fsvParseRunnerOutput,
   verifyMatrix: fsvVerifyMatrix,
   isReferenceStub: fsvIsReferenceStub,
+  validateManifest: fsvValidateManifest,
+  checkManifestCoverage: fsvCheckManifestCoverage,
+  checkAdrLines: fsvCheckAdrLines,
+  FIX_MANIFEST: FSV_FIX_MANIFEST,
+  NO_ADR: FSV_NO_ADR,
+  NO_AUTO_TEST: FSV_NO_AUTO_TEST,
 } = await import(`${SCRIPTS}/lib/fix-status-verify.mjs`);
+const { buildCorpusSearch: fsvBuildCorpusSearch } = await import(`${SCRIPTS}/lib/adr-corpus.mjs`);
 
 suite('fix-status-verify — parseAnchors');
 
@@ -11943,6 +11950,224 @@ test('verifyMatrix: all-green case → ok:true with no error findings', () => {
   assert.equal(findings.filter((f) => f.level === 'error').length, 0);
 });
 
+// ── fix-status-verify — manifest (Phase 2, A-sot) ────────────────────────────
+
+suite('fix-status-verify — validateManifest');
+
+test('validateManifest: real FIX_MANIFEST is structurally clean', () => {
+  assert.deepEqual(fsvValidateManifest(FSV_FIX_MANIFEST), []);
+});
+
+test('validateManifest: duplicate fixId → MANIFEST_DUP_FIXID', () => {
+  const m = [
+    { fixId: 1, testNames: ['t'], adrPath: null, adrKeyLine: FSV_NO_ADR },
+    { fixId: 1, testNames: ['u'], adrPath: null, adrKeyLine: FSV_NO_ADR },
+  ];
+  const f = fsvValidateManifest(m);
+  assert.ok(f.some((x) => x.class === 'MANIFEST_DUP_FIXID' && x.fixNum === 1));
+});
+
+test('validateManifest: empty testNames → MANIFEST_EMPTY_TESTS', () => {
+  const m = [{ fixId: 2, testNames: [], adrPath: null, adrKeyLine: FSV_NO_ADR }];
+  const f = fsvValidateManifest(m);
+  assert.ok(f.some((x) => x.class === 'MANIFEST_EMPTY_TESTS' && x.fixNum === 2));
+});
+
+test('validateManifest: NO_AUTO_TEST mixed with real name → MANIFEST_SENTINEL_MIX', () => {
+  const m = [
+    { fixId: 3, testNames: [FSV_NO_AUTO_TEST, 'real'], adrPath: null, adrKeyLine: FSV_NO_ADR },
+  ];
+  const f = fsvValidateManifest(m);
+  assert.ok(f.some((x) => x.class === 'MANIFEST_SENTINEL_MIX' && x.fixNum === 3));
+});
+
+test('validateManifest: lone NO_AUTO_TEST is allowed (no sentinel-mix)', () => {
+  const m = [{ fixId: 4, testNames: [FSV_NO_AUTO_TEST], adrPath: null, adrKeyLine: FSV_NO_ADR }];
+  const f = fsvValidateManifest(m);
+  assert.ok(!f.some((x) => x.class === 'MANIFEST_SENTINEL_MIX'));
+});
+
+test('validateManifest: blank adrKeyLine → MANIFEST_EMPTY_KEYLINE', () => {
+  const m = [{ fixId: 5, testNames: ['t'], adrPath: 'decisions/x.md', adrKeyLine: '   ' }];
+  const f = fsvValidateManifest(m);
+  assert.ok(f.some((x) => x.class === 'MANIFEST_EMPTY_KEYLINE' && x.fixNum === 5));
+});
+
+test('validateManifest: NO_ADR with non-null adrPath → MANIFEST_NO_ADR_SHAPE', () => {
+  const m = [{ fixId: 6, testNames: ['t'], adrPath: 'decisions/x.md', adrKeyLine: FSV_NO_ADR }];
+  const f = fsvValidateManifest(m);
+  assert.ok(f.some((x) => x.class === 'MANIFEST_NO_ADR_SHAPE' && x.fixNum === 6));
+});
+
+test('validateManifest: real adrKeyLine with null adrPath → MANIFEST_NO_ADR_SHAPE', () => {
+  const m = [{ fixId: 7, testNames: ['t'], adrPath: null, adrKeyLine: 'some literal' }];
+  const f = fsvValidateManifest(m);
+  assert.ok(f.some((x) => x.class === 'MANIFEST_NO_ADR_SHAPE' && x.fixNum === 7));
+});
+
+suite('fix-status-verify — checkManifestCoverage');
+
+test('checkManifestCoverage: clean when rows match anchors + claims', () => {
+  const manifest = [{ fixId: 1, testNames: ['t1'], adrPath: null, adrKeyLine: FSV_NO_ADR }];
+  const anchors = new Map([[1, ['t1']]]);
+  const status = new Map([[1, 'merged']]);
+  assert.deepEqual(fsvCheckManifestCoverage({ manifest, anchors, status }), []);
+});
+
+test('checkManifestCoverage: claimed+anchored without row → MANIFEST_MISSING_ROW', () => {
+  const manifest = [];
+  const anchors = new Map([[9, ['t9']]]);
+  const status = new Map([[9, 'merged']]);
+  const f = fsvCheckManifestCoverage({ manifest, anchors, status });
+  assert.ok(f.some((x) => x.class === 'MANIFEST_MISSING_ROW' && x.fixNum === 9));
+});
+
+test('checkManifestCoverage: claimed but unanchored → no MISSING_ROW (NO_ANCHOR domain)', () => {
+  const manifest = [];
+  const anchors = new Map();
+  const status = new Map([[9, 'merged']]);
+  const f = fsvCheckManifestCoverage({ manifest, anchors, status });
+  assert.ok(!f.some((x) => x.class === 'MANIFEST_MISSING_ROW'));
+});
+
+test('checkManifestCoverage: testNames ≠ anchors → MANIFEST_TEST_DRIFT', () => {
+  const manifest = [
+    { fixId: 1, testNames: ['t1', 'stale'], adrPath: null, adrKeyLine: FSV_NO_ADR },
+  ];
+  const anchors = new Map([[1, ['t1']]]);
+  const status = new Map([[1, 'merged']]);
+  const f = fsvCheckManifestCoverage({ manifest, anchors, status });
+  assert.ok(f.some((x) => x.class === 'MANIFEST_TEST_DRIFT' && x.fixNum === 1));
+});
+
+test('checkManifestCoverage: NO_AUTO_TEST row set-equal to anchor → no drift', () => {
+  const manifest = [
+    { fixId: 20, testNames: [FSV_NO_AUTO_TEST], adrPath: null, adrKeyLine: FSV_NO_ADR },
+  ];
+  const anchors = new Map([[20, [FSV_NO_AUTO_TEST]]]);
+  const status = new Map([[20, 'merged']]);
+  assert.deepEqual(fsvCheckManifestCoverage({ manifest, anchors, status }), []);
+});
+
+test('checkManifestCoverage: drift is order-insensitive', () => {
+  const manifest = [{ fixId: 1, testNames: ['b', 'a'], adrPath: null, adrKeyLine: FSV_NO_ADR }];
+  const anchors = new Map([[1, ['a', 'b']]]);
+  const status = new Map([[1, 'merged']]);
+  assert.deepEqual(fsvCheckManifestCoverage({ manifest, anchors, status }), []);
+});
+
+suite('fix-status-verify — checkAdrLines');
+
+test('checkAdrLines: clean when adrPath exists and literal found', () => {
+  const manifest = [{ fixId: 1, testNames: ['t'], adrPath: 'decisions/x.md', adrKeyLine: 'LIT' }];
+  const f = fsvCheckAdrLines({ manifest, searchFn: () => true, adrExistsFn: () => true });
+  assert.deepEqual(f, []);
+});
+
+test('checkAdrLines: literal not in corpus → ADR_LINE_MISSING', () => {
+  const manifest = [{ fixId: 1, testNames: ['t'], adrPath: 'decisions/x.md', adrKeyLine: 'LIT' }];
+  const f = fsvCheckAdrLines({ manifest, searchFn: () => false, adrExistsFn: () => true });
+  assert.ok(f.some((x) => x.class === 'ADR_LINE_MISSING' && x.fixNum === 1));
+});
+
+test('checkAdrLines: adrPath unresolved → ADR_PATH_MISSING', () => {
+  const manifest = [{ fixId: 1, testNames: ['t'], adrPath: 'decisions/x.md', adrKeyLine: 'LIT' }];
+  const f = fsvCheckAdrLines({ manifest, searchFn: () => true, adrExistsFn: () => false });
+  assert.ok(f.some((x) => x.class === 'ADR_PATH_MISSING' && x.fixNum === 1));
+});
+
+test('checkAdrLines: NO_ADR row is skipped entirely', () => {
+  const manifest = [{ fixId: 1, testNames: ['t'], adrPath: null, adrKeyLine: FSV_NO_ADR }];
+  // Even with searchFn always false, a NO_ADR row produces no finding.
+  const f = fsvCheckAdrLines({ manifest, searchFn: () => false, adrExistsFn: () => false });
+  assert.deepEqual(f, []);
+});
+
+suite('fix-status-verify — buildCorpusSearch (self-match exclusion)');
+
+test('buildCorpusSearch: finds a literal present in an included dir', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'scripts'), { recursive: true });
+    writeFileSync(join(root, 'scripts', 'foo.mjs'), 'const x = "UNIQUE_DECISION_LINE";\n');
+    const search = fsvBuildCorpusSearch({ repoRoot: root, includeDirs: ['scripts'] });
+    assert.equal(search('UNIQUE_DECISION_LINE'), true);
+    assert.equal(search('not present anywhere'), false);
+  });
+});
+
+test('buildCorpusSearch: CRITICAL — excluded manifest does NOT self-satisfy the grep', () => {
+  withTmpDir((root) => {
+    // Literal lives ONLY inside scripts/lib/fix-manifest.mjs (the manifest).
+    mkdirSync(join(root, 'scripts', 'lib'), { recursive: true });
+    writeFileSync(
+      join(root, 'scripts', 'lib', 'fix-manifest.mjs'),
+      "export const FIX_MANIFEST = [{ adrKeyLine: 'ONLY_IN_MANIFEST' }];\n",
+    );
+    writeFileSync(join(root, 'scripts', 'other.mjs'), '// no decision literal here\n');
+    // With the manifest excluded, the literal is NOT found → ADR_LINE_MISSING
+    // would correctly fire. This is the guard that keeps the gate non-vacuous.
+    const excluded = fsvBuildCorpusSearch({
+      repoRoot: root,
+      includeDirs: ['scripts'],
+      excludePaths: ['scripts/lib/fix-manifest.mjs'],
+    });
+    assert.equal(excluded('ONLY_IN_MANIFEST'), false);
+    // Without the exclusion, it self-matches — proving exclusion is the mechanism.
+    const notExcluded = fsvBuildCorpusSearch({ repoRoot: root, includeDirs: ['scripts'] });
+    assert.equal(notExcluded('ONLY_IN_MANIFEST'), true);
+  });
+});
+
+test('buildCorpusSearch: case-sensitive fixed-string match', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'hooks'), { recursive: true });
+    writeFileSync(join(root, 'hooks', 'h.mjs'), 'WIKI_AUTOCLOSE marker\n');
+    const search = fsvBuildCorpusSearch({ repoRoot: root, includeDirs: ['hooks'] });
+    assert.equal(search('WIKI_AUTOCLOSE'), true);
+    assert.equal(search('wiki_autoclose'), false);
+  });
+});
+
+test('buildCorpusSearch: missing include dir is tolerated (not fatal)', () => {
+  withTmpDir((root) => {
+    const search = fsvBuildCorpusSearch({ repoRoot: root, includeDirs: ['does-not-exist'] });
+    assert.equal(search('anything'), false);
+  });
+});
+
+test('manifest integration: real FIX_MANIFEST verifies clean against the real corpus', () => {
+  // Regression guard for the adrKeyLine curation: every non-NO_ADR row's literal
+  // must still exist in the production corpus (excluding the manifest itself),
+  // and every adrPath must resolve under the wiki. Skips if the wiki is absent.
+  const f1 = fsvValidateManifest(FSV_FIX_MANIFEST);
+  assert.deepEqual(f1, []);
+  const search = fsvBuildCorpusSearch({
+    repoRoot: REPO,
+    includeDirs: ['scripts', 'hooks', 'commands', 'skills', 'templates'],
+    excludePaths: ['scripts/lib/fix-manifest.mjs'],
+  });
+  const wikiDecisions = join(homedir(), 'hypomnema', 'projects', 'hypomnema');
+  const adrExists = (p) => existsSync(join(wikiDecisions, p));
+  const haveWiki = FSV_FIX_MANIFEST.every(
+    (r) => r.adrPath == null || existsSync(join(wikiDecisions, r.adrPath)),
+  );
+  // ADR-line grep is corpus-only (no wiki dependency); always assert it.
+  const lineFindings = fsvCheckAdrLines({
+    manifest: FSV_FIX_MANIFEST,
+    searchFn: search,
+    adrExistsFn: () => true,
+  }).filter((x) => x.class === 'ADR_LINE_MISSING');
+  assert.deepEqual(lineFindings, [], `ADR_LINE_MISSING: ${JSON.stringify(lineFindings)}`);
+  if (haveWiki) {
+    const pathFindings = fsvCheckAdrLines({
+      manifest: FSV_FIX_MANIFEST,
+      searchFn: search,
+      adrExistsFn: adrExists,
+    }).filter((x) => x.class === 'ADR_PATH_MISSING');
+    assert.deepEqual(pathFindings, [], `ADR_PATH_MISSING: ${JSON.stringify(pathFindings)}`);
+  }
+});
+
 // ── fix-status-verify CLI integration ────────────────────────────────────────
 
 suite('fix-status-verify — CLI integration');
@@ -11960,6 +12185,11 @@ test('CLI: green fixture → exit 0', () => {
         "console.log('  ✓ green-fixture-test');",
       ].join('\n'),
     );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(
+      manifestPath,
+      "export const FIX_MANIFEST = [{ fixId: 100, testNames: ['green-fixture-test'], adrPath: null, adrKeyLine: 'NO_ADR' }];\n",
+    );
     const r = spawnSync(
       process.execPath,
       [
@@ -11968,6 +12198,8 @@ test('CLI: green fixture → exit 0', () => {
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
@@ -11975,7 +12207,7 @@ test('CLI: green fixture → exit 0', () => {
     );
     assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
     assert.match(r.stdout, /verified/);
-    assert.match(r.stdout, /ADR core decision grep NOT checked/);
+    assert.match(r.stdout, /ADR-line grep \(Phase 2\)/);
   });
 });
 
@@ -11992,6 +12224,8 @@ test('CLI: type:reference stub spec → exit 1 with STUB_SPEC', () => {
       runnerPath,
       ['#!/usr/bin/env node', '// @fix #100: t', "console.log('  ✓ t');"].join('\n'),
     );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(manifestPath, 'export const FIX_MANIFEST = [];\n');
     const r = spawnSync(
       process.execPath,
       [
@@ -12000,6 +12234,8 @@ test('CLI: type:reference stub spec → exit 1 with STUB_SPEC', () => {
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
         '--json',
@@ -12026,6 +12262,8 @@ test('CLI: vacuous spec (anchors but 0 claims) → exit 1 with STUB_SPEC', () =>
       runnerPath,
       ['#!/usr/bin/env node', '// @fix #100: t', "console.log('  ✓ t');"].join('\n'),
     );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(manifestPath, 'export const FIX_MANIFEST = [];\n');
     const r = spawnSync(
       process.execPath,
       [
@@ -12034,6 +12272,8 @@ test('CLI: vacuous spec (anchors but 0 claims) → exit 1 with STUB_SPEC', () =>
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
         '--json',
@@ -12053,6 +12293,8 @@ test('CLI: missing anchor → exit 1 with NO_ANCHOR finding', () => {
     writeFileSync(specPath, '| #200 | merged | **resolved (PR #1)** — body |\n');
     const runnerPath = join(wikiDir, 'fixture-runner.mjs');
     writeFileSync(runnerPath, '// no anchor for #200\n');
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(manifestPath, 'export const FIX_MANIFEST = [];\n');
     const r = spawnSync(
       process.execPath,
       [
@@ -12061,6 +12303,8 @@ test('CLI: missing anchor → exit 1 with NO_ANCHOR finding', () => {
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
@@ -12084,6 +12328,11 @@ test('CLI: anchor names test that does not run → exit 1 with MISSING_TEST', ()
         "console.log('  ✓ different-name');",
       ].join('\n'),
     );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(
+      manifestPath,
+      "export const FIX_MANIFEST = [{ fixId: 300, testNames: ['ghost-test-name'], adrPath: null, adrKeyLine: 'NO_ADR' }];\n",
+    );
     const r = spawnSync(
       process.execPath,
       [
@@ -12092,6 +12341,8 @@ test('CLI: anchor names test that does not run → exit 1 with MISSING_TEST', ()
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
@@ -12111,6 +12362,11 @@ test('CLI: --json emits machine-readable report with ok flag', () => {
       runnerPath,
       ['#!/usr/bin/env node', '// @fix #400: t', "console.log('  ✓ t');"].join('\n'),
     );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(
+      manifestPath,
+      "export const FIX_MANIFEST = [{ fixId: 400, testNames: ['t'], adrPath: null, adrKeyLine: 'NO_ADR' }];\n",
+    );
     const r = spawnSync(
       process.execPath,
       [
@@ -12119,6 +12375,8 @@ test('CLI: --json emits machine-readable report with ok flag', () => {
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
         '--json',
@@ -12133,7 +12391,7 @@ test('CLI: --json emits machine-readable report with ok flag', () => {
     // Mandatory note string is identical in human and JSON outputs.
     assert.equal(
       j.note,
-      'test-linkage + green only — ADR core decision grep NOT checked, see Phase 2 / v1.3.0',
+      'test-linkage + green + ADR-line grep (Phase 2): manifest evidence checked against production corpus',
     );
   });
 });
@@ -12149,6 +12407,11 @@ test('CLI: anchored test fails → exit 1 with FAILING_TEST', () => {
         '\n',
       ),
     );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(
+      manifestPath,
+      "export const FIX_MANIFEST = [{ fixId: 500, testNames: ['real-test'], adrPath: null, adrKeyLine: 'NO_ADR' }];\n",
+    );
     const r = spawnSync(
       process.execPath,
       [
@@ -12157,6 +12420,8 @@ test('CLI: anchored test fails → exit 1 with FAILING_TEST', () => {
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
@@ -12177,6 +12442,8 @@ test('CLI: test command exits nonzero → exit 1 with TEST_RUN_NONZERO_EXIT', ()
       runnerPath,
       ['#!/usr/bin/env node', "console.log('  ✓ a test passed');", 'process.exit(7);'].join('\n'),
     );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(manifestPath, 'export const FIX_MANIFEST = [];\n');
     const r = spawnSync(
       process.execPath,
       [
@@ -12185,6 +12452,8 @@ test('CLI: test command exits nonzero → exit 1 with TEST_RUN_NONZERO_EXIT', ()
         specPath,
         '--runner',
         runnerPath,
+        '--manifest',
+        manifestPath,
         '--test-command',
         `${process.execPath} ${runnerPath}`,
         '--json',
@@ -12198,6 +12467,88 @@ test('CLI: test command exits nonzero → exit 1 with TEST_RUN_NONZERO_EXIT', ()
     assert.ok(
       j.findings.some((f) => f.class === 'TEST_RUN_NONZERO_EXIT'),
       `expected TEST_RUN_NONZERO_EXIT finding: ${JSON.stringify(j.findings)}`,
+    );
+  });
+});
+
+test('CLI: manifest adrKeyLine absent from corpus → exit 1 with ADR_LINE_MISSING', () => {
+  withTmpDir((wikiDir) => {
+    const specPath = join(wikiDir, 'spec.md');
+    writeFileSync(specPath, '| #600 | merged | **TRUE_MERGED** — body |\n');
+    const runnerPath = join(wikiDir, 'fixture-runner.mjs');
+    writeFileSync(
+      runnerPath,
+      ['#!/usr/bin/env node', '// @fix #600: t600', "console.log('  ✓ t600');"].join('\n'),
+    );
+    // adrPath resolves (temp wiki has the file) so the ONLY failure is the
+    // missing corpus literal.
+    mkdirSync(join(wikiDir, 'projects', 'hypomnema', 'decisions'), { recursive: true });
+    writeFileSync(join(wikiDir, 'projects', 'hypomnema', 'decisions', 'real.md'), '# adr\n');
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(
+      manifestPath,
+      "export const FIX_MANIFEST = [{ fixId: 600, testNames: ['t600'], adrPath: 'decisions/real.md', adrKeyLine: 'ZZ_LITERAL_NOT_IN_ANY_PRODUCTION_FILE_zz' }];\n",
+    );
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'fix-status-verify.mjs'),
+        '--spec',
+        specPath,
+        '--runner',
+        runnerPath,
+        '--manifest',
+        manifestPath,
+        '--hypo-dir',
+        wikiDir,
+        '--test-command',
+        `${process.execPath} ${runnerPath}`,
+        '--json',
+      ],
+      { encoding: 'utf-8', cwd: REPO },
+    );
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+    const j = JSON.parse(r.stdout);
+    assert.ok(
+      j.findings.some((f) => f.class === 'ADR_LINE_MISSING' && f.fixNum === 600),
+      `expected ADR_LINE_MISSING: ${JSON.stringify(j.findings)}`,
+    );
+    assert.ok(!j.findings.some((f) => f.class === 'ADR_PATH_MISSING'));
+  });
+});
+
+test('CLI: claimed+anchored fix with no manifest row → exit 1 with MANIFEST_MISSING_ROW', () => {
+  withTmpDir((wikiDir) => {
+    const specPath = join(wikiDir, 'spec.md');
+    writeFileSync(specPath, '| #700 | merged | **TRUE_MERGED** — body |\n');
+    const runnerPath = join(wikiDir, 'fixture-runner.mjs');
+    writeFileSync(
+      runnerPath,
+      ['#!/usr/bin/env node', '// @fix #700: t700', "console.log('  ✓ t700');"].join('\n'),
+    );
+    const manifestPath = join(wikiDir, 'manifest.mjs');
+    writeFileSync(manifestPath, 'export const FIX_MANIFEST = [];\n');
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'fix-status-verify.mjs'),
+        '--spec',
+        specPath,
+        '--runner',
+        runnerPath,
+        '--manifest',
+        manifestPath,
+        '--test-command',
+        `${process.execPath} ${runnerPath}`,
+        '--json',
+      ],
+      { encoding: 'utf-8', cwd: REPO },
+    );
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+    const j = JSON.parse(r.stdout);
+    assert.ok(
+      j.findings.some((f) => f.class === 'MANIFEST_MISSING_ROW' && f.fixNum === 700),
+      `expected MANIFEST_MISSING_ROW: ${JSON.stringify(j.findings)}`,
     );
   });
 });


### PR DESCRIPTION
## What

v1.3.0 **Track A-sot** — extends `fix-status-verify` (learned_behavior #6 automation) from Phase 1 (test-green only) to **Phase 2**: verify each fix's ADR core-decision line actually shipped to production code, backed by a curated evidence manifest. Implements spec §A #2 (ADR_LINE grep) + #3 (bare-anchor) + #4 (manifest), per **ADR 0036** (manifest = evidence-only, spec stays status SoT).

## Changes

- **#4 `scripts/lib/fix-manifest.mjs`** — 8-row evidence map `{fixId, testNames, adrPath, adrKeyLine}`, **no `status` field** (ADR 0036 decision 2). `NO_ADR` sentinel for ADR-less fixes (#36, schema-vocab).
- **#2 ADR_LINE grep** (`scripts/lib/adr-corpus.mjs` + verifier) — each non-`NO_ADR` `adrKeyLine` must exist verbatim in the production corpus `scripts/ hooks/ commands/ skills/ templates/`.
  - **CRITICAL self-match guard**: `scripts/lib/fix-manifest.mjs` is excluded from the corpus — it lives *inside* `scripts/` and holds every literal, so without exclusion every line self-matches and `ADR_LINE_MISSING` could never fire (vacuous gate). A direct regression test proves the exclusion is the mechanism.
  - `templates/` added to corpus (**spec §A amendment**: it ships via npm `files`; #20's proactive-close-offer evidence is template text). New findings `ADR_LINE_MISSING` / `ADR_PATH_MISSING`.
- **manifest validation + coverage/drift** — `MANIFEST_MISSING_ROW` (**error** — a missing row bypasses the grep), `MANIFEST_TEST_DRIFT` (**error** — order-insensitive set equality vs runner anchors), plus dup/empty-tests/sentinel-mix/empty-keyline/NO_ADR-shape structural checks.
- **#3 bare-anchor promotion: 0 of 7 promoted** — `#6/#7/#8/#11/#23/#28/#31` are all non-claimed in the archive spec, so promoting them would create ORPHAN regressions. Staying bare is the correct outcome (Ship Gate "ORPHAN regression 0"). Verified empirically.
- **CLI** — `--manifest <path>` injection (default = built-in constant), `async main()` with exit-2 error path.

## Review trail (OSS 2-stage codex)

- **Design stage** (codex 2 workers, both **BLOCKER**) — all findings reflected: `MANIFEST_MISSING_ROW`=error (not warn), drift in scope, self-match path exclusion, `templates/` corpus, `NO_ADR` shape. `ADR_KEY_LINE_NOT_IN_ADR` **deliberately deferred** (would re-introduce the dual-sync burden ADR 0036 rejected).
- **Pre-commit stage** (codex 1 worker): **CLEAR** — independently re-ran `npm test` (585) + CLI against archive spec (`ok:true`) + `git diff --check`.

## Ship Gate (A)

- `fix:verify` against archived real spec → `statusClaims:8`, exit 0 ✅
- reference-stub default → STUB_SPEC fail-loud (OQ-A1) ✅
- ADR_LINE_MISSING / STUB_SPEC / MANIFEST_MISSING_ROW fixtures + self-match direct test green ✅
- bare-anchor promotion ORPHAN regression 0 (only pre-existing #18 ORPHAN_ANCHOR warn) ✅
- `npm test` **560 → 585 (+25)** green, lint 0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)