### PR TITLE
fix(upgrade): guard plugin installs from double-registering core hooks (ISSUE-6)

### DIFF
--- a/commands/upgrade.md
+++ b/commands/upgrade.md
@@ -28,6 +28,8 @@ node <package-root>/scripts/upgrade.mjs [--hypo-dir="<path>"]
 
 Show the output verbatim.
 
+> **Plugin installs**: if the output begins with `ℹ Plugin install detected`, the core hooks, slash commands, and `settings.json` wiring are managed by the Claude Code plugin loader — **not** by `/hypo:upgrade`. Do **not** run `--apply` expecting it to update them (it intentionally skips those to avoid double-registering every hook). To upgrade the plugin itself: `/plugin marketplace update hypomnema` then `/reload-plugins`. `--apply` in plugin mode applies vault-side migrations (SCHEMA, `.hypoignore`), refreshes package metadata, and still syncs any vault extensions — but does **not** install the core hooks/commands/settings (the plugin provides those).
+
 > **Note**: A major SCHEMA bump is only **detected** in this step. The informational `MIGRATION-vX.Y.md` file is written later by `--apply` (Step 4) and only on a major bump. `SCHEMA.md` is never auto-overwritten.
 
 ---

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -458,7 +458,7 @@ function applyHypoignoreMigration(result) {
   return appended;
 }
 
-function writeMigrationReport(hypoDir, fromVersion, toVersion) {
+function writeMigrationReport(hypoDir, fromVersion, toVersion, { pluginMode = false } = {}) {
   const today = new Date().toISOString().slice(0, 10);
   const filename = `MIGRATION-v${toVersion}.md`;
   const dest = join(hypoDir, filename);
@@ -544,9 +544,15 @@ Review the SCHEMA diff and update your wiki pages accordingly.
 
 ## Action items
 
-This report was generated during \`/hypo:upgrade --apply\`. Hook files and settings.json
-entries were applied by that run (or skipped with a warning if the target was malformed —
-see the upgrade output). \`SCHEMA.md\` is intentionally **not** overwritten by upgrade — the
+This report was generated during \`/hypo:upgrade --apply\`. ${
+        pluginMode
+          ? 'You are on a **plugin install**, so the core hook files and settings.json hook ' +
+            'registrations were NOT touched — the Claude Code plugin loader owns them (upgrade the ' +
+            'plugin via `/plugin marketplace update hypomnema` then `/reload-plugins`). Vault ' +
+            'extensions, if any, were still synced.'
+          : 'Hook files and settings.json entries were applied by that run (or skipped with a ' +
+            'warning if the target was malformed — see the upgrade output).'
+      } \`SCHEMA.md\` is intentionally **not** overwritten by upgrade — the
 remaining steps are manual:
 
 - [ ] Compare your \`SCHEMA.md\` (v${fromVersion}) with the package template (v${toVersion}) and merge changes manually
@@ -749,6 +755,31 @@ function applyCommands(commandResults, force) {
   return applied;
 }
 
+// ISSUE-6: in plugin mode `applyCommands` is skipped (no command copy), but the
+// runtime still needs hypo-pkg.json to resolve PKG_ROOT for lint/feedback scripts
+// (hooks/hypo-shared.mjs → hypo-personal-check). Write minimal metadata pointing
+// at the plugin's package root, preserving any existing fields (e.g. `extensions`)
+// but DROPPING any prior `commands` map (no commands were copied, so a stale map
+// would falsely assert ownership of ~/.claude/commands/hypo).
+function writePluginModeMetadata() {
+  const path = pkgJsonPath();
+  // Drop any prior top-level `commands` SHA map: no commands were copied in plugin
+  // mode, so keeping a manual install's map would falsely assert ownership of
+  // ~/.claude/commands/hypo. Preserve every other field (e.g. `extensions`).
+  const { commands: _droppedCommands, ...existing } = readPkgJsonSafe(path) || {};
+  let pkgVersion = null;
+  try {
+    pkgVersion = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf-8')).version;
+  } catch {}
+  writePkgJsonAtomic(path, {
+    ...existing,
+    pkgRoot: PKG_ROOT,
+    pkgVersion,
+    schemaVersion: '2.0',
+  });
+  return true;
+}
+
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
@@ -759,6 +790,29 @@ const claudeHooksDir = join(HOME, '.claude', 'hooks');
 const claudeSettingsPath = join(HOME, '.claude', 'settings.json');
 const codexHooksDir = join(HOME, '.codex', 'hooks');
 const codexSettingsPath = join(HOME, '.codex', 'settings.json');
+
+// ISSUE-6: when `/hypo:upgrade` runs as the Claude Code PLUGIN, the 15 core hooks
+// and 14 slash commands are provided by the plugin's hooks.json + commands/
+// (auto-wired by Claude Code), NOT copied into ~/.claude/. The manual/npm health
+// check below would then report all of them "missing" and recommend `--apply`,
+// which copies the hooks into ~/.claude/hooks/ and registers 14 settings.json
+// events → Claude Code runs BOTH the plugin hooks.json AND user settings.json, so
+// every hook fires TWICE. The decisive signal: the plugin command runs the
+// PLUGIN's upgrade.mjs, so PKG_ROOT lives under ~/.claude/plugins/. (A manual/npm
+// upgrade.mjs run while the plugin is ALSO enabled is a different failure mode —
+// dual install — tracked as ISSUE-8.)
+// Match the Claude plugin cache shape specifically (`~/.claude/plugins/…`), NOT a
+// generic `/plugins/` substring — this flag now GATES install behavior, so a
+// legitimate npm/dev checkout under some unrelated `…/plugins/…` path must not be
+// misclassified and silently stop managing its hooks. (detectChannel's broad
+// `/plugins/` test is fine for the notifier's display-only use, but too loose here.)
+const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
+// Surface policy: pluginMode gates ONLY the Claude core surface (hooks/settings/
+// commands/hook-name migration), which the plugin already provides. The codex
+// core surface (--codex) and vault-defined extensions are NOT plugin-provided, so
+// they stay managed. Package metadata (hypo-pkg.json) is still written so the
+// runtime can resolve PKG_ROOT for lint/feedback scripts (hooks/hypo-shared.mjs).
+const managesClaudeCore = !pluginMode;
 
 const schema = checkSchemaVersion(args.hypoDir);
 const hooks = checkHookFiles(claudeHooksDir);
@@ -871,21 +925,34 @@ if (args.apply) {
       process.exit(2);
     }
   }
-  if (oldHookRefs.length > 0) {
-    appliedHookNameRenames = applyHookNameMigration(
-      oldHookRefs,
-      claudeSettingsPath,
-      claudeHooksDir,
-    );
-  }
+  // Migration report is vault-side (writes into the Hypomnema root) and applies
+  // in both install models.
   if (schema.bump === 'major' && schema.installed && schema.current && existsSync(args.hypoDir)) {
-    migrationPath = writeMigrationReport(args.hypoDir, schema.installed, schema.current);
+    migrationPath = writeMigrationReport(args.hypoDir, schema.installed, schema.current, {
+      pluginMode,
+    });
   }
-  appliedHooks = applyHookFiles(hooks, claudeHooksDir);
-  appliedSettings = applySettingsJson(settings, claudeSettingsPath);
-  // applyCommands handles the single atomic hypo-pkg.json write (pkgRoot, version, schema, commands map)
-  appliedCommands = applyCommands(commands, args.forceCommands);
-  appliedPkgJson = true;
+  if (managesClaudeCore) {
+    if (oldHookRefs.length > 0) {
+      appliedHookNameRenames = applyHookNameMigration(
+        oldHookRefs,
+        claudeSettingsPath,
+        claudeHooksDir,
+      );
+    }
+    appliedHooks = applyHookFiles(hooks, claudeHooksDir);
+    appliedSettings = applySettingsJson(settings, claudeSettingsPath);
+    // applyCommands handles the single atomic hypo-pkg.json write (pkgRoot, version, schema, commands map)
+    appliedCommands = applyCommands(commands, args.forceCommands);
+    appliedPkgJson = true;
+  } else {
+    // ISSUE-6 plugin mode: the plugin loader owns the core hooks/commands and
+    // settings.json wiring — copying them here would double-register. Skip those,
+    // but STILL write minimal package metadata so the runtime can resolve PKG_ROOT
+    // for lint/feedback scripts (hooks/hypo-shared.mjs → hypo-personal-check). The
+    // commands SHA map is intentionally omitted (no command copy happened).
+    appliedPkgJson = writePluginModeMetadata();
+  }
   appliedHypoignore = applyHypoignoreMigration(hypoignore);
   // codex core hooks + settings + wiki-*→hypo-* rename mirror. Same order
   // as the claude side (rename first so subsequent hook copy can find renamed targets).
@@ -939,17 +1006,28 @@ const codexCoreDrift =
     invalidSettingsCodex ||
     (oldHookRefsCodex?.length ?? 0) > 0);
 
-const hasDrift =
+// Claude core-surface drift (hooks/settings/commands/rename/metadata). In plugin
+// mode these are plugin-managed, so they must NOT count as drift — otherwise the
+// report nags "N items need updating" and recommends a double-registering --apply.
+// Plugin-provided surface (hooks/settings/commands/rename) — excluded from drift
+// in plugin mode. pkgJsonDrift is intentionally NOT here: hypo-pkg.json is written
+// in BOTH install models (plugin mode writes minimal metadata so the runtime can
+// resolve PKG_ROOT for lint/feedback), so a missing/stale metadata file should
+// still prompt a (safe, metadata-only) --apply.
+const claudeCoreDrift =
   staleHooks.length > 0 ||
   missingSettings.length > 0 ||
-  schemaDrift ||
   invalidSettings ||
-  pkgJsonDrift ||
   oldHookRefs.length > 0 ||
   staleCommands.length > 0 ||
   userModifiedCommands.length > 0 ||
   orphanedCommands.length > 0 ||
-  nonRegularCommands.length > 0 ||
+  nonRegularCommands.length > 0;
+
+const hasDrift =
+  (managesClaudeCore && claudeCoreDrift) ||
+  pkgJsonDrift ||
+  schemaDrift ||
   hypoignore.status === 'needs-migration' ||
   extDrift ||
   codexCoreDrift;
@@ -958,6 +1036,7 @@ if (args.json) {
   console.log(
     JSON.stringify(
       {
+        pluginMode,
         schema,
         hooks,
         settings,
@@ -1001,6 +1080,23 @@ if (args.json) {
 
 // Human-readable report
 const lines = [];
+
+// ISSUE-6: lead with the plugin-mode banner so the user understands why the core
+// hook/command/settings sections read "managed by plugin" and that `--apply` will
+// NOT touch them (only vault-side migrations + package metadata).
+if (pluginMode) {
+  lines.push(
+    'ℹ Plugin install detected — Hypomnema is loaded via the Claude Code plugin.',
+    '  Core hooks, slash commands, and settings.json wiring are provided by the',
+    '  plugin loader, so `/hypo:upgrade` does NOT manage them (and `--apply` will',
+    '  not copy/register them — that would double-register every hook).',
+    '  → To upgrade the plugin: `/plugin marketplace update hypomnema` then `/reload-plugins`.',
+    '  → `/hypo:upgrade --apply` here applies vault-side migrations (SCHEMA,',
+    '    .hypoignore), refreshes package metadata, and still syncs any vault',
+    '    extensions — but does NOT install the core hooks/commands/settings.',
+    '',
+  );
+}
 
 // Schema version
 if (schema.bump === 'none') {
@@ -1047,7 +1143,13 @@ function pushHookSummary(hookList, label, targetPath) {
     }
   }
 }
-pushHookSummary(hooks, '', '~/.claude/hooks/');
+if (managesClaudeCore) {
+  pushHookSummary(hooks, '', '~/.claude/hooks/');
+} else {
+  lines.push(
+    '✓ Hook files          provided by the plugin loader (not managed in ~/.claude/hooks/)',
+  );
+}
 if (hooksCodex) pushHookSummary(hooksCodex, ' (codex)', '~/.codex/hooks/');
 
 // settings.json registrations (target-aware mirror; fix #48).
@@ -1066,7 +1168,13 @@ function pushSettingsSummary(sList, label, invalidFlag) {
     }
   }
 }
-pushSettingsSummary(settings, '', invalidSettings);
+if (managesClaudeCore) {
+  pushSettingsSummary(settings, '', invalidSettings);
+} else {
+  lines.push(
+    '✓ settings.json       hook wiring provided by the plugin (no ~/.claude registration)',
+  );
+}
 if (settingsCodex) pushSettingsSummary(settingsCodex, ' (codex)', invalidSettingsCodex);
 
 // Package metadata
@@ -1087,7 +1195,9 @@ const cmdMissCount = commands.filter((c) => c.status === 'missing').length;
 const cmdUserCount = userModifiedCommands.length;
 const cmdOrphanCount = orphanedCommands.length;
 const cmdNonRegCount = nonRegularCommands.length;
-if (commands.length === 0) {
+if (!managesClaudeCore) {
+  lines.push('✓ Slash commands    provided by the plugin loader (not ~/.claude/commands/hypo/)');
+} else if (commands.length === 0) {
   lines.push(`⚠ Slash commands    package commands/ is empty`);
 } else if (
   cmdStaleCount === 0 &&
@@ -1134,7 +1244,10 @@ function pushHookNameSummary(refs, label) {
     lines.push(`✓ ${colN}All hook references use current hypo-*.mjs names`);
   }
 }
-pushHookNameSummary(oldHookRefs, '');
+// In plugin mode the Claude settings.json is plugin-owned and --apply skips the
+// rename migration, so do not print a "run --apply to rename" instruction it will
+// not honor. (codex hook-name migration is unaffected by pluginMode.)
+if (managesClaudeCore) pushHookNameSummary(oldHookRefs, '');
 if (oldHookRefsCodex) pushHookNameSummary(oldHookRefsCodex, ' (codex)');
 
 // .hypoignore migration (ensure required runtime patterns are present)
@@ -1269,17 +1382,23 @@ pushAppliedExt(appliedExtensionsCodex, ' (codex)');
 
 // Summary
 lines.push('');
+// Claude core-surface item count — zeroed in plugin mode (plugin-managed), so the
+// summary never reads "N items need updating" for hooks/settings/commands.
+const claudeCoreCount = managesClaudeCore
+  ? staleHooks.length +
+    missingSettings.length +
+    (invalidSettings ? 1 : 0) +
+    oldHookRefs.length +
+    staleCommands.length +
+    userModifiedCommands.length +
+    orphanedCommands.length +
+    nonRegularCommands.length
+  : 0;
+
 const totalDrift =
-  staleHooks.length +
-  missingSettings.length +
-  (schemaDrift ? 1 : 0) +
-  (invalidSettings ? 1 : 0) +
+  claudeCoreCount +
   (pkgJsonDrift ? 1 : 0) +
-  oldHookRefs.length +
-  staleCommands.length +
-  userModifiedCommands.length +
-  orphanedCommands.length +
-  nonRegularCommands.length +
+  (schemaDrift ? 1 : 0) +
   (hypoignore.status === 'needs-migration' ? hypoignore.missing.length : 0) +
   extCheck.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2346,6 +2346,201 @@ test('--apply migration report tags are all in installed SCHEMA vocab', () => {
   });
 });
 
+// ── ISSUE-6: plugin-mode guard (upgrade.mjs) ───────────────────
+// When /hypo:upgrade runs as the Claude Code PLUGIN, the core hooks/commands/
+// settings are provided by the plugin loader, not ~/.claude/. The manual-model
+// check must NOT report them "missing" and `--apply` must NOT copy/register them
+// (double-registration). pluginMode is gated on PKG_ROOT containing /.claude/plugins/,
+// so we run a COPY of upgrade.mjs from a fake root whose path matches that shape.
+suite('upgrade.mjs — plugin-mode guard (ISSUE-6)');
+
+// underPlugins=true → fake root under .claude/plugins (channel 'plugin');
+// false → under node_modules (channel 'npm', regression baseline).
+function withFakeUpgradeInstall(underPlugins, fn) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-upg-'));
+  try {
+    const root = underPlugins
+      ? join(base, '.claude', 'plugins', 'cache', 'mp', 'hypomnema', '1.3.0')
+      : join(base, 'lib', 'node_modules', 'hypomnema');
+    mkdirSync(root, { recursive: true });
+    cpSync(SCRIPTS, join(root, 'scripts'), { recursive: true });
+    cpSync(HOOKS, join(root, 'hooks'), { recursive: true });
+    cpSync(join(REPO, 'commands'), join(root, 'commands'), { recursive: true });
+    cpSync(join(REPO, 'templates'), join(root, 'templates'), { recursive: true });
+    cpSync(join(REPO, 'package.json'), join(root, 'package.json'));
+    const home = join(base, 'home');
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    const wiki = join(base, 'wiki');
+    mkdirSync(wiki, { recursive: true });
+    writeFileSync(join(wiki, 'hypo-config.md'), '---\ntitle: config\ntype: reference\n---\n');
+    cpSync(join(REPO, 'templates', 'SCHEMA.md'), join(wiki, 'SCHEMA.md'));
+    fn({ upgrade: join(root, 'scripts', 'upgrade.mjs'), root, home, wiki });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function runUpgrade(upgrade, args, home) {
+  return spawnSync(process.execPath, [upgrade, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HYPO_DIR: '', HOME: home },
+  });
+}
+
+test('plugin mode: check reports core surfaces as plugin-managed, not missing', () => {
+  withFakeUpgradeInstall(true, ({ upgrade, home, wiki }) => {
+    const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`], home);
+    assert.match(r.stdout, /Plugin install detected/, 'missing plugin banner');
+    assert.match(r.stdout, /provided by the plugin loader/, 'hooks not relabeled plugin-managed');
+    // the manual-model "✗ <hook>.mjs [not found ...]" per-hook nag must be absent
+    assert.doesNotMatch(
+      r.stdout,
+      /✗ hypo-session-start\.mjs/,
+      'plugin mode must not report core hooks missing',
+    );
+    // The legacy bug surfaced ~47 items; plugin mode must only ever flag the
+    // (safe, metadata-only) hypo-pkg.json — never a multi-item hook/command nag.
+    const m = r.stdout.match(/Result: (\d+) item\(s\) need updating/);
+    if (m) assert.ok(Number(m[1]) <= 1, `plugin check over-reported drift: ${m[0]}`);
+  });
+});
+
+test('plugin mode: --json sets pluginMode true', () => {
+  withFakeUpgradeInstall(true, ({ upgrade, home, wiki }) => {
+    const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.pluginMode, true, 'pluginMode flag not set in JSON');
+  });
+});
+
+test('plugin mode: --apply does NOT copy hooks or register settings (no double-registration)', () => {
+  withFakeUpgradeInstall(true, ({ upgrade, home, wiki }) => {
+    const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+    assert.equal(r.status, 0, `plugin --apply should exit 0: ${r.stderr}`);
+    assert.equal(
+      existsSync(join(home, '.claude', 'hooks')),
+      false,
+      '--apply must NOT create ~/.claude/hooks in plugin mode (double-registration footgun)',
+    );
+    assert.equal(
+      existsSync(join(home, '.claude', 'commands', 'hypo')),
+      false,
+      '--apply must NOT create ~/.claude/commands/hypo in plugin mode',
+    );
+    // settings.json must not gain hypo-* hook registrations
+    const settingsPath = join(home, '.claude', 'settings.json');
+    if (existsSync(settingsPath)) {
+      assert.doesNotMatch(
+        readFileSync(settingsPath, 'utf-8'),
+        /hypo-session-start/,
+        'plugin --apply must not register hooks into settings.json',
+      );
+    }
+  });
+});
+
+test('plugin mode: --apply still writes hypo-pkg.json so runtime resolves PKG_ROOT (lint/feedback)', () => {
+  withFakeUpgradeInstall(true, ({ upgrade, root, home, wiki }) => {
+    runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+    const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+    assert.ok(existsSync(pkgPath), 'plugin --apply must still write hypo-pkg.json metadata');
+    const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    // realpath both sides: macOS /var is a symlink to /private/var, and the
+    // executed script path resolves to the realpath form.
+    assert.equal(
+      realpathSync(meta.pkgRoot),
+      realpathSync(root),
+      'hypo-pkg.json pkgRoot must point at the plugin package root',
+    );
+    // hypo-personal-check resolves lint.mjs/feedback-sync.mjs under pkgRoot/scripts:
+    assert.ok(
+      existsSync(join(meta.pkgRoot, 'scripts', 'lint.mjs')),
+      'pkgRoot must contain the runtime scripts (PreCompact gate dependency)',
+    );
+    // no command-SHA map is recorded (no commands were copied)
+    assert.ok(!('commands' in meta), 'plugin metadata must not record a command-SHA map');
+    // steady state: with metadata now written, a fresh check has no drift → exit 0
+    // (no perpetual nag for a plugin user who has already applied once).
+    const recheck = runUpgrade(upgrade, [`--hypo-dir=${wiki}`], home);
+    assert.equal(
+      recheck.status,
+      0,
+      `plugin check after --apply should be clean (exit 0): ${recheck.stdout}`,
+    );
+  });
+});
+
+test('regression: non-plugin install (npm path) still manages core hooks/commands', () => {
+  withFakeUpgradeInstall(false, ({ upgrade, home, wiki }) => {
+    const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.pluginMode, false, 'non-plugin install must not enter plugin mode');
+    // manual model: core hooks are reported (missing here, since fake HOME is empty)
+    assert.ok(
+      out.hooks.some((h) => h.status === 'missing'),
+      'npm mode should still check hooks',
+    );
+    const apply = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+    assert.equal(apply.status, 0, `npm --apply should exit 0: ${apply.stderr}`);
+    assert.ok(
+      existsSync(join(home, '.claude', 'hooks')),
+      'npm mode --apply must install hooks into ~/.claude/hooks (unchanged behavior)',
+    );
+  });
+});
+
+test('plugin mode: --apply drops a stale command-SHA map but preserves other metadata', () => {
+  withFakeUpgradeInstall(true, ({ upgrade, home, wiki }) => {
+    // Simulate a prior manual install: hypo-pkg.json with a commands map + an
+    // unrelated extensions field that must survive.
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(
+      join(home, '.claude', 'hypo-pkg.json'),
+      JSON.stringify({
+        pkgRoot: '/old/manual/root',
+        pkgVersion: '1.0.0',
+        schemaVersion: '2.0',
+        commands: { 'resume.md': 'deadbeef' },
+        extensions: { claude: { 'x.mjs': 'cafe' } },
+      }),
+    );
+    runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+    const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+    assert.ok(!('commands' in meta), 'stale command-SHA map must be dropped in plugin mode');
+    assert.deepEqual(
+      meta.extensions,
+      { claude: { 'x.mjs': 'cafe' } },
+      'extensions must be preserved',
+    );
+  });
+});
+
+test('plugin mode: check does NOT print a hook-name rename instruction --apply will not honor', () => {
+  withFakeUpgradeInstall(true, ({ upgrade, home, wiki }) => {
+    // Seed a legacy wiki-*.mjs reference in ~/.claude/settings.json (the source of
+    // oldHookRefs). In plugin mode --apply skips the rename, so the report must not
+    // tell the user to run it.
+    writeFileSync(
+      join(home, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [{ type: 'command', command: 'node ~/.claude/hooks/wiki-session-start.mjs' }],
+            },
+          ],
+        },
+      }),
+    );
+    const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`], home);
+    assert.doesNotMatch(
+      r.stdout,
+      /old wiki-\*\.mjs reference/,
+      'plugin mode must not surface the Claude hook-name rename instruction',
+    );
+  });
+});
+
 // ── extensions companion sync (ADR 0024) ──────────────────────
 
 suite('extensions companion sync (upgrade.mjs, ADR 0024)');


### PR DESCRIPTION
## Bug (ISSUE-6)

When `/hypo:upgrade` runs as the **Claude Code plugin**, the 15 core hooks and 14 slash commands are provided by the plugin's `hooks.json` + `commands/` (auto-wired by Claude Code) — **not** copied into `~/.claude/`. But `upgrade.mjs` assumed the manual/npm install model: it checks `~/.claude/hooks/`, `~/.claude/settings.json` registrations, and `~/.claude/commands/hypo/`. A plugin user therefore saw ~47 items reported "missing" and was told to run `--apply`.

Running `--apply` then **copied** the hooks into `~/.claude/hooks/` and **registered** 14 `settings.json` events → Claude Code ran **both** the plugin `hooks.json` **and** the user `settings.json`, so every hook fired **twice** (double git commit/push, double session record, double context inject).

## Fix — plugin-mode guard

`pluginMode` is keyed on the Claude plugin cache shape: `PKG_ROOT` (the running `upgrade.mjs`'s package root) containing `/.claude/plugins/`. This is a **strict path check, not the broad `/plugins/` substring** — because the flag now gates install behavior, a legitimate npm/dev checkout under some unrelated `…/plugins/…` path must not be misclassified.

`pluginMode` gates **only the Claude core surface** (hooks / settings / commands / hook-name migration):
- **Report**: those sections are relabeled "provided by the plugin loader", with a leading banner explaining the situation. `--json` gains a `pluginMode` flag.
- **Drift**: `hasDrift` / `totalDrift` exclude the core surface, so a plugin user is no longer nagged "N items need updating".
- **`--apply`**: skips copying hooks / registering settings / copying commands / hook-name rename — the double-registration footgun.

**Still managed in plugin mode** (these are *not* plugin-provided, so skipping them would be a regression — caught in design review):
- **codex core** (`--codex`) and **vault extensions** — the plugin ships neither.
- **`hypo-pkg.json` metadata** — `hooks/hypo-shared.mjs` resolves `PKG_ROOT` *only* from this file, and `hypo-personal-check` uses it to run `lint.mjs` / `feedback-sync.mjs` (PreCompact gates). In plugin mode `--apply` writes minimal metadata pointing at the plugin root and **drops** any stale `commands` SHA map.

The migration-report text and `commands/upgrade.md` are corrected to say `--apply` *also* syncs vault extensions, and only the **core** hooks/commands/settings are skipped (upgrade the plugin via `/plugin marketplace update hypomnema` then `/reload-plugins`).

## Scope (deliberate)

`pluginMode` is **PKG_ROOT-path-based only**. A *manual/npm* `upgrade.mjs` run **while the plugin is also enabled** (dual install) is a **different failure mode** (different authority — like the prior ISSUE-1 → ISSUE-7 split) and is deferred to **ISSUE-8**. `enabledPlugins` detection is intentionally not added: its schema is undocumented, and a false-positive would **block a legitimate npm user's `--apply`** — a worse asymmetric cost than the rare dual-install.

## Tests

A `withFakeUpgradeInstall` helper runs a copy of `upgrade.mjs` from a fake `~/.claude/plugins/…` root:
- plugin check relabels the core surface, omits per-hook "missing" nags, and caps drift at the (safe, metadata-only) `hypo-pkg.json` item;
- `--json` sets `pluginMode: true`;
- `--apply` creates **no** `~/.claude/hooks` and adds **no** `settings.json` hook registrations;
- `--apply` still writes `hypo-pkg.json` whose `pkgRoot` resolves the runtime scripts (PreCompact dependency), and post-apply re-check is clean (exit 0);
- a stale `commands` map is dropped while `extensions` is preserved;
- the hook-name rename instruction is **not** surfaced in plugin mode;
- a **non-plugin (npm-path) regression baseline** still manages core hooks/commands as before.

`npm test` → **609 passed, 0 failed**. prettier clean.

## Review

2-stage codex cross-review (2 workers each): design → **BLOCKER ×2** (metadata runtime dependency + extensions over-skip → both reverted to "keep managing"); commit → **BLOCKER ×2** (stale commands map, hook-name report leak, over-broad detection, text overstatement → all fixed); re-review → **NIT / NIT** (stale comments → fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)