### PR TITLE
fix(release): fetch annotated tag object so bilingual --tag gate works in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,23 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # fetch-depth: 0 fetches full history including annotated tag objects;
-          # the default shallow clone leaves git unable to read the tag body
-          # that `check-bilingual --tag` validates.
+          # fetch-depth: 0 fetches full history, but actions/checkout still
+          # materializes the *triggering tag* as a LIGHTWEIGHT local ref (it
+          # fetches the commit by SHA, not the annotated tag object). So
+          # `git rev-parse <tag>^{tag}` — how check-bilingual detects annotation
+          # — fails in CI on a tag that is annotated on the remote. The explicit
+          # tag re-fetch below restores the annotated object. (Verified: this
+          # was the v1.3.0 release-gate false-fail.)
           fetch-depth: 0
+
+      - name: Fetch annotated tag object
+        # Without this, check-bilingual --tag sees the triggering tag as
+        # lightweight (see checkout note above) and the bilingual gate
+        # false-fails on a genuinely annotated tag.
+        run: |
+          git fetch --force origin \
+            "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+          git cat-file -t "${GITHUB_REF_NAME}"   # prints "tag" for annotated
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## The bug (blocked v1.3.0)

The release workflow's **Validate bilingual release docs** step runs `check-bilingual.mjs --tag`, which detects annotated tags via `git rev-parse <ref>^{tag}` — requiring the annotated tag **object** locally. `actions/checkout@v5` (even with `fetch-depth: 0`) materializes the triggering tag as a **lightweight** local ref (fetches the commit by SHA, not the tag object), so `^{tag}` fails and the gate **false-fails on a tag that is annotated on the remote**.

This gate (#70) shipped in v1.3.0, and v1.3.0 was its **first-ever tag-triggered CI run** — so the local-vs-CI gap (it passes locally where the annotated object resolves) surfaced only at push. Observed: CI run `27096380258` failed the bilingual step in 17s; publish never ran.

## The fix

Add a **Fetch annotated tag object** step after checkout that force-fetches the exact tag refspec, restoring the annotated object. `check-bilingual.mjs` is left **unchanged** (pure validator — the CI environment was the bug, not the rule).

## Verification (local CI-repro)

```
git tag v1.3.0 HEAD                  # force lightweight = reproduce CI
git rev-parse --verify --quiet v1.3.0^{tag}   → exit 1   (reproduces the false-fail)
git fetch --force origin refs/tags/v1.3.0:refs/tags/v1.3.0
git rev-parse --verify --quiet v1.3.0^{tag}   → exit 0   (fix works)
check-bilingual.mjs --tag v1.3.0     → OK
```

- codex 1-worker pre-commit review: **CLEAR** (correctness of refspec, `--force` safety on ephemeral runner ref, step placement, validator-unchanged call, YAML/shell, no scope creep all confirmed).

## Scope

This PR fixes **only** the bilingual-gate CI false-fail. It does **not** touch the separate **publish-step E404** credential issue — that predates v1.3.0 (CI auto-publish worked through v1.1.0 [provenance attestation present], then 1.2.0/1.2.1 were published **manually** [`dist.attestations: NONE`]). That's a separate CI-credential PR; v1.3.0 ships via manual publish like 1.2.x. See `qa-runs/2026-06-07-pre-ship-v1.3.0.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)