### PR TITLE
fix(session-close,resume): surface silent project-resolution divergence on stderr

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -536,6 +536,19 @@ function applySessionClose(args) {
     console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
     process.exit(1);
   }
+  // The freshness verification below (and at the post-apply check) already honors
+  // payload.project — `project` wins over the inferred active project, and the
+  // post-apply sessionCloseFileStatus call passes it as projectOverride. But when the
+  // payload targets a DIFFERENT project than the one active-project resolution infers
+  // (probe.project), that divergence used to be silent, so an operator couldn't tell
+  // which project the close actually verified. Surface it on stderr (the stdout JSON
+  // contract is untouched) so the verified/closed project is always explicit.
+  if (payload.project && probe.project && probe.project !== payload.project) {
+    process.stderr.write(
+      `note: payload.project="${payload.project}" differs from the inferred active ` +
+        `project "${probe.project}"; verifying and closing "${payload.project}".\n`,
+    );
+  }
   const date = payload.date || todayLocal();
 
   // Preflight: lint the wiki BEFORE writing any payload bytes. If lint

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -83,6 +83,33 @@ function pickByCwd(hypoDir, slugs, cwd) {
   return best;
 }
 
+// When cwd is set but no project's working_dir matches it, resume falls back to
+// recency silently — the user lands in an unrelated project with no clue why.
+// Emit a one-line stderr diagnostic (stdout `Project:`/`--json` contract is untouched)
+// naming why each candidate failed: missing index.md, missing working_dir, or a
+// working_dir that simply doesn't contain cwd. Logic mirrors pickByCwd's lookup.
+function warnCwdFallback(hypoDir, slugs, cwd) {
+  // No cwd, or no candidate rows at all (fresh-init / no real project): there is
+  // nothing to "fall back to most-recent" toward, so stay silent — the caller
+  // surfaces the real "no active project found" error instead.
+  if (!cwd || slugs.length === 0) return;
+  const reasons = [];
+  for (const slug of slugs) {
+    const indexPath = join(hypoDir, 'projects', slug, 'index.md');
+    if (!existsSync(indexPath)) {
+      reasons.push(`${slug} (no index.md)`);
+      continue;
+    }
+    const wd = parseFrontmatterField(readFileSync(indexPath, 'utf-8'), 'working_dir');
+    if (!wd) reasons.push(`${slug} (no working_dir)`);
+    // else: has working_dir but didn't contain cwd — expected, not flagged.
+  }
+  const detail = reasons.length ? ` Candidates missing cwd metadata: ${reasons.join(', ')}.` : '';
+  process.stderr.write(
+    `note: cwd "${cwd}" matched no project working_dir; falling back to most-recent.${detail}\n`,
+  );
+}
+
 function resolveActiveProject(hypoDir, cwd = null) {
   const hotPath = join(hypoDir, 'hot.md');
   if (!existsSync(hotPath)) return null;
@@ -115,6 +142,12 @@ function resolveActiveProject(hypoDir, cwd = null) {
     }
     // No cwd match → most recent by date (stable-sort keeps the first table row
     // on a tie, the legacy behavior).
+    if (cwd)
+      warnCwdFallback(
+        hypoDir,
+        wikiRows.map((r) => r.slug),
+        cwd,
+      );
     wikiRows.sort((a, b) => b.date.localeCompare(a.date));
     return wikiRows[0].slug;
   }
@@ -124,6 +157,7 @@ function resolveActiveProject(hypoDir, cwd = null) {
     if (cwd) {
       const picked = pickByCwd(hypoDir, mdSlugs, cwd);
       if (picked) return picked;
+      warnCwdFallback(hypoDir, mdSlugs, cwd);
     }
     return mdSlugs[0]; // legacy: first table row
   }
@@ -141,6 +175,7 @@ function resolveActiveProject(hypoDir, cwd = null) {
   if (cwd) {
     const picked = pickByCwd(hypoDir, candidates, cwd);
     if (picked) return picked;
+    warnCwdFallback(hypoDir, candidates, cwd);
   }
   let latest = null;
   let latestMtime = 0;

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2134,6 +2134,14 @@ test('session-close: post-apply verify follows payload.project on same-date tie 
         'beta',
         `verification must check payload.project (beta), not the table-top (test-project): ${JSON.stringify(out.verification)}`,
       );
+      // ISSUE-17: the same payload≠inferred divergence must be surfaced on stderr so
+      // the operator can see which project the close actually verified. stdout (parsed
+      // above) stays pure JSON — the note must NOT leak there.
+      assert.match(
+        r.stderr,
+        /payload\.project="beta" differs from the inferred active project "test-project"/,
+        `ISSUE-17: payload targeting a project other than the inferred active one must emit a stderr note: ${JSON.stringify(r.stderr)}`,
+      );
     },
   );
 });
@@ -8278,6 +8286,14 @@ test('resume on fresh-init vault: graceful "no active project found" — no slug
       !r.stdout.includes('slug') && !r.stderr.includes('"slug"'),
       `slug placeholder must not leak: stdout=${r.stdout} stderr=${r.stderr}`,
     );
+    // The mtime-fallback branch runs with zero candidate projects here (_template is
+    // skipped). warnCwdFallback must stay silent — there is nothing to "fall back to
+    // most-recent" toward, so the misleading note must NOT appear alongside the real
+    // "no active project found" error.
+    assert.ok(
+      !/falling back to most-recent/.test(r.stderr),
+      `empty-candidate fresh-init must not emit a fallback note: ${JSON.stringify(r.stderr)}`,
+    );
   });
 });
 
@@ -8541,6 +8557,106 @@ test('resume.mjs cwd-first: cwd-matched older project wins over a newer non-matc
     });
     assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
     assert.ok(r.stdout.startsWith('Project: beta'), `expected 'Project: beta', got: ${r.stdout}`);
+    // Negative: a successful cwd match must NOT emit the fallback diagnostic.
+    assert.ok(
+      !/matched no project working_dir/.test(r.stderr),
+      `cwd-matched resume must stay silent on stderr: ${JSON.stringify(r.stderr)}`,
+    );
+  });
+});
+
+test('resume.mjs cwd no-match: emits a stderr fallback diagnostic, --json stdout stays pure (ISSUE-15)', () => {
+  withTmpDir((dir) => {
+    // cwd is an unrelated repo: NO project's working_dir contains it. alpha (newest)
+    // has no index.md at all; beta's working_dir points elsewhere. Pre-fix this fell
+    // back to recency SILENTLY — the user couldn't tell why an unrelated project
+    // loaded. Now resolveActiveProject emits a one-line stderr note naming the gap.
+    const realDir = realpathSync(dir);
+    const hypoDir = join(dir, 'wiki');
+    makeTieBreakWiki(hypoDir, [
+      { slug: 'alpha', date: '2026-06-12' }, // newest, no working_dir → no index.md
+      { slug: 'beta', date: '2026-06-11', workingDir: join(realDir, 'code/beta') },
+    ]);
+    for (const s of ['alpha', 'beta']) {
+      writeFileSync(
+        join(hypoDir, 'projects', s, 'session-state.md'),
+        `---\ntitle: ss — ${s}\ntype: session-state\nupdated: 2026-06-11\n---\n\n## 다음\n- t\n`,
+      );
+    }
+    const unrelatedCwd = join(realDir, 'code/elsewhere');
+    mkdirSync(unrelatedCwd, { recursive: true });
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`, '--json'],
+      {
+        encoding: 'utf-8',
+        cwd: unrelatedCwd,
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    // stdout stays pure JSON (the diagnostic must NOT leak onto stdout) and recency
+    // fallback resolves to the newest project, alpha.
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.project,
+      'alpha',
+      `expected recency fallback to alpha, got: ${JSON.stringify(out.project)}`,
+    );
+    // stderr carries the diagnostic, naming the candidate that lacks cwd metadata.
+    assert.match(
+      r.stderr,
+      /matched no project working_dir; falling back to most-recent/,
+      `expected fallback note on stderr: ${JSON.stringify(r.stderr)}`,
+    );
+    assert.match(
+      r.stderr,
+      /alpha \(no index\.md\)/,
+      `expected per-candidate reason for alpha: ${JSON.stringify(r.stderr)}`,
+    );
+  });
+});
+
+test('resume.mjs mtime-fallback branch cwd no-match: emits the fallback diagnostic (ISSUE-15)', () => {
+  withTmpDir((dir) => {
+    // hot.md has NO project rows → resolveActiveProject reaches the mtime fallback,
+    // the THIRD warnCwdFallback call site. A real project (gamma) exists with a
+    // session-state but no index.md, and cwd is unrelated → it warns yet still
+    // resolves gamma by mtime (candidates is non-empty, so the guard lets it speak).
+    const realDir = realpathSync(dir);
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    writeFileSync(
+      join(hypoDir, 'hot.md'),
+      `---\ntitle: Hot\ntype: reference\nupdated: 2026-06-08\n---\n\n## Active Projects\n\n(none)\n`,
+    );
+    mkdirSync(join(hypoDir, 'projects', 'gamma'), { recursive: true });
+    writeFileSync(
+      join(hypoDir, 'projects', 'gamma', 'session-state.md'),
+      `---\ntitle: ss — gamma\ntype: session-state\nupdated: 2026-06-08\n---\n\n## 다음\n- t\n`,
+    );
+    const unrelatedCwd = join(realDir, 'code/elsewhere');
+    mkdirSync(unrelatedCwd, { recursive: true });
+    const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
+      encoding: 'utf-8',
+      cwd: unrelatedCwd,
+      env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+    });
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.ok(
+      r.stdout.startsWith('Project: gamma'),
+      `expected mtime fallback to gamma, got: ${r.stdout}`,
+    );
+    assert.match(
+      r.stderr,
+      /matched no project working_dir; falling back to most-recent/,
+      `expected mtime branch fallback note: ${JSON.stringify(r.stderr)}`,
+    );
+    assert.match(
+      r.stderr,
+      /gamma \(no index\.md\)/,
+      `expected per-candidate reason for gamma: ${JSON.stringify(r.stderr)}`,
+    );
   });
 });
 
@@ -8569,6 +8685,59 @@ test('cwd-first applies to the legacy markdown-link row branch (ADR 0044)', () =
     assert.equal(resolveActiveProject(dir, join(dir, 'code/beta')), 'beta');
     // no cwd → legacy first row stands.
     assert.equal(resolveActiveProject(dir), 'alpha');
+  });
+});
+
+test('resume.mjs md-link branch cwd no-match: emits the fallback diagnostic (ISSUE-15)', () => {
+  withTmpDir((dir) => {
+    // Legacy markdown-link rows (no wikilink rows) exercise the SECOND warnCwdFallback
+    // call site. cwd is unrelated: alpha has no index.md, beta's working_dir points
+    // elsewhere → md-link branch returns the first row (alpha) and warns.
+    const realDir = realpathSync(dir);
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    const hot = `---\ntitle: Hot\ntype: reference\nupdated: 2026-06-08\n---\n
+## Active Projects
+
+| Project | Last Session |
+|---|---|
+| [alpha](projects/alpha/hot.md) | 2026-06-08 |
+| [beta](projects/beta/hot.md) | 2026-06-08 |
+`;
+    writeFileSync(join(hypoDir, 'hot.md'), hot);
+    for (const s of ['alpha', 'beta']) {
+      mkdirSync(join(hypoDir, 'projects', s), { recursive: true });
+      writeFileSync(
+        join(hypoDir, 'projects', s, 'session-state.md'),
+        `---\ntitle: ss — ${s}\ntype: session-state\nupdated: 2026-06-08\n---\n\n## 다음\n- t\n`,
+      );
+    }
+    writeFileSync(
+      join(hypoDir, 'projects', 'beta', 'index.md'),
+      `---\ntitle: beta\ntype: project-index\nupdated: 2026-06-08\nworking_dir: "${join(realDir, 'code/beta')}"\n---\n# beta\n`,
+    );
+    const unrelatedCwd = join(realDir, 'code/elsewhere');
+    mkdirSync(unrelatedCwd, { recursive: true });
+    const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
+      encoding: 'utf-8',
+      cwd: unrelatedCwd,
+      env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+    });
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.ok(
+      r.stdout.startsWith('Project: alpha'),
+      `expected md-link first-row alpha, got: ${r.stdout}`,
+    );
+    assert.match(
+      r.stderr,
+      /matched no project working_dir; falling back to most-recent/,
+      `expected md-link branch fallback note: ${JSON.stringify(r.stderr)}`,
+    );
+    assert.match(
+      r.stderr,
+      /alpha \(no index\.md\)/,
+      `expected per-candidate reason for alpha: ${JSON.stringify(r.stderr)}`,
+    );
   });
 });
 


### PR DESCRIPTION
## What

Two project-resolution gaps in the session lifecycle resolved invisibly, leaving the operator unable to tell which project a command acted on. Both now emit a one-line **stderr** diagnostic; stdout contracts (`--json`, `Project:`) are untouched.

### `crystallize --apply-session-close`
The apply path already honors `payload.project` for the write and the post-apply freshness check. But when the payload targets a project different from the **inferred active project**, that divergence was silent, so it was unclear which project the close actually verified. Now a note is emitted:

```
note: payload.project="security-ops-kb" differs from the inferred active project "hypomnema"; verifying and closing "security-ops-kb".
```

### `resume`
When `cwd` matched no project's `working_dir` (a project missing `index.md`, or its frontmatter missing `working_dir`), resume fell back to recency **silently** — an unrelated project would load with no explanation. A `warnCwdFallback` diagnostic now fires at all three fallback call sites (wikilink / md-link / mtime), naming the per-candidate reason:

```
note: cwd "/Users/me/code/guardia" matched no project working_dir; falling back to most-recent. Candidates missing cwd metadata: guardia (no index.md).
```

It stays silent when there are no candidate projects at all (fresh-init has nothing to fall back to).

## Tests

722 passed. Coverage added:
- crystallize: payload≠inferred emits the note, stdout stays parseable JSON.
- resume: per-branch no-match positive tests (wikilink / md-link / mtime), plus negatives that a successful cwd match and an empty-candidate fresh-init both stay silent.

## Review

Two-stage codex cross-review (design + pre-commit), 1 worker each. Design pass corrected the framing (freshness was already correct via the post-apply `projectOverride`; the real gap is observability) and the diagnostic split. Pre-commit pass flagged the empty-candidate guard and the single-branch test coverage, both addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)