### PR TITLE
fix(ci): restore NODE_AUTH_TOKEN on precheck dry-run (smoke-pack needs it)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,9 +118,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Dry-run publish (build + prepublishOnly, no PUT, no auth)
+      - name: Dry-run publish (build + prepublishOnly, no PUT)
         # `--dry-run` packs the tarball and runs prepublishOnly
         # (test/lint/smoke-pack/check:bilingual) but performs NO registry PUT, so
-        # nothing is published and no token is needed. Confirms the package still
-        # builds and the publish gates pass.
+        # nothing is published. NODE_AUTH_TOKEN IS required: prepublishOnly runs
+        # `smoke-pack`, which `npm install`s the packed tarball, and setup-node
+        # writes an always-auth `.npmrc` — without the token that nested install
+        # fails (exit 254). This matches the real publish job, whose prepublishOnly
+        # runs with the same token.
         run: npm publish --dry-run --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Bug

The `publish-precheck` job (PR #89) ran red on its first `workflow_dispatch` validation — the **dry-run step failed with smoke-pack exit 254**. Root cause: the dry-run dropped `NODE_AUTH_TOKEN` (a least-privilege suggestion in the #89 review), but `npm publish --dry-run` runs `prepublishOnly` → `smoke-pack`, which `npm install`s the packed tarball; setup-node writes an **always-auth `.npmrc`**, so the nested install needs the token. Without it → 254.

The real publish job's `prepublishOnly` runs with the token (that's why it never hit this), so this just realigns the dry-run to the same environment.

## Fix

Restore `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on the dry-run step + correct the comment.

## Still safe

`--dry-run` performs **no registry PUT** — "never publishes" holds. The job remains `workflow_dispatch`-only and the real publish job stays gated to tag pushes.

## Validation (empirical, stronger than static review here)

The #89 `workflow_dispatch` run already proved the important half: **credential check PASS** (`whoami` + read-write on `hypomnema`) and **publish job SKIPPED** (safety). Only the dry-run env was wrong. This PR's fix is confirmed by **re-running the dispatch to green end-to-end** after merge (the env-specific failure that static review — including the review that introduced it — mis-analyzed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)