### PR TITLE
fix(precompact): scope transcript-less lint fallback to close files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **Migration for existing plugin users:** the install identifier changes from `hypomnema@hypomnema` to `hypo@hypomnema`. Disable or remove the old plugin, then run `/plugin install hypo@hypomnema` followed by `/reload-plugins`. Until you reinstall, the old `/hypomnema:*` commands keep working from the cached plugin. The npm/manual `/hypo:upgrade` dual-install guard now recognizes both the new `hypo` and the legacy `hypomnema` plugin entry in `enabledPlugins`, so it still suppresses the double-registration of core hooks across the migration window, and the update notifier resolves the plugin's latest version under either name.
 
+### Fixed
+
+- **A transcript-less PreCompact no longer blocks `/compact` on unrelated lint debt.** The session-close gate scopes blocking lint to the files this session is accountable for (the mandatory close files, plus any file the transcript shows it edited), surfacing everything else as a non-blocking notice. The no-transcript fallback was the exception: it reverted to gating the **whole vault**, so a lint error in another project or a shared page (debt this session never touched) would hold `/compact` hostage. The fallback now scopes to the mandatory close files (`closeFileTargets`), the only files derivable without a transcript. Normal interactive `/compact` is unaffected (both manual and automatic compaction always carry a transcript, per the Claude Code hooks contract); this only changes the headless / programmatic path, where the old global gate was the wrong scope rather than a safer one. The have-transcript path is behavior-preserving.
+
 ### 한글 요약
 
 - **Claude 마켓플레이스 플러그인 이름을 `hypomnema`에서 `hypo`로 변경해 슬래시 커맨드가 문서와 일치하게 됨.** Claude Code는 플러그인 슬래시 커맨드를 플러그인의 `name` 필드로 네임스페이싱한다. 그래서 이름이 `hypomnema`인 플러그인은 커맨드를 실제로 `/hypomnema:resume`, `/hypomnema:init` 등으로 등록했다. 모든 문서·커맨드 본문·`/hypo:init` 안내는 `/hypo:*`을 가정했으므로, 마켓플레이스로 설치하고 README를 따라 한 사용자는 "command not found"를 만났다. (npm/수동 설치 경로는 영향이 없었다: 커맨드 파일을 `~/.claude/commands/hypo/`로 복사하므로 처음부터 `/hypo:*`이 된다.) 플러그인 이름을 `hypo`로 바꾸면 두 설치 경로 모두 문서가 설명하는 동일한 `/hypo:*` 네임스페이스를 노출한다. 마켓플레이스 이름(`hypomnema`)은 그대로라 `/plugin marketplace add`와 `/plugin marketplace update hypomnema`는 불변이며, 설치 명령의 플러그인 식별자만 바뀐다.
 
   **기존 플러그인 사용자 마이그레이션:** 설치 식별자가 `hypomnema@hypomnema`에서 `hypo@hypomnema`로 바뀐다. 기존 플러그인을 비활성/제거한 뒤 `/plugin install hypo@hypomnema` 다음 `/reload-plugins`를 실행하라. 재설치 전까지는 캐시된 플러그인의 기존 `/hypomnema:*` 커맨드가 계속 동작한다. npm/수동 `/hypo:upgrade`의 dual-install 가드는 이제 `enabledPlugins`에서 새 `hypo`와 레거시 `hypomnema` 항목을 모두 인식하므로 마이그레이션 기간에도 core 훅 중복 등록을 계속 막고, 업데이트 notifier도 두 이름 중 어느 쪽으로든 플러그인 최신 버전을 해석한다.
+
+### Fixed (한글)
+
+- **transcript가 없는 PreCompact가 무관한 lint debt로 `/compact`를 더는 차단하지 않음.** session-close 게이트는 차단성 lint을 이 세션이 책임지는 파일(필수 close 파일 + transcript가 보여주는 편집 파일)로 스코프하고 나머지는 non-blocking notice로 표시한다. 무-transcript fallback만 예외로 **vault 전체**를 게이트해서, 이 세션이 건드리지도 않은 타 프로젝트·공유 페이지의 lint error가 `/compact`를 인질로 잡았다. 이제 fallback은 필수 close 파일(`closeFileTargets`)로 스코프된다. 이 파일들은 transcript 없이 도출 가능한 유일한 파일이다. 일반 인터랙티브 `/compact`는 영향 없음(manual·auto 압축 모두 Claude Code 훅 계약상 항상 transcript를 실음). 이 변경은 headless/프로그램적 경로에만 적용되며, 거기서 옛 전역 게이트는 더 안전한 스코프가 아니라 잘못된 스코프였다. transcript가 있는 경로는 동작이 보존된다.
 
 ## [1.3.1] - 2026-06-09
 

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -125,30 +125,36 @@ process.stdin.on('end', () => {
       const allErrors = parsed.errors || [];
       const allW8 = (parsed.warns || []).filter((w) => w.id === 'W8');
       // Bug B: judge this session on the files IT touched, not the whole vault.
-      // A readable transcript lets us scope (edited files ∪ mandatory close
-      // files); a missing/unreadable transcript falls back to the conservative
-      // global gate (never weaker than before).
+      // Scope = the mandatory close files (always derivable without a transcript)
+      // plus the files this session edited (only knowable with a transcript). A
+      // readable transcript widens the scope to the session's Edit/Write targets.
+      // Without one (headless, apply-path close, or programmatic invocation) the
+      // scope is exactly closeFileTargets, the mandatory close files and the only
+      // files derivable without a transcript. (crystallize --apply-session-close
+      // can also write an optional pages/open-questions.md, but PreCompact cannot
+      // locate that without a transcript or payload and the apply path gates it
+      // on its own.) Cross-project or shared-page debt the
+      // session did not touch becomes a non-blocking notice either way, so an
+      // unrelated lint error elsewhere never holds /compact hostage. See ADR 0041,
+      // which reverses ADR 0037's conservative global fallback (real interactive
+      // /compact always carries a transcript, so the old fallback only ever fired
+      // in transcript-less modes where closeFileTargets is already complete).
       const haveTranscript = !!(transcriptPath && existsSync(transcriptPath));
+      const scope = new Set(closeFileTargets(HYPO_DIR));
       if (haveTranscript) {
-        const scope = new Set([
-          ...extractTouchedWikiFiles(transcriptPath, HYPO_DIR),
-          ...closeFileTargets(HYPO_DIR),
-        ]);
-        const part = partitionLintScope(allErrors, scope);
-        lintBlockers = part.blocking;
-        lintNotices = part.notice;
-        // W8 (design-history stale) is the CURRENT project's close
-        // responsibility, not cross-project debt — block on the active
-        // project's, surface others' as notices.
-        if (closeFiles.project) {
-          const mine = `projects/${closeFiles.project}/design-history.md`;
-          lintW8 = allW8.filter((w) => w.file === mine);
-          lintNotices.push(...allW8.filter((w) => w.file !== mine));
-        } else {
-          lintW8 = allW8;
-        }
+        for (const f of extractTouchedWikiFiles(transcriptPath, HYPO_DIR)) scope.add(f);
+      }
+      const part = partitionLintScope(allErrors, scope);
+      lintBlockers = part.blocking;
+      lintNotices = part.notice;
+      // W8 (design-history stale) is the CURRENT project's close
+      // responsibility, not cross-project debt: block on the active project's,
+      // surface others' as notices.
+      if (closeFiles.project) {
+        const mine = `projects/${closeFiles.project}/design-history.md`;
+        lintW8 = allW8.filter((w) => w.file === mine);
+        lintNotices.push(...allW8.filter((w) => w.file !== mine));
       } else {
-        lintBlockers = allErrors;
         lintW8 = allW8;
       }
     } catch (err) {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1375,6 +1375,63 @@ test('PreCompact with transcript touching an out-of-scope file → that file blo
   );
 });
 
+test('no-transcript PreCompact: active project design-history stale → blocks (W8)', () => {
+  // W8 (design-history stale) for the ACTIVE project is this session's close
+  // responsibility and must block, in the no-transcript path too (ADR 0041
+  // unifies the branches so W8 is scoped to the active project either way).
+  withWiki(
+    (dir) => {
+      writeFileSync(
+        join(dir, 'projects', 'test-project', 'design-history.md'),
+        '---\ntitle: design-history\ntype: design-history\nupdated: 2026-01-01\n---\n\n## 2026-01-01\n- old\n',
+      );
+    },
+    (dir) => {
+      const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.decision,
+        'block',
+        `active-project stale design-history must block: ${r.stdout}`,
+      );
+      assert.ok(
+        out.reason.includes('design-history stale'),
+        `block reason should name design-history staleness: ${out.reason}`,
+      );
+    },
+  );
+});
+
+test('no-transcript PreCompact: another project design-history stale → notice, not blocking (W8 scoped to active, ADR 0041)', () => {
+  // A DIFFERENT project's stale design-history is cross-project debt, not this
+  // session's responsibility. The old no-transcript branch gated on all
+  // projects' W8 (lintW8 = allW8); the unified branch scopes W8 to the active
+  // project, so another project's staleness surfaces as a notice, not a block.
+  withWiki(
+    (dir, today) => {
+      const otherLog = join(dir, 'projects', 'other-proj', 'session-log');
+      mkdirSync(otherLog, { recursive: true });
+      writeFileSync(
+        join(dir, 'projects', 'other-proj', 'design-history.md'),
+        '---\ntitle: design-history\ntype: design-history\nupdated: 2026-01-01\n---\n\n## 2026-01-01\n- old\n',
+      );
+      writeFileSync(
+        join(otherLog, `${today.slice(0, 7)}.md`),
+        `---\ntitle: Session Log\ntype: session-log\nupdated: ${today}\n---\n\n## [${today}] other session\n`,
+      );
+    },
+    (dir) => {
+      const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.continue,
+        true,
+        `another project's stale design-history must not block the active project's compact: ${r.stdout}`,
+      );
+    },
+  );
+});
+
 test('open-questions.md absent/stale → still passes (conditional, not gated)', () => {
   withWiki(
     (dir) => {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1271,6 +1271,42 @@ test('lint blockers without id field → reason names files, no empty placeholde
   // never carry an id (only W8 warns do). The result was a reason like
   // `lint blockers: , , , , , , ,` — blocks correctly but tells the user
   // nothing actionable. Fix: fall back to file path + dedupe.
+  //
+  // The lint error must live in an IN-SCOPE close file (ADR 0041): a no-transcript
+  // PreCompact scopes blocking lint to closeFileTargets, so an out-of-scope page
+  // would only surface as a notice. session-state.md (a mandatory close file)
+  // missing its required next-task heading is a SCHEMA-independent lint error.
+  withWiki(
+    (dir, today) => {
+      writeFileSync(
+        join(dir, 'projects', 'test-project', 'session-state.md'),
+        `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n## Wrong Heading\n\n- next\n`,
+      );
+    },
+    (dir) => {
+      const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.decision, 'block', `expected block: ${r.stdout}`);
+      assert.ok(
+        out.reason.includes('lint blockers: projects/test-project/session-state.md'),
+        `lint blockers should name the file, got: ${out.reason}`,
+      );
+      assert.ok(
+        !/lint blockers:\s*,/.test(out.reason),
+        `lint blockers section must not start with empty commas: ${out.reason}`,
+      );
+    },
+  );
+});
+
+test('no-transcript PreCompact: out-of-scope lint error → notice, not blocking (ADR 0041)', () => {
+  // ADR 0041 (reverses ADR 0037's global fallback): a PreCompact with no
+  // transcript scopes blocking lint to closeFileTargets. An error in a file this
+  // session did not touch (other project / shared page) must NOT hold /compact
+  // hostage — it surfaces as a non-blocking notice. Real interactive /compact
+  // always carries a transcript, so this fallback only fires in headless /
+  // apply-path / programmatic modes where closeFileTargets is the complete set
+  // of session-accountable files.
   withWiki(
     (dir) => {
       mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
@@ -1282,14 +1318,58 @@ test('lint blockers without id field → reason names files, no empty placeholde
     (dir) => {
       const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir });
       const out = JSON.parse(r.stdout);
-      assert.equal(out.decision, 'block', `expected block: ${r.stdout}`);
-      assert.ok(
-        out.reason.includes('lint blockers: pages/feedback/broken.md'),
-        `lint blockers should name the file, got: ${out.reason}`,
+      assert.equal(
+        out.continue,
+        true,
+        `out-of-scope lint debt must not block a no-transcript compact: ${r.stdout}`,
       );
       assert.ok(
-        !/lint blockers:\s*,/.test(out.reason),
-        `lint blockers section must not start with empty commas: ${out.reason}`,
+        out.systemMessage && out.systemMessage.includes('pages/feedback/broken.md'),
+        `the out-of-scope error should surface as a notice naming the file: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('PreCompact with transcript touching an out-of-scope file → that file blocks', () => {
+  // The transcript widens the scope: a file the session actually edited via
+  // Edit/Write is in-scope and its lint error blocks, even though it lives
+  // outside closeFileTargets. This is the have-transcript half of ADR 0041.
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(
+        join(dir, 'pages', 'feedback', 'broken.md'),
+        '---\ntitle: broken\ntype: feedback\nstatus: active\nscope: INVALID-SCOPE\nsensitivity: public\nupdated: 2026-05-26\n---\n',
+      );
+    },
+    (dir) => {
+      const transcript = join(dir, 'transcript.jsonl');
+      writeFileSync(
+        transcript,
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: join(dir, 'pages', 'feedback', 'broken.md') },
+              },
+            ],
+          },
+        }),
+      );
+      const r = runHook(
+        'hypo-personal-check.mjs',
+        { transcript_path: transcript },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.decision, 'block', `a touched file's lint error must block: ${r.stdout}`);
+      assert.ok(
+        out.reason.includes('lint blockers: pages/feedback/broken.md'),
+        `block reason should name the touched file: ${out.reason}`,
       );
     },
   );


### PR DESCRIPTION
## What

The session-close PreCompact gate scopes blocking lint to the files this session is accountable for (the mandatory close files, plus any file the transcript shows it edited) and surfaces everything else as a non-blocking notice. The **no-transcript fallback was the exception**: it reverted to gating the whole vault, so a lint error in another project or a shared page (debt this session never touched) would block `/compact`.

This scopes the fallback to `closeFileTargets`, the mandatory close files, which are the only files derivable without a transcript.

## Why it's safe

- Real interactive `/compact` always carries a `transcript_path` for both manual and automatic compaction (Claude Code hooks contract, confirmed against 649/649 recorded sessions). The fallback only fires in headless / apply-path / programmatic invocations.
- In exactly those transcript-less modes, the only wiki files a session writes are the mandatory close files (the apply path writes them via Bash). So scoping to `closeFileTargets` is the precise scope, not a weakening. The old global gate was the wrong scope, holding `/compact` hostage to unrelated debt.
- The two branches are unified, so the have-transcript path is behavior-preserving (scope = touched ∪ close-files). W8 (design-history stale) now scopes to the active project in both paths.
- No-active-project case (scope = `{hot.md, log.md}`) is safe: `sessionCloseFileStatus` already blocks an unresolved project independently, so project-file lint notices cannot mask success.

## Tests

651 → 653.
- Reworked the lint-blocker reason-formatting test to use an **in-scope** close-file error (a `session-state.md` missing its required next-task heading).
- New: out-of-scope error + no transcript → notice, not blocking.
- New: out-of-scope error + transcript that touched the file → blocks.

## Review

Two-stage codex cross-review (design + pre-commit), both CLEAR/CONCERN with the concerns addressed (don't overstate `closeFileTargets` as the complete writer-touch set; the apply path also writes an optional open-questions page that PreCompact cannot derive without a transcript). The accompanying decision record reverses the earlier "conservative global fallback" choice with the evidence above.

---

## 한글 요약

session-close PreCompact 게이트는 차단성 lint을 이 세션이 책임지는 파일(필수 close 파일 + transcript가 보여주는 편집 파일)로 스코프하고 나머지는 non-blocking notice로 표시한다. **무-transcript fallback만 예외**로 vault 전체를 게이트해서, 이 세션이 건드리지도 않은 타 프로젝트·공유 페이지의 lint error가 `/compact`를 인질로 잡았다.

이 PR은 fallback을 필수 close 파일(`closeFileTargets`, transcript 없이 도출 가능한 유일한 파일)로 스코프한다.

**안전성**: 인터랙티브 `/compact`는 manual·auto 모두 항상 transcript를 싣는다(Claude Code 훅 계약, 기록 세션 649/649 전수 확인). fallback은 headless/apply-path/프로그램적 호출에서만 발화하고, 그 모드에서 세션이 쓰는 파일은 필수 close 파일뿐이라 스코프 축소가 아니라 정확한 스코프다. 두 분기를 통합해 transcript가 있는 경로는 동작이 보존되며, no-project 케이스는 `sessionCloseFileStatus`가 이미 독립적으로 차단하므로 안전하다.

**테스트** 651→653: reason-formatting 테스트를 in-scope 에러로 재작성 + out-of-scope→notice + transcript-touch→block 신규 2건. 설계·commit 직전 2단계 codex 교차 검토 반영.