### PR TITLE
feat(crystallize): session-close advisory reflections #41~#44 (ADR 0029 Phase B)

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -11,7 +11,20 @@ You are running `/hypo:crystallize`. This command serves two purposes:
 
 ## Step 1 — Detect context
 
-If the user invoked `/hypo:crystallize` to close a session (phrases like "세션 종료", "오늘 작업 마무리", "session close", or "wrap up"), run Steps 2–4 (session-close mechanical apply + recovery) **before** the synthesis scan. Otherwise skip to Step 5.
+If the user invoked `/hypo:crystallize` to close a session (phrases like "세션 종료", "오늘 작업 마무리", "session close", or "wrap up"), run Step 1a (advisory reflections) then Steps 2–4 (session-close mechanical apply + recovery) **before** the synthesis scan. Otherwise skip to Step 5.
+
+---
+
+## Step 1a — Session-close advisory reflections
+
+Before composing the payload (Step 2), run these four reflections and surface each to the user. Every one is **advisory** (ADR 0029 identity guard) — the user confirms or declines, and none performs an automatic action, writes a file on its own, or bypasses the mandatory gate.
+
+1. **Trivial-session check (#44)** — Was this session trivial (a single bug fix, a single-file edit, or Q&A with no durable artifact)? If so, recommend skipping session-close: *"이 세션은 trivial해 보입니다 — session-close를 건너뛸까요?"* and proceed only if the user wants a close. A trivial skip is a recommendation, **not** a bypass: it must not mark the session closed, must not run `--mark-session-closed`, and must not claim `/compact` can pass. Any real close still requires all 5 mandatory files.
+2. **ADR-candidate check (#41)** — Did this session make an architectural or design decision (a new pattern, a tradeoff chosen, a convention established)? If yes, ask whether it warrants an ADR and, if so, capture that intent in the `sessionLog` entry you compose in Step 2. If nothing rose to ADR level, record `ADR 없음 — <one-line reason>` in that same `sessionLog` entry. **Never auto-write an ADR file** — recording the decision (or its absence) in the session-log payload is the only action here.
+3. **design-history staleness check (#42)** — If `projects/<name>/design-history.md` exists and this session changed design decisions it does not yet reflect, recommend updating it (the W8 lint warning flags this mechanically; an active-project W8 can also block at PreCompact). If the file does not exist, skip silently — do **not** create it just for this check. Never auto-update it.
+4. **Ingest check (#43)** — Did this session consume trustworthy external knowledge (a fetched URL, official docs, or code you verified directly)? If so, recommend running `/hypo:ingest` to capture it under `sources/`. Proceed only on the user's confirmation.
+
+These are judgment calls; when uncertain, surface the question rather than skip it. None of the four blocks the close or writes on its own.
 
 ---
 

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -43,7 +43,18 @@ Show the output verbatim.
 
 ## Step 3 — Session-close checklist (if triggered at session end)
 
-If `/hypo:crystallize` was invoked as a session-close action, run through this checklist before synthesizing. Proceed automatically without confirmation unless the user has not said "auto".
+If `/hypo:crystallize` was invoked as a session-close action, run through this checklist before synthesizing. The mechanical checklist items (1–6 below) proceed automatically without confirmation unless the user has not said "auto"; the advisory reflections that precede them (#41~#44) always surface to the user for confirmation — they are recommendations, never auto-actions.
+
+### Advisory reflections (run before the checklist below — advisory only)
+
+Surface each of these four to the user first. Every one is **advisory** (ADR 0029 identity guard): the user confirms or declines, and none performs an automatic action, writes a file on its own, or bypasses the mandatory gate.
+
+- **Trivial-session check (#44)** — Was this session trivial (a single bug fix, a single-file edit, or Q&A with no durable artifact)? If so, recommend skipping session-close: *"이 세션은 trivial해 보입니다 — session-close를 건너뛸까요?"* A trivial skip is a recommendation, **not** a bypass: it must not mark the session closed, must not run `--mark-session-closed`, and must not claim `/compact` can pass. Any real close still requires all 5 mandatory files.
+- **ADR-candidate check (#41)** — Did this session make an architectural or design decision (a new pattern, a tradeoff, a convention)? If yes, ask whether it warrants an ADR and capture that intent in the session-log entry. If nothing rose to ADR level, record `ADR 없음 — <one-line reason>` in that same session-log entry. **Never auto-write an ADR file** — the session-log note is the only action here.
+- **design-history staleness check (#42)** — If `projects/<name>/design-history.md` exists and this session changed design decisions it does not yet reflect, recommend updating it (W8 lint flags this mechanically; an active-project W8 can also block at PreCompact). If the file does not exist, skip silently — do **not** create it just for this check. Never auto-update it.
+- **Ingest check (#43)** — Did this session consume trustworthy external knowledge (a fetched URL, official docs, or code you verified directly)? If so, recommend running `/hypo:ingest` to capture it under `sources/`. Proceed only on the user's confirmation.
+
+When uncertain, surface the question rather than skip it. None of the four blocks the close or writes on its own.
 
 1. **session-state.md** — update `projects/<name>/session-state.md` with the next tasks list (what to tackle first next time).
 2. **hot.md (project)** — update `projects/<name>/hot.md` with a session snapshot: what changed and decisions made. Keep under 500 words. Do not put next-step tasks here; those belong in session-state.md.

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -12553,6 +12553,74 @@ test('CLI: claimed+anchored fix with no manifest row → exit 1 with MANIFEST_MI
   });
 });
 
+// ── session-close advisory reflections (#41~#44) — surface-drift guard ───────
+// The four advisories are prompt text, not script logic. The defect class is
+// "a shipped session-close surface drifts and silently loses an advisory" — so
+// these tests assert each advisory + each identity-guard phrase is present on
+// every IN-SCOPE shipped close surface. hypo-guide.md is intentionally out of
+// scope (ADR 0019/0022 auto-layer, not 0029 advisory-layer; not machine-read by
+// readChecklist — no `[ ] 0.` marker). Reconciling it is logged as #47.
+suite('session-close advisory reflections (#41~#44) — present on shipped surfaces');
+
+const ADVISORY_SURFACES = [
+  join(REPO, 'commands', 'crystallize.md'),
+  join(REPO, 'skills', 'crystallize', 'SKILL.md'),
+];
+
+// Markers that must appear on every in-scope surface. Keyed by advisory.
+const ADVISORY_MARKERS = {
+  '#44 trivial': ['(#44)', 'Trivial-session check'],
+  '#41 ADR-candidate': ['(#41)', 'ADR-candidate check', 'Never auto-write an ADR'],
+  '#42 design-history': ['(#42)', 'design-history staleness check'],
+  '#43 ingest': ['(#43)', 'Ingest check', '/hypo:ingest'],
+};
+
+// Identity-guard phrases (ADR 0029): advisory-only, no auto-action, no gate
+// bypass. The no-auto contract asserts the actual contract sentence — not just
+// the word "advisory" — so a future surface that keeps "advisory" while
+// permitting an auto-action (auto-ingest, auto-update) still fails this gate.
+const GUARD_PHRASES = [
+  'ADR 0029',
+  'advisory', // advisory-only framing
+  'none performs an automatic action', // no-auto contract (not merely the word "advisory")
+  'writes on its own', // closing reminder: none writes on its own
+  'must not run `--mark-session-closed`', // #44 must not bypass the gate
+  'Any real close still requires all 5 mandatory files', // gate still applies
+];
+
+for (const surface of ADVISORY_SURFACES) {
+  const rel = surface.slice(REPO.length + 1);
+  test(`${rel}: all four advisories (#41~#44) present`, () => {
+    const txt = readFileSync(surface, 'utf-8');
+    for (const [advisory, needles] of Object.entries(ADVISORY_MARKERS)) {
+      for (const needle of needles) {
+        assert.ok(
+          txt.includes(needle),
+          `${rel} missing ${advisory} marker: ${JSON.stringify(needle)}`,
+        );
+      }
+    }
+  });
+
+  test(`${rel}: identity-guard phrases (advisory-only, no gate bypass) present`, () => {
+    const txt = readFileSync(surface, 'utf-8');
+    for (const phrase of GUARD_PHRASES) {
+      assert.ok(txt.includes(phrase), `${rel} missing guard phrase: ${JSON.stringify(phrase)}`);
+    }
+  });
+}
+
+// hypo-guide.md is the deliberately-excluded auto-layer surface. Pin that it is
+// NOT in the in-scope list so a future edit that "helpfully" adds it here has to
+// consciously remove this assertion (and address the #47 backstop reconcile).
+test('hypo-guide.md intentionally excluded from advisory surfaces (#47 follow-up)', () => {
+  const guidePath = join(REPO, 'templates', 'hypo-guide.md');
+  assert.ok(
+    !ADVISORY_SURFACES.includes(guidePath),
+    'templates/hypo-guide.md must stay out of ADVISORY_SURFACES until #47 reconciles its auto-layer wording',
+  );
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
## What

Adds the four ADR-0029 Phase B **advisory reflections** (#41~#44) to the two shipped session-close prompt surfaces, plus a surface-drift guard test.

| fix | advisory |
|---|---|
| **#44** trivial-session | recommend skipping close on a trivial session (single bug/file/Q&A) |
| **#41** ADR-candidate | ask if a design decision warrants an ADR; record `ADR 없음 — reason` in the session-log otherwise |
| **#42** design-history | recommend updating a stale `design-history.md` |
| **#43** ingest | recommend `/hypo:ingest` for external sources consumed this session |

Surfaces updated (both shipped via `package.json` `files`):
- `commands/crystallize.md` — new **Step 1a** before payload compose
- `skills/crystallize/SKILL.md` — advisory preamble at top of **Step 3**

## Identity guard (ADR 0029)

All four are **advisory only**: the user confirms or declines, **none auto-acts, none bypasses the 5-mandatory gate, none auto-writes a file**.
- #44 explicitly forbids reading "trivial skip" as a gate bypass (no `--mark-session-closed`, no `/compact`-pass claim).
- The skill's `"Proceed automatically … auto"` line is **narrowed to the mechanical checklist (items 1–6)** so it cannot override advisory confirmations.

## Scope reconciliation (codex 2-worker verify + 2-worker design review)

- **#45** (commit-push) — already covered by `hooks/hypo-auto-commit.mjs` (Stop hook stage+commit+pull+push). Optional manual-CLI `--commit` flag deferred.
- **#46** (session-log monthly shard) — already implemented (`crystallize.mjs` read+write `session-log/YYYY-MM.md`).
- **`templates/hypo-guide.md` intentionally excluded** — it is the ADR 0019/0022 **auto-layer** (auto-ingest/auto-close), not 0029, and is **not machine-read** by `readChecklist` (no `[ ] 0.` marker). Its backstop reconcile is logged as follow-up **#47**. The guard test pins this exclusion so a future edit must consciously revisit it.

## Test

Surface-drift guard (`tests/runner.mjs`): asserts all four advisories + the identity-guard / no-auto / no-gate-bypass **contract phrases** are present on both in-scope surfaces. The no-auto assertion checks the actual contract sentence, not merely the word "advisory".

Prompt-only change; no script logic touched. **585 → 590 tests**, prettier clean.

## Review trail

- Done-state verification: codex 2-worker → CONCERN (surfaced the 3rd surface) → reconciled.
- Design review: codex 2-worker → CONCERN×2 (7 points) → all folded.
- Pre-commit review: codex 1-worker → CONCERN (loose guard phrase) → strengthened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)