### PR TITLE
fix(close): gate every today-active project, not a single recency pick

### DIFF
--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -28,13 +28,13 @@ import {
   PKG_ROOT,
   hypoIsClean,
   hotMdIsClean,
-  sessionCloseFileStatus,
+  sessionCloseGlobalStatus,
   readChecklist,
   isGateSkipped,
   isClosePattern,
   extractUserMessages,
   extractTouchedWikiFiles,
-  closeFileTargets,
+  closeFileTargetsGlobal,
   partitionLintScope,
 } from './hypo-shared.mjs';
 
@@ -99,7 +99,10 @@ process.stdin.on('end', () => {
   // checklist). closeFiles gates the 5 mandatory files (steps 1-4 + log.md);
   // open-questions.md (step 5) is conditional ("변경 시") and intentionally
   // ungated — see hypo-shared.mjs sessionCloseFileStatus and spec §5.2.7.
-  const closeFiles = sessionCloseFileStatus(HYPO_DIR);
+  // ADR 0043: global invariant — block if ANY today-active project has a
+  // dangling close, never a single recency/cwd pick. Flat aliases
+  // (.missing/.stale/.project) keep a single-project session byte-identical.
+  const closeFiles = sessionCloseGlobalStatus(HYPO_DIR);
   const closeFilesReason = closeFiles.ok
     ? ''
     : `memory files not updated this session: ${[
@@ -140,20 +143,22 @@ process.stdin.on('end', () => {
       // /compact always carries a transcript, so the old fallback only ever fired
       // in transcript-less modes where closeFileTargets is already complete).
       const haveTranscript = !!(transcriptPath && existsSync(transcriptPath));
-      const scope = new Set(closeFileTargets(HYPO_DIR));
+      const scope = new Set(closeFileTargetsGlobal(HYPO_DIR));
       if (haveTranscript) {
         for (const f of extractTouchedWikiFiles(transcriptPath, HYPO_DIR)) scope.add(f);
       }
       const part = partitionLintScope(allErrors, scope);
       lintBlockers = part.blocking;
       lintNotices = part.notice;
-      // W8 (design-history stale) is the CURRENT project's close
-      // responsibility, not cross-project debt: block on the active project's,
-      // surface others' as notices.
-      if (closeFiles.project) {
-        const mine = `projects/${closeFiles.project}/design-history.md`;
-        lintW8 = allW8.filter((w) => w.file === mine);
-        lintNotices.push(...allW8.filter((w) => w.file !== mine));
+      // W8 (design-history stale) is each today-active project's own close
+      // responsibility, not cross-project debt: block on every today-active
+      // project's design-history, surface others' as notices (ADR 0043 —
+      // multiple projects can be closing in one session).
+      const activeSlugs = (closeFiles.projects || []).map((p) => p.project).filter(Boolean);
+      if (activeSlugs.length > 0) {
+        const mine = new Set(activeSlugs.map((s) => `projects/${s}/design-history.md`));
+        lintW8 = allW8.filter((w) => mine.has(w.file));
+        lintNotices.push(...allW8.filter((w) => !mine.has(w.file)));
       } else {
         lintW8 = allW8;
       }

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -6,7 +6,15 @@
  * Hooks are deployed to ~/.claude/hooks/ — no external imports allowed.
  */
 
-import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from 'fs';
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  appendFileSync,
+  mkdirSync,
+  rmSync,
+  readdirSync,
+} from 'fs';
 import { join, relative, basename } from 'path';
 import { homedir, hostname, tmpdir } from 'os';
 import { spawnSync } from 'child_process';
@@ -419,6 +427,169 @@ export function sessionCloseFileStatus(hypoDir, { projectOverride = null } = {})
   }
 
   return { ok: stale.length === 0 && missing.length === 0, project, dates, stale, missing };
+}
+
+// ── global session-close gate (ADR 0043) ────
+// The no-payload close paths must NOT pick one project (recency / cwd) and check
+// it — that re-derivation is the prior session-close false-block, and a cwd
+// tie-break here would let a fresh cwd mask a DIFFERENT project's dangling
+// close. Instead the gate enforces a global invariant: no project may end a
+// session with a partial close. resume stays cwd-positive; close never picks.
+// The two copies of resolveActiveProject deliberately differ — see resume.mjs.
+
+// Root hot.md Active-Projects rows as {slug, date}. The per-row date column is
+// project-scoped (unlike the shared frontmatter `updated:`), so a today-dated
+// row is a legitimate close-activity signal. Mirrors resolveActiveProject's regex.
+function rootHotRows(hypoDir) {
+  const hotPath = join(hypoDir, 'hot.md');
+  if (!existsSync(hotPath)) return [];
+  let content;
+  try {
+    content = readFileSync(hotPath, 'utf-8').replace(/<!--[\s\S]*?-->/g, '');
+  } catch {
+    return [];
+  }
+  return [
+    ...content.matchAll(
+      /\|\s*([^|]+?)\s*\|\s*(\d{4}-\d{2}-\d{2})?\s*\|\s*\[\[projects\/([^\]/]+)\/[^\]]+\]\]/g,
+    ),
+  ].map((m) => ({ slug: m[3], date: m[2] || '' }));
+}
+
+// Candidate slugs the global gate must consider: real project dirs (with a
+// session-state.md, skip _template) ∪ slugs in a today-dated `## [today] session
+// | P` log.md entry ∪ slugs in a today-dated root hot.md row. The log/row unions
+// catch a dangling close whose own project files are missing —
+// sessionCloseFileStatus(projectOverride) reports those as `missing` correctly.
+function closeCandidateSlugs(hypoDir, dates) {
+  const slugs = new Set();
+  const projectsDir = join(hypoDir, 'projects');
+  if (existsSync(projectsDir)) {
+    let entries = [];
+    try {
+      entries = readdirSync(projectsDir);
+    } catch {
+      entries = [];
+    }
+    for (const p of entries) {
+      if (p === '_template') continue;
+      if (existsSync(join(projectsDir, p, 'session-state.md'))) slugs.add(p);
+    }
+  }
+  for (const r of rootHotRows(hypoDir)) {
+    if (r.date && dates.includes(r.date)) slugs.add(r.slug);
+  }
+  const logPath = join(hypoDir, 'log.md');
+  if (existsSync(logPath)) {
+    let content = '';
+    try {
+      content = readFileSync(logPath, 'utf-8');
+    } catch {
+      content = '';
+    }
+    for (const d of dates) {
+      const re = new RegExp('^## \\[' + escapeRegExp(d) + '\\] session \\| (\\S+)', 'gm');
+      for (const m of content.matchAll(re)) slugs.add(m[1]);
+    }
+  }
+  return slugs;
+}
+
+// True when project P shows ANY today close-activity signal: session-state or
+// project hot.md frontmatter `updated:` today, a today-dated session-log heading,
+// a today log.md `session | P` entry, or a today-dated root hot.md row for P.
+// (Root hot.md *frontmatter* is shared and is NOT a signal; the per-project ROW
+// date is.)
+function hasTodayCloseActivity(hypoDir, project, dates) {
+  const fresh = (rel) => {
+    const full = join(hypoDir, rel);
+    if (!existsSync(full)) return false;
+    try {
+      return dates.includes(frontmatterUpdated(readFileSync(full, 'utf-8')));
+    } catch {
+      return false;
+    }
+  };
+  if (fresh(join('projects', project, 'session-state.md'))) return true;
+  if (fresh(join('projects', project, 'hot.md'))) return true;
+  for (const d of dates) {
+    const sl = join(hypoDir, 'projects', project, 'session-log', `${d.slice(0, 7)}.md`);
+    if (existsSync(sl)) {
+      try {
+        if (hasSessionLogHeading(readFileSync(sl, 'utf-8'), d)) return true;
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  const logPath = join(hypoDir, 'log.md');
+  if (existsSync(logPath)) {
+    try {
+      const c = readFileSync(logPath, 'utf-8');
+      if (dates.some((d) => hasLogEntry(c, d, project))) return true;
+    } catch {
+      /* skip */
+    }
+  }
+  for (const r of rootHotRows(hypoDir)) {
+    if (r.slug === project && r.date && dates.includes(r.date)) return true;
+  }
+  return false;
+}
+
+/**
+ * Global session-close status for the no-payload close paths (ADR 0043).
+ * Checks EVERY project with today close-activity; ok only when all are complete.
+ * When no project has today activity, falls back to the legacy single recency
+ * project (preserves "force the initial close" behavior, byte-identical gate).
+ *
+ * stale/missing entries are self-describing paths — project-specific files carry
+ * `projects/<slug>/…`, root files (`hot.md`/`log.md`) are shared — so the flat
+ * aliases need no project prefix and a single-project session is byte-identical
+ * to sessionCloseFileStatus (back-compat for the flat-field readers).
+ *
+ * @param {string} hypoDir
+ * @returns {{ok: boolean, projects: Array<{project:string, ok:boolean, stale:string[], missing:string[]}>,
+ *            dates: string[], fallback: boolean, primary: string|null,
+ *            project: string|null, stale: string[], missing: string[]}}
+ */
+export function sessionCloseGlobalStatus(hypoDir) {
+  const dates = freshDates();
+  const recency = resolveActiveProject(hypoDir); // no cwd — close never picks by cwd
+  const todayActive = [...closeCandidateSlugs(hypoDir, dates)].filter((p) =>
+    hasTodayCloseActivity(hypoDir, p, dates),
+  );
+
+  if (todayActive.length === 0) {
+    const legacy = sessionCloseFileStatus(hypoDir);
+    return {
+      ok: legacy.ok,
+      projects: legacy.project
+        ? [{ project: legacy.project, ok: legacy.ok, stale: legacy.stale, missing: legacy.missing }]
+        : [],
+      dates,
+      fallback: true,
+      primary: legacy.project,
+      project: legacy.project,
+      stale: legacy.stale,
+      missing: legacy.missing,
+    };
+  }
+
+  // primary = the recency project when it is itself today-active, else the first
+  // today-active slug (stable order from the candidate set). Used only as the
+  // single-slug alias (marker `project` field, message header) — never to gate.
+  const primary = recency && todayActive.includes(recency) ? recency : todayActive[0];
+  const ordered = [primary, ...todayActive.filter((p) => p !== primary)];
+
+  const projects = ordered.map((p) => {
+    const s = sessionCloseFileStatus(hypoDir, { projectOverride: p });
+    return { project: p, ok: s.ok, stale: s.stale, missing: s.missing };
+  });
+  const ok = projects.every((x) => x.ok);
+  const stale = [...new Set(projects.flatMap((x) => x.stale))];
+  const missing = [...new Set(projects.flatMap((x) => x.missing))];
+  return { ok, projects, dates, fallback: false, primary, project: primary, stale, missing };
 }
 
 // ── sync-state ────────────────────────────────────────────
@@ -961,6 +1132,31 @@ export function closeFileTargets(hypoDir) {
     out.add(`projects/${project}/hot.md`);
     const month = freshDates()[0].slice(0, 7);
     out.add(`projects/${project}/session-log/${month}.md`);
+  }
+  return out;
+}
+
+/**
+ * Global variant of closeFileTargets for the no-payload lint-scope callers
+ * (ADR 0043). Union of the close files over every today-active project
+ * (fallback: the recency project when none is active). Includes the session-log
+ * month for EVERY freshDate (not just dates[0]) so the lint scope matches what
+ * sessionCloseFileStatus actually checks across a local/UTC month boundary.
+ */
+export function closeFileTargetsGlobal(hypoDir) {
+  const dates = freshDates();
+  const out = new Set(['hot.md', 'log.md']);
+  let active = [...closeCandidateSlugs(hypoDir, dates)].filter((p) =>
+    hasTodayCloseActivity(hypoDir, p, dates),
+  );
+  if (active.length === 0) {
+    const recency = resolveActiveProject(hypoDir);
+    if (recency) active = [recency];
+  }
+  for (const p of active) {
+    out.add(`projects/${p}/session-state.md`);
+    out.add(`projects/${p}/hot.md`);
+    for (const d of dates) out.add(`projects/${p}/session-log/${d.slice(0, 7)}.md`);
   }
   return out;
 }

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -76,11 +76,12 @@ import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import {
   sessionCloseFileStatus,
+  sessionCloseGlobalStatus,
   writeSessionClosedMarker,
   sessionClosedMarkerPath,
   hypoIsClean,
   extractTouchedWikiFiles,
-  closeFileTargets,
+  closeFileTargetsGlobal,
   partitionLintScope,
 } from '../hooks/hypo-shared.mjs';
 
@@ -145,7 +146,9 @@ function parseArgs(argv) {
 // flow can self-verify before /compact triggers PreCompact.
 
 function runSessionCloseCheck(args) {
-  const status = sessionCloseFileStatus(args.hypoDir);
+  // ADR 0043: no-payload self-check uses the global invariant
+  // so it mirrors the PreCompact gate (every today-active project must be closed).
+  const status = sessionCloseGlobalStatus(args.hypoDir);
 
   if (args.json) {
     console.log(
@@ -339,10 +342,12 @@ function runMarkSessionClosed(args) {
     process.exit(1);
   }
   // ADR 0022 amendment 2026-05-19 Q2: marker write authority requires BOTH
-  // sessionCloseFileStatus.ok AND hypoIsClean.clean — git dirty would let a
-  // Stop hook pass while wiki changes are still uncommitted (auto-commit may
-  // have failed in this run). Codex Worker-1 BLOCKER (pre-commit review).
-  const status = sessionCloseFileStatus(args.hypoDir);
+  // close gate ok AND hypoIsClean.clean — git dirty would let a Stop hook pass
+  // while wiki changes are still uncommitted (auto-commit may have failed in
+  // this run). Codex Worker-1 BLOCKER (pre-commit review).
+  // ADR 0043: global invariant — a marker must not be written
+  // while ANY today-active project still has a dangling close (no recency pick).
+  const status = sessionCloseGlobalStatus(args.hypoDir);
   const git = hypoIsClean(args.hypoDir);
   if (!status.ok || !git.clean) {
     const result = {
@@ -385,7 +390,7 @@ function runMarkSessionClosed(args) {
     if (scopedLint) {
       const scope = new Set([
         ...extractTouchedWikiFiles(args.transcriptPath, args.hypoDir),
-        ...closeFileTargets(args.hypoDir),
+        ...closeFileTargetsGlobal(args.hypoDir),
       ]);
       const { blocking } = partitionLintScope(scopedLint.errors || [], scope);
       if (blocking.length > 0) {
@@ -450,7 +455,9 @@ function applySessionClose(args) {
   // for any actual apply work (readPayload below surfaces "payload is
   // required" the same way it always has).
   if (!args.force && !args.payload) {
-    const probe = sessionCloseFileStatus(args.hypoDir);
+    // ADR 0043: no-payload "already complete?" probe uses the
+    // global invariant, not a recency pick.
+    const probe = sessionCloseGlobalStatus(args.hypoDir);
     if (probe.ok) {
       const result = {
         ok: true,

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -742,6 +742,8 @@ const {
   isClosePattern,
   extractTouchedWikiFiles,
   closeFileTargets,
+  closeFileTargetsGlobal,
+  sessionCloseGlobalStatus,
   partitionLintScope,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
@@ -8246,6 +8248,234 @@ test('resume.mjs honors process.cwd() for same-date tie (ISSUE-1 wiring)', () =>
     assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
     assert.ok(r.stdout.startsWith('Project: beta'), `expected 'Project: beta', got: ${r.stdout}`);
   });
+});
+
+// ── sessionCloseGlobalStatus — global close invariant (ADR 0043) ──────────────
+suite('sessionCloseGlobalStatus — global close invariant (ADR 0043)');
+
+// Build a wiki where each project's 5 close files can be independently fresh or
+// stale. `projects`: [{ slug, date, sessionState?, projectHot?, sessionLog?,
+// logEntry?, hotRow? }] — each optional field defaults to `date` (fresh) and can
+// be set to an old date string (or false to omit). Root hot.md rows are built
+// from `hotRow ?? date`; root hot.md frontmatter `updated:` is always today.
+function makeMultiProjectWiki(dir, today, projects) {
+  mkdirSync(dir, { recursive: true });
+  const ym = today.slice(0, 7);
+  const rows = [];
+  const logLines = [];
+  for (const p of projects) {
+    const d = p.date ?? today;
+    const pdir = join(dir, 'projects', p.slug);
+    mkdirSync(join(pdir, 'session-log'), { recursive: true });
+    const ss = p.sessionState === false ? null : (p.sessionState ?? d);
+    if (ss !== null) {
+      writeFileSync(
+        join(pdir, 'session-state.md'),
+        `---\ntitle: ss\ntype: session-state\nupdated: ${ss}\n---\n\n## next\n`,
+      );
+    }
+    const ph = p.projectHot === false ? null : (p.projectHot ?? d);
+    if (ph !== null) {
+      writeFileSync(
+        join(pdir, 'hot.md'),
+        `---\ntitle: hot\ntype: reference\nupdated: ${ph}\n---\n\n# Hot\n`,
+      );
+    }
+    const slDate = p.sessionLog === false ? null : (p.sessionLog ?? d);
+    if (slDate !== null) {
+      writeFileSync(
+        join(pdir, 'session-log', `${slDate.slice(0, 7)}.md`),
+        `---\ntitle: log\ntype: session-log\nupdated: ${slDate}\n---\n\n## [${slDate}] session\n`,
+      );
+    } else {
+      // still create the current month's file (empty of today heading) so the
+      // status reports it `stale`, not `missing`.
+      writeFileSync(
+        join(pdir, 'session-log', `${ym}.md`),
+        `---\ntitle: log\ntype: session-log\nupdated: 2000-01-01\n---\n\n## [2000-01-01] old\n`,
+      );
+    }
+    const le = p.logEntry === false ? null : (p.logEntry ?? d);
+    if (le !== null) logLines.push(`## [${le}] session | ${p.slug}`);
+    const hr = p.hotRow === false ? null : (p.hotRow ?? d);
+    if (hr !== null) rows.push(`| ${p.slug} | ${hr} | [[projects/${p.slug}/hot]] |`);
+  }
+  writeFileSync(join(dir, 'log.md'), logLines.join('\n') + '\n');
+  writeFileSync(
+    join(dir, 'hot.md'),
+    `---\ntitle: Hot\nupdated: ${today}\n---\n# Hot\n\n## Active Projects\n\n` +
+      `| Project | Last Session | Hot Cache |\n|---|---|---|\n${rows.join('\n')}\n`,
+  );
+}
+
+test('no-payload incident form: fully-closed B passes even though stale A is the top hot.md row', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // A is the recency/top row but has NO today activity (last touched long ago).
+    // B is fully closed today. Legacy recency pick would resolve A and false-block.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: '2020-01-01' }, // top row, all stale, zero today activity
+      { slug: 'beta', date: today }, // fully closed today
+    ]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(
+      s.ok,
+      true,
+      `beta is fully closed; alpha has no today activity → ok. got ${JSON.stringify(s)}`,
+    );
+    assert.deepEqual(
+      s.projects.map((p) => p.project),
+      ['beta'],
+      'only beta is today-active',
+    );
+  });
+});
+
+test('masking guard: a DIFFERENT project with a partial close still blocks (no single-pick mask)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha fully closed; beta has a today log.md entry (activity) but stale own files.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      {
+        slug: 'beta',
+        date: today,
+        sessionState: '2020-01-01',
+        projectHot: '2020-01-01',
+        sessionLog: false,
+      },
+    ]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, false, 'beta has a dangling close → block');
+    const beta = s.projects.find((p) => p.project === 'beta');
+    assert.ok(beta && !beta.ok, 'beta reported incomplete');
+    assert.ok(
+      s.stale.some((f) => f.includes('projects/beta/')),
+      `block names beta's stale files: ${JSON.stringify(s.stale)}`,
+    );
+  });
+});
+
+test('from-zero fallback: no project has today activity → legacy force-close of the recency project blocks', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: '2020-01-01', hotRow: '2020-01-01' },
+      { slug: 'beta', date: '2020-01-01', hotRow: '2020-01-01' },
+    ]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.fallback, true, 'no today activity → fallback path');
+    assert.equal(s.ok, false, 'recency project is stale → still blocks (force initial close)');
+    assert.ok(s.primary, 'a recency primary is resolved');
+  });
+});
+
+test('multi today-active: both complete → ok; one partial → block only the partial one', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      { slug: 'beta', date: today },
+    ]);
+    assert.equal(sessionCloseGlobalStatus(dir).ok, true, 'both complete → ok');
+
+    // now break beta's session-state
+    writeFileSync(
+      join(dir, 'projects', 'beta', 'session-state.md'),
+      `---\ntitle: ss\ntype: session-state\nupdated: 2020-01-01\n---\n\n## next\n`,
+    );
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, false, 'beta now incomplete → block');
+    assert.ok(s.projects.find((p) => p.project === 'alpha').ok, 'alpha still ok');
+    assert.ok(!s.projects.find((p) => p.project === 'beta').ok, 'beta blocked');
+    assert.ok(
+      s.stale.some((f) => f === 'projects/beta/session-state.md'),
+      'names beta session-state',
+    );
+    assert.ok(!s.stale.some((f) => f.startsWith('projects/alpha/')), 'does not flag alpha files');
+  });
+});
+
+test('back-compat: single today-active project → flat aliases byte-identical (unprefixed paths)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [{ slug: 'solo', date: today, logEntry: '2020-01-01' }]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, false, 'solo log.md entry stale → block');
+    assert.equal(s.project, 'solo', 'flat .project alias = the single project');
+    assert.ok(
+      s.missing.concat(s.stale).includes('log.md'),
+      'log.md flagged unprefixed (root file)',
+    );
+  });
+});
+
+test('project-dir-only candidate is gated (readdirSync leg) — guards the swallowed-import false-pass', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha is fully closed and visible via root hot.md row + log.md entry.
+    // gamma has today activity ONLY in its own session-state.md — it is absent
+    // from both the root hot.md rows and log.md, so ONLY the project-dirs leg
+    // (readdirSync over projects/*) can surface it. If that leg silently drops
+    // (e.g. an unimported readdirSync swallowed by the try/catch), gamma's
+    // dangling close is missed and the gate false-passes.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      {
+        slug: 'gamma',
+        date: today,
+        hotRow: false,
+        logEntry: false,
+        sessionLog: false,
+        projectHot: '2020-01-01',
+      },
+    ]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.ok(
+      s.projects.some((p) => p.project === 'gamma'),
+      `gamma must be found via the project-dirs leg: ${JSON.stringify(s.projects.map((p) => p.project))}`,
+    );
+    assert.equal(s.ok, false, 'gamma has a dangling close → block (must not false-pass)');
+  });
+});
+
+test('closeFileTargetsGlobal: union over today-active projects, all freshDate months', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      { slug: 'beta', date: today },
+    ]);
+    const t = closeFileTargetsGlobal(dir);
+    assert.ok(t.has('hot.md') && t.has('log.md'), 'root files always in scope');
+    for (const p of ['alpha', 'beta']) {
+      assert.ok(t.has(`projects/${p}/session-state.md`), `${p} session-state in scope`);
+      assert.ok(t.has(`projects/${p}/hot.md`), `${p} hot in scope`);
+      assert.ok(
+        [...t].some((f) => new RegExp(`^projects/${p}/session-log/`).test(f)),
+        `${p} session-log in scope`,
+      );
+    }
+  });
+});
+
+test('regression: the close path never passes cwd into resolveActiveProject (resume=cwd / close=no-pick split)', () => {
+  // ADR 0043: close callers must not import a cwd-aware project pick. Guard the
+  // source so a future "re-sync" with resume.mjs cannot reintroduce cwd masking.
+  const shared = readFileSync(join(HOOKS, 'hypo-shared.mjs'), 'utf-8');
+  // Every CALL to resolveActiveProject in hypo-shared.mjs (the close-side module)
+  // must be single-arg. The 2-arg form lives only in the function DEFINITION
+  // (for resume.mjs, a separate file) — exclude that line, then assert no call
+  // passes a 2nd (cwd) argument.
+  const cwdCalls = shared
+    .split('\n')
+    .filter((l) => !/function resolveActiveProject/.test(l))
+    .filter((l) => /resolveActiveProject\([^)]*,/.test(l));
+  assert.equal(
+    cwdCalls.length,
+    0,
+    `close-side resolveActiveProject calls must be single-arg (no cwd); found: ${JSON.stringify(cwdCalls)}`,
+  );
 });
 
 // ── hypo-auto-minimal-crystallize.mjs (ADR 0022 Layer 3) ─────


### PR DESCRIPTION
## What

The no-payload session-close paths picked a single project from root `hot.md`'s top row (recency) and checked only it. Two failure modes:

- **False-block**: when the project you actually closed is not the recency winner, a *completed* close gets `ok:false` (the 2026-06-09 incident, in the no-payload form). Part A (PR #97) fixed only the payload/apply path.
- **Masking risk**: naively adding a cwd tie-break here (mirroring resume) would let a fresh cwd mask a *different* project's dangling close.

## How

Global invariant — **no project may end a session with a partial close**. New `sessionCloseGlobalStatus(hypoDir)`:

- Candidate slugs = real project dirs (`projects/*` with `session-state.md`) ∪ slugs in a today-dated `## [today] session | P` `log.md` entry ∪ slugs in a today-dated root `hot.md` row.
- Checks every project with today close-activity via the existing `sessionCloseFileStatus(projectOverride)`; `ok` only when all are complete.
- When no project has today activity, falls back to the legacy single recency project (from-zero force-close unchanged).
- Flat aliases (`.project/.stale/.missing`) keep a single-project session **byte-identical**; entries are self-describing paths.

Converted the no-payload callers: PreCompact gate, `--check-session-close`, `--mark-session-closed` (+ its lint scope), the no-payload apply probe, and the lint scope (`closeFileTargetsGlobal`, which also fixes a month-boundary gap by covering every freshDate month). The apply path (`payload.project` authority, post-apply verify) is untouched. W8 design-history now scopes to each today-active project.

`resume` stays cwd-positive; close never picks by cwd — a regression test locks that split.

## Review

Two-stage codex cross-review:
- **Design**: BLOCKER (4 findings — `crystallize:388` misclassification, root-hot-row signal hole, candidate-set union, flat-alias back-compat) — all incorporated before implementation.
- **Pre-commit**: BLOCKER — `readdirSync` was used in `hypo-shared.mjs` but not imported; swallowed by a try/catch, the project-dirs candidate leg was always empty → a real false-pass. Fixed (import added) and guarded by a test empirically proven to fail pre-fix (`["alpha"]` only, gamma missed) and pass post-fix.

## Tests

673 passed, 0 failed. New suite covers incident-form, masking guard, from-zero fallback, multi-active, single-project back-compat, `closeFileTargetsGlobal`, the cwd-no-pick regression, and the project-dirs-only candidate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
