### PR TITLE
fix(resume): cwd-aware same-date tie-break for active project selection (ISSUE-1)

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -232,13 +232,56 @@ export function freshDates() {
   return local === utc ? [local] : [local, utc];
 }
 
+// Parse a single frontmatter scalar (mirrors hypo-session-start.mjs /
+// hypo-cwd-change.mjs; local copy per the hook self-contained convention).
+function parseFrontmatterField(content, key) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const line = m[1].split('\n').find((l) => l.startsWith(`${key}:`));
+  if (!line) return null;
+  return line
+    .slice(key.length + 1)
+    .trim()
+    .replace(/^['"]|['"]$/g, '');
+}
+
+// Among `slugs`, return the one whose projects/<slug>/index.md `working_dir`
+// is the LONGEST prefix of cwd (so /repo/sub wins over /repo). Returns null
+// when cwd is falsy or matches none. Used only as a same-date tie-breaker.
+function pickByCwd(hypoDir, slugs, cwd) {
+  if (!cwd) return null;
+  let best = null;
+  let bestLen = -1;
+  for (const slug of slugs) {
+    const indexPath = join(hypoDir, 'projects', slug, 'index.md');
+    if (!existsSync(indexPath)) continue;
+    const wd = parseFrontmatterField(readFileSync(indexPath, 'utf-8'), 'working_dir');
+    if (!wd) continue;
+    let resolved = wd.startsWith('~/') ? join(homedir(), wd.slice(2)) : wd;
+    resolved = resolved.replace(/\/+$/, ''); // trailing-slash normalize
+    if ((cwd === resolved || cwd.startsWith(resolved + '/')) && resolved.length > bestLen) {
+      bestLen = resolved.length;
+      best = slug;
+    }
+  }
+  return best;
+}
+
 /**
  * Resolve the most-recently-active project slug from root hot.md.
- * Mirrors scripts/resume.mjs resolveActiveProject — kept in sync by hand.
+ * The cwd helpers (parseFrontmatterField / pickByCwd) and the same-date
+ * tie-break are kept in sync with scripts/resume.mjs by hand; the surrounding
+ * wrapper intentionally differs (resume.mjs adds an mtime fallback, this does not).
+ * `cwd` is an optional same-date tie-breaker (ISSUE-1): resume passes
+ * process.cwd(); session-close callers (sessionCloseFileStatus /
+ * closeFileTargets) intentionally pass null — close has a different
+ * authority (payload.project / freshness), tracked separately as ISSUE-7.
+ * When cwd is omitted, behavior is identical to the legacy version.
  * @param {string} hypoDir
+ * @param {string|null} [cwd]
  * @returns {string|null}
  */
-export function resolveActiveProject(hypoDir) {
+export function resolveActiveProject(hypoDir, cwd = null) {
   const hotPath = join(hypoDir, 'hot.md');
   if (!existsSync(hotPath)) return null;
   let content;
@@ -257,6 +300,19 @@ export function resolveActiveProject(hypoDir) {
   ].map((m) => ({ name: m[1].trim(), date: m[2] || '', slug: m[3] }));
   if (wikiRows.length > 0) {
     wikiRows.sort((a, b) => b.date.localeCompare(a.date));
+    // Same-date tie-break (ISSUE-1): when the top date is shared by >1 row,
+    // prefer the project whose working_dir contains cwd. No cwd / no match →
+    // keep the stable-sort winner (the legacy "first table row" behavior).
+    const topDate = wikiRows[0].date;
+    const tied = wikiRows.filter((r) => r.date === topDate);
+    if (cwd && tied.length > 1) {
+      const picked = pickByCwd(
+        hypoDir,
+        tied.map((r) => r.slug),
+        cwd,
+      );
+      if (picked) return picked;
+    }
     return wikiRows[0].slug;
   }
   // Legacy markdown-link rows: | [name](projects/name/...) | ...

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -16,6 +16,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import { homedir } from 'os';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
@@ -33,7 +34,43 @@ function parseArgs(argv) {
 
 // ── active project from hot.md ───────────────────────────────────────────────
 
-function resolveActiveProject(hypoDir) {
+// Parse a single frontmatter scalar (mirrors the hook helpers in
+// hypo-session-start.mjs / hypo-cwd-change.mjs — kept local per the hook
+// self-contained convention rather than shared, to avoid script↔hook coupling).
+function parseFrontmatterField(content, key) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const line = m[1].split('\n').find((l) => l.startsWith(`${key}:`));
+  if (!line) return null;
+  return line
+    .slice(key.length + 1)
+    .trim()
+    .replace(/^['"]|['"]$/g, '');
+}
+
+// Among `slugs`, return the one whose projects/<slug>/index.md `working_dir`
+// is the LONGEST prefix of cwd (so /repo/sub wins over /repo). Returns null
+// when cwd is falsy or matches none. Used only as a same-date tie-breaker.
+function pickByCwd(hypoDir, slugs, cwd) {
+  if (!cwd) return null;
+  let best = null;
+  let bestLen = -1;
+  for (const slug of slugs) {
+    const indexPath = join(hypoDir, 'projects', slug, 'index.md');
+    if (!existsSync(indexPath)) continue;
+    const wd = parseFrontmatterField(readFileSync(indexPath, 'utf-8'), 'working_dir');
+    if (!wd) continue;
+    let resolved = wd.startsWith('~/') ? join(homedir(), wd.slice(2)) : wd;
+    resolved = resolved.replace(/\/+$/, ''); // trailing-slash normalize
+    if ((cwd === resolved || cwd.startsWith(resolved + '/')) && resolved.length > bestLen) {
+      bestLen = resolved.length;
+      best = slug;
+    }
+  }
+  return best;
+}
+
+function resolveActiveProject(hypoDir, cwd = null) {
   const hotPath = join(hypoDir, 'hot.md');
   if (!existsSync(hotPath)) return null;
 
@@ -49,6 +86,19 @@ function resolveActiveProject(hypoDir) {
   ].map((m) => ({ name: m[1].trim(), date: m[2] || '', slug: m[3] }));
   if (wikiRows.length > 0) {
     wikiRows.sort((a, b) => b.date.localeCompare(a.date));
+    // Same-date tie-break (ISSUE-1): when the top date is shared by >1 row,
+    // prefer the project whose working_dir contains cwd. No cwd / no match →
+    // keep the stable-sort winner (the legacy "first table row" behavior).
+    const topDate = wikiRows[0].date;
+    const tied = wikiRows.filter((r) => r.date === topDate);
+    if (cwd && tied.length > 1) {
+      const picked = pickByCwd(
+        hypoDir,
+        tied.map((r) => r.slug),
+        cwd,
+      );
+      if (picked) return picked;
+    }
     return wikiRows[0].slug;
   }
   // Legacy markdown-link rows: | [name](projects/name/...) | ...
@@ -93,7 +143,7 @@ function readHot(hypoDir, project) {
 
 const args = parseArgs(process.argv);
 
-const project = args.project || resolveActiveProject(args.hypoDir);
+const project = args.project || resolveActiveProject(args.hypoDir, process.cwd());
 
 if (!project) {
   console.error('Error: no active project found. Use --project=<name> or create a hot.md entry.');

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -20,6 +20,7 @@ import {
   unlinkSync,
   utimesSync,
   cpSync,
+  realpathSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -28,7 +29,7 @@ import { fileURLToPath } from 'node:url';
 // entry check, so importing it for unit tests does not run the CLI.
 import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync.mjs';
 import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
-import { buildProjectSuggestionLine } from '../hooks/hypo-shared.mjs';
+import { buildProjectSuggestionLine, resolveActiveProject } from '../hooks/hypo-shared.mjs';
 import { parseSchemaVocab } from '../scripts/lib/schema-vocab.mjs';
 import {
   validateChangelog,
@@ -7427,6 +7428,155 @@ tags: [wiki, operations]
       !r.stdout.includes('slug') && !r.stderr.includes('"slug"'),
       `slug placeholder must not leak: stdout=${r.stdout} stderr=${r.stderr}`,
     );
+  });
+});
+
+// ── ISSUE-1: resolveActiveProject cwd same-date tie-break ─────────────────────
+
+suite('resolveActiveProject — cwd same-date tie-break (ISSUE-1)');
+
+// Build a tmp wiki: root hot.md pointer table + per-project index.md working_dir.
+// rows: [{ slug, date, workingDir? }]
+function makeTieBreakWiki(wikiDir, rows) {
+  mkdirSync(wikiDir, { recursive: true });
+  const tableRows = rows.map((r) => `| ${r.slug} | ${r.date} | [[projects/${r.slug}/hot]] |`);
+  const hot = `---
+title: Hot
+type: reference
+updated: 2026-06-08
+---
+
+## Active Projects
+
+| Project | Last Session | Hot Cache |
+|---|---|---|
+${tableRows.join('\n')}
+`;
+  writeFileSync(join(wikiDir, 'hot.md'), hot);
+  for (const r of rows) {
+    const pdir = join(wikiDir, 'projects', r.slug);
+    mkdirSync(pdir, { recursive: true });
+    if (r.workingDir) {
+      writeFileSync(
+        join(pdir, 'index.md'),
+        `---\ntitle: ${r.slug}\ntype: project-index\nupdated: 2026-06-08\nworking_dir: "${r.workingDir}"\n---\n# ${r.slug}\n`,
+      );
+    }
+  }
+}
+
+test('same-date tie → cwd-matched project wins over table order', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'alpha', date: '2026-06-08' }, // table-top, no working_dir
+      { slug: 'beta', date: '2026-06-08', workingDir: join(dir, 'code/beta') },
+    ]);
+    assert.equal(resolveActiveProject(dir, join(dir, 'code/beta')), 'beta');
+    // sanity: without cwd, the legacy first-row winner stands
+    assert.equal(resolveActiveProject(dir), 'alpha');
+  });
+});
+
+test('tie-breaker-only: newer single row kept even when cwd matches an older row', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'alpha', date: '2026-06-08' },
+      { slug: 'beta', date: '2026-06-07', workingDir: join(dir, 'code/beta') },
+    ]);
+    // cwd matches beta, but beta is older and NOT in the top-date group →
+    // most-recent alpha must still win (tie-breaker-only, not cwd-first).
+    assert.equal(resolveActiveProject(dir, join(dir, 'code/beta')), 'alpha');
+  });
+});
+
+test('longest working_dir prefix wins on tie (/repo vs /repo/sub)', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'parent', date: '2026-06-08', workingDir: join(dir, 'repo') },
+      { slug: 'child', date: '2026-06-08', workingDir: join(dir, 'repo/sub') },
+    ]);
+    assert.equal(resolveActiveProject(dir, join(dir, 'repo/sub/x')), 'child');
+  });
+});
+
+test('cwd null → legacy stable-sort winner (no behavior change)', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'alpha', date: '2026-06-08', workingDir: join(dir, 'code/alpha') },
+      { slug: 'beta', date: '2026-06-08', workingDir: join(dir, 'code/beta') },
+    ]);
+    assert.equal(resolveActiveProject(dir), 'alpha');
+  });
+});
+
+test('cwd matches no project on tie → legacy first row', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'alpha', date: '2026-06-08' },
+      { slug: 'beta', date: '2026-06-08', workingDir: join(dir, 'code/beta') },
+    ]);
+    assert.equal(resolveActiveProject(dir, join(dir, 'elsewhere')), 'alpha');
+  });
+});
+
+test('all rows dateless → cwd still breaks the all-tie group', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'alpha', date: '' },
+      { slug: 'beta', date: '', workingDir: join(dir, 'code/beta') },
+    ]);
+    assert.equal(resolveActiveProject(dir, join(dir, 'code/beta')), 'beta');
+  });
+});
+
+test('sibling-prefix is not a match (/repo does not match cwd /repoX)', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'alpha', date: '2026-06-08' },
+      { slug: 'beta', date: '2026-06-08', workingDir: join(dir, 'repo') },
+    ]);
+    // cwd is a sibling dir sharing a string prefix but not a path prefix →
+    // must NOT match beta; legacy first row stands.
+    assert.equal(resolveActiveProject(dir, join(dir, 'repoX')), 'alpha');
+  });
+});
+
+test('trailing-slash working_dir is normalized before matching', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'alpha', date: '2026-06-08' },
+      { slug: 'beta', date: '2026-06-08', workingDir: `${join(dir, 'code/beta')}/` },
+    ]);
+    assert.equal(resolveActiveProject(dir, join(dir, 'code/beta')), 'beta');
+  });
+});
+
+test('resume.mjs honors process.cwd() for same-date tie (ISSUE-1 wiring)', () => {
+  withTmpDir((dir) => {
+    // process.cwd() reports the realpath, so the fixture working_dir must use
+    // the realpath too (tmpdir is /var → /private/var on macOS).
+    const realDir = realpathSync(dir);
+    const hypoDir = join(dir, 'wiki');
+    const betaWd = join(realDir, 'code/beta');
+    makeTieBreakWiki(hypoDir, [
+      { slug: 'alpha', date: '2026-06-08' },
+      { slug: 'beta', date: '2026-06-08', workingDir: betaWd },
+    ]);
+    for (const s of ['alpha', 'beta']) {
+      writeFileSync(
+        join(hypoDir, 'projects', s, 'session-state.md'),
+        `---\ntitle: ss — ${s}\ntype: session-state\nupdated: 2026-06-08\n---\n\n## 다음\n- t\n`,
+      );
+    }
+    const cwd = betaWd;
+    mkdirSync(cwd, { recursive: true });
+    const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
+      encoding: 'utf-8',
+      cwd,
+      env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+    });
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.ok(r.stdout.startsWith('Project: beta'), `expected 'Project: beta', got: ${r.stdout}`);
   });
 });
 


### PR DESCRIPTION
## 요약 (ISSUE-1)
무인자 `/hypo:resume`이 root `hot.md`의 **동률 날짜**에서 cwd를 무시하고 테이블 최상단 프로젝트를 오선택하던 문제 수정. (재현: hypomnema·security-ops-kb 둘 다 같은 날짜 → cwd가 후자인데도 전자 로드. `--project=` 명시로만 회피 가능했음.)

## 변경
- `scripts/resume.mjs` + `hooks/hypo-shared.mjs`: `resolveActiveProject(hypoDir, cwd = null)` — 최고-날짜 동률 그룹(크기>1)에서만 cwd↔`working_dir` **longest-prefix** 매칭으로 tie를 깬다. 두 파일에 동일 `parseFrontmatterField`/`pickByCwd` 헬퍼 + tie-break 동기화("kept in sync by hand").
- `resume.mjs` main만 `process.cwd()` 전달. session-close caller(`sessionCloseFileStatus`/`closeFileTargets`)는 cwd 미전달 → 동작 변화 0.
- `tests/runner.mjs`: 9 케이스 추가.

## 설계 결정
- **tie-breaker-only** (not cwd-first): cwd는 동률에서만 tie를 깸. 더 최신 비매칭보다 구식 cwd-매칭을 우선하지 않음 → 기존 "most recently active" 의미 보존.
- session-close는 `payload.project`/freshness가 더 강한 authority라 cwd 직접 배선은 "쓴 프로젝트 vs 검증한 프로젝트" 갈림 위험 → **ISSUE-7로 분리**(별도 SoT 설계 선행). `hypo-shared.mjs`의 시그니처는 이미 `cwd` 받을 준비 완료.

## 하위호환
cwd 미전달 / 매칭 없음 / legacy markdown row / dateless → 전부 기존 동작. 회귀 0.

## 테스트
`599 passed, 0 failed`. ISSUE-1 신규 9: 동률 매칭 / tie-breaker-only / longest-prefix(/repo vs /repo/sub) / sibling-prefix 비매칭(/repo vs /repoX) / trailing-slash normalize / cwd null / 매칭없음 / dateless / CLI `process.cwd()` 배선.

## 검토
설계 직후 + commit 직전 2-stage codex 교차검토 (설계 **CLEAR**: 옵션1 권고 → commit **NIT**: 머지 가능). NIT(`Mirrors` 주석 정밀화 + /repoX·trailing-slash 테스트) 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)