### PR TITLE
feat(gate): block wiki-internal tracker IDs in OSS-public artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,17 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  tracker-ids:
+    name: Tracker-id gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - name: No wiki-internal tracker ids in public artifacts
+        run: npm run check:tracker-ids
+
   init-snapshot:
     name: Init snapshot
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`/hypo:resume` no longer leaks the literal `"slug"` as the active project on a fresh `init` vault (fix #68).** `scripts/resume.mjs` parsed `templates/hot.md`'s HTML-commented example row (`<!-- Row format: | ... | [[projects/slug/hot]] | -->`) as if it were a real entry, returning `slug` from the regex. Three-place defense-in-depth fix: (1) `scripts/resume.mjs` strips HTML comments before the wikilink regex AND skips the `projects/_template` scaffold in the mtime fallback (init.mjs writes `_template/session-state.md`, which would otherwise be chosen on a fresh vault); (2) `hooks/hypo-shared.mjs`'s mirrored `resolveActiveProject` applies the same comment strip; (3) `templates/hot.md` rewrites the example to no longer embed a real `[[...]]` shape. Pre-existing in v1.2.0 (confirmed via `git show v1.2.0:...`); surfaced by the v1.2.1 pre-ship QA matrix row 18 with guard D orchestrator-side live re-verification. Three new regression tests in `tests/runner.mjs` cover fresh-init graceful exit, real-project-vs-`_template`-mtime-newer override, and back-compat against vaults that still carry the pre-fix `[[projects/slug/hot]]` comment form.
+- **`/hypo:resume` no longer leaks the literal `"slug"` as the active project on a fresh `init` vault.** `scripts/resume.mjs` parsed `templates/hot.md`'s HTML-commented example row (`<!-- Row format: | ... | [[projects/slug/hot]] | -->`) as if it were a real entry, returning `slug` from the regex. Three-place defense-in-depth fix: (1) `scripts/resume.mjs` strips HTML comments before the wikilink regex AND skips the `projects/_template` scaffold in the mtime fallback (init.mjs writes `_template/session-state.md`, which would otherwise be chosen on a fresh vault); (2) `hooks/hypo-shared.mjs`'s mirrored `resolveActiveProject` applies the same comment strip; (3) `templates/hot.md` rewrites the example to no longer embed a real `[[...]]` shape. Pre-existing in v1.2.0 (confirmed via `git show v1.2.0:...`); surfaced by the v1.2.1 pre-ship QA matrix row 18 with guard D orchestrator-side live re-verification. Three new regression tests in `tests/runner.mjs` cover fresh-init graceful exit, real-project-vs-`_template`-mtime-newer override, and back-compat against vaults that still carry the pre-fix `[[projects/slug/hot]]` comment form.
 
 ### 한글 요약
 
@@ -109,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`lint` emits `W8` design-history-stale warning (fix #49).** The PreCompact
+- **`lint` emits `W8` design-history-stale warning.** The PreCompact
   hook (`hypo-personal-check.mjs`) has filtered `lint --json` warns for
   `id === 'W8'` since the initial OSS hook drop, but `scripts/lint.mjs` never
   emitted that id — so `design-history.md` aging next to a fresher
@@ -120,7 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the consumer's `file.split('/')` contract stays portable. The JSON `warn`
   shape gains an optional `id` field, omitted for legacy id-less warns.
 
-- **`lint` emits `W8` design-history-stale warning (fix #49).** The PreCompact
+- **`lint` emits `W8` design-history-stale warning.** The PreCompact
   hook (`hypo-personal-check.mjs`) has filtered `lint --json` warns for
   `id === 'W8'` since the initial OSS hook drop, but `scripts/lint.mjs` never
   emitted that id — so `design-history.md` aging next to a fresher
@@ -130,7 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project with a POSIX-separated `file` literal (`projects/<name>/design-history.md`)
   so the consumer's `file.split('/')` contract stays portable. The JSON `warn`
   shape gains an optional `id` field, omitted for legacy id-less warns.
-- **`hypomnema upgrade --codex` mirrors core hooks (fix #48).** `init --codex`
+- **`hypomnema upgrade --codex` mirrors core hooks.** `init --codex`
   has always installed Hypomnema's core hooks into `~/.codex/hooks/` and
   registered them in `~/.codex/settings.json`, but `upgrade` only mirrored
   user extensions — so a v1.1.x → v1.2.0 codex user's core hooks stayed
@@ -166,9 +166,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session. Per-channel notification state prevents the same banner from
   repeating, and `current >= latest` (local dev) is silently skipped. Opt out
   with `HYPO_NO_UPDATE_CHECK`, `NO_UPDATE_NOTIFIER`, or `CI`.
-- **`feedback`-as-source-of-truth + one-way projections to MEMORY / `<learned_behaviors>` (ADR 0031, fix #37, PR #36).** A new `pages/feedback/<slug>.md` page type replaces ad-hoc human-side sync of behavior corrections across three storage surfaces. `hypomnema feedback-sync` derives `~/.claude/projects/<project-id>/memory/MEMORY.md` (200-line cap) and `~/.claude/CLAUDE.md` `<learned_behaviors>` (max 10 entries, strict gate: `scope:global` + `tier:L1` + `targets:claude-learned` + `promote_to_global:true` + `sensitivity ∈ {public, sanitized}`) from the wiki. Managed blocks are marker- and hash-fenced; hand-edits are flagged as `CONFLICT_MANUAL_EDIT`. PreCompact integration runs inside `hypo-personal-check` (single-blocking-gate invariant). `sensitivity: private` is forbidden — the wiki is git-pushed; private data must stay outside the wiki entirely. `/hypo:feedback` slash command writes pages directly; `hypomnema feedback-sync --bootstrap` scaffolds drafts from existing MEMORY/CLAUDE state under `pages/feedback/_drafts/` for human review.
+- **`feedback`-as-source-of-truth + one-way projections to MEMORY / `<learned_behaviors>` (ADR 0031, PR #36).** A new `pages/feedback/<slug>.md` page type replaces ad-hoc human-side sync of behavior corrections across three storage surfaces. `hypomnema feedback-sync` derives `~/.claude/projects/<project-id>/memory/MEMORY.md` (200-line cap) and `~/.claude/CLAUDE.md` `<learned_behaviors>` (max 10 entries, strict gate: `scope:global` + `tier:L1` + `targets:claude-learned` + `promote_to_global:true` + `sensitivity ∈ {public, sanitized}`) from the wiki. Managed blocks are marker- and hash-fenced; hand-edits are flagged as `CONFLICT_MANUAL_EDIT`. PreCompact integration runs inside `hypo-personal-check` (single-blocking-gate invariant). `sensitivity: private` is forbidden — the wiki is git-pushed; private data must stay outside the wiki entirely. `/hypo:feedback` slash command writes pages directly; `hypomnema feedback-sync --bootstrap` scaffolds drafts from existing MEMORY/CLAUDE state under `pages/feedback/_drafts/` for human review.
 - **Extensions companion sync (ADR 0024, PRs #42~#47).** A new `extensions/` taxonomy in the wiki (`agents/`, `commands/`, `hooks/`, `skills/`) lets users ship Claude Code / Codex companion files alongside their wiki. `hypomnema init` scaffolds the directory; `hypomnema upgrade` mirrors the inventory into `~/.claude/` and (with `--codex`) **only the `hooks` and `commands` subset** into `~/.codex/` (agents/skills are Claude-only and skipped on the Codex target by design — see `scripts/lib/extensions.mjs` `CODEX_TYPES`). Conflict detection (`--force-extensions` to overwrite), and `hypomnema doctor extensions` audits integrity (orphan duplicates, matcher drift, non-registrable orphans). `hypomnema uninstall` cleans up the companion files. PR #49 added settings.json mixed-group surgical write so settings.json edits stay minimal and merge-friendly.
-- **`hypomnema upgrade --codex` mirrors core hooks (fix #48, PR #50).** `init --codex`
+- **`hypomnema upgrade --codex` mirrors core hooks (PR #50).** `init --codex`
   has always installed Hypomnema's core hooks into `~/.codex/hooks/` and
   registered them in `~/.codex/settings.json`, but `upgrade` only mirrored
   user extensions — so a v1.1.x → v1.2.0 codex user's core hooks stayed
@@ -180,7 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching `applied.*Codex` keys. Without `--codex` nothing under `~/.codex/`
   is inspected (parity with the existing extensions behaviour).
 - **`hypomnema upgrade` v1→v2 migration report (ADR 0034, PR #60).** Major SCHEMA bump now writes `MIGRATION-v2.0.md` into the wiki root with v1→v2-specific guidance: ADR 0031 / ADR 0034 references, all 9 unconditional `feedback` fields, the conditional `claude-learned` set, the explicit no-auto-stub policy, the "fix existing pages before `/hypo:feedback` append" warning, the PR #59 `project-id` ↔ slug regex caveat, and a closing re-run-lint checklist. Other major jumps keep the original generic body. PR #57 invariants preserved: `SCHEMA.md` is byte-equal after `--apply` (Option C), report tag stays `[schema]` (the only token historically valid across all shipped Meta vocabularies).
-- **PostToolUse WebFetch / WebSearch auto-ingest signal (fix #2, PR #48).** When Claude resolves a URL via WebFetch or runs WebSearch, the PostToolUse hook injects a nudge in `hookSpecificOutput.additionalContext` so Claude considers running `/hypo:ingest`. URL query/hash tokens and userinfo (`user:pass@host`) are stripped before injection. Non-HTTP schemes (`file://`, `ftp://`, `data:`) and missing URLs are silent skips. Opt out with `HYPO_SKIP_GATE=1`. Fail-open on invalid JSON stdin; stderr carries the unified `[hypo-web-fetch-ingest] error:` tag.
+- **PostToolUse WebFetch / WebSearch auto-ingest signal (PR #48).** When Claude resolves a URL via WebFetch or runs WebSearch, the PostToolUse hook injects a nudge in `hookSpecificOutput.additionalContext` so Claude considers running `/hypo:ingest`. URL query/hash tokens and userinfo (`user:pass@host`) are stripped before injection. Non-HTTP schemes (`file://`, `ftp://`, `data:`) and missing URLs are silent skips. Opt out with `HYPO_SKIP_GATE=1`. Fail-open on invalid JSON stdin; stderr carries the unified `[hypo-web-fetch-ingest] error:` tag.
 - **Stop-chain auto-minimal-crystallize (ADR 0022 Layer 3, PR #34).** A session that crossed a "non-trivial" threshold now offers (and on `Y` runs) `/hypo:crystallize --apply-session-close --minimal` automatically from the Stop hook chain. Combined with PR #31~#33 `/clear` detection and SessionEnd marker / SessionStart `source=clear` recovery, the personal-check gate now catches forgotten session closes and reopens cleanly when the user runs `/clear`.
 - **`crystallize --apply-session-close` programmatic entrypoint (PRs #21, #23~#26).** Strict 11-step session-close validation (PreCompact hard gate + crystallize). `--payload <json>` and `--apply-session-close` make the path machine-callable from the Stop hook chain; `--probe` early-exit (option D) keeps no-op closes fast. Lint preflight + post-apply gate ensures the wiki ends up clean.
 - **Auto-project creation on cwd match (ADR 0023, PR #41).** When you start a session
@@ -211,12 +211,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`doctor` orphan duplicate scan + matcher drift surfacing (PRs #53~#56, fix #47 / PR #54 follow-ups).** `doctor extensions` now surfaces non-registrable orphans, gated `matcher:""` specific message on `hookExact`, and reports orphan duplicate counts. `parseManifest` handles empty matcher; the canonical-pick mirror keeps the doctor view aligned with the actual registered hook.
-- **`extensions` settings.json mixed-group surgical write (fix #47, PR #49, ADR 0024 amendment).** Edits to `settings.json` for extensions registration are now surgical inside mixed groups, leaving siblings + matcher in the source group exactly as found.
-- **`crystallize --apply-session-close` lint preflight + post-apply gate (fix #40, PR #25).** Lint runs before AND after the apply to fail loudly on dirty input or post-write drift.
-- **PreCompact `/clear` detection + SessionEnd marker recovery (PRs #31~#33, fix #25/#26 + amendments, ADR 0022).** `compact-guard` detects `/clear` so it does not block; `personal-check` capacity bypass removed (#32); SessionEnd marker + SessionStart `source=clear` recovery makes /clear-then-restart cleanup work end-to-end.
-- **Test hermeticity — child HOME isolation in `tests/runner.mjs` (fix #3, PR #30).** Tests no longer rely on the dev's real `$HOME`; child processes get an isolated home so external writes can't pollute or break the suite.
-- **`withWiki()` fixture date local-time alignment (fix #39, PR #52).** UTC vs local boundary flake removed.
+- **`doctor` orphan duplicate scan + matcher drift surfacing (PRs #53~#56, PR #54 follow-ups).** `doctor extensions` now surfaces non-registrable orphans, gated `matcher:""` specific message on `hookExact`, and reports orphan duplicate counts. `parseManifest` handles empty matcher; the canonical-pick mirror keeps the doctor view aligned with the actual registered hook.
+- **`extensions` settings.json mixed-group surgical write (PR #49, ADR 0024 amendment).** Edits to `settings.json` for extensions registration are now surgical inside mixed groups, leaving siblings + matcher in the source group exactly as found.
+- **`crystallize --apply-session-close` lint preflight + post-apply gate (PR #25).** Lint runs before AND after the apply to fail loudly on dirty input or post-write drift.
+- **PreCompact `/clear` detection + SessionEnd marker recovery (PRs #31~#33 + amendments, ADR 0022).** `compact-guard` detects `/clear` so it does not block; `personal-check` capacity bypass removed (#32); SessionEnd marker + SessionStart `source=clear` recovery makes /clear-then-restart cleanup work end-to-end.
+- **Test hermeticity — child HOME isolation in `tests/runner.mjs` (PR #30).** Tests no longer rely on the dev's real `$HOME`; child processes get an isolated home so external writes can't pollute or break the suite.
+- **`withWiki()` fixture date local-time alignment (PR #52).** UTC vs local boundary flake removed.
 
 ### Maintenance
 

--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -30,7 +30,7 @@ These are judgment calls; when uncertain, surface the question rather than skip 
 
 ## Step 2 — Compose the session-close payload
 
-The session-close path is **payload-driven** (fix #38). Instead of writing the 5 mandatory files one-by-one, you compose a single JSON payload that describes the full session-close state, then hand it to `crystallize.mjs --apply-session-close`, which performs idempotent atomic writes and gates the result with lint.
+The session-close path is **payload-driven**. Instead of writing the 5 mandatory files one-by-one, you compose a single JSON payload that describes the full session-close state, then hand it to `crystallize.mjs --apply-session-close`, which performs idempotent atomic writes and gates the result with lint.
 
 Payload shape (5 required + 1 conditional, per Spec §5.2.7 / §8.3 + ADR 0029):
 
@@ -84,7 +84,7 @@ node <package-root>/scripts/crystallize.mjs \
   --json
 ```
 
-**`--session-id` (fix #27 PR-C):** pass the current session's id whenever you
+**`--session-id`:** pass the current session's id whenever you
 know it — most importantly when this close was triggered by a `[WIKI_AUTOCLOSE]`
 Stop-hook block (the block reason prints the exact `--session-id` to use). On a
 verified close (`ok: true` + clean git tree), it writes the per-session marker
@@ -93,7 +93,7 @@ Stop-chain Layer 3 hook (`hypo-auto-minimal-crystallize`) the session is closed,
 so it stops re-prompting. Omit it only when running crystallize purely for
 synthesis (no session-close intent) — the marker is then simply not written.
 
-**Behavior (fix #39 option D + fix #40 lint gates):**
+**Behavior (option D + lint gates):**
 
 | Invocation | Behavior |
 |---|---|
@@ -102,7 +102,7 @@ synthesis (no session-close intent) — the marker is then simply not written.
 | `--apply-session-close --payload=<path> --session-id=<id>` | Same as above, **plus** writes the per-session closed marker on success (clean git required). The Stop-chain Layer 3 path. |
 | `--apply-session-close --force` | Skips the probe early-exit. `--payload` still required for any actual apply work. |
 
-**Two lint gates run automatically (fix #40), scoped to the files this close writes:**
+**Two lint gates run automatically, scoped to the files this close writes:**
 
 Both gates judge only the **payload files** (the 5 mandatory close files + `open-questions.md`). Lint debt in other projects or shared `pages/` this close did not author is reported as a non-blocking `notices[]` entry, never gated — so an unrelated broken page elsewhere cannot block your close.
 

--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -2,7 +2,7 @@
 description: Record an AI behavior correction or preference into the wiki
 ---
 
-You are running `/hypo:feedback`. Capture a behavior correction or preference into `pages/feedback/` — the **single source of truth** for learned behaviors (ADR 0031 / fix #37).
+You are running `/hypo:feedback`. Capture a behavior correction or preference into `pages/feedback/` — the **single source of truth** for learned behaviors (ADR 0031).
 
 ## What this does
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -142,7 +142,7 @@ npm run fix:verify # Phase 1 of learned_behavior #6 — verifies fix #N status c
 When a test verifies behavior tied to a numbered fix in the wiki spec, add an anchor immediately above the `suite(...)` or `test(...)` call:
 
 ```js
-// @fix #25: replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE
+// @fix #N: replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE
 test('replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE', () => { ... });
 ```
 

--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * hypo-auto-minimal-crystallize.mjs — Stop hook (fix #27 PR-C, ADR 0022 Layer 3)
+ * hypo-auto-minimal-crystallize.mjs — Stop hook (ADR 0022 Layer 3)
  *
  * Last hook in the Stop chain: a final-line defense that blocks `Stop` when
  * the current session performed mutation work but never produced a verified
@@ -69,7 +69,7 @@ function emitBlock(sessionId, transcriptPath) {
     JSON.stringify({
       decision: 'block',
       reason,
-      stopReason: 'session-close incomplete (fix #27 PR-C / ADR 0022 Layer 3)',
+      stopReason: 'session-close incomplete (ADR 0022 Layer 3)',
     }),
   );
 }

--- a/hooks/hypo-compact-guard.mjs
+++ b/hooks/hypo-compact-guard.mjs
@@ -2,7 +2,7 @@
 /**
  * hypo-compact-guard.mjs — UserPromptSubmit hook
  *
- * Scope: detects "/compact" or "/clear" typed in chat only (ADR 0022 Layer 2, fix #25).
+ * Scope: detects "/compact" or "/clear" typed in chat only (ADR 0022 Layer 2).
  * The CLI built-in /compact does NOT fire UserPromptSubmit — use personal-wiki-check.mjs
  * (PreCompact hook) as the hard gate for that path. /clear has no PreCompact event, so
  * this hook is the only chat-side gate that can prompt session-close before context wipe.

--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -137,7 +137,7 @@ process.stdin.on('end', () => {
       return;
     }
 
-    // MISS: cwd matches no project. fix #23 / ADR 0023 — offer to create one
+    // MISS: cwd matches no project. ADR 0023 — offer to create one
     // when the trigger conditions hold. Same nudge-only model as session-start.
     let suggestPrefix = '';
     if (shouldSuggestProjectCreation(newCwd, HYPO_DIR)) {

--- a/hooks/hypo-first-prompt.mjs
+++ b/hooks/hypo-first-prompt.mjs
@@ -3,9 +3,9 @@
  * hypo-first-prompt.mjs — UserPromptSubmit hook
  *
  * Consumes the marker written by hypo-session-start.mjs (source omitted /
- * 'session-start') or hypo-cwd-change.mjs (source 'cwd-change', fix #13).
+ * 'session-start') or hypo-cwd-change.mjs (source 'cwd-change').
  * On the FIRST user prompt after the marker is written, FORCES a one-line
- * resume summary into the reply (fix #3 — the old "answer only if related"
+ * resume summary into the reply (the old "answer only if related"
  * conditional is removed; the line is injected unconditionally).
  *
  * hot.md / session-state.md content is NOT re-injected here — the upstream

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -3,8 +3,8 @@
  * hypo-personal-check.mjs — PreCompact hook
  *
  * Hard gate before /compact. Blocks if:
- *   - the session-close memory files were not updated this session (fix #17:
- *     session-state.md, project hot.md, root hot.md, session-log, log.md)
+ *   - the session-close memory files were not updated this session
+ *     (session-state.md, project hot.md, root hot.md, session-log, log.md)
  *   - wiki git repo has uncommitted/unpushed changes
  *   - hot.md has forbidden structure
  *   - lint blockers exist
@@ -14,7 +14,7 @@
  *   2. HYPO_SKIP_GATE=1 in a recent *user-role* transcript message
  *      (assistant/tool output is excluded to prevent self-triggering from block reason text)
  *
- * NOTE: capacity bypass (wiki-context-critical.json ≥90%) was REMOVED by fix #26
+ * NOTE: capacity bypass (wiki-context-critical.json ≥90%) was REMOVED
  * (ADR 0022 amendment 2026-05-13). Spec §7.5: even at full context, minimal
  * session-close is mandatory — auto-bypass on capacity caused silent state loss.
  */
@@ -52,7 +52,7 @@ process.stdin.on('end', () => {
     /* fail-open */
   }
 
-  // ── Capacity bypass (≥90%) REMOVED — fix #26, ADR 0022 amendment 2026-05-13.
+  // ── Capacity bypass (≥90%) REMOVED — ADR 0022 amendment 2026-05-13.
   //    Even at full context, minimal session-close is mandatory (spec §7.5).
   //    Bypass paths are now only: HYPO_SKIP_GATE env / HYPO_SKIP_GATE in transcript.
 
@@ -170,7 +170,7 @@ process.stdin.on('end', () => {
           .join(', ')}${lintNotices.length > 5 ? ', …' : ''} — clean up when convenient.`
       : '';
 
-  // ── fix #37 Phase C: feedback projection drift (ADR 0031) ──
+  // ── Phase C: feedback projection drift (ADR 0031) ──
   // Single blocking gate invariant (spec §7.5): integrate into THIS hook, never
   // add a separate PreCompact hook. `feedback-sync --check --strict` reports
   // projection drift (wiki feedback SoT vs MEMORY / CLAUDE.md learned-behaviors

--- a/hooks/hypo-pre-commit.mjs
+++ b/hooks/hypo-pre-commit.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * hypo-pre-commit.mjs — wiki git pre-commit hook worker (§6.8 fix #24)
+ * hypo-pre-commit.mjs — wiki git pre-commit hook worker (§6.8)
  *
  * Blocks staged files that match .hypoignore patterns.
  * Installed by `hypo init` to <wiki>/.git/hooks/pre-commit.

--- a/hooks/hypo-session-end.mjs
+++ b/hooks/hypo-session-end.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * hypo-session-end.mjs — SessionEnd hook (fix #25 PR-A2, ADR 0022 Layer 2)
+ * hypo-session-end.mjs — SessionEnd hook (ADR 0022 Layer 2)
  *
  * `/clear` cannot be blocked: it never fires UserPromptSubmit (Stage 0 PoC,
  * 2026-05-14). The only intervention point is the SessionEnd(reason='clear')

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -176,7 +176,7 @@ function readLastGrowthLine() {
 }
 
 /**
- * fix #25 PR-A2 (ADR 0022 amendment 2026-05-14): if the prior session ended
+ * ADR 0022 amendment 2026-05-14: if the prior session ended
  * via `/clear`, hypo-session-end stashed its identity in `.cache/clear-marker.json`.
  * Read it (with 7-day stale guard), unlink it (one-shot), and return a
  * `[WIKI_AUTOCLOSE]` recovery line for additionalContext + stderr.
@@ -212,8 +212,8 @@ function gitPull(dir) {
 }
 
 /**
- * fix #10: surface unresolved sync failures recorded by a prior session's
- * Stop hook (fix #9). The entry is cleared only once this session's pull has
+ * Surface unresolved sync failures recorded by a prior session's
+ * Stop hook. The entry is cleared only once this session's pull has
  * succeeded AND there is no unpushed commit left behind by a failed push
  * (`[ahead N]`).
  *
@@ -323,7 +323,7 @@ let raw = '';
 process.stdin.setEncoding('utf-8');
 process.stdin.on('data', (chunk) => (raw += chunk));
 process.stdin.on('end', () => {
-  // ISSUE-5: declared before the try so every emit branch — including the outer
+  // Declared before the try so every emit branch — including the outer
   // catch — carries the same `systemMessage` (the user-visible update/sibling
   // banner). Reassigned once below after the notices are computed.
   let outExtra = { continue: true, suppressOutput: true };
@@ -343,14 +343,14 @@ process.stdin.on('end', () => {
     const clearRecoveryLine = buildClearRecoveryLine(data.source);
     const updateLine = buildUpdateNotice();
     const siblingLine = buildSiblingNotice();
-    // ISSUE-5: the update + stale-sibling banners must reach the USER. On a
+    // The update + stale-sibling banners must reach the USER. On a
     // SessionStart hook that exits 0, stderr is invisible in the normal TUI
     // (only shown on exit 2 / --verbose) and additionalContext is model-only —
     // `systemMessage` is the documented user-visible channel. Route those two
     // banners there. They ALSO stay in noticePrefix → additionalContext below,
     // so the model and the user start the session looking at the same state.
     // (The other stderr notices — sync/growth/clear/suggest — are intentionally
-    // transcript/--verbose only and out of ISSUE-5's scope.)
+    // transcript/--verbose only and out of this banner's scope.)
     const userMessage = [updateLine, siblingLine].filter(Boolean).join('\n\n');
     if (userMessage) outExtra = { ...outExtra, systemMessage: userMessage };
     const notices = [syncLine, growthLine, clearRecoveryLine, updateLine, siblingLine].filter(
@@ -417,7 +417,7 @@ process.stdin.on('end', () => {
       return;
     }
 
-    // MISS: cwd matches no project. fix #23 / ADR 0023 — offer to create one
+    // MISS: cwd matches no project. ADR 0023 — offer to create one
     // when the ADR trigger conditions hold (git repo + project marker + no
     // cooldown + not previously declined). The actual scaffold is the LLM's
     // job on a "Y" reply (scripts/lib/project-create.mjs); the hook only nudges.

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -173,7 +173,7 @@ export function hotMdIsClean() {
 // so a second session on the same day that skips updating a file still passes
 // if an earlier close that day already stamped it. freshDates() accepting both
 // local and UTC dates widens that window by up to one UTC offset. A per-session
-// boundary is out of scope for fix #17.
+// boundary is out of scope for the strict session-close check.
 
 /** Parse the frontmatter `updated:` field. Returns the trimmed value or null. */
 function frontmatterUpdated(content) {
@@ -272,10 +272,10 @@ function pickByCwd(hypoDir, slugs, cwd) {
  * The cwd helpers (parseFrontmatterField / pickByCwd) and the same-date
  * tie-break are kept in sync with scripts/resume.mjs by hand; the surrounding
  * wrapper intentionally differs (resume.mjs adds an mtime fallback, this does not).
- * `cwd` is an optional same-date tie-breaker (ISSUE-1): resume passes
+ * `cwd` is an optional same-date tie-breaker: resume passes
  * process.cwd(); session-close callers (sessionCloseFileStatus /
  * closeFileTargets) intentionally pass null — close has a different
- * authority (payload.project / freshness), tracked separately as ISSUE-7.
+ * authority (payload.project / freshness), tracked separately.
  * When cwd is omitted, behavior is identical to the legacy version.
  * @param {string} hypoDir
  * @param {string|null} [cwd]
@@ -300,7 +300,7 @@ export function resolveActiveProject(hypoDir, cwd = null) {
   ].map((m) => ({ name: m[1].trim(), date: m[2] || '', slug: m[3] }));
   if (wikiRows.length > 0) {
     wikiRows.sort((a, b) => b.date.localeCompare(a.date));
-    // Same-date tie-break (ISSUE-1): when the top date is shared by >1 row,
+    // Same-date tie-break: when the top date is shared by >1 row,
     // prefer the project whose working_dir contains cwd. No cwd / no match →
     // keep the stable-sort winner (the legacy "first table row" behavior).
     const topDate = wikiRows[0].date;
@@ -322,7 +322,7 @@ export function resolveActiveProject(hypoDir, cwd = null) {
 }
 
 /**
- * Strict session-close verification (fix #17, spec §5.2.7 / §8.3).
+ * Strict session-close verification (spec §5.2.7 / §8.3).
  * Confirms the memory files a session close must touch were updated today:
  *   - projects/<project>/session-state.md       — frontmatter `updated:` is today
  *   - projects/<project>/hot.md                 — frontmatter `updated:` is today
@@ -423,9 +423,9 @@ export function sessionCloseFileStatus(hypoDir, { projectOverride = null } = {})
 
 // ── sync-state ────────────────────────────────────────────
 // `.cache/sync-state.json` is JSONL: one {timestamp, op, error, host} entry per
-// line. hypo-auto-commit (fix #9) appends on pull/push failure; hypo-session-start
-// (fix #10) surfaces open entries and clears them once sync is healthy again;
-// doctor (fix #11) warns while entries remain. Keep the schema defined here only.
+// line. hypo-auto-commit appends on pull/push failure; hypo-session-start
+// surfaces open entries and clears them once sync is healthy again;
+// doctor warns while entries remain. Keep the schema defined here only.
 
 /** @returns {string} path to the sync-state JSONL file for a wiki root. */
 function syncStatePath(hypoDir) {
@@ -1036,14 +1036,14 @@ export function isClearCommand(prompt) {
   return prompt === '/clear' || /^\/clear(\s|$)/.test(prompt);
 }
 
-/** Returns true if the prompt is either /compact or /clear (ADR 0022 Layer 2, fix #25). */
+/** Returns true if the prompt is either /compact or /clear (ADR 0022 Layer 2). */
 export function isCompactOrClearCommand(prompt) {
   return isCompactCommand(prompt) || isClearCommand(prompt);
 }
 
 /**
  * Extract recent user-role message text from a JSONL transcript (last `tailN`
- * lines). Promoted from hypo-personal-check.mjs (fix #27 PR-C) so both the
+ * lines). Promoted from hypo-personal-check.mjs so both the
  * PreCompact gate and the Stop-chain Layer 3 hook share one close-intent
  * signal source. Claude Code transcript format: each line is
  * `{ type:"user", message:{ role:"user", content: ... } }`; the older

--- a/hooks/hypo-web-fetch-ingest.mjs
+++ b/hooks/hypo-web-fetch-ingest.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 /**
- * hypo-web-fetch-ingest.mjs — PostToolUse hook (fix #2)
+ * hypo-web-fetch-ingest.mjs — PostToolUse hook
  *
  * When the LLM uses WebFetch or WebSearch, nudge it to follow §8.4 path A:
  * "external research → /hypo:ingest into sources/". This hook produces a
  * *signal*, not an automatic ingest call — per spec §5.4.6 Q-5.4.6:
- *   "WebFetch/WebSearch 자동 ingest 시그널은 별도 hook(fix #2)으로 분리."
+ *   "WebFetch/WebSearch 자동 ingest 시그널은 별도 hook으로 분리."
  *
  * Why signal-only (not direct ingest):
  *   - slug derivation is LLM-driven (commands/ingest.md), so a hook cannot

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
     "graph": "node scripts/graph.mjs",
     "smoke-pack": "node scripts/smoke-pack.mjs",
     "check:bilingual": "node scripts/check-bilingual.mjs --changelog",
+    "check:tracker-ids": "node scripts/check-tracker-ids.mjs --all",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "node scripts/install-git-hooks.mjs",
-    "prepublishOnly": "npm test && npm run lint && npm run smoke-pack && npm run check:bilingual"
+    "prepublishOnly": "npm test && npm run lint && npm run smoke-pack && npm run check:bilingual && npm run check:tracker-ids"
   },
   "devDependencies": {
     "prettier": "^3.8.3"

--- a/scripts/check-tracker-ids.mjs
+++ b/scripts/check-tracker-ids.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * check-tracker-ids.mjs — CLI gate: no wiki-internal tracker IDs (ISSUE-N,
+ * fix #N) in OSS-public artifacts.
+ *
+ * Rule source: CLAUDE.md learned_behaviors (no-internal-tracker-ids-in-oss-
+ * artifacts, 2026-06-09). The repo ships through npm + a Claude Code plugin;
+ * a `fix #N` / `ISSUE-N` in any shipped file or in README/CHANGELOG is a
+ * dangling pointer into the maintainer's PRIVATE wiki tracker. GitHub refs
+ * (`PR #N`, `(#N)`, `#N`, issue URLs) are legitimate and never flagged.
+ *
+ * Modes:
+ *   --all (default)        Walk the public-artifact scope and scan every text
+ *                          file. Wired into npm `prepublishOnly` and CI.
+ *   --staged               Scan the STAGED blob of every in-scope file in the
+ *                          index (git show :path), mirroring the pre-commit
+ *                          formatter's name-status/-z/diff-filter plumbing so
+ *                          deletes, type-changes, symlinks and submodules are
+ *                          skipped. Used by the pre-commit hook.
+ *   --commit-msg <file>    Scan a commit message. Drops the --verbose scissors
+ *                          diff, then strips comment lines ONLY when git added
+ *                          its template (editor/strip mode); for `commit -m` /
+ *                          whitespace / verbatim (no template) it scans comment
+ *                          lines too, since git keeps them. Used by the
+ *                          commit-msg hook.
+ *   --json                 Machine-readable output.
+ *
+ * Exit: 0 clean · 1 violations · 2 usage error.
+ *
+ * Scope (public): README.md, README.ko.md, CHANGELOG.md, package.json (npm
+ * auto-ships it) + shipped trees commands/ hooks/ scripts/ skills/ templates/
+ * docs/ .github/ .claude-plugin/. Excluded: tests/ and qa-runs/ (internal
+ * maintainer artifacts — a tracker id in a test description aids traceability
+ * and never reaches an installed user), node_modules/, .git/. The checker's OWN
+ * sources are scanned (NOT exempt); their examples use `N` placeholders so they
+ * stay clean.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative, sep, extname } from 'node:path';
+import { scanText, stripScissors, messageHasGitTemplate } from './lib/check-tracker-ids.mjs';
+import {
+  parseNameStatus,
+  parseLsFilesStage,
+  filterRegularFiles,
+} from './lib/pre-commit-format.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Root resolves from this script's location (so --staged always gates the real
+// Hypomnema index regardless of cwd). CHECK_TRACKER_ROOT is a TEST-ONLY seam;
+// the installed git hooks `unset CHECK_TRACKER_ROOT` before invoking (see
+// install-git-hooks.mjs gateLines) so an inherited/hostile value cannot redirect
+// the real gate. Read-only either way (no writes), so it only changes what is
+// scanned, never what is written.
+const REPO_ROOT = process.env.CHECK_TRACKER_ROOT || join(__dirname, '..');
+
+const RULE_REF =
+  'Rule: CLAUDE.md learned_behaviors (no-internal-tracker-ids-in-oss-artifacts). ' +
+  'OSS-public artifacts must not reference the private wiki tracker (ISSUE-N / fix #N). ' +
+  'Use a GitHub ref (#N / PR #N) or drop the reference.';
+
+// Top-level public-artifact entry points. Files are scanned directly; dirs are
+// walked recursively. Anything outside this set is out of scope. package.json is
+// here because npm auto-ships it (it is not in the `files` allowlist but is
+// always packed), so a tracker id in its metadata is a public leak too.
+const SCOPE_FILES = ['README.md', 'README.ko.md', 'CHANGELOG.md', 'package.json'];
+const SCOPE_DIRS = [
+  'commands',
+  'hooks',
+  'scripts',
+  'skills',
+  'templates',
+  'docs',
+  '.github',
+  '.claude-plugin',
+];
+
+// Never scanned even when under a scope dir. tests/ and qa-runs/ are
+// internal-maintainer artifacts (a tracker id in a test name aids traceability
+// and never reaches an installed user). The checker's OWN sources are NOT
+// excluded — they use `N` placeholders in their examples so they scan clean.
+const EXCLUDED_DIRS = new Set(['node_modules', '.git', 'tests', 'qa-runs']);
+const EXCLUDED_FILES = new Set();
+
+// Only text artifacts. Binary / lockfiles add noise and never carry prose refs.
+const TEXT_EXT = new Set(['.md', '.mjs', '.js', '.cjs', '.json', '.yml', '.yaml', '.sh', '.txt']);
+
+function isExcludedRel(relPath) {
+  const parts = relPath.split(sep);
+  if (parts.some((p) => EXCLUDED_DIRS.has(p))) return true;
+  if (EXCLUDED_FILES.has(relPath)) return true;
+  return false;
+}
+
+function isTextFile(p) {
+  return TEXT_EXT.has(extname(p).toLowerCase());
+}
+
+// Single public-scope predicate shared by --all and --staged so the two modes
+// can never disagree on what counts as a public artifact (a root file like
+// `foo.md` is out of scope for both; `package.json` and scope-dir files are in).
+function isInScope(relPath) {
+  if (isExcludedRel(relPath)) return false;
+  if (!isTextFile(relPath)) return false;
+  if (SCOPE_FILES.includes(relPath)) return true;
+  return SCOPE_DIRS.includes(relPath.split(sep)[0]);
+}
+
+// Recursively collect in-scope text files under an absolute dir.
+function walk(absDir, acc) {
+  let entries;
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    const abs = join(absDir, ent.name);
+    const rel = relative(REPO_ROOT, abs);
+    if (isExcludedRel(rel)) continue;
+    if (ent.isDirectory()) {
+      walk(abs, acc);
+    } else if (ent.isFile() && isTextFile(abs)) {
+      acc.push(rel);
+    }
+  }
+}
+
+function collectAllScopeFiles() {
+  const files = [];
+  for (const f of SCOPE_FILES) {
+    if (existsSync(join(REPO_ROOT, f))) files.push(f);
+  }
+  for (const d of SCOPE_DIRS) {
+    walk(join(REPO_ROOT, d), files);
+  }
+  return files;
+}
+
+// ── violation reporting ──────────────────────────────────────────────────────
+
+function report(violations, json) {
+  if (json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: violations.length === 0,
+          count: violations.length,
+          violations,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else if (violations.length === 0) {
+    process.stdout.write('[check-tracker-ids] OK: no wiki-internal tracker ids found.\n');
+  } else {
+    process.stderr.write(
+      `[check-tracker-ids] FAIL: ${violations.length} tracker-id reference(s):\n`,
+    );
+    for (const v of violations) {
+      process.stderr.write(
+        `  ${v.file}:${v.line}:${v.col}  ${v.match}  (${v.label})\n` +
+          `      ${v.lineText.trim()}\n`,
+      );
+    }
+    process.stderr.write(`${RULE_REF}\n`);
+  }
+  return violations.length === 0 ? 0 : 1;
+}
+
+// ── git helpers (scoped env not required: read-only, no GIT_DIR attack surface
+//    here — the hook shim already pins identity before invoking) ──────────────
+
+function git(args, opts = {}) {
+  return spawnSync('git', args, { cwd: REPO_ROOT, encoding: 'utf-8', ...opts });
+}
+
+// ── modes ────────────────────────────────────────────────────────────────────
+
+function runAll(json) {
+  const files = collectAllScopeFiles();
+  const violations = [];
+  for (const rel of files) {
+    let text;
+    try {
+      text = readFileSync(join(REPO_ROOT, rel), 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const h of scanText(text)) violations.push({ file: rel, ...h });
+  }
+  process.exit(report(violations, json));
+}
+
+function runStaged(json) {
+  const diff = git(['diff', '--cached', '--name-status', '-z', '--diff-filter=ACMR', '--']);
+  if (diff.status !== 0) {
+    // Can't read the index → fail OPEN (don't block a commit on a git probe
+    // failure); the --all CI gate is the hard backstop.
+    process.stdout.write(
+      '[check-tracker-ids] staged: git diff failed; skipping (CI is the backstop).\n',
+    );
+    process.exit(0);
+  }
+  const staged = parseNameStatus(diff.stdout || '');
+  // Restrict to in-scope public artifacts (same predicate --all uses).
+  const inScope = staged.filter((e) => isInScope(e.path));
+  if (!inScope.length) {
+    if (json) report([], json);
+    process.exit(0);
+  }
+  // Drop symlinks / submodules via the staged mode bits.
+  const ls = git(['ls-files', '--stage', '-z', '--', ...inScope.map((e) => e.path)]);
+  let regular = inScope;
+  if (ls.status === 0) {
+    regular = filterRegularFiles(inScope, parseLsFilesStage(ls.stdout || ''));
+  }
+  const violations = [];
+  for (const e of regular) {
+    // Scan the STAGED blob, not the working tree — only what is actually being
+    // committed is gated (partial stage safety).
+    const show = git(['show', `:${e.path}`]);
+    if (show.status !== 0) continue;
+    for (const h of scanText(show.stdout || '')) violations.push({ file: e.path, ...h });
+  }
+  process.exit(report(violations, json));
+}
+
+function runCommitMsg(file, json) {
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf-8');
+  } catch (err) {
+    process.stderr.write(
+      `[check-tracker-ids] cannot read commit-msg file ${file}: ${err.message}\n`,
+    );
+    process.exit(2);
+  }
+  // Decide comment/scissors handling by whether git added its editor template
+  // (NOT by config, which the hook can't fully resolve). Two branches:
+  //
+  //   template present (editor commit) → git honors the --verbose scissors AND,
+  //     in the default cleanup, strips `#` comment lines. Replicate: cut the
+  //     scissors diff, then `stripspace --strip-comments`. This matches what git
+  //     records and avoids a false-positive on the template's own branch/file
+  //     names (e.g. a ticket-numbered branch in `# On branch ...`).
+  //
+  //   template absent (`git commit -m` / `-F` / whitespace / verbatim) → git
+  //     keeps `#` lines and does NOT treat a bare `>8` line as scissors, so scan
+  //     the message VERBATIM. This is what closes both -m gaps (a `#`-prefixed
+  //     tracker id, and content after a user-written `>8` line).
+  //
+  // KNOWN LIMITATION (documented, exotic): an EDITOR commit run with an explicit
+  // non-default `--cleanup=whitespace`/`verbatim` does carry a template yet keeps
+  // `#` lines, so a tracker id sitting in a comment line there is not caught.
+  // This needs a non-default flag AND a `#`-prefixed id; the prose path (the real
+  // risk) is always caught, and the file gate (--all/--staged/CI) is the hard
+  // guarantee. commit-msg is best-effort.
+  let text;
+  if (messageHasGitTemplate(raw)) {
+    const noScissors = stripScissors(raw);
+    const strip = git(['stripspace', '--strip-comments'], { input: noScissors });
+    text = strip.status === 0 ? strip.stdout || '' : noScissors;
+  } else {
+    text = raw;
+  }
+  const violations = scanText(text).map((h) => ({ file: relative(REPO_ROOT, file) || file, ...h }));
+  process.exit(report(violations, json));
+}
+
+// ── arg parsing ────────────────────────────────────────────────────────────
+
+function usage(code) {
+  process.stdout.write(
+    'Usage:\n' +
+      '  node scripts/check-tracker-ids.mjs [--all] [--json]\n' +
+      '  node scripts/check-tracker-ids.mjs --staged [--json]\n' +
+      '  node scripts/check-tracker-ids.mjs --commit-msg <file> [--json]\n',
+  );
+  process.exit(code);
+}
+
+const argv = process.argv.slice(2);
+if (argv.includes('--help') || argv.includes('-h')) usage(0);
+const json = argv.includes('--json');
+
+if (argv.includes('--commit-msg')) {
+  const i = argv.indexOf('--commit-msg');
+  const file = argv[i + 1];
+  if (!file || file.startsWith('--')) {
+    process.stderr.write('[check-tracker-ids] --commit-msg requires a file path\n');
+    usage(2);
+  }
+  runCommitMsg(file, json);
+} else if (argv.includes('--staged')) {
+  runStaged(json);
+} else {
+  // default + explicit --all
+  runAll(json);
+}

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -12,16 +12,16 @@
  * Options:
  *   --hypo-dir=<path>        Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
  *   --min-group=<n>          Min pages per tag group to report (default: 2)
- *   --check-session-close    Verify the strict session-close memory files — 5 mandatory + open-questions conditional (fix #17)
+ *   --check-session-close    Verify the strict session-close memory files — 5 mandatory + open-questions conditional
  *   --apply-session-close    Apply a JSON payload that updates the 5 mandatory memory files
  *                            (+ optional open-questions). Idempotent — re-running with the same
  *                            payload is a no-op. Always finishes with the strict gate check.
  *
  *                            Without --payload, runs as a cheap "already complete?" probe:
  *                            if the strict gate is ok, exits 0 with alreadyComplete:true;
- *                            otherwise exits 1 with "payload is required". Fix #39 (option D):
+ *                            otherwise exits 1 with "payload is required". Option D:
  *                            payload presence = explicit close intent → always full apply
- *                            (fix #38's per-entry idempotency keeps re-apply cheap).
+ *                            (the per-entry idempotency keeps re-apply cheap).
  *   --payload=<path|->       Path to JSON payload (file or `-` for stdin). Required for any
  *                            apply work; omit only for the probe path above.
  *   --force                  Bypass the no-payload probe early-exit. Payload is still required
@@ -29,7 +29,7 @@
  *                            shortcut. Reserved for explicit diagnostics / scripted recovery.
  *   --json                   Output as JSON
  *
- * Payload schema (fix #38):
+ * Payload schema:
  *   {
  *     "project":      "<slug>",                       // optional — defaults to resolveActiveProject()
  *     "date":         "YYYY-MM-DD",                   // optional — defaults to today (local)
@@ -45,7 +45,7 @@
  * stale date, the final sessionCloseFileStatus check fails with a clear error so the
  * caller fixes the payload and retries. Silent rewrites would mask payload bugs.
  *
- * Lint gates (fix #40):
+ * Lint gates:
  *   • Preflight — runs `lint.mjs --json` BEFORE any payload byte is written.
  *     Errors in files this payload will OVERWRITE (sessionState/projectHot/
  *     rootHot/openQuestions) are filtered out — they're about to be replaced,
@@ -94,7 +94,7 @@ const LINT_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'lint.mjs');
 // with valid JSON is a normal "errors present" signal, not a crash.
 // maxBuffer raised to 64 MiB: warn-only output on a large wiki can otherwise
 // trip Node's 1 MiB default, truncate stdout, and turn a clean wiki into a
-// JSON.parse crash (codex P3 — fix #40 follow-up).
+// JSON.parse crash (codex P3 follow-up).
 function runLint(hypoDir) {
   const r = spawnSync(process.execPath, [LINT_SCRIPT, `--hypo-dir=${hypoDir}`, '--json'], {
     encoding: 'utf-8',
@@ -283,7 +283,7 @@ function todayLocal() {
 // bug, not a no-op. Caller is the LLM session-close flow, which composes the
 // payload deliberately; partial payloads must fail loudly so caller fixes them
 // rather than silently relying on yesterday's freshness state. (Codex review
-// of fix #38 — Worker 1 finding 1.)
+// of the apply path — Worker 1 finding 1.)
 const REQUIRED_PAYLOAD_FIELDS = [
   ['sessionState', 'content'],
   ['projectHot', 'content'],
@@ -440,9 +440,9 @@ function runMarkSessionClosed(args) {
 }
 
 function applySessionClose(args) {
-  // Fix #39 (option D): early-exit fires only when NO payload was supplied.
+  // Option D: early-exit fires only when NO payload was supplied.
   // Rationale: payload presence is explicit close intent and must always run
-  // the full apply path — fix #38's per-entry idempotency (writeIfChanged +
+  // the full apply path — the per-entry idempotency (writeIfChanged +
   // exact-entry append dedup) keeps re-apply cheap without short-circuiting,
   // and avoids silent-success when a same-day second close brings new bytes.
   // Payload-less invocation is treated as a cheap "already complete?" probe.
@@ -508,7 +508,7 @@ function applySessionClose(args) {
   const date = payload.date || todayLocal();
   const ym = date.slice(0, 7);
 
-  // Fix #40 preflight: lint the wiki BEFORE writing any payload bytes. If lint
+  // Preflight: lint the wiki BEFORE writing any payload bytes. If lint
   // has blockers (errors) in files this apply WON'T overwrite, the wiki is in
   // a degraded state and apply would mask the root cause — abort fail-fast.
   //
@@ -590,7 +590,7 @@ function applySessionClose(args) {
   // dated today". The freshness gate (sessionCloseFileStatus) is what answers
   // "was this file touched today?"; that's a different concern and must not
   // be reused for apply-time dedup, or a legitimate same-day second close gets
-  // silently dropped (Codex review of fix #38 — Worker 1 finding 2).
+  // silently dropped (Codex review of the apply path — Worker 1 finding 2).
   const entryAlreadyPresent = (entry) => (content) =>
     content.includes(entry.endsWith('\n') ? entry.replace(/\n+$/, '') : entry);
 
@@ -620,7 +620,7 @@ function applySessionClose(args) {
   // a completed close (the 2026-06-09 security-ops-kb incident).
   const verification = sessionCloseFileStatus(args.hypoDir, { projectOverride: project });
 
-  // Fix #40 post-apply lint: payload may have introduced a malformed body or
+  // Post-apply lint: payload may have introduced a malformed body or
   // bad frontmatter. Surface as a distinct `stage` so caller can tell "lint
   // broke" apart from "frontmatter stale". This runs even if the freshness gate
   // also failed — both failure modes are useful to the caller.

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -222,7 +222,7 @@ function checkDirectories(hypoDir) {
     'projects',
     'sources',
     // Extensions baseline (ADR 0024). Existence only — SHA / settings /
-    // manifest integrity is E5 (fix #33).
+    // manifest integrity is E5.
     'extensions/hooks',
     'extensions/commands',
     'extensions/skills',
@@ -310,7 +310,7 @@ function checkSettingsJson() {
   // stale hypo-* entries (uninstall remnants).
   // hypo-ext-* commands are user-extension entries (ADR 0024) — not core hooks,
   // so they are intentionally absent from HOOK_MAP. Excluded here; their
-  // integrity (SHA + manifest + entry match) is checked separately in E5 (fix #33).
+  // integrity (SHA + manifest + entry match) is checked separately in E5.
   const isExtCommand = (cmd) => /(?:^|[/\s])hypo-ext-[^/\s]+\.mjs(?=$|["'\s])/.test(cmd);
   const expectedCmds = new Set(
     Object.entries(HOOK_MAP).flatMap(([, files]) =>
@@ -352,7 +352,7 @@ function checkSettingsJson() {
       if (!g || typeof g !== 'object') continue;
       for (const h of g.hooks || []) {
         if (typeof h.command !== 'string' || !/hypo-[^/]+\.mjs/.test(h.command)) continue;
-        if (isExtCommand(h.command)) continue; // ext duplicates are E5's concern (fix #33)
+        if (isExtCommand(h.command)) continue; // ext duplicates are E5's concern
         if (seen.has(h.command)) dupes.push(`${event}:${h.command}`);
         else seen.add(h.command);
       }
@@ -399,10 +399,7 @@ function checkGit(hypoDir) {
       );
     }
   } else {
-    warn(
-      '.git/hooks/pre-commit',
-      'Not installed — run /hypo:init to install .hypoignore guard (fix #24)',
-    );
+    warn('.git/hooks/pre-commit', 'Not installed — run /hypo:init to install .hypoignore guard');
   }
 }
 
@@ -679,7 +676,7 @@ function checkCodexPaths() {
 //
 // E5 is doctor SURFACE for extensions integrity. The mixed-group surgical
 // *write* (preserve sibling-plugin hooks, swap only ours) used to be deferred
-// here; fix #47 (ADR 0024 amendment 2026-05-23) lifted that deferral —
+// here; ADR 0024 amendment 2026-05-23 lifted that deferral —
 // registerSettings (extensions.mjs:478 docstring) now does occurrence-first +
 // 8-rank canonical write, and the (b) loop below mirrors that read-path via
 // collectOurOccurrences so a valid mixed-group occurrence is no longer warned
@@ -773,7 +770,7 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
     const expected = buildExpectedSettingsEntries(discovered.hooks, hooksDir);
 
     // (b) for each registrable hook: locate every occurrence of our command
-    // (single-hook OR mixed group, fix #47) and pick the canonical via the
+    // (single-hook OR mixed group) and pick the canonical via the
     // SAME 8-rank logic registerSettings uses.
     // Without this mirror, doctor picked the first traversal-order occurrence
     // under the target event and warned "differs" even when a later

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * feedback-sync.mjs — project wiki feedback as SoT, external memory as projection (ADR 0031, fix #37)
+ * feedback-sync.mjs — project wiki feedback as SoT, external memory as projection (ADR 0031)
  *
  * Wiki `pages/feedback/<slug>.md` is the single source of truth for
  * learning/correction knowledge. Two Claude Code memory surfaces are derived

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -928,7 +928,7 @@ if (args.hooks) {
   }
   for (const r of extResult.registered) log('merged', `extension ${r}`);
   for (const w of extResult.warnings) log('skipped', `extension: ${w}`);
-  // E3 (fix #31): a hard conflict (unowned/symlinked target) blocks install — surface
+  // E3: a hard conflict (unowned/symlinked target) blocks install — surface
   // the recovery and force a non-zero exit. Drift is advisory (resolvable, no block).
   if (extResult.conflicts.length > 0) {
     log('errors', '[WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -79,10 +79,39 @@ function shellSingleQuote(s) {
   return `'` + s.replace(/'/g, `'\\''`) + `'`;
 }
 
-function shimBody(root, gitDir) {
+// Hook-specific gate body. Runs AFTER the shared identity guards, so everything
+// here is already proven to be our trusted checkout. `set +e` is active, so the
+// gate must explicitly `|| exit 1` to BLOCK a commit; a missing script is a
+// fail-open skip (old checkout that predates the script).
+function gateLines(kind) {
+  // CHECK_TRACKER_ROOT is a test-only seam in check-tracker-ids.mjs. Clear any
+  // inherited value so the real hook always gates THIS checkout's index, never a
+  // redirected one.
+  const unsetSeam = 'unset CHECK_TRACKER_ROOT';
+  if (kind === 'pre-commit') {
+    // 1) Auto-format staged files (its own exit 1 = a true git-add failure block).
+    //    The sentinel tells pre-commit-format.mjs it runs under the trusted shim,
+    //    so it preserves an inherited GIT_INDEX_FILE (index-whitelist defence).
+    // 2) Tracker-id gate on the staged blobs — blocks the commit on a leak.
+    return `${unsetSeam}
+FMT="$HYPOMNEMA_ROOT/scripts/pre-commit-format.mjs"
+[ -f "$FMT" ] && { HYPOMNEMA_HOOK_INVOCATION=1 node "$FMT" || exit 1; }
+TRK="$HYPOMNEMA_ROOT/scripts/check-tracker-ids.mjs"
+[ -f "$TRK" ] && { node "$TRK" --staged || exit 1; }
+exit 0`;
+  }
+  // commit-msg: scan the message file (passed as $1) for wiki tracker ids.
+  return `${unsetSeam}
+TRK="$HYPOMNEMA_ROOT/scripts/check-tracker-ids.mjs"
+[ -f "$TRK" ] || exit 0
+node "$TRK" --commit-msg "$1" || exit 1
+exit 0`;
+}
+
+function shimBody(kind, root, gitDir) {
   return `#!/bin/sh
-# hypomnema-pre-commit-marker v1
-# Fail-open at every guard. Only the .mjs (after identity checks) can exit nonzero.
+# hypomnema-${kind}-marker v2
+# Fail-open at every identity/setup guard. Only the gate below can exit nonzero.
 set +e
 HYPOMNEMA_ROOT=${shellSingleQuote(root)}
 HYPOMNEMA_GIT_DIR=${shellSingleQuote(gitDir)}
@@ -91,28 +120,51 @@ TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 [ "$TOPLEVEL" = "$HYPOMNEMA_ROOT" ] || exit 0
 ABSGITDIR="$(git rev-parse --absolute-git-dir 2>/dev/null)" || exit 0
 [ "$ABSGITDIR" = "$HYPOMNEMA_GIT_DIR" ] || exit 0
-SCRIPT="$HYPOMNEMA_ROOT/scripts/pre-commit-format.mjs"
-[ -f "$SCRIPT" ] || exit 0
 command -v node >/dev/null 2>&1 || exit 0
-# Sentinel: tells the .mjs it is running under our trusted shim (not direct
-# attacker invocation). The .mjs preserves inherited GIT_INDEX_FILE only when
-# this sentinel is present — direct invocation drops it and falls back to the
-# default \`.git/index\`. This closes prefix-matching attacks on the index
-# whitelist (e.g. attacker-crafted .git/next-index-attack.lock).
-HYPOMNEMA_HOOK_INVOCATION=1 exec node "$SCRIPT"
+${gateLines(kind)}
 `;
 }
 
-function writeShim(target, root, gitDir) {
+// Write a single hook shim. Returns true on success, false on write failure.
+// Does NOT exit — the caller installs multiple hooks and reports once.
+function writeShim(target, kind, root, gitDir) {
   try {
-    fs.writeFileSync(target, shimBody(root, gitDir), { mode: 0o755 });
+    fs.writeFileSync(target, shimBody(kind, root, gitDir), { mode: 0o755 });
     try {
       fs.chmodSync(target, 0o755);
     } catch {}
-    return exitSilent(`installed pre-commit hook for ${root}`);
-  } catch (e) {
-    return exitSilent(`write hook failed: ${e.code || e.message}; skipping`);
+    return true;
+  } catch {
+    return false;
   }
+}
+
+// Install/refresh one hook of the given kind under absHooksDir. Returns a short
+// status string (never throws, never exits). Refreshes our own marker (any
+// version) so a checkout move or a shim-body change re-propagates; never
+// clobbers a user's own non-marker hook or a symlink.
+function installHook(kind, absHooksDir, root, gitDir) {
+  const target = path.join(absHooksDir, kind);
+  let existing;
+  try {
+    existing = fs.lstatSync(target);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return writeShim(target, kind, root, gitDir) ? `installed ${kind}` : `write ${kind} failed`;
+    }
+    return `stat ${kind} failed: ${e.code}`;
+  }
+  if (existing.isSymbolicLink()) return `${kind} is symlink; not overwriting`;
+  let head;
+  try {
+    head = fs.readFileSync(target, 'utf-8').split('\n').slice(0, 3).join('\n');
+  } catch {
+    return `read ${kind} failed; skipping`;
+  }
+  if (head.includes(`hypomnema-${kind}-marker`)) {
+    return writeShim(target, kind, root, gitDir) ? `refreshed ${kind}` : `refresh ${kind} failed`;
+  }
+  return `existing non-marker ${kind}; not overwriting`;
 }
 
 async function main() {
@@ -225,31 +277,14 @@ async function main() {
       return exitSilent('hooks dir outside .git/; skipping');
     }
 
-    // (7) Existing pre-commit logic.
-    const target = path.join(absHooksDir, 'pre-commit');
-    let existing;
-    try {
-      existing = fs.lstatSync(target);
-    } catch (e) {
-      if (e.code === 'ENOENT') {
-        return writeShim(target, expectedRoot, absGitDir);
-      }
-      return exitSilent(`stat target failed: ${e.code}; skipping`);
-    }
-    if (existing.isSymbolicLink()) {
-      return exitSilent('pre-commit is symlink; not overwriting');
-    }
-    let head;
-    try {
-      head = fs.readFileSync(target, 'utf-8').split('\n').slice(0, 3).join('\n');
-    } catch {
-      return exitSilent('read existing pre-commit failed; skipping');
-    }
-    if (head.includes('hypomnema-pre-commit-marker v1')) {
-      // Same marker — regenerate (refreshes embedded root if checkout moved).
-      return writeShim(target, expectedRoot, absGitDir);
-    }
-    return exitSilent('existing non-marker pre-commit; not overwriting');
+    // (7) Install both hooks: pre-commit (format + tracker-id gate on staged
+    //     blobs) and commit-msg (tracker-id gate on the message). Each is
+    //     independently marker-detected so a user's own hook is never clobbered.
+    const results = [
+      installHook('pre-commit', absHooksDir, expectedRoot, absGitDir),
+      installHook('commit-msg', absHooksDir, expectedRoot, absGitDir),
+    ];
+    return exitSilent(results.join('; '));
   } catch (e) {
     return exitSilent(`unexpected: ${e.code || e.message}; skipping`);
   }

--- a/scripts/lib/check-tracker-ids.mjs
+++ b/scripts/lib/check-tracker-ids.mjs
@@ -1,0 +1,115 @@
+/**
+ * lib/check-tracker-ids.mjs — pure scanner for wiki-internal tracker IDs.
+ *
+ * The OSS repo must not ship references to the maintainer's PRIVATE wiki issue
+ * tracker (`ISSUE-N`) or fix tracker (`fix #N`) in public artifacts: an OSS user
+ * who opens a shipped file or reads the README/CHANGELOG just sees a dangling
+ * pointer into a tracker they cannot access. GitHub references (`PR #N`, `(#N)`,
+ * bare `#N`, issue URLs) are legitimate and must NOT be flagged.
+ *
+ * This module is PURE (no fs, no git, no process) so it is unit-testable; the
+ * CLI wrapper (scripts/check-tracker-ids.mjs) does the file/git/commit-msg I/O.
+ *
+ * Blocked (examples use an `N` placeholder, NOT a real digit, so this file
+ * itself scans clean and is NOT exempted from --all):
+ *   - /\bISSUE-\d+\b/i      → the wiki issue tracker, any case (e.g. ISSUE-N)
+ *   - /\bfix[ \t ]+#\d+\b/i → the wiki fix tracker, any case (e.g. fix #N)
+ *
+ * Accepted edge cases (documented, not bugs):
+ *   - FALSE POSITIVE: `FOO-ISSUE-N` matches (the `-` gives a word boundary
+ *     before ISSUE). Such a string in this repo would still be a tracker ref.
+ *   - The `fix #N` matcher requires the literal word `fix` immediately before the
+ *     `#`, so `prefix #N`, `suffix #N`, `PR #N`, `(#N)`, and bare `#N` are all
+ *     safe — none start the word `fix` right before the `#`.
+ */
+
+// Each entry: a named, /g/i regex over a single line of text.
+export const BLOCKED_PATTERNS = [
+  {
+    name: 'ISSUE-N',
+    label: 'wiki issue-tracker id',
+    re: /\bISSUE-\d+\b/gi,
+  },
+  {
+    name: 'fix #N',
+    label: 'wiki fix-tracker id',
+    re: /\bfix[ \t ]+#\d+\b/gi,
+  },
+];
+
+/**
+ * Scan a blob of text. Returns an array of hits:
+ *   { pattern, label, match, line, col, lineText }
+ * `line`/`col` are 1-based. Empty array => clean.
+ */
+export function scanText(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+  const hits = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const lineText = lines[i];
+    for (const { name, label, re } of BLOCKED_PATTERNS) {
+      re.lastIndex = 0; // reset shared /g regex between lines
+      let m;
+      while ((m = re.exec(lineText)) !== null) {
+        hits.push({
+          pattern: name,
+          label,
+          match: m[0],
+          line: i + 1,
+          col: m.index + 1,
+          lineText,
+        });
+        if (m.index === re.lastIndex) re.lastIndex++; // never-zero-width guard
+      }
+    }
+  }
+  return hits;
+}
+
+/**
+ * Strip a `--verbose` commit diff: everything from the scissors line onward is
+ * dropped by git before the commit is recorded, so it must not be scanned. The
+ * scissors art is comment-char-prefixed but the `>8` token is constant across
+ * comment chars, so match on that. Returns the text up to (excluding) the
+ * scissors line. If no scissors line is present, returns the input unchanged.
+ */
+// git's real scissors line is COMMENT-prefixed (`# ----- >8 -----`); a bare
+// `--- >8 ---` line is NOT a scissors marker (git keeps it as body), so it must
+// not trigger truncation. Require the leading comment char (default `#`, or `;`).
+const SCISSORS_RE = /^[ \t]*[#;][ \t]*-{2,}[ \t]*>8[ \t]*-{2,}/;
+
+export function stripScissors(text) {
+  if (typeof text !== 'string') return '';
+  const lines = text.split(/\r?\n/);
+  const idx = lines.findIndex((l) => SCISSORS_RE.test(l));
+  if (idx === -1) return text;
+  return lines.slice(0, idx).join('\n');
+}
+
+/**
+ * Does a commit-message file carry git's auto-generated template? git ONLY adds
+ * the instructional / status comment block (and the --verbose scissors) when the
+ * effective cleanup mode will STRIP comment lines (the editor default). In the
+ * comment-PRESERVING modes (`git commit -m` → whitespace, `--cleanup=verbatim`)
+ * git adds NO template, so a `#` line there is real committed content.
+ *
+ * The commit-msg hook therefore decides comment handling by template presence,
+ * not by config alone: template present ⇒ scan the strip-comments view (matches
+ * git, no false-positive on the template's branch/file names); template absent ⇒
+ * scan the raw view so a `#`-prefixed tracker id git WILL keep is still caught.
+ *
+ * Markers cover the default English git template + the scissors line. Other
+ * locales may miss the template and fall through to the raw (comment-keeping)
+ * scan — which is the SAFE direction for a gate (catches more, never less).
+ */
+export function messageHasGitTemplate(text) {
+  if (typeof text !== 'string') return false;
+  if (SCISSORS_RE_M.test(text)) return true; // --verbose scissors (comment-prefixed)
+  return /^[#;] *(Please enter the commit message|On branch |Changes to be committed:|Changes not staged for commit:|Untracked files:|Your branch (is|and))/m.test(
+    text,
+  );
+}
+
+// Multiline form of SCISSORS_RE for whole-message detection.
+const SCISSORS_RE_M = /^[ \t]*[#;][ \t]*-{2,}[ \t]*>8[ \t]*-{2,}/m;

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -1,5 +1,5 @@
 /**
- * scripts/lib/extensions.mjs — User extensions companion sync (ADR 0024, fix #29 + #30).
+ * scripts/lib/extensions.mjs — User extensions companion sync (ADR 0024).
  *
  * `~/hypomnema/extensions/{hooks,commands,skills,agents}/` holds user-authored
  * extensions, git-tracked alongside the wiki. init/upgrade hard-copy them into
@@ -80,7 +80,7 @@ function pkgRootDir(target) {
 
 /**
  * Discover sync-eligible extensions under `extDir`. Returns a per-type map plus a
- * `warnings` array. Applies the `.hypoignore` filter (fix #30), the basename
+ * `warnings` array. Applies the `.hypoignore` filter, the basename
  * whitelist (plan §5 #9), and pairs each file with its optional `<name>.manifest.json`.
  * No-ops gracefully when extDir is absent (e.g. --from-remote clones, plan §5 #8).
  */
@@ -364,7 +364,7 @@ export function syncExtensions({
   const discovered = discoverExtensions(extDir, patterns, hypoDir);
   result.warnings.push(...discovered.warnings);
 
-  // E4 (fix #32): Codex supports hooks + commands only. If the user authored
+  // E4: Codex supports hooks + commands only. If the user authored
   // skills/agents extensions, surface a one-time notice that they are skipped
   // for this target rather than silently dropping them (plan §2 E4).
   if (target === 'codex') {
@@ -505,7 +505,7 @@ export function syncExtensions({
  *   7. non-target event · mixed                                        (extract + append new)
  *   8. no occurrence                                                   (append new)
  *
- * Mixed-group invariant (fix #47, ADR 0024 amendment 2026-05-23): foreign hooks
+ * Mixed-group invariant (ADR 0024 amendment 2026-05-23): foreign hooks
  * sharing the matcher group are NEVER read, modified, or reordered. The hosting
  * group's matcher is also left exactly as-is once we extract — even when our
  * extraction is the reason the group becomes single-foreign. Foreign handler-

--- a/scripts/lib/fix-manifest.mjs
+++ b/scripts/lib/fix-manifest.mjs
@@ -76,10 +76,10 @@ export const FIX_MANIFEST = [
     // deliberate removal-marker comment + the negative-control test.
     fixId: 26,
     testNames: [
-      'replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (fix #26 negative control)',
+      'replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (negative control)',
     ],
     adrPath: 'decisions/0022-session-close-ux-automation.md',
-    adrKeyLine: 'Capacity bypass (≥90%) REMOVED — fix #26',
+    adrKeyLine: 'Capacity bypass (≥90%) REMOVED',
   },
   {
     fixId: 27,

--- a/scripts/lib/fix-status-verify.mjs
+++ b/scripts/lib/fix-status-verify.mjs
@@ -27,8 +27,8 @@ const NEGATIVE_STATUS_TOKENS = ['STALE_MERGED', 'partial', 'retired'];
 /**
  * Parse anchor comments out of runner.mjs source text.
  *
- *   // @fix #15: all type-conditional fields present → green
- *   // @fix #15: another test name
+ *   // @fix #N: all type-conditional fields present → green
+ *   // @fix #N: another test name
  *
  * The `@fix` prefix is mandatory — distinguishes anchors from prose comments
  * that mention "fix #N" in passing. Each anchor line maps ONE fix # to ONE
@@ -79,8 +79,9 @@ export function parseStatus(specText) {
   // For each line, find every fix # mention and check whether a positive
   // status token sits within a small proximity window AFTER the mention. This
   // avoids false positives when a line mentions multiple fix #s with status
-  // tokens that only apply to some of them (e.g. "fix #38 (resolved); fix #41
-  // (v1.3.0 advisory)" — only #38 should be picked up).
+  // tokens that only apply to some of them (e.g. a line where the first
+  // mention is "(resolved)" and a later one is "(advisory)" — only the first
+  // should be picked up).
   const lines = specText.split('\n');
   const PROXIMITY = 120; // chars after fix # to scan for status
   for (const line of lines) {

--- a/scripts/lib/project-create.mjs
+++ b/scripts/lib/project-create.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * project-create.mjs — atomic auto-project scaffold (fix #23, ADR 0023)
+ * project-create.mjs — atomic auto-project scaffold (ADR 0023)
  *
  * Invoked by the LLM (NOT a user-facing subcommand — ADR 0023 deprecated
  * `hypomnema project new`) after the user answers "Y" to a SessionStart /

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -81,7 +81,7 @@ const TYPE_CONDITIONAL_FIELDS = {
   'tool-eval': ['status'],
   postmortem: ['outcome'],
   learning: ['source'],
-  // feedback: ADR 0031 / fix #37 — projection SoT requires full classification
+  // feedback: ADR 0031 — projection SoT requires full classification
   feedback: [
     'status',
     'scope',
@@ -102,7 +102,7 @@ const TYPE_ENUM_FIELDS = {
   prd: { status: ['draft', 'active', 'completed', 'cancelled', 'archived'] },
   adr: { status: ['proposed', 'accepted', 'deprecated', 'superseded'] },
   'tool-eval': { status: ['adopted', 'evaluating', 'rejected'] },
-  // feedback: ADR 0031 / fix #37 — sensitivity:private is forbidden (wiki is a
+  // feedback: ADR 0031 — sensitivity:private is forbidden (wiki is a
   // git-pushed public surface)
   feedback: {
     status: ['active', 'superseded', 'archived'],

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -94,7 +94,7 @@ function resolveActiveProject(hypoDir, cwd = null) {
   ].map((m) => ({ name: m[1].trim(), date: m[2] || '', slug: m[3] }));
   if (wikiRows.length > 0) {
     wikiRows.sort((a, b) => b.date.localeCompare(a.date));
-    // Same-date tie-break (ISSUE-1): when the top date is shared by >1 row,
+    // Same-date tie-break: when the top date is shared by >1 row,
     // prefer the project whose working_dir contains cwd. No cwd / no match →
     // keep the stable-sort winner (the legacy "first table row" behavior).
     const topDate = wikiRows[0].date;

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -15,7 +15,7 @@
  *   --force-extensions   Remove user-modified extension files (hypo-ext-*) instead of preserving them
  *   --hooks-dir=<path>   Override Claude hooks directory (default: ~/.claude/hooks)
  *
- * Extensions (ADR 0024 fix #34): hypo-ext-* hard-copies under
+ * Extensions (ADR 0024): hypo-ext-* hard-copies under
  * ~/.claude/{hooks,commands,skills,agents}/ and ~/.codex/{hooks,commands}/ (with
  * --codex) are removed when their on-disk SHA matches the recorded one in
  * ~/.claude/hypo-pkg.json#extensions.<target>. User-modified copies are preserved

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -16,8 +16,8 @@
  *   --force-extensions  Overwrite user-modified / conflicting extension copies (creates .bak)
  *   --codex             Mirror to ~/.codex/{hooks,commands,settings.json} — core
  *                       hook drift/apply, settings.json registration, the
- *                       wiki-*.mjs → hypo-*.mjs rename migration (fix #48), and
- *                       the user-extensions companion sync (E4 / fix #32).
+ *                       wiki-*.mjs → hypo-*.mjs rename migration, and
+ *                       the user-extensions companion sync (E4).
  *   --json              Output results as JSON
  *   --allow-downgrade   Override the guard that refuses to overwrite a NEWER
  *                       active install with an older package (ADR 0038)
@@ -412,7 +412,7 @@ function applyHookNameMigration(oldRefs, settingsPath, hooksDir) {
   if (applied.length > 0) {
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
     // Copy renamed hook files to the target hooks dir (~/.claude/hooks or
-    // ~/.codex/hooks per the caller — fix #48 mirror).
+    // ~/.codex/hooks per the caller — codex mirror).
     for (const [oldName, newName] of Object.entries(HOOK_RENAMES)) {
       const oldPath = join(hooksDir, oldName);
       const newPath = join(hooksDir, newName);
@@ -761,7 +761,7 @@ function applyCommands(commandResults, force) {
   return applied;
 }
 
-// ISSUE-6: in plugin mode `applyCommands` is skipped (no command copy), but the
+// In plugin mode `applyCommands` is skipped (no command copy), but the
 // runtime still needs hypo-pkg.json to resolve PKG_ROOT for lint/feedback scripts
 // (hooks/hypo-shared.mjs → hypo-personal-check). Write minimal metadata pointing
 // at the plugin's package root, preserving any existing fields (e.g. `extensions`)
@@ -797,7 +797,7 @@ const claudeSettingsPath = join(HOME, '.claude', 'settings.json');
 const codexHooksDir = join(HOME, '.codex', 'hooks');
 const codexSettingsPath = join(HOME, '.codex', 'settings.json');
 
-// ISSUE-6: when `/hypo:upgrade` runs as the Claude Code PLUGIN, the 15 core hooks
+// When `/hypo:upgrade` runs as the Claude Code PLUGIN, the 15 core hooks
 // and 14 slash commands are provided by the plugin's hooks.json + commands/
 // (auto-wired by Claude Code), NOT copied into ~/.claude/. The manual/npm health
 // check below would then report all of them "missing" and recommend `--apply`,
@@ -865,7 +865,7 @@ const extCheck = syncExtensions({
   force: args.forceExtensions,
 });
 
-// E4 (fix #32): --codex mirrors the extensions sync into ~/.codex (hooks + commands
+// E4: --codex mirrors the extensions sync into ~/.codex (hooks + commands
 // only; skills/agents skipped with a notice). The per-target SHA map lives in the
 // same ~/.claude/hypo-pkg.json under extensions.codex, so pkgPath is unchanged.
 const extCodexSettingsPath = codexSettingsPath;
@@ -977,7 +977,7 @@ if (args.apply) {
     appliedCommands = applyCommands(commands, args.forceCommands);
     appliedPkgJson = true;
   } else if (pluginMode) {
-    // ISSUE-6 plugin mode: the plugin loader owns the core hooks/commands and
+    // Plugin mode: the plugin loader owns the core hooks/commands and
     // settings.json wiring — copying them here would double-register. Skip those,
     // but STILL write minimal package metadata so the runtime can resolve PKG_ROOT
     // for lint/feedback scripts (hooks/hypo-shared.mjs → hypo-personal-check). The
@@ -1030,7 +1030,7 @@ if (args.apply) {
     apply: true,
     force: args.forceExtensions,
   });
-  // E4 (fix #32): codex apply runs AFTER the claude apply so it reads the freshly
+  // E4: codex apply runs AFTER the claude apply so it reads the freshly
   // written hypo-pkg.json and merges extensions.codex alongside extensions.claude
   // (the per-target spread in syncExtensions preserves the other target's map).
   if (args.codex) {
@@ -1139,7 +1139,7 @@ if (args.json) {
 // Human-readable report
 const lines = [];
 
-// ISSUE-6: lead with the plugin-mode banner so the user understands why the core
+// Lead with the plugin-mode banner so the user understands why the core
 // hook/command/settings sections read "managed by plugin" and that `--apply` will
 // NOT touch them (only vault-side migrations + package metadata).
 if (pluginMode) {
@@ -1203,7 +1203,7 @@ if (schema.bump === 'none') {
   );
 }
 
-// Hook files (target-aware so --codex can mirror the same block; fix #48).
+// Hook files (target-aware so --codex can mirror the same block).
 function pushHookSummary(hookList, label, targetPath) {
   const colHook = `Hook files${label}`.padEnd(20);
   const up = hookList.filter((h) => h.status === 'up-to-date').length;
@@ -1236,7 +1236,7 @@ if (managesClaudeCore) {
 }
 if (hooksCodex) pushHookSummary(hooksCodex, ' (codex)', '~/.codex/hooks/');
 
-// settings.json registrations (target-aware mirror; fix #48).
+// settings.json registrations (target-aware mirror).
 function pushSettingsSummary(sList, label, invalidFlag) {
   const colS = `settings.json${label}`.padEnd(20);
   const reg = sList.filter((s) => s.status === 'registered').length;
@@ -1387,7 +1387,7 @@ function pushExtSummary(check, label) {
     for (const c of check.conflicts) lines.push(`    ✗ ${c.file}  [${c.action} — left untouched]`);
     for (const d of check.drifts) lines.push(`    ⚠ ${d.file}  [drift — left untouched]`);
   }
-  // E3 (fix #31): a hard conflict blocks install (exit 1, even under --apply); drift is
+  // E3: a hard conflict blocks install (exit 1, even under --apply); drift is
   // resolvable advisory. Emit the spec'd WIKI messages so the user knows the recovery.
   if (nConflicts > 0) {
     lines.push('  [WIKI: existing file conflicts. Backup and retry, or use --force-extensions]');
@@ -1503,11 +1503,11 @@ const totalDrift =
   extCheck.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
   ).length +
-  // E3 (fix #31): unresolved drift/conflict is pending work too — without these the
+  // E3: unresolved drift/conflict is pending work too — without these the
   // summary printed "up to date" while the exit code was 1.
   extCheck.conflicts.length +
   extCheck.drifts.length +
-  // E4 (fix #32): codex-target pending work counts identically (same message/exit
+  // E4: codex-target pending work counts identically (same message/exit
   // consistency the E3 review caught — a codex conflict must not read "up to date").
   (extCheckCodex
     ? extCheckCodex.actions.filter(
@@ -1548,7 +1548,7 @@ if (totalDrift === 0) {
 
 console.log(lines.join('\n'));
 
-// E3 (fix #31): a hard extension conflict blocks even under --apply (unlike ordinary
+// E3: a hard extension conflict blocks even under --apply (unlike ordinary
 // drift, which only fails check mode). --force-extensions clears the resolvable
 // cases; an unfollowable symlink/non-regular dest still counts and stays exit 1.
 const extBlocked = extCheck.conflicts.length > 0 || (extCheckCodex?.conflicts.length ?? 0) > 0;

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -69,7 +69,7 @@ After completing the checklist, verify it before reporting:
 node <package-root>/scripts/crystallize.mjs --check-session-close [--hypo-dir="<path>"]
 ```
 
-This runs the same strict check as the PreCompact hard gate (fix #17). Fix any
+This runs the same strict check as the PreCompact hard gate. Fix any
 file reported `missing` or `stale` and re-run until it passes — otherwise
 `/compact` will be blocked.
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -38,6 +38,11 @@ import {
   countHangul,
   HANGUL_BODY_THRESHOLD,
 } from '../scripts/lib/check-bilingual.mjs';
+import {
+  scanText,
+  stripScissors,
+  messageHasGitTemplate,
+} from '../scripts/lib/check-tracker-ids.mjs';
 
 const HOME = homedir();
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -1363,11 +1368,11 @@ test('HYPO_SKIP_GATE=1 bypasses an incomplete session close', () => {
 });
 
 // ── replay-personal-check-bypass-order (ADR 0022 amendment 2026-05-13) ──
-// @fix #26: replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (fix #26 negative control)
+// @fix #26: replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (negative control)
 // Capacity bypass (wiki-context-critical.json ≥90%) was removed. Spec §7.5:
 // the only bypass paths are HYPO_SKIP_GATE env / transcript user-role message.
 
-test('replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (fix #26 negative control)', () => {
+test('replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (negative control)', () => {
   withWiki(
     (dir) => {
       // Make session-close stale so the gate would normally block.
@@ -12350,11 +12355,47 @@ test('installer: fresh repo → installs shim with marker + 0755', () => {
     const target = join(dir, '.git', 'hooks', 'pre-commit');
     assert.ok(existsSync(target));
     const content = readFileSync(target, 'utf-8');
-    assert.ok(content.includes('hypomnema-pre-commit-marker v1'));
+    assert.ok(content.includes('hypomnema-pre-commit-marker v2'));
     assert.ok(content.includes('HYPOMNEMA_ROOT='));
     assert.ok(content.includes('HYPOMNEMA_GIT_DIR='));
+    // pre-commit chains the format step AND the tracker-id gate on staged blobs.
+    assert.ok(content.includes('pre-commit-format.mjs'));
+    assert.ok(content.includes('check-tracker-ids.mjs'));
+    assert.ok(content.includes('"$TRK" --staged'));
     const mode = statSync(target).mode & 0o777;
     assert.equal(mode & 0o100, 0o100, 'should be executable');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: fresh repo → also installs commit-msg hook (tracker gate)', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const r = runInstaller(dir);
+    assert.equal(r.status, 0);
+    const target = join(dir, '.git', 'hooks', 'commit-msg');
+    assert.ok(existsSync(target), 'commit-msg hook installed');
+    const content = readFileSync(target, 'utf-8');
+    assert.ok(content.includes('hypomnema-commit-msg-marker v2'));
+    assert.ok(content.includes('check-tracker-ids.mjs'));
+    assert.ok(content.includes('"$TRK" --commit-msg "$1"'));
+    assert.equal(statSync(target).mode & 0o100, 0o100, 'should be executable');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installer: existing non-marker commit-msg → not overwritten', () => {
+  const { dir } = setupHypomnemaFixture();
+  try {
+    const target = join(dir, '.git', 'hooks', 'commit-msg');
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, '#!/bin/sh\n# user commit-msg hook\nexit 0\n');
+    const before = readFileSync(target, 'utf-8');
+    const r = runInstaller(dir);
+    assert.equal(r.status, 0);
+    assert.equal(readFileSync(target, 'utf-8'), before, 'user commit-msg hook preserved');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -13429,6 +13470,244 @@ test('hypo-guide.md intentionally excluded from advisory surfaces (#47 follow-up
     !ADVISORY_SURFACES.includes(guidePath),
     'templates/hypo-guide.md must stay out of ADVISORY_SURFACES until #47 reconciles its auto-layer wording',
   );
+});
+
+// ── tracker-id gate (no-internal-tracker-ids-in-oss-artifacts) ───────────────
+suite('tracker-id gate (check-tracker-ids)');
+
+test('scanText flags ISSUE-N and fix #N (case + tab/space tolerant)', () => {
+  assert.equal(scanText('see ISSUE-7 here').length, 1);
+  assert.equal(scanText('issue-42 lowercase').length, 1);
+  assert.equal(scanText('(fix #68)')[0].match, 'fix #68');
+  assert.equal(scanText('Fix\t#40').length, 1);
+  assert.equal(scanText('fix  #3 multi-space').length, 1);
+  assert.equal(scanText('ISSUE-1 and fix #2').length, 2); // two hits on one line
+});
+
+test('scanText allows GitHub refs and lookalikes', () => {
+  for (const s of [
+    'PR #50',
+    'PRs #53~#56',
+    '(#101)',
+    'see #48',
+    'prefix #7',
+    'suffix #3',
+    'ADR 0040',
+    'decisions/0040',
+    'https://github.com/x/y/issues/3',
+  ]) {
+    assert.equal(scanText(s).length, 0, `should not flag: ${s}`);
+  }
+});
+
+test('scanText reports 1-based line/col', () => {
+  const hits = scanText('clean\nleak ISSUE-9 here');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].line, 2);
+  assert.equal(hits[0].col, 6);
+});
+
+test('messageHasGitTemplate detects editor template / scissors, not -m messages', () => {
+  assert.equal(messageHasGitTemplate('subject\n\nbody only\n'), false);
+  assert.equal(messageHasGitTemplate('subject\n\n# a plain user comment\n'), false);
+  assert.ok(
+    messageHasGitTemplate('subject\n# Please enter the commit message for your changes.\n'),
+  );
+  assert.ok(messageHasGitTemplate('subject\n# On branch main\n'));
+  assert.ok(
+    messageHasGitTemplate('subject\n# ------------------------ >8 ------------------------\n'),
+  );
+});
+
+test('stripScissors drops the --verbose diff from the >8 line onward', () => {
+  const msg =
+    'subject\n\nbody clean\n# ------------------------ >8 ------------------------\ndiff with fix #9 in it';
+  const out = stripScissors(msg);
+  assert.ok(out.includes('body clean'));
+  assert.ok(!out.includes('fix #9'));
+  assert.equal(stripScissors('plain\nmessage'), 'plain\nmessage'); // no scissors → unchanged
+});
+
+function runChecker(args, env = {}) {
+  return spawnSync(process.execPath, [join(SCRIPTS, 'check-tracker-ids.mjs'), ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: SESSION_TMP_HOME, ...env },
+  });
+}
+
+test('CLI --commit-msg: blocks a leak (exit 1)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(f, 'feat: thing\n\nImplements fix #99.\n');
+    const r = runChecker(['--commit-msg', f]);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /fix #99/);
+  });
+});
+
+test('CLI --commit-msg: clean with GitHub refs (exit 0)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(f, 'feat: thing (#101)\n\nSee PR #50 and #48. ADR 0040.\n');
+    assert.equal(runChecker(['--commit-msg', f]).status, 0);
+  });
+});
+
+test('CLI --commit-msg: a #-comment leak IS flagged when git has no template (commit -m / whitespace keeps it)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    // No git template present → this is a `commit -m` / whitespace-style message,
+    // where git KEEPS the `#` line. Must be flagged (closes the false-negative).
+    writeFileSync(f, 'clean subject\n\n# ISSUE-7 kept by whitespace cleanup\nreal body\n');
+    assert.equal(runChecker(['--commit-msg', f]).status, 1);
+  });
+});
+
+test('CLI --commit-msg: a leak after a bare ">8" line IS flagged with no template (git keeps it in -m)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    // No git template (commit -m / -F style). A bare ">8" line is NOT a git
+    // scissors marker (git only honors a comment-prefixed one in editor mode),
+    // so git keeps the line below it — the checker must scan it.
+    writeFileSync(
+      f,
+      'subject\n\n------------------------ >8 ------------------------\nafter fix #55\n',
+    );
+    const r = runChecker(['--commit-msg', f]);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /fix #55/);
+  });
+});
+
+test('CLI --commit-msg: a #-comment leak is ignored when git WILL strip it (editor template present)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    // Editor/strip mode: git appends its instructional template and strips ALL
+    // `#` lines, so a tracker id in a comment never reaches the commit → not flagged.
+    writeFileSync(
+      f,
+      'clean subject\n\n# ISSUE-7 in an editor comment\n' +
+        '# Please enter the commit message for your changes. Lines starting\n' +
+        '# with "#" will be ignored, and an empty message aborts the commit.\n' +
+        '# On branch feat/x\n',
+    );
+    assert.equal(runChecker(['--commit-msg', f]).status, 0);
+  });
+});
+
+test('CLI --commit-msg: a real prose leak is flagged even with an editor template', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(
+      f,
+      'feat: thing\n\nImplements fix #99 in the body.\n' +
+        '# Please enter the commit message for your changes.\n# On branch main\n',
+    );
+    const r = runChecker(['--commit-msg', f]);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /fix #99/);
+  });
+});
+
+// Synthetic git repo isolates --staged from the real index (CHECK_TRACKER_ROOT
+// test seam). Covers the staged-blob-vs-working-tree distinction codex flagged.
+function withSyntheticRepo(fn) {
+  withTmpDir((dir) => {
+    const env0 = {
+      ...process.env,
+      HOME: SESSION_TMP_HOME,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_SYSTEM: '/dev/null',
+    };
+    const g = (args) => spawnSync('git', args, { cwd: dir, encoding: 'utf-8', env: env0 });
+    g(['init', '-q']);
+    g(['config', 'user.email', 't@t']);
+    g(['config', 'user.name', 't']);
+    g(['config', 'commit.gpgsign', 'false']);
+    mkdirSync(join(dir, 'docs'), { recursive: true });
+    fn({ dir, g });
+  });
+}
+
+test('CLI --staged: blocks a staged leak, passes when clean', () => {
+  withSyntheticRepo(({ dir, g }) => {
+    writeFileSync(join(dir, 'docs', 'a.md'), 'clean see PR #5 and (#9)\n');
+    g(['add', 'docs/a.md']);
+    assert.equal(
+      runChecker(['--staged'], { CHECK_TRACKER_ROOT: dir }).status,
+      0,
+      'clean staged set should pass',
+    );
+    writeFileSync(join(dir, 'docs', 'b.md'), 'leak fix #9 here\n');
+    g(['add', 'docs/b.md']);
+    const r = runChecker(['--staged'], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 1, 'staged leak should block');
+    assert.match(r.stderr, /fix #9/);
+  });
+});
+
+test('CLI --staged: a working-tree-only leak is NOT gated (only the staged blob)', () => {
+  withSyntheticRepo(({ dir, g }) => {
+    writeFileSync(join(dir, 'docs', 'c.md'), 'clean\n');
+    g(['add', 'docs/c.md']);
+    writeFileSync(join(dir, 'docs', 'c.md'), 'clean\nfix #7 unstaged\n'); // working tree only
+    assert.equal(
+      runChecker(['--staged'], { CHECK_TRACKER_ROOT: dir }).status,
+      0,
+      'unstaged leak must not block — only the staged blob is gated',
+    );
+  });
+});
+
+test('CLI --staged: a leak in an EXCLUDED path (tests/) is not gated', () => {
+  withSyntheticRepo(({ dir, g }) => {
+    mkdirSync(join(dir, 'tests'), { recursive: true });
+    writeFileSync(join(dir, 'tests', 't.mjs'), '// ISSUE-7 legit test anchor\n');
+    g(['add', 'tests/t.mjs']);
+    assert.equal(
+      runChecker(['--staged'], { CHECK_TRACKER_ROOT: dir }).status,
+      0,
+      'tests/ is excluded maintainer scope',
+    );
+  });
+});
+
+test('CLI --all: package.json IS in scope (npm auto-ships it); a stray root file is NOT', () => {
+  withTmpDir((dir) => {
+    // package.json leak → flagged
+    writeFileSync(join(dir, 'package.json'), '{ "description": "leak fix #123" }\n');
+    assert.equal(
+      runChecker(['--all'], { CHECK_TRACKER_ROOT: dir }).status,
+      1,
+      'package.json leak must be caught',
+    );
+  });
+  withTmpDir((dir) => {
+    // an out-of-scope root file → NOT flagged (matches --staged scope)
+    writeFileSync(join(dir, 'NOTES.md'), 'random fix #123 in an unshipped root file\n');
+    assert.equal(
+      runChecker(['--all'], { CHECK_TRACKER_ROOT: dir }).status,
+      0,
+      'stray root file is out of scope',
+    );
+  });
+});
+
+test('CLI --staged: package.json leak is gated (scope agrees with --all)', () => {
+  withSyntheticRepo(({ dir, g }) => {
+    writeFileSync(join(dir, 'package.json'), '{ "description": "leak fix #7" }\n');
+    g(['add', 'package.json']);
+    const r = runChecker(['--staged'], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 1, 'staged package.json leak must block');
+    assert.match(r.stderr, /fix #7/);
+  });
+});
+
+test('CLI checker source files are NOT exempt — they scan clean via N placeholders', () => {
+  // Regression guard for the self-exclusion blocker: the shipped checker files
+  // must be scanned by --all and must be clean.
+  const r = runChecker(['--all']);
+  assert.equal(r.status, 0, `repo has tracker-id leaks:\n${r.stdout}${r.stderr}`);
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

A mechanical gate that keeps wiki-internal tracker IDs (the issue tracker
`ISSUE-N` and the fix tracker `fix #N`) out of OSS-public artifacts. These point
into the maintainer's private wiki and are dangling references for any OSS user;
a soft load-time reminder never hard-stopped them, so they accumulated across
shipped code, README/CHANGELOG, and command/skill docs.

## How

Enforced at three points (a leak fails the commit locally and CI authoritatively):

- **Scanner** (`scripts/lib/check-tracker-ids.mjs`) — pure, unit-tested. Blocks
  `ISSUE-N` / `fix #N` (case-insensitive, whitespace-tolerant). GitHub refs
  (`PR #N`, `(#N)`, bare `#N`, issue URLs) and ADR refs are deliberately allowed.
- **CLI** (`scripts/check-tracker-ids.mjs`) — `--all` (CI + `prepublishOnly`),
  `--staged` (pre-commit; scans the staged blob via the formatter's
  name-status/-z/diff-filter plumbing), `--commit-msg` (commit-msg hook).
- **Hooks** (`install-git-hooks.mjs`) — adds a commit-msg hook and chains the
  staged gate into pre-commit, preserving the fail-open identity model.

`--commit-msg` replicates git's own cleanup: editor (strip) commits drop comment
lines, while `commit -m` / whitespace / verbatim keep them and are scanned
verbatim. One exotic case is documented in code (an editor commit forced to a
non-default keep-cleanup); the file gate (`--all` / `--staged` / CI) is the hard
guarantee, commit-msg is best-effort.

Scope: `README(.ko).md`, `CHANGELOG.md`, `package.json`, and the shipped trees.
`tests/` and `qa-runs/` are internal-maintainer scope. The checker's own sources
are scanned (examples use an `N` placeholder, never a real digit).

## Cleanup

Removes the ~100 pre-existing references across the shipped tree, CHANGELOG, and
docs so the gate runs strict from day one (accompanying PR/ADR refs kept).

## Review + verification

- Two-stage codex review (design + pre-commit) plus a focused re-review; all
  findings incorporated and verified (self-file scanning, the git scissors /
  comment-cleanup edge cases, the test-seam env, and `--all`/`--staged` scope
  agreement).
- 651 tests green (unit + CLI integration across all three modes). The gate
  dogfoods on this very PR: the new hooks ran on this commit.

## Follow-up (not in this PR)

ADR references (`ADR NNNN` / `decisions/NNNN`) are the same class of dangling
private-wiki pointer but are deferred to a separate change (remove vs publish
the decision records is its own decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
