### PR TITLE
fix(plugin): rename marketplace plugin hypomnema → hypo so slash commands match the /hypo:* docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "hypomnema",
+      "name": "hypo",
       "source": "./",
       "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
       "version": "1.3.1",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "hypomnema",
+  "name": "hypo",
   "version": "1.3.1",
   "description": "LLM-native personal wiki system — session-aware knowledge base for Claude Code",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Claude marketplace plugin is renamed `hypomnema` to `hypo`, so its slash commands now match the docs.** Claude Code namespaces a plugin's slash commands by the plugin's `name` field, so the plugin (named `hypomnema`) actually registered its commands as `/hypomnema:resume`, `/hypomnema:init`, and so on. Every doc, command body, and `/hypo:init` reference assumed `/hypo:*`, so a user who installed via the marketplace and followed the README hit "command not found". (The npm/manual install path was never affected: it copies the command files into `~/.claude/commands/hypo/`, which already yields `/hypo:*`.) Renaming the plugin to `hypo` makes both install paths expose the same `/hypo:*` namespace the docs describe. The marketplace itself keeps its name (`hypomnema`), so `/plugin marketplace add` and `/plugin marketplace update hypomnema` are unchanged; only the plugin identifier in the install command changes.
+
+  **Migration for existing plugin users:** the install identifier changes from `hypomnema@hypomnema` to `hypo@hypomnema`. Disable or remove the old plugin, then run `/plugin install hypo@hypomnema` followed by `/reload-plugins`. Until you reinstall, the old `/hypomnema:*` commands keep working from the cached plugin. The npm/manual `/hypo:upgrade` dual-install guard now recognizes both the new `hypo` and the legacy `hypomnema` plugin entry in `enabledPlugins`, so it still suppresses the double-registration of core hooks across the migration window, and the update notifier resolves the plugin's latest version under either name.
+
+### 한글 요약
+
+- **Claude 마켓플레이스 플러그인 이름을 `hypomnema`에서 `hypo`로 변경해 슬래시 커맨드가 문서와 일치하게 됨.** Claude Code는 플러그인 슬래시 커맨드를 플러그인의 `name` 필드로 네임스페이싱한다. 그래서 이름이 `hypomnema`인 플러그인은 커맨드를 실제로 `/hypomnema:resume`, `/hypomnema:init` 등으로 등록했다. 모든 문서·커맨드 본문·`/hypo:init` 안내는 `/hypo:*`을 가정했으므로, 마켓플레이스로 설치하고 README를 따라 한 사용자는 "command not found"를 만났다. (npm/수동 설치 경로는 영향이 없었다: 커맨드 파일을 `~/.claude/commands/hypo/`로 복사하므로 처음부터 `/hypo:*`이 된다.) 플러그인 이름을 `hypo`로 바꾸면 두 설치 경로 모두 문서가 설명하는 동일한 `/hypo:*` 네임스페이스를 노출한다. 마켓플레이스 이름(`hypomnema`)은 그대로라 `/plugin marketplace add`와 `/plugin marketplace update hypomnema`는 불변이며, 설치 명령의 플러그인 식별자만 바뀐다.
+
+  **기존 플러그인 사용자 마이그레이션:** 설치 식별자가 `hypomnema@hypomnema`에서 `hypo@hypomnema`로 바뀐다. 기존 플러그인을 비활성/제거한 뒤 `/plugin install hypo@hypomnema` 다음 `/reload-plugins`를 실행하라. 재설치 전까지는 캐시된 플러그인의 기존 `/hypomnema:*` 커맨드가 계속 동작한다. npm/수동 `/hypo:upgrade`의 dual-install 가드는 이제 `enabledPlugins`에서 새 `hypo`와 레거시 `hypomnema` 항목을 모두 인식하므로 마이그레이션 기간에도 core 훅 중복 등록을 계속 막고, 업데이트 notifier도 두 이름 중 어느 쪽으로든 플러그인 최신 버전을 해석한다.
+
 ## [1.3.1] - 2026-06-09
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,7 +45,7 @@ Claude Code 안에서:
 
 ```
 /plugin marketplace add sk-lim19f/Hypomnema
-/plugin install hypomnema@hypomnema
+/plugin install hypo@hypomnema
 /hypo:init
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Inside Claude Code:
 
 ```
 /plugin marketplace add sk-lim19f/Hypomnema
-/plugin install hypomnema@hypomnema
+/plugin install hypo@hypomnema
 /hypo:init
 ```
 

--- a/hooks/version-check-fetch.mjs
+++ b/hooks/version-check-fetch.mjs
@@ -14,7 +14,7 @@
  * Usage: node version-check-fetch.mjs [cachePath]
  */
 
-import { defaultCachePath, mergeLatest } from './version-check.mjs';
+import { defaultCachePath, mergeLatest, selectPluginVersion } from './version-check.mjs';
 
 const NPM_URL = 'https://registry.npmjs.org/hypomnema/latest';
 const PLUGIN_URL =
@@ -42,13 +42,7 @@ async function fetchNpmLatest() {
 
 async function fetchPluginLatest() {
   const data = await fetchJson(PLUGIN_URL);
-  if (!data || !Array.isArray(data.plugins)) return null;
-  // Select by name rather than plugins[0]: a future marketplace.json could list
-  // more than one plugin or reorder entries, which would otherwise read the
-  // wrong version.
-  const entry = data.plugins.find((p) => p && p.name === 'hypomnema');
-  const v = entry && entry.version;
-  return typeof v === 'string' ? v : null;
+  return selectPluginVersion(data && data.plugins);
 }
 
 async function main() {

--- a/hooks/version-check.mjs
+++ b/hooks/version-check.mjs
@@ -138,6 +138,24 @@ export function detectChannel(pkgRoot) {
   return 'unknown';
 }
 
+/**
+ * Pick the plugin's published version out of a marketplace.json `plugins` array.
+ * Select by name rather than plugins[0]: the file could list more than one
+ * plugin or reorder entries. Accept the current name (`hypo`) and the legacy one
+ * (`hypomnema`) so a stale-cached or transitional marketplace.json still
+ * resolves. Returns the version string or null.
+ */
+export function selectPluginVersion(plugins) {
+  if (!Array.isArray(plugins)) return null;
+  // Prefer the current name over the legacy one so that a transitional
+  // marketplace.json listing BOTH aliases resolves to `hypo` regardless of the
+  // entries' order (a legacy-first list must not shadow a newer `hypo` entry).
+  const entry =
+    plugins.find((p) => p && p.name === 'hypo') || plugins.find((p) => p && p.name === 'hypomnema');
+  const v = entry && entry.version;
+  return typeof v === 'string' ? v : null;
+}
+
 /** Channel-specific one-line update instruction. */
 export function buildUpdateLine(channel, current, latest) {
   const head = `[Hypomnema] Update available! ${current} → ${latest}`;

--- a/scripts/lib/plugin-detect.mjs
+++ b/scripts/lib/plugin-detect.mjs
@@ -9,14 +9,19 @@
 // positive blocks/alters a legitimate npm-only user's upgrade, which is worse
 // than the rare dual-install double-register it guards against. So it fails open
 // (returns false) on every uncertainty and only fires on an exact, well-formed
-// `enabledPlugins` entry whose plugin name is precisely `hypomnema`.
+// `enabledPlugins` entry whose plugin name is precisely `hypo` (the current
+// plugin name) or `hypomnema` (the legacy name, pre-rename). Both are matched so
+// the guard survives the rename's migration window: an existing user keeps the
+// legacy `hypomnema@<marketplace>` key in `enabledPlugins` until they reinstall
+// as `hypo@<marketplace>`, and the guard must hold across that gap.
 
 import { readFileSync } from 'node:fs';
 
 /**
  * @param {string} settingsPath  path to a Claude Code settings.json (e.g. ~/.claude/settings.json)
  * @returns {boolean} true iff `enabledPlugins` contains a key shaped
- *   `hypomnema@<marketplace>` whose value is strictly `true`.
+ *   `hypo@<marketplace>` (or the legacy `hypomnema@<marketplace>`) whose value
+ *   is strictly `true`.
  */
 export function isHypomnemaPluginEnabled(settingsPath) {
   let raw;
@@ -41,11 +46,15 @@ export function isHypomnemaPluginEnabled(settingsPath) {
   for (const [key, value] of Object.entries(enabled)) {
     if (value !== true) continue; // strictly true only — no truthy coercion
     // Require a real `name@marketplace` shape: an `@` that is neither the first
-    // nor the last char. A bare `"hypomnema": true` (no marketplace) must NOT
-    // trigger — that is not a valid enabledPlugins identifier.
+    // nor the last char. A bare `"hypo": true` / `"hypomnema": true` (no
+    // marketplace) must NOT trigger — that is not a valid enabledPlugins
+    // identifier.
     const at = key.indexOf('@');
     if (at <= 0 || at === key.length - 1) continue;
-    if (key.slice(0, at) === 'hypomnema') return true; // exact, case-sensitive
+    const name = key.slice(0, at);
+    // Match the current plugin name and the legacy one (pre-rename) so the
+    // guard holds across the migration window. Exact, case-sensitive.
+    if (name === 'hypo' || name === 'hypomnema') return true;
   }
   return false;
 }

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -819,7 +819,8 @@ const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
 // provides the core hooks/commands/settings. A manual/npm `--apply` would copy and
 // register them on top, and every core hook fires twice. The detector is fail-open
 // (see lib/plugin-detect.mjs): a false positive would wrongly alter a legitimate
-// npm-only user's upgrade, so it only fires on an exact `hypomnema@<mp>: true`.
+// npm-only user's upgrade, so it only fires on an exact `hypo@<mp>: true` (or the
+// legacy `hypomnema@<mp>: true`, matched across the plugin-rename migration window).
 const hypomnemaPluginEnabled = !pluginMode && isHypomnemaPluginEnabled(claudeSettingsPath);
 const dualInstallCoreConflict = hypomnemaPluginEnabled;
 // Surface policy: the Claude core surface (hooks/settings/commands/hook-name

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2633,7 +2633,13 @@ function withSettingsFile(content, fn) {
   }
 }
 
-test('enabled: hypomnema@<marketplace> mapped to true → true', () => {
+test('enabled: hypo@<marketplace> mapped to true → true (current plugin name)', () => {
+  withSettingsFile({ enabledPlugins: { 'hypo@hypomnema': true } }, (p) => {
+    assert.equal(isHypomnemaPluginEnabled(p), true);
+  });
+});
+
+test('enabled: legacy hypomnema@<marketplace> mapped to true → true (migration window)', () => {
   withSettingsFile({ enabledPlugins: { 'hypomnema@hypomnema': true } }, (p) => {
     assert.equal(isHypomnemaPluginEnabled(p), true);
   });
@@ -2657,8 +2663,20 @@ test('only other plugins enabled → false', () => {
   );
 });
 
+test('bare "hypo": true (no @marketplace) → false (not a valid identifier)', () => {
+  withSettingsFile({ enabledPlugins: { hypo: true } }, (p) => {
+    assert.equal(isHypomnemaPluginEnabled(p), false);
+  });
+});
+
 test('bare "hypomnema": true (no @marketplace) → false (not a valid identifier)', () => {
   withSettingsFile({ enabledPlugins: { hypomnema: true } }, (p) => {
+    assert.equal(isHypomnemaPluginEnabled(p), false);
+  });
+});
+
+test('prefix collision hypo-foo@mp: true → false (exact name only)', () => {
+  withSettingsFile({ enabledPlugins: { 'hypo-foo@mp': true } }, (p) => {
     assert.equal(isHypomnemaPluginEnabled(p), false);
   });
 });
@@ -10379,6 +10397,45 @@ test('buildUpdateLine: channel-specific update command', () => {
   );
   assert.match(vc.buildUpdateLine('plugin', '1.0.0', '1.1.0'), /reload-plugins/);
   assert.match(vc.buildUpdateLine('unknown', '1.0.0', '1.1.0'), /1\.0\.0 → 1\.1\.0/);
+});
+
+test('selectPluginVersion: resolves current name, legacy name, ordering, and bad input', () => {
+  // current plugin name
+  assert.equal(vc.selectPluginVersion([{ name: 'hypo', version: '1.3.2' }]), '1.3.2');
+  // legacy name (stale/transitional marketplace.json)
+  assert.equal(vc.selectPluginVersion([{ name: 'hypomnema', version: '1.3.1' }]), '1.3.1');
+  // selects by name, not index — other plugins listed first must not win
+  assert.equal(
+    vc.selectPluginVersion([
+      { name: 'other', version: '9.9.9' },
+      { name: 'hypo', version: '1.3.2' },
+    ]),
+    '1.3.2',
+  );
+  // both aliases present → prefer `hypo` regardless of order (no legacy shadowing)
+  assert.equal(
+    vc.selectPluginVersion([
+      { name: 'hypomnema', version: '1.3.1' },
+      { name: 'hypo', version: '1.3.2' },
+    ]),
+    '1.3.2',
+  );
+  assert.equal(
+    vc.selectPluginVersion([
+      { name: 'hypo', version: '1.3.2' },
+      { name: 'hypomnema', version: '1.3.1' },
+    ]),
+    '1.3.2',
+  );
+  // no matching entry → null
+  assert.equal(vc.selectPluginVersion([{ name: 'other', version: '9.9.9' }]), null);
+  // non-string / missing version → null
+  assert.equal(vc.selectPluginVersion([{ name: 'hypo' }]), null);
+  assert.equal(vc.selectPluginVersion([{ name: 'hypo', version: 42 }]), null);
+  // not an array → null
+  assert.equal(vc.selectPluginVersion(null), null);
+  assert.equal(vc.selectPluginVersion(undefined), null);
+  assert.equal(vc.selectPluginVersion({}), null);
 });
 
 test('cacheIsFresh: fresh / stale / future / missing', () => {


### PR DESCRIPTION
## Problem / 문제

Claude Code namespaces a plugin's slash commands by the plugin's `name` field. The plugin was named `hypomnema`, so it registered its commands as `/hypomnema:resume`, `/hypomnema:init`, etc. while **every doc, command body, and `/hypo:init` reference assumes `/hypo:*`**. A user who installed via the marketplace and followed the README hit "command not found".

The npm/manual install path was never affected: it copies the command files into `~/.claude/commands/hypo/`, which already yields `/hypo:*`. So only the **plugin-install** path was broken, which is why it went unnoticed (the maintainer's own install is npm).

Claude Code 플러그인은 슬래시 커맨드를 플러그인 `name` 필드로 네임스페이싱합니다. 플러그인 이름이 `hypomnema`라 실제로는 `/hypomnema:*`로 등록됐는데, 모든 문서는 `/hypo:*`을 가정합니다. 마켓플레이스로 설치한 사용자는 "command not found"를 만났습니다. npm/수동 설치는 `~/.claude/commands/hypo/`로 복사되어 처음부터 `/hypo:*`이라 영향이 없었습니다.

## Fix / 해결

Rename the **plugin** `hypomnema` → `hypo` so both install paths expose the same `/hypo:*` namespace the docs describe. The npm package name, the **marketplace** name (`hypomnema`), and the repo path are unchanged.

플러그인 이름만 `hypo`로 변경 → 두 설치 경로 모두 문서가 설명하는 `/hypo:*` 노출. npm 패키지명·마켓플레이스명(`hypomnema`)·레포 경로는 불변.

### Changes

- `plugin.json` / `marketplace.json`: plugin `name` `hypomnema` → `hypo`
- `README.md` / `README.ko.md`: install command `hypomnema@hypomnema` → `hypo@hypomnema` (marketplace `add` / `update hypomnema` unchanged — those use the marketplace name)
- `plugin-detect.mjs`: dual-install guard matches **both** `hypo` and the legacy `hypomnema` `enabledPlugins` entry, so an un-migrated plugin user's npm `/hypo:upgrade` still suppresses the core-hook double-registration across the migration window
- `version-check.mjs` / `version-check-fetch.mjs`: update-notifier marketplace fetch resolves the plugin version under either name (logic extracted as `selectPluginVersion`, prefers the current name so a transitional list can't shadow a newer `hypo` entry)
- `CHANGELOG.md`: `[Unreleased]` entry + migration note (published `[1.3.1]` history untouched)
- `tests/runner.mjs`: retain legacy positives, add `hypo` equivalents + `selectPluginVersion` coverage

## Migration for existing plugin users / 기존 플러그인 사용자 마이그레이션

The install identifier changes from `hypomnema@hypomnema` to `hypo@hypomnema`. Disable/remove the old plugin, then `/plugin install hypo@hypomnema` followed by `/reload-plugins`. Until reinstall, the cached `/hypomnema:*` commands keep working.

## Verification

- `npm test` — **632 passed, 0 failed**
- `npm run check:bilingual --changelog Unreleased` — OK
- `npm run smoke-pack` — pass
- 2-stage codex cross-review (design + pre-commit): design returned CONCERN (missed `version-check-fetch.mjs` identifier — now fixed); pre-commit returned NIT (`selectPluginVersion` order-dependence — now fixed with current-name preference + regression tests)
- `npm run lint` failures are pre-existing wiki-content debt unrelated to this diff

> ⚠️ Tag-time QA gate (tracked separately): after the rename both paths emit `/hypo:*`, so a user who installed via npm first (stale `~/.claude/commands/hypo/`) then added the plugin has two sources for the same command. Confirm Claude Code's shadow/dup behavior before tagging a release. Also verify on a real renamed plugin install that `/hypo:resume` actually appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)