### PR TITLE
fix(session-close): unify both marker writers with the /compact gate

### DIFF
--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -48,13 +48,14 @@ import {
   extractUserMessages,
   isClosePattern,
   isGateSkipped,
+  precompactGateStatus,
 } from './hypo-shared.mjs';
 
 function emitContinue() {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
 }
 
-function emitBlock(sessionId, transcriptPath) {
+function emitBlock(sessionId, transcriptPath, gate = null) {
   // One-line, skill-first. /hypo:crystallize is the documented session-close
   // alias; passing --session-id there writes the per-session marker that clears
   // this block. CLI fallback + bypass live in commands/crystallize.md, not here
@@ -64,7 +65,23 @@ function emitBlock(sessionId, transcriptPath) {
   // coherence: a marker written without lint would only let Stop pass for
   // /compact to immediately re-block on the same errors).
   const transcriptHint = transcriptPath ? ` --transcript-path=${transcriptPath}` : '';
-  const reason = `[WIKI_AUTOCLOSE] session-close 미완료 — /hypo:crystallize 실행으로 마무리 (session_id=${sessionId}${transcriptHint}).`;
+  const markCmd = `crystallize --mark-session-closed --session-id=${sessionId}${transcriptHint}`;
+  // ADR 0047: refine the message with the read-only /compact gate result.
+  // - gate green → the close is compact-ready and ONLY the marker is missing
+  //   (the hand-edit close case: files Written + committed directly, bypassing
+  //   the marker writer). Say so precisely + give the one command, instead of
+  //   the generic "미완료" that reads as "you never closed".
+  // - gate has blockers → surface them so the user fixes the real issue first.
+  // - gate null (tooling error/unavailable) → generic message (fail-open).
+  let reason;
+  if (gate && gate.ok) {
+    reason = `[WIKI_AUTOCLOSE] close gate green — only the session-closed marker is missing. Run \`${markCmd}\` to finish (session_id=${sessionId}).`;
+  } else if (gate && gate.blockers && gate.blockers.length > 0) {
+    const blockers = gate.blockers.map((b) => b.reason).join('; ');
+    reason = `[WIKI_AUTOCLOSE] session-close incomplete — resolve: ${blockers}. Then run \`${markCmd}\` (session_id=${sessionId}).`;
+  } else {
+    reason = `[WIKI_AUTOCLOSE] session-close 미완료 — /hypo:crystallize 실행으로 마무리 (session_id=${sessionId}${transcriptHint}).`;
+  }
   console.log(
     JSON.stringify({
       decision: 'block',
@@ -141,7 +158,20 @@ process.stdin.on('end', () => {
       return;
     }
 
-    emitBlock(sessionId, transcriptPath);
+    // ADR 0047: read-only /compact gate (same precompactGateStatus the real
+    // PreCompact hook uses) sharpens the block message — distinguishes "close
+    // is compact-ready, only the marker is missing" from "there are real
+    // blockers". The hook NEVER writes the marker here (file-header invariant);
+    // this is read-only. Any error → null → emitBlock falls back to the generic
+    // message (fail-open).
+    let gate = null;
+    try {
+      gate = precompactGateStatus(HYPO_DIR, transcriptPath ? { transcriptPath } : {});
+    } catch {
+      gate = null;
+    }
+
+    emitBlock(sessionId, transcriptPath, gate);
   } catch (err) {
     // Fail-open on any unexpected error.
     process.stderr.write(`[hypo-auto-minimal-crystallize] error: ${err?.message ?? String(err)}\n`);

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -80,9 +80,7 @@ import {
   precompactGateStatus,
   writeSessionClosedMarker,
   sessionClosedMarkerPath,
-  hypoIsClean,
-  extractTouchedWikiFiles,
-  closeFileTargetsGlobal,
+  readSessionClosedMarker,
   partitionLintScope,
 } from '../hooks/hypo-shared.mjs';
 
@@ -156,6 +154,23 @@ function runSessionCloseCheck(args) {
   const status = precompactGateStatus(args.hypoDir, { transcriptPath: args.transcriptPath });
   const close = status.close;
 
+  // ADR 0047: when a --session-id is supplied, report whether THIS session's
+  // per-session marker (the Stop-chain completion signal) exists. This is a
+  // separate field, NOT folded into `ok` — `ok` stays the ADR 0046 compact-
+  // readiness verdict. A green gate with marker_present=false is exactly the
+  // hand-edit close state: close is compact-ready but the Stop hook will
+  // still block until the marker is written.
+  //
+  // Use the SAME reader the Stop hook gates on (readSessionClosedMarker), not
+  // raw file existence: a stale/corrupt marker file exists on disk but the hook
+  // rejects (and unlinks) it, so raw existsSync would report marker_present=true
+  // while /compact's Stop still blocks — the exact incoherence this ADR closes
+  // (codex pre-commit CONCERN). readSessionClosedMarker unlinks an invalid
+  // marker as it reads, matching the hook's behavior on the next Stop.
+  const markerPresent = args.sessionId
+    ? readSessionClosedMarker(args.hypoDir, args.sessionId) !== null
+    : null;
+
   if (args.json) {
     console.log(
       JSON.stringify(
@@ -169,6 +184,7 @@ function runSessionCloseCheck(args) {
           blockers: status.blockers,
           notices: status.notices,
           skipped: status.skipped,
+          ...(args.sessionId ? { session_id: args.sessionId, marker_present: markerPresent } : {}),
         },
         null,
         2,
@@ -206,6 +222,16 @@ function runSessionCloseCheck(args) {
   if (status.notices.length > 0) {
     console.log('');
     for (const n of status.notices) console.log(`  · ${n.reason}`);
+  }
+  // ADR 0047: surface the per-session marker state (separate from compact-
+  // readiness) so a green-but-unmarked close is visible at verify time.
+  if (args.sessionId) {
+    console.log('');
+    console.log(
+      markerPresent
+        ? `  ✓ session-closed marker present (session_id: ${args.sessionId}).`
+        : `  · session-closed marker absent (session_id: ${args.sessionId}) — the Stop hook will block until it is written. Run \`crystallize --mark-session-closed --session-id=${args.sessionId}${args.transcriptPath ? ` --transcript-path=${args.transcriptPath}` : ''}\`.`,
+    );
   }
   console.log('');
   console.log(
@@ -352,8 +378,9 @@ function validatePayloadShape(payload) {
 // crystallize` is the only Reader; writer authority is intentionally split
 // between this CLI and the auto-write at the tail of applySessionClose.
 //
-// Contract: marker is only written when sessionCloseFileStatus(hypoDir).ok.
-// A failed check exits 1 with no marker — the next Stop hook will re-block.
+// Contract: the marker is written only when the FULL /compact gate
+// (precompactGateStatus, ADR 0046) is green. A failed gate exits 1 with no
+// marker — the next Stop hook re-blocks.
 
 function runMarkSessionClosed(args) {
   if (!args.sessionId) {
@@ -361,22 +388,30 @@ function runMarkSessionClosed(args) {
     console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
     process.exit(1);
   }
-  // ADR 0022 amendment 2026-05-19 Q2: marker write authority requires BOTH
-  // close gate ok AND hypoIsClean.clean — git dirty would let a Stop hook pass
-  // while wiki changes are still uncommitted (auto-commit may have failed in
-  // this run). Codex Worker-1 BLOCKER (pre-commit review).
-  // ADR 0043: global invariant — a marker must not be written
-  // while ANY today-active project still has a dangling close (no recency pick).
-  const status = sessionCloseGlobalStatus(args.hypoDir);
-  const git = hypoIsClean(args.hypoDir);
-  if (!status.ok || !git.clean) {
+  // ADR 0047: the per-session marker is the THIRD session-close completion
+  // signal (after the PreCompact gate and `--check-session-close`). It must use
+  // the SAME gate that governs /compact — precompactGateStatus — so the marker
+  // can never attest "closed" while /compact would still block. This subsumes
+  // the prior (sessionCloseGlobalStatus + hypoIsClean + scoped-lint) gate and
+  // additionally enforces feedback projection (over-cap/conflict), W8 design-
+  // history staleness, and root hot.md structure — the checks that the narrower
+  // marker gate skipped (the divergence behind this fix). git-clean is now a
+  // `git` blocker inside the gate. Pass --transcript-path to widen the lint
+  // scope to this session's edited files exactly as the interactive hook does;
+  // without it the scope is the mandatory close files only.
+  const gate = precompactGateStatus(
+    args.hypoDir,
+    args.transcriptPath ? { transcriptPath: args.transcriptPath } : {},
+  );
+  const status = gate.close;
+  if (!gate.ok) {
     const result = {
       ok: false,
       session_id: args.sessionId,
       project: status.project,
       missing: status.missing,
       stale: status.stale,
-      git_reason: git.clean ? null : git.reason,
+      blockers: gate.blockers,
       error: 'session-close gate not satisfied — marker not written',
     };
     if (args.json) {
@@ -385,54 +420,9 @@ function runMarkSessionClosed(args) {
       console.log(
         `✗ session-close gate not satisfied — marker not written (project: ${status.project || '(unresolved)'}):`,
       );
-      for (const f of status.missing) console.log(`  ✗ ${f} (missing)`);
-      for (const f of status.stale) console.log(`  ✗ ${f} (stale)`);
-      if (!git.clean) console.log(`  ✗ git: ${git.reason}`);
+      for (const b of gate.blockers) console.log(`  ✗ ${b.reason}`);
     }
     process.exit(1);
-  }
-  // Bug A coherence: the marker suppresses the Stop hook, but PreCompact blocks
-  // on lint. If a transcript is provided, refuse the marker when THIS session's
-  // own files (edited ∪ mandatory close files) carry lint errors — otherwise
-  // Stop would pass only for /compact to immediately re-block. No transcript →
-  // legacy freshness+git recovery path (lint left to PreCompact).
-  if (args.transcriptPath) {
-    let scopedLint = null;
-    try {
-      scopedLint = runLint(args.hypoDir);
-    } catch (err) {
-      // Lint crash → fail-open (never strand the marker writer on tooling), same
-      // posture as the PreCompact hook.
-      process.stderr.write(
-        `[crystallize] mark-session-closed lint skipped: ${err?.message ?? err}\n`,
-      );
-    }
-    if (scopedLint) {
-      const scope = new Set([
-        ...extractTouchedWikiFiles(args.transcriptPath, args.hypoDir),
-        ...closeFileTargetsGlobal(args.hypoDir),
-      ]);
-      const { blocking } = partitionLintScope(scopedLint.errors || [], scope);
-      if (blocking.length > 0) {
-        const files = [...new Set(blocking.map((b) => b.file))];
-        const result = {
-          ok: false,
-          session_id: args.sessionId,
-          project: status.project,
-          lint_blockers: files,
-          error: "session-close gate not satisfied — lint errors in this session's files",
-        };
-        if (args.json) {
-          console.log(JSON.stringify(result, null, 2));
-        } else {
-          console.log(
-            `✗ lint errors in files this session touched — marker not written (fix then re-run):`,
-          );
-          for (const b of blocking) console.log(`  ✗ ${b.file}: ${b.message}`);
-        }
-        process.exit(1);
-      }
-    }
   }
   writeSessionClosedMarker(args.hypoDir, args.sessionId, { project: status.project });
   // Marker writer swallows IO errors (best-effort, see hypo-shared.mjs). Verify
@@ -453,6 +443,12 @@ function runMarkSessionClosed(args) {
     session_id: args.sessionId,
     project: status.project,
     date: status.dates[0],
+    notices: gate.notices,
+    // ADR 0047: pure feedback-projection drift is a non-blocker — the marker
+    // attests "compact-ready (no human-fixable blocker)", and the PreCompact
+    // hook self-heals the projection (feedback-sync --write) at /compact. Surface
+    // the deferral so the caller knows MEMORY/CLAUDE sync is pending, not lost.
+    drift_deferred: gate.driftTargets,
   };
   if (args.json) {
     console.log(JSON.stringify(result, null, 2));
@@ -460,6 +456,11 @@ function runMarkSessionClosed(args) {
     console.log(
       `✓ session-closed marker written (session_id: ${args.sessionId}, project: ${status.project}).`,
     );
+    if (gate.driftTargets.length > 0) {
+      console.log(
+        `  · feedback projection drift (${gate.driftTargets.join(', ')}) — will self-heal at /compact.`,
+      );
+    }
   }
   process.exit(0);
 }
@@ -687,18 +688,26 @@ function applySessionClose(args) {
   // ADR 0022 amendment 2026-05-19: auto-write the per-session
   // closed marker on a verified close. Hook authority is read-only; this is
   // one of the two writer paths (the other is --mark-session-closed standalone).
-  // Marker requires BOTH file/lint gate (already in `ok`) AND clean git tree —
-  // ADR Q2 explicit. Auto-commit may have failed silently in the Stop chain;
-  // a dirty git would otherwise let the marker pass for an unrecorded close.
+  //
+  // ADR 0047: the marker write is governed by the SAME gate as standalone
+  // --mark-session-closed and /compact (precompactGateStatus), NOT just apply's
+  // `ok` + git-clean. Apply's payload preflight/post-apply lint and `ok` still
+  // govern apply SUCCESS (exit code below), but the marker must additionally
+  // clear feedback projection / W8 design-history / hot.md structure, else this
+  // path could issue a marker the standalone path would refuse (the second
+  // divergence codex flagged). git-clean is subsumed by the gate's git blocker.
   if (ok && args.sessionId) {
-    const git = hypoIsClean(args.hypoDir);
-    if (git.clean) {
+    const markerGate = precompactGateStatus(
+      args.hypoDir,
+      args.transcriptPath ? { transcriptPath: args.transcriptPath } : {},
+    );
+    if (markerGate.ok) {
       writeSessionClosedMarker(args.hypoDir, args.sessionId, { project });
     }
-    // git not clean → silent skip: caller's `result.ok` already reflects the
+    // gate not ok → silent skip: caller's `result.ok` already reflects the
     // file/lint state; surfacing a "marker skipped" warning here would
-    // confuse the close-applied success path. Next Stop re-blocks until
-    // git is clean (auto-commit retries on subsequent runs).
+    // confuse the close-applied success path. Next Stop re-blocks until the
+    // remaining blocker (git/feedback/W8/hot/lint) is resolved.
   }
   const stage = ok
     ? null

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -92,7 +92,17 @@ Ask: *"이 작업이 마무리되었나요? 세션을 정리(crystallize)할까�
    error in a close file or a feedback projection over-cap. (Not a hard
    guarantee: the live gate can still differ on a context-≥70% prompt,
    `HYPO_SKIP_GATE`, or a transcript-scoped lint error — pass `--transcript-path`
-   to include the last.)
+   to include the last.) Pass `--session-id=<id>` to also see `marker_present`
+   (step 7).
+7. Record the session-closed marker (ADR 0047). The Stop hook blocks until this
+   session's per-session marker exists, and a hand-edit close (writing the files
+   directly + committing) never writes it; the marker is written only by the
+   crystallize writer, never by the hook (ADR 0022 bypass guard). Normal path:
+   close via `crystallize.mjs --apply-session-close --session-id=<id> --transcript-path=<path>`,
+   which writes the marker once the gate is green. Hand-edit recovery: after
+   committing the files, run `crystallize.mjs --mark-session-closed --session-id=<id> --transcript-path=<path>`.
+   Both writers gate the marker on the SAME `precompactGateStatus` as `/compact`,
+   so the marker only lands when step 6 would print **"Compact-ready"**.
 
 Skip session close for: single bug fix, single-file edit, Q&A only.
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -8714,9 +8714,13 @@ test('replay-auto-minimal-crystallize-on-incomplete-close: mutating + no marker 
       /WIKI_AUTOCLOSE/.test(out.reason),
       `reason must mention WIKI_AUTOCLOSE: ${out.reason}`,
     );
+    // ADR 0047: the recovery command is now `crystallize --mark-session-closed`
+    // (gate-green / blockers branches) or `/hypo:crystallize` (generic fallback
+    // when the read-only gate is unavailable). All paths name a crystallize
+    // recovery action.
     assert.ok(
-      /\/hypo:crystallize/.test(out.reason),
-      'reason must point at /hypo:crystallize skill',
+      /crystallize/.test(out.reason),
+      `reason must point at a crystallize recovery command: ${out.reason}`,
     );
     assert.ok(out.reason.includes('s-substantial'), 'reason must embed the session_id to use');
   });
@@ -8947,7 +8951,12 @@ test('--mark-session-closed with ok gate but dirty git → exit 1, no marker (AD
     assert.equal(r.status, 1, `expected exit 1 on dirty git, stdout: ${r.stdout}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, false);
-    assert.ok(out.git_reason, `dirty-git result must carry git_reason: ${JSON.stringify(out)}`);
+    // ADR 0047: git-clean is now a `git` blocker inside the unified gate
+    // (precompactGateStatus), not a separate git_reason field.
+    assert.ok(
+      (out.blockers || []).some((b) => b.type === 'git'),
+      `dirty-git result must carry a git blocker: ${JSON.stringify(out)}`,
+    );
     assert.ok(
       !existsSync(join(dir, '.cache', 'session-closed-s-dirty.marker')),
       'marker must not land on dirty git',
@@ -9011,9 +9020,10 @@ test('--mark-session-closed --transcript-path: lint error in a TOUCHED file → 
       assert.equal(r.status, 1, `expected marker refused, got ${r.status}\n${r.stdout}`);
       const out = JSON.parse(r.stdout);
       assert.equal(out.ok, false);
+      // ADR 0047: lint failures are now `lint` blockers in the unified gate.
       assert.ok(
-        (out.lint_blockers || []).some((f) => f.endsWith('note.md')),
-        `lint_blockers should name the touched file: ${r.stdout}`,
+        (out.blockers || []).some((b) => b.type === 'lint' && /note\.md/.test(b.reason)),
+        `a lint blocker should name the touched file: ${r.stdout}`,
       );
       assert.ok(
         !existsSync(join(dir, '.cache', 'session-closed-s-touch.marker')),
@@ -9397,6 +9407,293 @@ test('check-session-close surfaces a feedback over-cap as a gate blocker (not ju
       (report.blockers || []).some((b) => b.type === 'feedback' && /over cap/.test(b.reason)),
       `feedback over-cap must appear in the check's blockers (proves the feedback path ran): ${r.stdout}`,
     );
+  });
+});
+
+// ── ADR 0047: both marker writers share the /compact gate ────────────────────
+// The per-session marker is the THIRD session-close completion signal. It used
+// to gate on a NARROWER check (close files + git + optional scoped-lint) than
+// the real /compact gate (precompactGateStatus also enforces feedback
+// projection over-cap/conflict, W8 design-history, and hot.md structure). That
+// divergence let a marker attest "closed" while /compact would still block.
+// These tests lock the writer⟺gate coherence for BOTH writer paths (standalone
+// --mark-session-closed and --apply-session-close), the pure-drift carve-out,
+// the verify marker field, and the refined Stop message. They use a controlled
+// HOME with hypo-pkg.json so the crystallize/hook child resolves PKG_ROOT and
+// actually runs the lint + feedback subprocesses (under a clean CI HOME those
+// paths skip, making the test a no-op) — same hermetic pattern as the
+// check-session-close over-cap test above.
+suite('ADR 0047 — marker writers share the /compact gate (precompactGateStatus)');
+
+function adr47CommitWiki(dir) {
+  spawnSync('git', ['init'], { cwd: dir });
+  spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir });
+  spawnSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  spawnSync('git', ['add', '-A'], { cwd: dir });
+  spawnSync('git', ['commit', '-m', 'init'], { cwd: dir });
+}
+
+function adr47ControlledHome(dir) {
+  const home = join(dir, 'home');
+  mkdirSync(join(home, '.claude'), { recursive: true });
+  writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+  writeFileSync(
+    join(home, '.claude', 'CLAUDE.md'),
+    '# Global\n<learned_behaviors>\n</learned_behaviors>\n',
+  );
+  return home;
+}
+
+function adr47SeedFeedback(wiki, count) {
+  mkdirSync(join(wiki, 'pages', 'feedback'), { recursive: true });
+  for (let i = 0; i < count; i++) {
+    writeFileSync(
+      join(wiki, 'pages', 'feedback', `rule-${i}.md`),
+      fbPage({
+        ...FB_GLOBAL_L1,
+        title: `R${i}`,
+        global_summary: `do thing ${i}`,
+        memory_summary: `m ${i}`,
+      }),
+    );
+  }
+}
+
+test('--mark-session-closed refuses the marker on a feedback over-cap even when close files are fresh + git clean', () => {
+  withTmpDir((dir) => {
+    const wiki = join(dir, 'wiki');
+    const today = todayLocal();
+    mkdirSync(wiki, { recursive: true });
+    buildCleanWikiTree(wiki, today); // 5 close files fresh
+    adr47SeedFeedback(wiki, 11); // 11 global-L1 → CLAUDE projection over the 10 cap
+    adr47CommitWiki(wiki); // git clean
+    const home = adr47ControlledHome(dir);
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'crystallize.mjs'),
+        '--mark-session-closed',
+        '--session-id=s-overcap',
+        `--hypo-dir=${wiki}`,
+        '--json',
+      ],
+      { encoding: 'utf-8', env: { ...process.env, HOME: home, HYPO_DIR: '' } },
+    );
+    assert.equal(r.status, 1, `over-cap must refuse the marker: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(
+      (out.blockers || []).some((b) => b.type === 'feedback' && /over cap/.test(b.reason)),
+      `marker must be refused on the feedback over-cap (the check the narrow gate skipped): ${r.stdout}`,
+    );
+    assert.ok(
+      !existsSync(join(wiki, '.cache', 'session-closed-s-overcap.marker')),
+      'marker must not land while the gate blocks',
+    );
+  });
+});
+
+test('--apply-session-close routes the marker write through the full gate — refuses on feedback over-cap', () => {
+  withTmpDir((dir) => {
+    const wiki = join(dir, 'wiki');
+    const today = todayLocal();
+    mkdirSync(wiki, { recursive: true });
+    buildCleanWikiTree(wiki, today);
+    adr47SeedFeedback(wiki, 11);
+    adr47CommitWiki(wiki);
+    const home = adr47ControlledHome(dir);
+    // Idempotent payload: full-content fields echo current bytes, append entries
+    // match the existing headings → apply writes NOTHING → git stays clean. So
+    // the only thing that can refuse the marker is the new gate (feedback), not
+    // a git-dirty masking it.
+    const payload = {
+      project: 'test-project',
+      date: today,
+      sessionState: {
+        content: readFileSync(join(wiki, 'projects', 'test-project', 'session-state.md'), 'utf-8'),
+      },
+      projectHot: {
+        content: readFileSync(join(wiki, 'projects', 'test-project', 'hot.md'), 'utf-8'),
+      },
+      rootHot: { content: readFileSync(join(wiki, 'hot.md'), 'utf-8') },
+      sessionLog: { entry: `## [${today}] test session\n` },
+      log: { entry: `## [${today}] session | test-project\n` },
+    };
+    const payloadPath = join(dir, 'payload.json'); // outside the wiki git tree
+    writeFileSync(payloadPath, JSON.stringify(payload));
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'crystallize.mjs'),
+        '--apply-session-close',
+        `--payload=${payloadPath}`,
+        '--session-id=s-apply-oc',
+        `--hypo-dir=${wiki}`,
+        '--json',
+      ],
+      { encoding: 'utf-8', env: { ...process.env, HOME: home, HYPO_DIR: '' } },
+    );
+    assert.equal(
+      r.status,
+      0,
+      `apply itself must succeed (idempotent no-op): ${r.stdout}\n${r.stderr}`,
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true, `apply ok (files fresh, lint clean): ${r.stdout}`);
+    const st = spawnSync('git', ['status', '--porcelain'], { cwd: wiki, encoding: 'utf-8' });
+    assert.equal(
+      st.stdout.trim(),
+      '',
+      `payload must be a no-op so git stays clean (else git, not feedback, masks the test): ${st.stdout}`,
+    );
+    assert.ok(
+      !existsSync(join(wiki, '.cache', 'session-closed-s-apply-oc.marker')),
+      'apply must NOT write the marker while the full gate blocks on feedback over-cap',
+    );
+  });
+});
+
+test('--mark-session-closed writes the marker on PURE feedback drift and surfaces drift_deferred', () => {
+  withTmpDir((dir) => {
+    const wiki = join(dir, 'wiki');
+    const today = todayLocal();
+    mkdirSync(wiki, { recursive: true });
+    buildCleanWikiTree(wiki, today);
+    adr47SeedFeedback(wiki, 2); // under the cap → pure drift (CLAUDE.md not yet synced)
+    adr47CommitWiki(wiki);
+    const home = adr47ControlledHome(dir);
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'crystallize.mjs'),
+        '--mark-session-closed',
+        '--session-id=s-drift',
+        `--hypo-dir=${wiki}`,
+        '--json',
+      ],
+      { encoding: 'utf-8', env: { ...process.env, HOME: home, HYPO_DIR: '' } },
+    );
+    assert.equal(r.status, 0, `pure drift must NOT block the marker: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.ok(
+      existsSync(join(wiki, '.cache', 'session-closed-s-drift.marker')),
+      'marker must land on pure drift (non-blocker)',
+    );
+    assert.ok(
+      Array.isArray(out.drift_deferred) && out.drift_deferred.length > 0,
+      `drift_deferred must surface the pending projection sync (self-heals at /compact): ${r.stdout}`,
+    );
+  });
+});
+
+test('--check-session-close --session-id reports marker presence without altering ok', () => {
+  withWiki(null, (dir) => {
+    const r1 = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--session-id=s-mp',
+      '--json',
+    ]);
+    const o1 = JSON.parse(r1.stdout);
+    assert.equal(o1.session_id, 's-mp');
+    assert.equal(o1.marker_present, false, `marker absent must report false: ${r1.stdout}`);
+    // `ok` is the compact-ready verdict and must NOT require the marker: a clean
+    // close is compact-ready even before the marker exists (that IS the hand-edit
+    // state). Prove independence directly rather than across two runs.
+    assert.equal(
+      o1.ok,
+      true,
+      `a clean close must be compact-ready without the marker: ${r1.stdout}`,
+    );
+    writeSessionClosedMarkerFile(dir, 's-mp');
+    // Commit the marker file so the second run's git tree stays clean (otherwise
+    // the new .cache/ file would dirty git and flip ok via the git blocker —
+    // unrelated to marker_present).
+    spawnSync('git', ['add', '-A'], { cwd: dir });
+    spawnSync('git', ['commit', '-m', 'marker'], { cwd: dir });
+    const r2 = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--session-id=s-mp',
+      '--json',
+    ]);
+    const o2 = JSON.parse(r2.stdout);
+    assert.equal(o2.marker_present, true, `marker present must report true: ${r2.stdout}`);
+    assert.equal(o1.ok, o2.ok, 'marker_present must not change the compact-ready ok verdict');
+  });
+});
+
+test('--check-session-close --session-id: a STALE marker reports marker_present:false (matches the Stop hook reader, not raw existsSync)', () => {
+  withWiki(null, (dir) => {
+    // A marker file exists on disk but is stale → the Stop hook would reject and
+    // unlink it, so /compact's Stop still blocks. marker_present must agree
+    // (codex pre-commit CONCERN: raw existsSync would falsely report true).
+    writeSessionClosedMarkerFile(dir, 's-stale-mp', '2020-01-01T00:00:00.000Z');
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--session-id=s-stale-mp',
+      '--json',
+    ]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.marker_present,
+      false,
+      `a stale marker must report marker_present:false: ${r.stdout}`,
+    );
+    // The shared reader unlinks the invalid marker as it reads (same as the hook).
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-stale-mp.marker')),
+      'stale marker should be unlinked by the validity check',
+    );
+  });
+});
+
+test('Stop hook: close gate green but marker absent → precise "close gate green" message', () => {
+  withTmpDir((dir) => {
+    const wiki = join(dir, 'wiki');
+    const today = todayLocal();
+    mkdirSync(wiki, { recursive: true });
+    buildCleanWikiTree(wiki, today); // no feedback pages → gate fully green once committed
+    adr47CommitWiki(wiki);
+    const home = adr47ControlledHome(dir); // PKG_ROOT resolves so the hook's read-only gate runs
+    const transcript = join(dir, 'stop.jsonl');
+    writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', name: 'Edit', input: { file_path: join(wiki, 'hot.md') } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: '오늘은 이만 마무리하자' },
+        }),
+      ].join('\n') + '\n',
+    );
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-minimal-crystallize.mjs')], {
+      input: JSON.stringify({
+        session_id: 's-green',
+        transcript_path: transcript,
+        stop_hook_active: false,
+      }),
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: home, HYPO_DIR: wiki },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block', `must block while the marker is absent: ${r.stdout}`);
+    assert.ok(
+      /close gate green/.test(out.reason),
+      `a green gate must produce the precise marker-missing message: ${out.reason}`,
+    );
+    assert.ok(/--mark-session-closed/.test(out.reason), 'message must give the exact mark command');
+    assert.ok(out.reason.includes('s-green'), 'message must embed the session_id');
   });
 });
 


### PR DESCRIPTION
## Problem

The per-session "session-closed" marker is the third session-close completion signal (after the PreCompact gate and `--check-session-close`). It gated on a **narrower** check (close files + git + optional scoped lint) than the real `/compact` gate (`precompactGateStatus`, which also enforces feedback projection over-cap/conflict, design-history staleness, and root `hot.md` structure).

That divergence is two-directional:
- **Marker written, /compact still blocks** — a marker attests "closed" while `/compact` blocks on a check the marker gate skipped (PR #80 Bug A family).
- **Marker absent, everything else done** — a hand-edit close (writing the files + committing, bypassing the writer) never writes the marker, so the Stop hook blocks `session-close 미완료` even though the close is complete.

## Change

Route **both** marker writers through `precompactGateStatus` so the marker joins the single source of truth introduced for the gate and `--check-session-close`:

- `runMarkSessionClosed` (standalone `--mark-session-closed`): replace the narrow gate; refuse the marker iff `gate.blockers` is non-empty. git-clean is now a gate blocker. Result shape `git_reason`/`lint_blockers` → unified `blockers[]`.
- `applySessionClose`: payload preflight + post-apply lint still govern apply success/exit; **only** the marker-write decision routes through the shared gate.
- **Pure feedback drift** stays a non-blocker — the marker is written and `drift_deferred` surfaces the deferral. Self-heal stays in the PreCompact hook; the writer remains read-only.
- **Stop hook**: after the existing mutation + close-intent + no-marker decision, call `precompactGateStatus` read-only (never writes the marker) to sharpen the message — gate green → "close gate green; only the marker is missing → `crystallize --mark-session-closed ...`"; blockers → list them; error → generic fallback (fail-open).
- **`--check-session-close --session-id`** reports `marker_present` using the same reader the Stop hook gates on (rejects/unlinks stale markers), not raw file existence. `ok` is unchanged.
- Add the marker-recording step to the session-close checklist (`templates/hypo-guide.md`): apply = normal path, mark = hand-edit recovery.

The marker stays writer-gated (the hook never writes it) — no auto-issue from freshness.

## Tests

681 → 687. New: standalone + apply refuse on feedback over-cap (close files fresh, git clean); pure drift writes the marker + `drift_deferred`; `--check --session-id` `marker_present` (incl. stale → false); Stop green-gate precise message. Three existing marker tests updated to the `blockers[]` shape (behavior unchanged).

Two-stage codex review: design **BLOCKER** (apply-path unification was required, not just the standalone writer) + pre-commit **CONCERN** (`marker_present` must use the shared validity reader, not raw `existsSync`) — both addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)