### PR TITLE
fix(notifier): route update + stale-sibling banners to user-visible systemMessage (ISSUE-5)

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -323,6 +323,10 @@ let raw = '';
 process.stdin.setEncoding('utf-8');
 process.stdin.on('data', (chunk) => (raw += chunk));
 process.stdin.on('end', () => {
+  // ISSUE-5: declared before the try so every emit branch — including the outer
+  // catch — carries the same `systemMessage` (the user-visible update/sibling
+  // banner). Reassigned once below after the notices are computed.
+  let outExtra = { continue: true, suppressOutput: true };
   try {
     let data = {};
     try {
@@ -339,10 +343,16 @@ process.stdin.on('end', () => {
     const clearRecoveryLine = buildClearRecoveryLine(data.source);
     const updateLine = buildUpdateNotice();
     const siblingLine = buildSiblingNotice();
-    // Intentional dual emit: stderr (yellow/cyan) is the human-visible nudge in
-    // the terminal; noticePrefix injects the same plain-text lines into the
-    // LLM's additionalContext so model and user start the session looking at
-    // the same state. ANSI escapes are kept out of additionalContext on purpose.
+    // ISSUE-5: the update + stale-sibling banners must reach the USER. On a
+    // SessionStart hook that exits 0, stderr is invisible in the normal TUI
+    // (only shown on exit 2 / --verbose) and additionalContext is model-only —
+    // `systemMessage` is the documented user-visible channel. Route those two
+    // banners there. They ALSO stay in noticePrefix → additionalContext below,
+    // so the model and the user start the session looking at the same state.
+    // (The other stderr notices — sync/growth/clear/suggest — are intentionally
+    // transcript/--verbose only and out of ISSUE-5's scope.)
+    const userMessage = [updateLine, siblingLine].filter(Boolean).join('\n\n');
+    if (userMessage) outExtra = { ...outExtra, systemMessage: userMessage };
     const notices = [syncLine, growthLine, clearRecoveryLine, updateLine, siblingLine].filter(
       Boolean,
     );
@@ -383,7 +393,7 @@ process.stdin.on('end', () => {
           JSON.stringify(
             buildOutput(
               `${noticePrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}]\n\n${parts.join('\n\n')}`,
-              { continue: true, suppressOutput: true },
+              outExtra,
             ),
           ),
         );
@@ -399,10 +409,7 @@ process.stdin.on('end', () => {
           JSON.stringify(
             buildOutput(
               `${noticePrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}, no snapshot yet]`,
-              {
-                continue: true,
-                suppressOutput: true,
-              },
+              outExtra,
             ),
           ),
         );
@@ -425,9 +432,9 @@ process.stdin.on('end', () => {
     if (!existsSync(GLOBAL_HOT)) {
       const notice = notices.join('\n\n');
       if (notice) {
-        console.log(JSON.stringify(buildOutput(notice, { continue: true, suppressOutput: true })));
+        console.log(JSON.stringify(buildOutput(notice, outExtra)));
       } else {
-        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+        console.log(JSON.stringify(outExtra));
       }
       return;
     }
@@ -439,9 +446,9 @@ process.stdin.on('end', () => {
       // would otherwise be silently dropped here.
       const notice = notices.join('\n\n');
       if (notice) {
-        console.log(JSON.stringify(buildOutput(notice, { continue: true, suppressOutput: true })));
+        console.log(JSON.stringify(buildOutput(notice, outExtra)));
       } else {
-        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+        console.log(JSON.stringify(outExtra));
       }
       return;
     }
@@ -449,12 +456,12 @@ process.stdin.on('end', () => {
       JSON.stringify(
         buildOutput(
           `${noticePrefix}[WIKI HOT CACHE: global — no project matched cwd=${cwd}]\n\n${globalContent}`,
-          { continue: true, suppressOutput: true },
+          outExtra,
         ),
       ),
     );
   } catch (err) {
     process.stderr.write(`[hypo-session-start] error: ${err?.message ?? String(err)}\n`);
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    console.log(JSON.stringify(outExtra));
   }
 });

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -10382,6 +10382,9 @@ test('session-start (D3): stale PATH sibling surfaces a one-shot notice, then th
       // additionalContext (LLM-visible) carries it too
       const out = JSON.parse(first.stdout);
       assert.match(out.additionalContext || '', /Stale install on PATH/);
+      // ISSUE-5: and the user-visible channel (systemMessage) carries it as well
+      // — stderr alone is invisible on a SessionStart hook that exits 0.
+      assert.match(out.systemMessage || '', /Stale install on PATH/);
       // second start: same tuple already notified → suppressed
       const second = spawnSync(process.execPath, [join(REPO, 'hooks', 'hypo-session-start.mjs')], {
         input: payload,
@@ -10418,6 +10421,98 @@ test('session-start (D3): opted out (CI/NO_UPDATE_NOTIFIER) suppresses the sibli
       });
       assert.doesNotMatch(r.stderr, /Stale install on PATH/);
     });
+  });
+});
+
+// ── ISSUE-5: update-notifier banner routed to user-visible systemMessage ──────
+// The update notice fires only for the npm/plugin channels (computeNotice skips
+// 'unknown'), and the channel is derived from the RUNNING hook's install root
+// (dirname(dirname(hook))). So copy the (self-contained) hooks/ tree into a fake
+// `node_modules/hypomnema` root — making detectChannel() resolve to 'npm' — and
+// run the COPIED hook with a seeded cache + fake HOME. Proves the banner reaches
+// `systemMessage` (the user channel), not just stderr/additionalContext.
+suite('update-notifier (ISSUE-5): banner routed to user-visible systemMessage');
+
+function withFakeNpmInstall(installedVersion, fn) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-npm-'));
+  try {
+    const root = join(base, 'node_modules', 'hypomnema');
+    mkdirSync(root, { recursive: true });
+    cpSync(HOOKS, join(root, 'hooks'), { recursive: true }); // hooks are self-contained
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'hypomnema', version: installedVersion }),
+    );
+    const home = join(base, 'home');
+    const cacheDir = join(home, '.claude', 'hypomnema', 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+    const wiki = join(base, 'wiki');
+    mkdirSync(wiki, { recursive: true });
+    fn({
+      hook: join(root, 'hooks', 'hypo-session-start.mjs'),
+      home,
+      wiki,
+      cachePath: join(cacheDir, 'version-check.json'),
+    });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function runFakeStart(hook, home, wiki, sessionId, extraEnv = {}) {
+  return spawnSync(process.execPath, [hook], {
+    input: JSON.stringify({ cwd: wiki, session_id: sessionId }),
+    encoding: 'utf-8',
+    env: { ...process.env, ...NOTIFY_ON, HOME: home, HYPO_DIR: wiki, ...extraEnv },
+  });
+}
+
+test('session-start: fresh npm update → systemMessage carries the banner (dual-emit keeps additionalContext)', () => {
+  withFakeNpmInstall('0.0.0', ({ hook, home, wiki, cachePath }) => {
+    writeFileSync(
+      cachePath,
+      JSON.stringify({ checkedAt: Date.now(), latest: { npm: '999.0.0' }, notifiedFor: {} }),
+    );
+    const out = JSON.parse(runFakeStart(hook, home, wiki, 'upd-issue5').stdout);
+    assert.match(
+      out.systemMessage || '',
+      /Update available! 0\.0\.0 → 999\.0\.0/,
+      `update banner missing from systemMessage: ${JSON.stringify(out.systemMessage)}`,
+    );
+    // dual emit: the model still sees the same state via additionalContext
+    assert.match(out.additionalContext || '', /Update available! 0\.0\.0 → 999\.0\.0/);
+  });
+});
+
+test('session-start: already-notified version → no systemMessage (no nag)', () => {
+  withFakeNpmInstall('0.0.0', ({ hook, home, wiki, cachePath }) => {
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        checkedAt: Date.now(),
+        latest: { npm: '999.0.0' },
+        notifiedFor: { npm: '999.0.0' },
+      }),
+    );
+    const out = JSON.parse(runFakeStart(hook, home, wiki, 'upd-issue5-nonag').stdout);
+    assert.ok(
+      !('systemMessage' in out),
+      `expected no systemMessage when already notified: ${JSON.stringify(out.systemMessage)}`,
+    );
+  });
+});
+
+test('session-start: opted out (CI) → update banner suppressed on every channel', () => {
+  withFakeNpmInstall('0.0.0', ({ hook, home, wiki, cachePath }) => {
+    writeFileSync(
+      cachePath,
+      JSON.stringify({ checkedAt: Date.now(), latest: { npm: '999.0.0' }, notifiedFor: {} }),
+    );
+    // CI:'true' overrides NOTIFY_ON's CI:'' → isOptedOut() true
+    const out = JSON.parse(
+      runFakeStart(hook, home, wiki, 'upd-issue5-optout', { CI: 'true' }).stdout,
+    );
+    assert.ok(!('systemMessage' in out), 'opted-out session must not surface an update banner');
   });
 });
 


### PR DESCRIPTION
## Bug (ISSUE-5)

The `hypo-session-start.mjs` SessionStart hook computes an **"Update available"** banner (`buildUpdateNotice`) and a **stale-sibling** banner (`buildSiblingNotice`), but emitted them on only two channels:

1. `process.stderr.write(...)` — **invisible in the normal TUI** on a hook that exits 0 (stderr only shows on exit 2 / `--verbose`).
2. `additionalContext` — **model-only**, never shown to the user.

Per the [Claude Code hooks contract](https://code.claude.com/docs/en/hooks), the user-visible channel for a SessionStart hook is the top-level **`systemMessage`** field, and `suppressOutput` does **not** hide it. The hook never set `systemMessage`, so neither banner ever reached the user. The shipped update notifier (ADR 0033) and the stale-sibling downgrade-footgun mitigation (ADR 0038 D3) were effectively no-ops on screen.

Observed in the wild: the version cache had `notifiedFor: { plugin: "1.3.0" }` (the notifier ran and marked itself "notified") yet the user never saw a banner — `markNotified` burned the one-shot suppression against an invisible channel.

## Fix

- Build `userMessage` from `updateLine` + `siblingLine` and attach it as top-level `systemMessage` on **every** emit branch. `outExtra` is declared before the `try` so the fail-open `catch` carries it too.
- Keep both banners in `noticePrefix → additionalContext` as well (intentional dual emit — model and user start from the same state).
- `buildOutput` is **unchanged**: `systemMessage` rides in via its `extra` arg (`{ ...extra, additionalContext }`), so other hooks that call `buildOutput` are unaffected.
- Correct the now-misleading "stderr is the human-visible nudge" comment.

**Scope:** only the update + stale-sibling notices route to `systemMessage`. `sync/growth/clear/suggest` stay on stderr — out of ISSUE-5's scope (tracked separately as a "confirm author intent" item).

## Tests

- Extended the existing D3 sibling integration test to assert `out.systemMessage` matches `/Stale install on PATH/` (alongside the existing `additionalContext` assertion).
- New `withFakeNpmInstall` suite: copies the self-contained `hooks/` into a fake `node_modules/hypomnema` root so `detectChannel()` resolves to `npm` (`computeNotice` skips the `unknown` channel — this was a design-review catch; a naïve `latest.unknown` fixture would never fire), seeds a fresh cache `latest.npm = 999.0.0`, and clears `CI`/opt-out env. Covers:
  - fresh update → `systemMessage` carries the banner **and** `additionalContext` too (dual emit),
  - already-notified version → no `systemMessage` (no nag),
  - opted-out (`CI=true`) → suppressed on every channel.

`npm test` → **602 passed, 0 failed**. prettier clean.

## Known limitation (accepted)

`markNotified` runs at notice-build time, before the JSON is emitted. Routing through `systemMessage` + reusing `outExtra` in the `catch` closes the common window, but a hard process kill between marking and stdout consumption could still suppress a one-shot banner. The hook is best-effort and one-shot throttling already worked this way, so this residual is accepted rather than refactored. Already-marked-invisible versions (e.g. plugin 1.3.0) stay suppressed; the next version bump notifies fresh.

## Review

2-stage codex cross-review (2 workers each): design → **CONCERN ×2** (test-fixture channel bug, catch-path coverage, stale comment — all fixed); pre-commit → **CLEAR / CLEAR** (both independently ran `npm test` = 602, traced every emit branch, confirmed no `buildOutput` regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)