### PR TITLE
fix(session-close): auto-derive the root log.md session entry

### DIFF
--- a/hooks/hypo-hot-rebuild.mjs
+++ b/hooks/hypo-hot-rebuild.mjs
@@ -12,7 +12,12 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { HYPO_DIR, computeSessionGrowth, formatGrowthMetrics } from './hypo-shared.mjs';
+import {
+  HYPO_DIR,
+  computeSessionGrowth,
+  formatGrowthMetrics,
+  deriveRootLogEntries,
+} from './hypo-shared.mjs';
 
 const HOT_PATH = join(HYPO_DIR, 'hot.md');
 const GROWTH_CACHE = join(HYPO_DIR, '.cache', 'last-session-growth.json');
@@ -106,6 +111,14 @@ try {
   rebuild();
 } catch (err) {
   process.stderr.write(`[hypo-hot-rebuild] error: ${err?.message ?? String(err)}\n`);
+}
+// Auto-derive the root log.md session entry from each project's session-log
+// heading (runs AFTER rebuild() so root hot.md is already fresh and isn't itself
+// counted as the project's open gate problem). Best-effort: own try/catch.
+try {
+  deriveRootLogEntries(HYPO_DIR);
+} catch (err) {
+  process.stderr.write(`[hypo-hot-rebuild] log-derive error: ${err?.message ?? String(err)}\n`);
 }
 try {
   emitGrowth();

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -604,6 +604,110 @@ export function sessionCloseGlobalStatus(hypoDir) {
   return { ok, projects, dates, fallback: false, primary, project: primary, stale, missing };
 }
 
+// ── derivable-artifact auto-derive: root log.md session entry ──────────────────
+// The root log.md `## [date] session | <slug>` entry is a DERIVABLE artifact —
+// it restates a project's session-log heading, which the close already authored.
+// root hot.md is already auto-derived here (rebuild() above); log.md was the only
+// derivable still left as a manual checklist step, so a hand-edited close that
+// skipped it left the global gate (sessionCloseGlobalStatus) hard-blocking /compact
+// for EVERY today-active project — cross-session, looking like a fresh bug each
+// time. This derives the missing entry from the session-log heading so the gate
+// never blocks on a purely-derivable gap. The session-closed MARKER is NOT derived
+// here: it is a proof artifact the close gate actually ran (ADR 0022 invariant).
+//
+// Safety guard (codex design review): derive ONLY for a project whose close is
+// otherwise complete — i.e. its sole gate problem is log.md. If session-state /
+// project hot / session-log are also stale/missing, the authored close is genuinely
+// incomplete and MUST keep blocking; deriving log.md then would mask it.
+
+// Build the canonical root log.md heading from a raw session-log heading tail.
+// The gate's session-log freshness check accepts ANY `## [date] ...` heading, but
+// the log.md check requires `## [date] session | <slug>` — so normalise to that
+// shape rather than copying a heading that might not carry `session | <slug>`.
+function deriveLogTitle(tail) {
+  let t = (tail || '').trim();
+  t = t.replace(/^session\b\s*/i, ''); // drop a leading "session" token
+  if (t.startsWith('|')) {
+    // Drop a leading "| <old label/slug>" segment up to the first em-dash, so a
+    // renamed-project heading (`| oldslug — title`) does not leak its old slug
+    // into the derived title. A pipe segment with no separator is a bare label
+    // (e.g. `| slug`) → no title.
+    const dash = t.indexOf('—');
+    t = dash === -1 ? '' : t.slice(dash);
+  }
+  return t.replace(/^\s*[—:-]\s*/, '').trim(); // drop a leading separator
+}
+
+/**
+ * Append any missing root log.md `## [date] session | <slug>` entries derived from
+ * each today-active project's session-log heading(s). Idempotent: dedups on the
+ * exact generated heading line, so re-running (or a same-day apply that already
+ * wrote the entry) is a no-op, and multiple same-day sessions each get their own
+ * entry. Best-effort and read-mostly: returns the number of entries appended.
+ *
+ * @param {string} hypoDir
+ * @returns {number} count of entries appended to log.md
+ */
+export function deriveRootLogEntries(hypoDir) {
+  const logPath = join(hypoDir, 'log.md');
+  if (!existsSync(logPath)) return 0;
+  const dates = freshDates();
+  const todayActive = [...closeCandidateSlugs(hypoDir, dates)].filter((p) =>
+    hasTodayCloseActivity(hypoDir, p, dates),
+  );
+  if (todayActive.length === 0) return 0;
+
+  let logContent;
+  try {
+    logContent = readFileSync(logPath, 'utf-8');
+  } catch {
+    return 0;
+  }
+
+  // Exact-LINE dedup: a titleless heading (`## [d] session | a`) is a substring/
+  // prefix of a titled one (`## [d] session | a — first`), so substring checks
+  // would wrongly drop a distinct same-day session. Track whole heading lines.
+  const seenHeadings = new Set((logContent || '').split(/\r?\n/));
+  const additions = [];
+  for (const slug of todayActive) {
+    // Guard: only the log.md entry may be the gap; an otherwise-incomplete close
+    // must keep blocking (do not mask missing authored files).
+    const st = sessionCloseFileStatus(hypoDir, { projectOverride: slug });
+    const problems = [...st.stale, ...st.missing];
+    if (!(problems.length === 1 && problems[0] === 'log.md')) continue;
+
+    for (const date of dates) {
+      const ym = date.slice(0, 7);
+      const slogPath = join(hypoDir, 'projects', slug, 'session-log', `${ym}.md`);
+      if (!existsSync(slogPath)) continue;
+      let slog;
+      try {
+        slog = readFileSync(slogPath, 'utf-8');
+      } catch {
+        continue;
+      }
+      const headingRe = new RegExp('^#{1,6} \\[' + escapeRegExp(date) + '\\]\\s*(.*)$', 'gm');
+      let m;
+      while ((m = headingRe.exec(slog)) !== null) {
+        const title = deriveLogTitle(m[1]);
+        const heading = `## [${date}] session | ${slug}` + (title ? ` — ${title}` : '');
+        if (seenHeadings.has(heading)) continue; // exact-line dedup (log.md + queued)
+        seenHeadings.add(heading);
+        additions.push(`${heading}\n→ [[projects/${slug}/hot]]`);
+      }
+    }
+  }
+
+  if (additions.length === 0) return 0;
+  const sep = logContent.endsWith('\n') ? '\n' : '\n\n';
+  try {
+    writeFileSync(logPath, logContent + sep + additions.join('\n\n') + '\n');
+  } catch {
+    return 0;
+  }
+  return additions.length;
+}
+
 // ── sync-state ────────────────────────────────────────────
 // `.cache/sync-state.json` is JSONL: one {timestamp, op, error, host} entry per
 // line. hypo-auto-commit appends on pull/push failure; hypo-session-start

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -746,6 +746,7 @@ const {
   closeFileTargets,
   closeFileTargetsGlobal,
   sessionCloseGlobalStatus,
+  deriveRootLogEntries,
   partitionLintScope,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
@@ -8636,6 +8637,129 @@ test('regression: the close path never passes cwd into resolveActiveProject (res
     0,
     `close-side resolveActiveProject calls must be single-arg (no cwd); found: ${JSON.stringify(cwdCalls)}`,
   );
+});
+
+// ── deriveRootLogEntries — auto-derive root log.md session entry ──────────────
+suite('deriveRootLogEntries — root log.md derivable auto-fill');
+
+test('derives the canonical log.md entry when only log.md is the gap', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha: fully closed today except the root log.md entry is missing.
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today, logEntry: false }]);
+    assert.equal(sessionCloseGlobalStatus(dir).ok, false, 'precondition: gate blocks on log.md');
+    const n = deriveRootLogEntries(dir);
+    assert.equal(n, 1, 'one entry derived');
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.match(log, new RegExp(`^## \\[${today}\\] session \\| alpha`, 'm'));
+    assert.equal(sessionCloseGlobalStatus(dir).ok, true, 'gate now passes after derive');
+  });
+});
+
+test('is idempotent — a second run appends nothing', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today, logEntry: false }]);
+    assert.equal(deriveRootLogEntries(dir), 1);
+    assert.equal(deriveRootLogEntries(dir), 0, 'no duplicate on re-run');
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.equal((log.match(/session \| alpha/g) || []).length, 1, 'exactly one alpha entry');
+  });
+});
+
+test('guard: does NOT derive when the authored close is otherwise incomplete', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // beta is today-active (fresh session-log heading) but session-state is stale
+    // AND log.md missing → incomplete authored close, must keep blocking.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'beta', date: today, sessionState: '2020-01-01', logEntry: false },
+    ]);
+    assert.equal(deriveRootLogEntries(dir), 0, 'log.md not masked while session-state stale');
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.doesNotMatch(log, /session \| beta/, 'no beta entry derived');
+    assert.equal(sessionCloseGlobalStatus(dir).ok, false, 'gate still blocks the real gap');
+  });
+});
+
+test('normalises a non-"session | slug" heading into the canonical entry', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today, logEntry: false }]);
+    // Overwrite the session-log with a titled, non-canonical heading shape.
+    writeFileSync(
+      join(dir, 'projects', 'alpha', 'session-log', `${today.slice(0, 7)}.md`),
+      `---\ntitle: log\ntype: session-log\nupdated: ${today}\n---\n\n## [${today}] Refactor the parser\n`,
+    );
+    assert.equal(deriveRootLogEntries(dir), 1);
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.match(
+      log,
+      new RegExp(`^## \\[${today}\\] session \\| alpha — Refactor the parser`, 'm'),
+    );
+  });
+});
+
+test('derives one entry per same-day session-log heading', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today, logEntry: false }]);
+    writeFileSync(
+      join(dir, 'projects', 'alpha', 'session-log', `${today.slice(0, 7)}.md`),
+      `---\ntitle: log\ntype: session-log\nupdated: ${today}\n---\n\n` +
+        `## [${today}] session | alpha — first\n\n## [${today}] session | alpha — second\n`,
+    );
+    assert.equal(deriveRootLogEntries(dir), 2, 'both same-day sessions derived');
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.match(log, /session \| alpha — first/);
+    assert.match(log, /session \| alpha — second/);
+  });
+});
+
+test('does not leak a renamed-project old slug into the derived title', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [{ slug: 'newslug', date: today, logEntry: false }]);
+    writeFileSync(
+      join(dir, 'projects', 'newslug', 'session-log', `${today.slice(0, 7)}.md`),
+      `---\ntitle: log\ntype: session-log\nupdated: ${today}\n---\n\n## [${today}] session | oldslug — Migrate\n`,
+    );
+    assert.equal(deriveRootLogEntries(dir), 1);
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.match(log, new RegExp(`^## \\[${today}\\] session \\| newslug — Migrate$`, 'm'));
+    assert.doesNotMatch(log, /oldslug/, 'old slug must not appear in the derived entry');
+  });
+});
+
+test('exact-line dedup keeps a titleless heading distinct from a titled one', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today, logEntry: false }]);
+    // A titleless and a titled same-day heading: a substring dedup would drop the
+    // titleless one (it is a prefix of the titled one); exact-line keeps both.
+    writeFileSync(
+      join(dir, 'projects', 'alpha', 'session-log', `${today.slice(0, 7)}.md`),
+      `---\ntitle: log\ntype: session-log\nupdated: ${today}\n---\n\n` +
+        `## [${today}] session | alpha — first\n\n## [${today}] session | alpha\n`,
+    );
+    assert.equal(deriveRootLogEntries(dir), 2, 'both the titled and titleless entries derived');
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.match(log, new RegExp(`^## \\[${today}\\] session \\| alpha — first$`, 'm'));
+    assert.match(log, new RegExp(`^## \\[${today}\\] session \\| alpha$`, 'm'));
+  });
+});
+
+test('hypo-hot-rebuild Stop hook fills the missing log.md entry end-to-end', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today, logEntry: false }]);
+    const r = runStop('hypo-hot-rebuild.mjs', dir);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+    assert.match(log, new RegExp(`^## \\[${today}\\] session \\| alpha`, 'm'));
+    assert.equal(sessionCloseGlobalStatus(dir).ok, true, 'gate passes after the Stop hook ran');
+  });
 });
 
 // ── hypo-auto-minimal-crystallize.mjs (ADR 0022 Layer 3) ─────


### PR DESCRIPTION
## Why

The root `log.md` `## [date] session | <slug>` entry is a **derivable** artifact: it restates a project's session-log heading, which the session-close already authored. The root `hot.md` pointer table is already auto-derived in the `hypo-hot-rebuild` Stop hook, but the `log.md` entry was the only derivable artifact still left as a **manual** session-close checklist step.

A hand-edited close (writing the session-log/hot/state files directly, without `crystallize --apply-session-close`, which requires a `log` payload field) silently skips that step. The **global** session-close gate then checks every today-active project, so the missing entry hard-blocks `/compact` — surfacing in a *different* later session and looking like a brand-new defect each time. This was the latest instance of a recurring "session-close blocks again" family; every prior fix hardened the *gate* (detection) rather than the *write* side.

## What

`deriveRootLogEntries(hypoDir)` in `hooks/hypo-shared.mjs`, called from `hypo-hot-rebuild.mjs` after `rebuild()` (best-effort, own try/catch):

- For each today-active project whose **sole** gate gap is `log.md` (`problems === ['log.md']`), derive the canonical `## [date] session | <slug> — <title>` entry from the project's session-log heading(s) and append any that are missing.
- **Safety guard**: an otherwise-incomplete authored close (stale/missing session-state, project hot, session-log) still has more than one gap, so it is skipped and keeps blocking — the derive never masks a real incomplete close.
- The session-closed **marker** is deliberately not derived: it is a proof artifact that the close gate actually ran.

This moves `log.md` from "manual checklist step + cross-session hard-block" to "auto-derived like root hot.md", completing the derivable-artifact auto-derivation pattern.

## Notes

- Normalizer tolerates non-canonical session-log headings (the gate accepts any `## [date] ...` heading) and renamed-project slugs.
- Exact-line dedup → idempotent; multiple same-day sessions each keep their own entry; a same-day `--apply` that already wrote the entry is a no-op.
- Known scope: `updated:` frontmatter dates remain a gate input that `apply` does not auto-fix; this PR addresses the `log.md` derivable only.

## Verification

- `node tests/runner.mjs` — 698 passed, 0 failed (8 new tests incl. an end-to-end Stop-hook run + the guard, idempotency, normalizer, and dedup edges)
- Design-stage + pre-commit codex review (CONCERN on substring dedup and the renamed-slug normalizer both addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)