### PR TITLE
ci(release): add GitHub Release step + idempotent publish guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # create the GitHub Release (was read; bumped for gh release create)
       id-token: write
 
     steps:
@@ -68,9 +68,35 @@ jobs:
         run: npm run lint
 
       - name: Publish
-        run: npm publish --access public --provenance
+        # Idempotent: re-running a release (e.g. after the GitHub Release step
+        # below failed) must not 409 on an already-published version. Skip the
+        # PUT only when this EXACT version is already on the registry; a
+        # genuinely new version still hard-publishes (keyed on
+        # `npm view <name>@<version>`). A network/lookup failure falls through to
+        # publish — never a silent skip that would read as "shipped".
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "hypomnema@${VERSION}" version >/dev/null 2>&1; then
+            echo "hypomnema@${VERSION} already published — skipping npm publish"
+          else
+            npm publish --access public --provenance
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        # Publish the GitHub Release from the annotated tag body (already
+        # bilingual-validated above). Idempotent: skip if a Release for this tag
+        # already exists, so a re-run does not error. Past v1.x Releases were
+        # hand-created — this automates them on every tag push.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "GitHub Release ${GITHUB_REF_NAME} already exists — skipping"
+          else
+            gh release create "${GITHUB_REF_NAME}" --verify-tag --notes-from-tag
+          fi
 
   publish-precheck:
     name: Publish credential pre-check (never publishes)


### PR DESCRIPTION
## 배경
v1.3.0 release run은 두 가지로 실패했습니다:
- (a) `npm publish` E404 — CI 토큰이 패키지 write 권한 상실(이후 `NPM_TOKEN` rotate 완료). npm 1.3.0은 로컬 수동 publish로 우회.
- (b) **release.yml에 GitHub Release 생성 스텝이 아예 없음** — tag가 있어도 git Release가 안 올라감(과거 v1.x Release는 전부 수동 생성).

이 PR은 (b)를 해결하고 재실행 안전성을 더합니다.

## 변경
- **permissions** `contents: read → write` (GitHub Release 생성용, `id-token: write`와 공존)
- **Publish idempotent 가드**: `npm view hypomnema@<version>`로 이미 있으면 skip, 새 버전은 hard-publish. lookup 실패는 publish로 fall-through → "출시된 척 통과"(silent skip) 방지. 재run 시 409 회피.
- **Create GitHub Release 스텝**: annotated tag body(`--notes-from-tag`, 이미 bilingual 검증됨)로 `gh release create --verify-tag`. idempotent(이미 있으면 skip).

## 운영 주의 (codex CONCERN)
GitHub UI에서 **이미 실패한 v1.3.0 run을 re-run하면 구 YAML이 적용**됩니다(re-run은 원래 run의 SHA/REF 사용). 따라서:
- v1.3.0 GitHub Release는 **수동 `gh release create`로 게시**(별도).
- 이 워크플로는 **v1.3.1 tag push부터** 적용 — 1.3.1이 토큰 실 PUT + auto GH-release의 첫 검증대.

## 검증
- YAML parse(prettier) 통과, `npm test` 599 passed, clean HOME에서 `npm run lint` 통과.
- commit 직전 codex 1워커 교차검토: **CONCERN**(운영 주의만, 코드 머지 가능). permissions·publish guard·`--verify-tag`/`--notes-from-tag`·스텝 순서 전부 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)