### PR TITLE
feat(session-close): nudge close on substantial read-only sessions

### DIFF
--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -3,7 +3,8 @@
  * hypo-auto-minimal-crystallize.mjs — Stop hook (ADR 0022 Layer 3)
  *
  * Last hook in the Stop chain: a final-line defense that blocks `Stop` when
- * the current session performed mutation work but never produced a verified
+ * the current session did substantial work (mutation, or a high-volume
+ * read-only investigation — see step 3) but never produced a verified
  * session-close. Forces Claude to run minimal session-close before the
  * conversation context evaporates.
  *
@@ -11,8 +12,10 @@
  *
  *   1. stop_hook_active === true  → continue       (loop guard; PoC 2026-05-14)
  *   2. wiki absent                 → continue       (fail-open)
- *   3. transcript has zero Edit/Write/MultiEdit/NotebookEdit tool_use
- *                                  → continue       (substantial-session gate)
+ *   3. not a substantial session   → continue       (substantial-session gate)
+ *        substantial = ≥1 mutation tool_use, OR ≥5 read-only investigation
+ *        calls (Read/Grep/Glob/Bash) — 6a, so read-only review/debug sessions
+ *        are also nudged to close. Pure Q&A / incidental lookups still skip.
  *   4. no recent user close-intent → continue       (close-intent gate, see below)
  *   5. readSessionClosedMarker(session_id) valid
  *                                  → continue       (close already verified)
@@ -43,7 +46,7 @@ import { join } from 'path';
 import {
   HYPO_DIR,
   PKG_ROOT,
-  hasMutatingTranscriptActivity,
+  isSubstantialSession,
   readSessionClosedMarker,
   extractUserMessages,
   isClosePattern,
@@ -129,8 +132,10 @@ process.stdin.on('end', () => {
     const sessionId = payload.session_id || payload.sessionId || null;
     const transcriptPath = payload.transcript_path || payload.transcriptPath || null;
 
-    // 3. substantial-session gate. Read-only / Q&A sessions skip the block.
-    if (!hasMutatingTranscriptActivity(transcriptPath)) {
+    // 3. substantial-session gate. Pure Q&A / incidental-lookup sessions skip
+    // the block; mutating sessions AND high-volume read-only investigations
+    // (6a) pass through to the close-intent gate.
+    if (!isSubstantialSession(transcriptPath)) {
       emitContinue();
       return;
     }

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1077,15 +1077,33 @@ export function clearSessionClosedMarker(hypoDir, sessionId) {
   }
 }
 
-// ── transcript activity heuristic (ADR 0022 amendment 2026-05-19) ──
-// Substantial-session gate for the Stop hook: a session that performed at least
-// one mutation tool call (Edit / Write / MultiEdit / NotebookEdit) is "worth"
-// blocking on for session-close. Pure Q&A / read-only sessions skip the block.
+// ── transcript activity heuristic (ADR 0022 amendment 2026-05-19; 6a 2026-06-14) ──
+// Substantial-session gate for the Stop hook: a session "worth" blocking on for
+// session-close is either (a) any mutation (Edit/Write/MultiEdit/NotebookEdit)
+// or (b) a high-volume read-only investigation (≥ READONLY_SUBSTANTIAL_THRESHOLD
+// Read/Grep/Glob/Bash calls). Pure Q&A / incidental lookups skip the block.
 //
-// Bash is intentionally excluded — running tests would otherwise trigger
-// block. Future fix may broaden to read-heavy sessions (Grep ≥ N).
+// 6a rationale: code-review / debugging sessions reach real conclusions worth
+// crystallizing while touching only read-only tools. The original gate keyed
+// purely on mutation tools, so those sessions were never nudged to close. The
+// investigation threshold (5) mirrors session-audit.mjs's "search-many" cutoff
+// (scripts/session-audit.mjs:206) and sits in the empirical gap between
+// incidental lookups (0–3 calls) and real investigation (16–22 calls). Bash is
+// now counted (it is the dominant signal in read-only sessions); over-firing is
+// bounded by the close-intent gate (the Stop hook only blocks when the user also
+// signalled wrap-up) — see hypo-auto-minimal-crystallize.mjs.
+//
+// NOTE: counting a Bash call here does NOT widen the lint scope. Lint scoping
+// (precompactGateStatus) still seeds only Edit/Write-touched files plus the
+// mandatory close files — a Bash-written wiki file is not auto-scoped.
 
 const MUTATING_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+// Read-only investigation tools. Bash included: read-only sessions are
+// Bash-dominant (git/grep/cat), so excluding it would leave most of them
+// undetectable (a real session had read=0, bash=16).
+const INVESTIGATION_TOOL_NAMES = new Set(['Read', 'Grep', 'Glob', 'Bash']);
+// Investigation-volume cutoff for a read-only session to count as substantial.
+const READONLY_SUBSTANTIAL_THRESHOLD = 5;
 
 /** Mirror of `scripts/session-audit.mjs` extractToolNames: handles both top-level
  *  `tool_use` entries (legacy fixtures) and nested `message.content[].tool_use`
@@ -1115,27 +1133,30 @@ function extractTranscriptToolNames(entry) {
 }
 
 /**
- * True if the JSONL transcript at `transcriptPath` contains ≥1 mutation
- * tool_use (Edit/Write/MultiEdit/NotebookEdit).
+ * Single-pass tool-use census over a JSONL transcript. Both public predicates
+ * (`hasMutatingTranscriptActivity`, `isSubstantialSession`) derive from this one
+ * census so the mutation leg stays identical between them. (They still diverge
+ * on read-only ≥ threshold sessions, where only `isSubstantialSession` is true.)
  *
- * Granularity:
- *   • Whole-file unreadable / missing path → returns false (fail-open).
+ * Granularity (shared contract):
+ *   • Whole-file unreadable / missing path → all counts 0 (fail-open).
  *   • Per-line malformed JSON → that line is skipped, scan continues. Real
  *     transcripts occasionally carry truncated lines; one bad line must not
- *     hide a clearly-mutating session that follows. (Codex Worker-2 CONCERN
+ *     hide a clearly-active session that follows. (Codex Worker-2 CONCERN
  *     resolved 2026-05-19: line-level skip is the intended contract.)
  *
  * @param {string|null|undefined} transcriptPath
- * @returns {boolean}
+ * @returns {{ mutationCount: number, investigationCount: number }}
  */
-export function hasMutatingTranscriptActivity(transcriptPath) {
-  if (!transcriptPath || typeof transcriptPath !== 'string') return false;
-  if (!existsSync(transcriptPath)) return false;
+function transcriptActivityStats(transcriptPath) {
+  const stats = { mutationCount: 0, investigationCount: 0 };
+  if (!transcriptPath || typeof transcriptPath !== 'string') return stats;
+  if (!existsSync(transcriptPath)) return stats;
   let raw;
   try {
     raw = readFileSync(transcriptPath, 'utf-8');
   } catch {
-    return false;
+    return stats;
   }
   for (const line of raw.split('\n')) {
     const trimmed = line.trim();
@@ -1147,10 +1168,41 @@ export function hasMutatingTranscriptActivity(transcriptPath) {
       continue;
     }
     for (const name of extractTranscriptToolNames(entry)) {
-      if (MUTATING_TOOL_NAMES.has(name)) return true;
+      if (MUTATING_TOOL_NAMES.has(name)) stats.mutationCount++;
+      else if (INVESTIGATION_TOOL_NAMES.has(name)) stats.investigationCount++;
     }
   }
-  return false;
+  return stats;
+}
+
+/**
+ * True if the JSONL transcript at `transcriptPath` contains ≥1 mutation
+ * tool_use (Edit/Write/MultiEdit/NotebookEdit). Kept as a precise, standalone
+ * helper (and regression oracle) even though the Stop hook now gates on the
+ * broader `isSubstantialSession`.
+ *
+ * @param {string|null|undefined} transcriptPath
+ * @returns {boolean}
+ */
+export function hasMutatingTranscriptActivity(transcriptPath) {
+  return transcriptActivityStats(transcriptPath).mutationCount > 0;
+}
+
+/**
+ * True if the session is "substantial" enough to nudge a session-close:
+ * any mutation, OR a read-only investigation of at least
+ * READONLY_SUBSTANTIAL_THRESHOLD Read/Grep/Glob/Bash calls (6a). The mutation
+ * leg is identical to `hasMutatingTranscriptActivity`, so mutating sessions
+ * behave exactly as before; only high-volume read-only sessions are newly
+ * caught. Over-firing on read-only sessions is bounded downstream by the
+ * close-intent gate in hypo-auto-minimal-crystallize.mjs.
+ *
+ * @param {string|null|undefined} transcriptPath
+ * @returns {boolean}
+ */
+export function isSubstantialSession(transcriptPath) {
+  const { mutationCount, investigationCount } = transcriptActivityStats(transcriptPath);
+  return mutationCount > 0 || investigationCount >= READONLY_SUBSTANTIAL_THRESHOLD;
 }
 
 // ── session-scoped lint classification ──────────────────────────────────────
@@ -1580,8 +1632,11 @@ export function isClosePattern(text) {
     /오늘은?\s*이만/,
   ];
   const enPatterns = [
-    // wrap up: requires session-level context or sentence-end, not code-level objects
-    /wrap(?:ping)?\s+up(?!\s+(?:this|the)\s+(?:pr|issue|bug|task|function|component|module|feature|code|test)\b)/i,
+    // wrap up: requires session-level context or sentence-end, not code-level
+    // objects. The review/analysis/debug/audit/investigation nouns were added
+    // for 6a — read-only review sessions are now "substantial", so "wrap up the
+    // review" must read as a task-level signal, not a session-close one.
+    /wrap(?:ping)?\s+up(?!\s+(?:this|the)\s+(?:pr|issue|bug|task|function|component|module|feature|code|test|review|analysis|investigation|debugging|debug|audit|refactor)\b)/i,
     /done\s+for\s+(?:today|now|the\s+day)/i,
     /that'?s?\s+(?:all|it)\s+for\s+(?:today|now|the\s+day)/i,
     /signing\s+off/i,

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -742,6 +742,8 @@ const {
   isGateSkipped,
   buildOutput,
   isClosePattern,
+  hasMutatingTranscriptActivity,
+  isSubstantialSession,
   extractTouchedWikiFiles,
   closeFileTargets,
   closeFileTargetsGlobal,
@@ -924,6 +926,13 @@ test('일반 작업 문장 → false (false-positive 방지)', () => {
   assert.equal(isClosePattern('작업 종료 조건을 바꿔줘'), false); // Codex P2
   assert.equal(isClosePattern('wrap up this PR'), false); // Codex P2
   assert.equal(isClosePattern('wrap up this feature'), false); // Codex P2
+  // 6a: read-only review/debug sessions are now "substantial", so task-level
+  // "wrap up the <work>" phrasing must NOT read as a session-close signal.
+  assert.equal(isClosePattern('wrap up the review'), false);
+  assert.equal(isClosePattern('wrap up this analysis'), false);
+  assert.equal(isClosePattern('wrapping up the investigation'), false);
+  assert.equal(isClosePattern('wrap up the debugging'), false);
+  assert.equal(isClosePattern('wrap up the audit'), false);
   assert.equal(isClosePattern(''), false);
   assert.equal(isClosePattern(null), false);
 });
@@ -931,6 +940,69 @@ test('일반 작업 문장 → false (false-positive 방지)', () => {
 test('혼합 텍스트(트랜스크립트)에서도 패턴 감지', () => {
   const transcript = '이 PR 리뷰 마저 봐줘\n오늘은 여기까지 하자\n내일 다시 볼게';
   assert.equal(isClosePattern(transcript), true);
+});
+
+// ── 6a: substantial-session gate (read-only investigation volume) ──
+suite('isSubstantialSession() / hasMutatingTranscriptActivity()');
+
+function writeJsonl(dir, entries) {
+  const path = join(dir, `t-${Math.random().toString(36).slice(2, 8)}.jsonl`);
+  writeFileSync(path, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+  return path;
+}
+function toolUse(name) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', name, input: {} }] } };
+}
+
+test('mutation tool → substantial AND mutating', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [toolUse('Edit')]);
+    assert.equal(hasMutatingTranscriptActivity(p), true);
+    assert.equal(isSubstantialSession(p), true);
+  });
+});
+
+test('read-only below threshold (4 investigation) → NOT substantial', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [toolUse('Read'), toolUse('Grep'), toolUse('Glob'), toolUse('Bash')]);
+    assert.equal(hasMutatingTranscriptActivity(p), false, 'no mutation tool');
+    assert.equal(isSubstantialSession(p), false, '4 < threshold 5');
+  });
+});
+
+test('read-only at threshold (5 investigation) → substantial, still NOT mutating', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      toolUse('Read'),
+      toolUse('Grep'),
+      toolUse('Glob'),
+      toolUse('Read'),
+      toolUse('Grep'),
+    ]);
+    assert.equal(
+      hasMutatingTranscriptActivity(p),
+      false,
+      'read-only never trips the mutation oracle',
+    );
+    assert.equal(isSubstantialSession(p), true, '5 >= threshold 5');
+  });
+});
+
+test('Bash-only at threshold (5) → substantial (Bash counts as investigation)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(
+      dir,
+      Array.from({ length: 5 }, () => toolUse('Bash')),
+    );
+    assert.equal(isSubstantialSession(p), true, 'Bash-dominant read-only session is substantial');
+  });
+});
+
+test('missing / null transcript → not substantial (fail-open)', () => {
+  withTmpDir((dir) => {
+    assert.equal(isSubstantialSession(null), false);
+    assert.equal(isSubstantialSession(join(dir, 'nope.jsonl')), false);
+  });
 });
 
 suite('isGateSkipped()');
@@ -9024,6 +9096,102 @@ test('replay-auto-minimal-crystallize-on-incomplete-close: HYPO_SKIP_GATE=1 → 
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.continue, true, 'HYPO_SKIP_GATE=1 → continue');
+  });
+});
+
+// ── 6a: read-only investigation sessions reach the close-intent gate ──
+// A read-only review/debug session (≥5 Read/Grep/Glob/Bash, no mutation) is now
+// "substantial". The block still requires a wrap-up signal; pure-volume alone
+// must NOT block (close-intent gate unchanged).
+function readonlyInvestigationLines(n) {
+  const tools = ['Read', 'Grep', 'Glob', 'Bash'];
+  return Array.from({ length: n }, (_, i) => ({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name: tools[i % tools.length], input: {} }] },
+  }));
+}
+
+test('replay-auto-minimal-crystallize-on-incomplete-close: read-only ≥5 + close-intent → block (6a)', () => {
+  withGrowthWiki((dir) => {
+    const transcript = writeTranscript(dir, [
+      { type: 'user', content: '이 모듈 좀 리뷰해줘' },
+      ...readonlyInvestigationLines(5),
+      { type: 'user', message: { role: 'user', content: '오늘은 이만 마무리하자' } },
+    ]);
+    const r = runAutoMinimal(dir, {
+      session_id: 's-readonly-close',
+      transcript_path: transcript,
+      stop_hook_active: false,
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.decision,
+      'block',
+      `read-only investigation + wrap-up must block: ${JSON.stringify(out)}`,
+    );
+    assert.ok(out.reason.includes('s-readonly-close'), 'reason embeds session_id');
+  });
+});
+
+test('replay-auto-minimal-crystallize-on-incomplete-close: read-only 4 (below threshold) + close-intent → continue (6a)', () => {
+  withGrowthWiki((dir) => {
+    const transcript = writeTranscript(dir, [
+      ...readonlyInvestigationLines(4),
+      { type: 'user', message: { role: 'user', content: '세션 마무리하자' } },
+    ]);
+    const r = runAutoMinimal(dir, {
+      session_id: 's-readonly-light',
+      transcript_path: transcript,
+      stop_hook_active: false,
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.continue,
+      true,
+      '4 investigation calls < threshold → not substantial → continue',
+    );
+    assert.equal(out.decision, undefined, 'must NOT block a light read-only session');
+  });
+});
+
+test('replay-auto-minimal-crystallize-on-incomplete-close: read-only ≥5, NO close-intent → continue (6a)', () => {
+  withGrowthWiki((dir) => {
+    // Substantial by volume, but no wrap-up signal → the close-intent gate must
+    // still continue. This is the every-turn-nag guard that bounds 6a's reach.
+    const transcript = writeTranscript(dir, [
+      { type: 'user', message: { role: 'user', content: '이 함수 어떻게 동작하는지 설명해줘' } },
+      ...readonlyInvestigationLines(6),
+    ]);
+    const r = runAutoMinimal(dir, {
+      session_id: 's-readonly-midwork',
+      transcript_path: transcript,
+      stop_hook_active: false,
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, 'no close-intent → continue even when substantial');
+    assert.equal(out.decision, undefined, 'close-intent gate bounds the 6a broadening');
+  });
+});
+
+test('replay-auto-minimal-crystallize-on-incomplete-close: read-only ≥5 + close-intent + valid marker → continue (6a)', () => {
+  withGrowthWiki((dir) => {
+    const transcript = writeTranscript(dir, [
+      ...readonlyInvestigationLines(5),
+      { type: 'user', message: { role: 'user', content: '세션 종료하자' } },
+    ]);
+    writeSessionClosedMarkerFile(dir, 's-readonly-closed');
+    const r = runAutoMinimal(dir, {
+      session_id: 's-readonly-closed',
+      transcript_path: transcript,
+      stop_hook_active: false,
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, 'valid marker overrides a substantial read-only session');
+    assert.equal(out.decision, undefined);
   });
 });
 


### PR DESCRIPTION
## What

The Stop-chain close gate (`hypo-auto-minimal-crystallize`) only treated a session as "substantial" — worth nudging toward session-close — when it contained a mutation tool_use (Edit/Write/MultiEdit/NotebookEdit). Read-only code-review and debugging sessions that reach real conclusions worth crystallizing were never nudged.

This broadens the substantial-session gate: a session is substantial if it has **any mutation OR at least 5 read-only investigation calls** (Read/Grep/Glob/Bash).

## Why these choices

- **Threshold 5** mirrors `session-audit.mjs`'s existing "search-many" cutoff and sits in the empirical gap between incidental lookups (0-3 calls measured across real transcripts) and real investigation (16-22).
- **Bash is counted** — read-only investigation sessions are Bash-dominant (git/grep/cat); one real session had read=0, bash=16. Excluding it would leave most undetectable.
- **Mutation leg unchanged** — mutating sessions behave exactly as before; only high-volume read-only sessions are newly caught. All prior tests pass untouched.
- **Over-firing is bounded** by the existing close-intent gate: a block still requires a user wrap-up signal, so this does not nag every turn.
- **No lint-scope change** — counting a Bash call here does not widen the lint scope (that still seeds only Edit/Write-touched files plus mandatory close files).

## Close-intent coherence

Because read-only review sessions are now substantial, the close-intent matcher could misread task-level "wrap up the review" as a session-close signal. `isClosePattern`'s wrap-up exclusion is broadened to cover review/analysis/investigation/debugging/audit/refactor.

## Implementation

Both predicates now derive from a single transcript census (`transcriptActivityStats`); `hasMutatingTranscriptActivity` stays exported as a precise oracle.

## Tests

+9 tests (707 total, 0 failed): unit boundary tests on `isSubstantialSession` (4 continue / 5 block / Bash-only / fail-open) and end-to-end hook replays (read-only ≥5 + close-intent → block; 4 → continue; ≥5 no-close-intent → continue; ≥5 + valid marker → continue), plus `isClosePattern` negatives for the new task-level phrases.

## Review

Two-stage codex cross-review: design-stage (CONCERN → close-intent exclusion gap fixed) and pre-commit (NIT → two comment-accuracy fixes applied). No correctness blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)