### PR TITLE
docs(resume): correct --hypo-dir resolution-order comment (ISSUE-2)

### DIFF
--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -9,7 +9,15 @@
  *   node scripts/resume.mjs [options]
  *
  * Options:
- *   --hypo-dir=<path>     Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
+ *   --hypo-dir=<path>     Hypomnema root. When omitted, resolveHypoRoot()
+ *                         (see lib/hypo-root.mjs) resolves it in priority order:
+ *                           1. $HYPO_DIR if set — returned immediately; the
+ *                              hypo-config.md scan below is then skipped.
+ *                           2. else the first of 7 fixed candidates
+ *                              (~/{hypomnema,wiki,notes,knowledge},
+ *                              ~/Documents/{hypomnema,wiki,notes}) that contains
+ *                              a hypo-config.md marker.
+ *                           3. else the default ~/hypomnema.
  *   --project=<name>      Project name (default: most recently active from hot.md)
  *   --json                Output as JSON
  */


### PR DESCRIPTION
## ISSUE-2 (문서 결함, 런타임 0)
`scripts/resume.mjs` 헤더의 `--hypo-dir` 주석 `HYPO_DIR / hypo-config.md / ~/hypomnema`가 **순차 폴백 체인**처럼 읽히지만 실제 `resolveHypoRoot()`(`lib/hypo-root.mjs`)와 두 군데 어긋났습니다:
- `$HYPO_DIR`이 set이면 **즉시 반환** — hypo-config.md 스캔은 실행조차 안 됨(폴백 아님, 최우선 단락).
- hypo-config.md는 임의 위치가 아니라 **7개 고정 후보**만 스캔(`~/{hypomnema,wiki,notes,knowledge}`, `~/Documents/{hypomnema,wiki,notes}`).

## 변경
주석을 실제 3-step 우선순위로 정정. 순수 주석 — 코드/런타임 변경 없음(`hypo-root.mjs`의 docblock은 이미 정확).

🤖 Generated with [Claude Code](https://claude.com/claude-code)