### PR TITLE
fix(crystallize): verify session-close against payload.project on same-date tie (ISSUE-7 Part A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session-close no longer false-blocks a completed close on a same-date project tie (ISSUE-7, Part A).** `crystallize --apply-session-close` resolves the authoritative project once (`payload.project || probe.project`) and writes the five mandatory close files for it (three project-scoped, plus the project's row/entry in root `hot.md` and `log.md`), but the **post-apply verification** re-derived the project via `resolveActiveProject()` — which, on a same-date tie in root `hot.md`'s pointer table, returns the table's **top** row (stable-sort). So a finished close of project B could be verified against a *different* project A and reported `ok:false` (A's `log.md` entry was missing), leaving the closed-marker unwritten and the Stop hook re-prompting (observed 2026-06-09: a completed `security-ops-kb` close was blocked by an unrelated `hypomnema` row). `sessionCloseFileStatus` now accepts a `projectOverride`, and the apply path passes the project it actually wrote, so write-project and verify-project can no longer diverge. Scope: the **apply** path only — the Stop-hook / payload-less probe paths still resolve from the pointer table (a cwd-aware tie-break there has a cross-project masking risk and is tracked separately as ISSUE-7 Part B). No signature change for any existing caller (new arg is an options object).
+
+### 한글 요약
+
+- **세션-close가 동률 날짜 프로젝트 tie에서 완료된 close를 더는 false-block 하지 않음 (ISSUE-7, Part A).** `crystallize --apply-session-close`는 닫는 프로젝트를 한 번 확정(`payload.project || probe.project`)해 그 프로젝트의 5개 필수 close 파일을 쓰지만(3개는 project-scoped, 나머지는 루트 `hot.md`·`log.md`의 해당 프로젝트 행/엔트리), **post-apply 검증**이 `resolveActiveProject()`로 프로젝트를 재해석했다 — 루트 `hot.md` 포인터 테이블에서 날짜가 동률이면 stable-sort로 **테이블 최상단** 행을 반환한다. 그래서 프로젝트 B의 완료된 close가 *다른* 프로젝트 A 기준으로 검증돼 `ok:false`(A의 `log.md` 엔트리 부재)를 받고, closed-marker 미기록 → Stop 훅 재프롬프트가 발생했다(2026-06-09 실증: 완료된 `security-ops-kb` close가 무관한 `hypomnema` 행 때문에 막힘). 이제 `sessionCloseFileStatus`가 `projectOverride`를 받고 apply 경로가 실제로 쓴 프로젝트를 전달 → write-project와 verify-project가 갈릴 수 없다. 범위: **apply** 경로만 — Stop-훅/무-payload probe 경로는 여전히 포인터 테이블로 해석(거기에 cwd tie-break을 넣으면 cross-project 마스킹 위험이라 ISSUE-7 Part B로 분리 추적). 기존 caller 시그니처 변경 없음(새 인자는 옵션 객체).
+
 ## [1.3.0] - 2026-06-07
 
 ### Added

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -333,12 +333,21 @@ export function resolveActiveProject(hypoDir, cwd = null) {
  * project A can't be masked by a fresh close of project B (and vice versa).
  * open-questions.md (file #5) is conditional and not gated.
  *
+ * `projectOverride` (ISSUE-7 Part A): when the caller already holds the
+ * authoritative project being closed (e.g. crystallize apply derives it from
+ * `payload.project`), it passes that slug so verification checks the SAME
+ * project it just wrote — instead of re-deriving via resolveActiveProject(),
+ * which on a same-date root-hot.md tie can resolve a DIFFERENT project and
+ * false-fail a completed close. When omitted, behavior is byte-identical to the
+ * legacy single-arg version (resolve from root hot.md).
+ *
  * @param {string} hypoDir
+ * @param {{projectOverride?: string|null}} [opts]
  * @returns {{ok: boolean, project: string|null, dates: string[], stale: string[], missing: string[]}}
  */
-export function sessionCloseFileStatus(hypoDir) {
+export function sessionCloseFileStatus(hypoDir, { projectOverride = null } = {}) {
   const dates = freshDates();
-  const project = resolveActiveProject(hypoDir);
+  const project = projectOverride || resolveActiveProject(hypoDir);
   if (!project) {
     return {
       ok: false,

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -613,7 +613,12 @@ function applySessionClose(args) {
     (wrote ? applied : skipped).push('log (log.md)');
   }
 
-  const verification = sessionCloseFileStatus(args.hypoDir);
+  // ISSUE-7 Part A: verify against the SAME project this apply just wrote
+  // (`project` = payload.project || probe.project, resolved at the top). Without
+  // the override, sessionCloseFileStatus re-derives via resolveActiveProject and,
+  // on a same-date root-hot.md tie, can pick a different project — false-failing
+  // a completed close (the 2026-06-09 security-ops-kb incident).
+  const verification = sessionCloseFileStatus(args.hypoDir, { projectOverride: project });
 
   // Fix #40 post-apply lint: payload may have introduced a malformed body or
   // bad frontmatter. Surface as a distinct `stage` so caller can tell "lint

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1674,6 +1674,78 @@ test('missing payload → exit 1 with clear error', () => {
   );
 });
 
+test('ISSUE-7: post-apply verify follows payload.project on same-date tie (no cross-project false-block)', () => {
+  // Reproduces the 2026-06-09 security-ops-kb incident. The payload closes
+  // project B, but root hot.md has A (table-top) and B tied on today's date.
+  // Pre-fix, the post-apply check re-resolved via resolveActiveProject → picked
+  // A (stable-sort top row) → flagged log.md stale (A has no entry) → returned a
+  // false ok:false on a COMPLETED B close. With projectOverride, verification
+  // checks B (the project actually written), so the completed close passes.
+  withWiki(
+    (dir, today) => {
+      const ym = today.slice(0, 7);
+      // Second project 'beta' (= B, the one actually being closed) — fresh files.
+      const betaDir = join(dir, 'projects', 'beta');
+      mkdirSync(join(betaDir, 'session-log'), { recursive: true });
+      writeFileSync(
+        join(betaDir, 'session-state.md'),
+        `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n## 다음 작업\n\n- next\n`,
+      );
+      writeFileSync(
+        join(betaDir, 'hot.md'),
+        `---\ntitle: hot\ntype: reference\nupdated: ${today}\n---\n\n# Hot\n`,
+      );
+      writeFileSync(
+        join(betaDir, 'session-log', `${ym}.md`),
+        `---\ntitle: Session Log\ntype: session-log\nupdated: ${today}\n---\n\n## [${today}] beta session\n`,
+      );
+      // Root hot.md: test-project (A) on TOP, beta (B) below — both dated today
+      // (same-date tie). Stable sort makes A the legacy resolveActiveProject win.
+      writeFileSync(
+        join(dir, 'hot.md'),
+        `---\ntitle: Hot\nupdated: ${today}\n---\n# Hot\n\n## Active Projects\n\n` +
+          `| Project | Last Session | Hot Cache |\n|---|---|---|\n` +
+          `| test-project | ${today} | [[projects/test-project/hot]] |\n` +
+          `| beta | ${today} | [[projects/beta/hot]] |\n`,
+      );
+      // log.md carries an unrelated project's entry — neither A nor B. So A's
+      // close is genuinely incomplete (no A entry); pre-fix the verify resolves
+      // to A and false-fails on the missing A entry.
+      writeFileSync(join(dir, 'log.md'), `## [${today}] session | gamma\n`);
+    },
+    (dir, today) => {
+      const payload = {
+        project: 'beta',
+        date: today,
+        sessionState: {
+          content: readFileSync(join(dir, 'projects', 'beta', 'session-state.md'), 'utf-8'),
+        },
+        projectHot: { content: readFileSync(join(dir, 'projects', 'beta', 'hot.md'), 'utf-8') },
+        rootHot: { content: readFileSync(join(dir, 'hot.md'), 'utf-8') },
+        sessionLog: { entry: `## [${today}] beta close\n` },
+        log: { entry: `## [${today}] session | beta\n` },
+      };
+      const r = runApply(dir, payload);
+      assert.equal(
+        r.status,
+        0,
+        `completed beta close must pass, got ${r.status}\n${r.stdout}\n${r.stderr}`,
+      );
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.ok,
+        true,
+        `ISSUE-7: same-date tie must not false-block a completed close: ${JSON.stringify(out.verification)}`,
+      );
+      assert.equal(
+        out.verification.project,
+        'beta',
+        `verification must check payload.project (beta), not the table-top (test-project): ${JSON.stringify(out.verification)}`,
+      );
+    },
+  );
+});
+
 test('same-day second close: distinct entries are both appended (W1 regression)', () => {
   // Sub-session within the same day must produce a second log entry, not be
   // silently deduped because today's heading already exists — exact-entry dedup


### PR DESCRIPTION
## What

Session-close (`crystallize --apply-session-close`) could **false-block a completed close** when two projects share the same date in root `hot.md`'s pointer table.

`applySessionClose` resolves the authoritative project once (`payload.project || probe.project`) and writes the five mandatory close files for it. But the **post-apply verification** re-called `sessionCloseFileStatus(hypoDir)` *without* the project, so it re-derived via `resolveActiveProject()` — which on a same-date tie returns the table's **top** row (stable sort). A completed close of project **B** then got verified against a different project **A**, returned `ok:false` (A's `log.md` entry was missing), left the closed-marker unwritten, and the Stop hook re-prompted.

**Observed 2026-06-09**: a completed `security-ops-kb` close was blocked by an unrelated `hypomnema` row tied on the same date.

## Fix

- `sessionCloseFileStatus(hypoDir, { projectOverride })` — use the override when present, else fall back to `resolveActiveProject()` (byte-identical to the legacy single-arg form).
- The apply path passes the project it actually wrote to the post-apply verify → write-project and verify-project can no longer diverge.

**Scope: the apply path only.** The Stop-hook / payload-less probe paths still resolve from the pointer table. A cwd-aware tie-break there has a cross-project masking risk (cwd=A fresh, incomplete close=B table-top → would wrongly pass) and needs a source-of-truth authority model first — tracked as **ISSUE-7 Part B**.

## Test

Regression test in `tests/runner.mjs` reproduces the incident faithfully (same-date tie, table-top ≠ `payload.project`, A missing its `log.md` entry):
- **pre-fix**: 609 passed, **1 failed** (status 1 — the false-block)
- **post-fix**: **610 passed, 0 failed**

No signature change for any existing caller (new arg is an options object). 2-stage codex review: design **CLEAR**, pre-commit **NIT** (CHANGELOG wording, addressed).

## 한글 요약

루트 `hot.md` 포인터 테이블에서 두 프로젝트가 같은 날짜로 동률일 때, 세션-close의 **post-apply 검증**이 `resolveActiveProject()`로 프로젝트를 재해석해 **테이블 최상단** 행을 골랐다. 그래서 프로젝트 B의 **완료된** close가 다른 프로젝트 A 기준으로 검증돼 `ok:false`(A의 `log.md` 엔트리 부재)를 받고, closed-marker 미기록 → Stop 훅 재프롬프트가 발생했다(2026-06-09 `security-ops-kb` 실증). `sessionCloseFileStatus`가 `projectOverride`를 받고 apply 경로가 실제로 쓴 프로젝트를 전달하도록 수정 → write/verify 프로젝트가 갈릴 수 없다. 범위는 **apply 경로만**, Stop-훅/probe의 cwd tie-break은 마스킹 위험으로 **ISSUE-7 Part B** 분리. 기존 caller 시그니처 변경 없음. regression test가 인시던트를 재현(pre-fix 609/1 fail → post-fix 610/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)