### PR TITLE
fix(ci): strip inherited npm_config_dry_run in smoke-pack (precheck-254 root fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,16 @@ jobs:
       - name: Dry-run publish (build + prepublishOnly, no PUT)
         # `--dry-run` packs the tarball and runs prepublishOnly
         # (test/lint/smoke-pack/check:bilingual) but performs NO registry PUT, so
-        # nothing is published. NODE_AUTH_TOKEN IS required: prepublishOnly runs
-        # `smoke-pack`, which `npm install`s the packed tarball, and setup-node
-        # writes an always-auth `.npmrc` — without the token that nested install
-        # fails (exit 254). This matches the real publish job, whose prepublishOnly
-        # runs with the same token.
+        # nothing is published.
+        #
+        # Historical note (precheck-254): this `--dry-run` exports
+        # `npm_config_dry_run=true` into the lifecycle env, which leaked into
+        # smoke-pack's nested `npm pack` — making it a no-op that wrote no tarball,
+        # so the nested `npm install` died with ENOENT (exit 254). Fixed in
+        # scripts/smoke-pack.mjs by stripping `npm_config_dry_run` for its nested
+        # npm calls. (NOT a missing-token problem — that was an earlier wrong
+        # theory.) NODE_AUTH_TOKEN is kept below to mirror the real publish job's
+        # environment, so this dry-run stays representative.
         run: npm publish --dry-run --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -32,6 +32,24 @@ import { fileURLToPath } from 'node:url';
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 const KEEP = process.argv.includes('--keep');
 
+// When this script runs inside `npm publish --dry-run` (the release workflow's
+// publish-credential pre-check), npm exports `npm_config_dry_run=true` into the
+// lifecycle environment. spawnSync inherits process.env, so the nested
+// `npm pack` below would ALSO run in dry-run mode — reporting a tarball
+// filename/size it never actually writes to disk — and the subsequent
+// `npm install <tarball>` then fails with ENOENT (npm maps errno -2 → exit 254).
+// Strip the flag so the nested npm commands always perform real writes,
+// matching the real tag-push publish job (which has no outer `--dry-run`). The
+// outer workflow stays dry-run and still skips the registry PUT.
+// (This was the precheck-254 root cause; the earlier "missing NODE_AUTH_TOKEN"
+// theory was wrong — it is file absence, not auth.)
+const npmEnv = { ...process.env };
+for (const key of Object.keys(npmEnv)) {
+  if (key.toLowerCase().replaceAll('-', '_') === 'npm_config_dry_run') {
+    delete npmEnv[key];
+  }
+}
+
 const PKG = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf-8'));
 const PKG_NAME = PKG.name;
 
@@ -64,7 +82,7 @@ try {
   const preCommitBefore = existsSync(preCommitPath) ? readFileSync(preCommitPath, 'utf-8') : null;
 
   step('npm pack');
-  const pack = run('npm', ['pack', '--json'], { cwd: REPO });
+  const pack = run('npm', ['pack', '--json'], { cwd: REPO, env: npmEnv });
   const meta = JSON.parse(pack.stdout)[0];
   const tarball = join(REPO, meta.filename);
   console.log(`  → ${meta.filename} (${meta.size} bytes, ${meta.entryCount} entries)`);
@@ -79,7 +97,10 @@ try {
       private: true,
     }) + '\n',
   );
-  run('npm', ['install', '--no-audit', '--no-fund', '--silent', tarball], { cwd: installRoot });
+  // No `--silent`: run() only prints npm's stdout/stderr on a non-zero exit, so
+  // a real nested-install failure must not be muted (the precheck-254 error was
+  // masked by `--silent` for two release cycles).
+  run('npm', ['install', '--no-audit', '--no-fund', tarball], { cwd: installRoot, env: npmEnv });
 
   // Move tarball into the work dir so it's not left in the repo.
   renameSync(tarball, join(work, meta.filename));


### PR DESCRIPTION
## Bug

The `publish-precheck` job (`workflow_dispatch`) has failed every dispatch since it landed, with smoke-pack reporting:

```
✗ smoke-pack failed: npm install --no-audit --no-fund --silent <tarball> exited 254
```

PR #90 theorized a missing `NODE_AUTH_TOKEN` and restored it — but the dispatch **still returned 254** afterward. That theory was wrong.

## Root cause (confirmed by local reproduction)

The precheck's outer command is `npm publish --dry-run`. npm exports its config to lifecycle scripts as `npm_config_*` env vars, so `npm_config_dry_run=true` is inherited all the way down to smoke-pack's nested `npm pack` (`spawnSync` inherits `process.env`). That nested pack runs **in dry-run mode** — it reports a tarball filename/size but **writes no file** — so the subsequent `npm install <tarball>` hits ENOENT, and npm maps `errno -2` → exit **254**.

The CI log matches exactly: `→ hypomnema-1.3.0.tgz (474347 bytes, 125 entries)` (dry-run pack reporting details) immediately followed by `install ... exited 254`. The `--silent` flag muted npm's real error message.

**This is not "environment-specific" (npm version / runner)** — it is the inherited `dry_run` config. Reproduced locally:

```
npm_config_dry_run=true node scripts/smoke-pack.mjs   # → 254 (before fix)
node scripts/smoke-pack.mjs                            # → passes
```

"dispatch 254 vs tag-push passes" is therefore an **outer-command difference**, not an environment difference: the real tag-push publish job has no `--dry-run`, so its nested pack writes a real tarball.

## Fix

1. **smoke-pack.mjs** — clone `process.env`, delete any key normalizing to `npm_config_dry_run` (covers lowercase / uppercase / hyphenated spellings), and pass that `env` to **both** nested `npm pack` and `npm install`. This makes the nested commands perform real writes regardless of the outer command, mirroring the real publish job. The outer workflow stays `--dry-run` and still skips the registry PUT.
2. **smoke-pack.mjs** — drop `--silent` from the nested install so a future real failure surfaces instead of being muted (`run()` only prints stdout/stderr on a non-zero exit, so success output stays quiet).
3. **release.yml** — correct the stale comment that blamed a missing `NODE_AUTH_TOKEN`. The token is retained as environment parity with the real publish job, not as the 254 fix.

## Validation

- `npm_config_dry_run=true node scripts/smoke-pack.mjs` → reproduced 254, now exits 0.
- Plain `node scripts/smoke-pack.mjs` → still passes.
- `npm test` → 599 passed, 0 failed. prettier clean.
- 2-stage codex cross-review (2 workers each): design → CONCERN + NIT (both — stale comment + case-insensitive scrub — incorporated); pre-commit → CLEAR + CLEAR (both independently re-reproduced across env spellings).

Final confirmation is the next `workflow_dispatch` running green end-to-end after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)