### PR TITLE
fix(lint): flush full --json stdout before exit; harden lint consumers

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1487,12 +1487,29 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       // Pass --hypo-dir explicitly: lint.mjs resolves the vault via HYPO_DIR /
       // home dirs and ignores cwd, so a --hypo-dir caller (crystallize, tests)
       // would otherwise lint the ambient wiki, not the one under test.
+      // maxBuffer matches crystallize's runLint (64 MiB): warn-heavy output on a
+      // large wiki easily exceeds Node's 1 MiB default, which would truncate
+      // stdout and (via the catch below) silently fail-open this gate.
       const r = spawnSync('node', [lintPath, '--json', `--hypo-dir=${hypoDir}`], {
         encoding: 'utf-8',
         cwd: hypoDir,
         timeout: 30000,
+        maxBuffer: 64 * 1024 * 1024,
       });
-      const parsed = JSON.parse(r.stdout || '{}');
+      // A spawn failure (ENOENT), a timeout/kill (status === null), or a crash
+      // that produced no stdout must NOT be parsed as `{}` and treated as a clean
+      // lint — that path leaves skipped.lint=false with no notice, an INVISIBLE
+      // fail-open. Throw instead so the catch below records skipped.lint=true WITH
+      // a reason notice.
+      if (r.error || r.status === null) {
+        throw new Error(`lint spawn failed: ${r.error?.code || `signal ${r.signal}`}`);
+      }
+      if (!r.stdout || !r.stdout.trim()) {
+        throw new Error(
+          `lint produced no stdout (exit=${r.status})${r.stderr ? `: ${r.stderr.slice(-500)}` : ''}`,
+        );
+      }
+      const parsed = JSON.parse(r.stdout);
       const allErrors = parsed.errors || [];
       const allW8 = (parsed.warns || []).filter((w) => w.id === 'W8');
       const scope = new Set(opts.lintScope || closeFileTargetsGlobal(hypoDir));
@@ -1521,8 +1538,14 @@ export function precompactGateStatus(hypoDir, opts = {}) {
         });
       }
       for (const w of w8Notice) notices.push({ type: 'design-history', reason: w.file });
-    } catch {
+    } catch (e) {
       skipped.lint = true; // fail-open on tooling error
+      // Surface WHY the gate skipped lint (truncated stdout, timeout, spawn error)
+      // instead of silently dropping the check — a fail-open is invisible otherwise.
+      notices.push({
+        type: 'lint',
+        reason: `lint skipped (fail-open): ${e.message || e.code || 'unknown error'}`,
+      });
     }
   }
 

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -106,8 +106,17 @@ function runLint(hypoDir) {
   try {
     return JSON.parse(r.stdout);
   } catch {
+    // Report diagnostic metadata (sizes, exit/signal, spawn error code, a stderr
+    // tail) instead of dumping the whole — possibly huge, possibly truncated —
+    // stdout. lint.mjs now sets exitCode and exits naturally so its stdout is no
+    // longer cut at the 64 KiB pipe boundary; if this still fires it signals a
+    // genuine crash, and these fields say which kind.
+    const stderrTail = (r.stderr || '').slice(-2000);
     throw new Error(
-      `lint helper produced unparseable output (exit=${r.status}):\n${r.stdout}\n${r.stderr}`,
+      `lint helper produced unparseable output ` +
+        `(exit=${r.status}, signal=${r.signal || 'none'}, ` +
+        `stdoutBytes=${(r.stdout || '').length}, spawnError=${r.error?.code || 'none'})` +
+        (stderrTail ? `\nstderr tail:\n${stderrTail}` : ''),
     );
   }
 }

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -474,4 +474,12 @@ if (args.json) {
   }
 }
 
-process.exit(errors.length > 0 ? 1 : 0);
+// Set exitCode and let Node exit naturally rather than calling process.exit():
+// when stdout is a pipe, the JSON write above is async, and a synchronous
+// process.exit() tears the process down before the OS pipe buffer (64 KiB) is
+// drained — truncating large `--json` output mid-string. Consumers that spawn
+// this script and JSON.parse the stdout (crystallize's runLint, the PreCompact
+// gate) then crash on the partial output. There are no pending async handles
+// here (pure synchronous fs), so the event loop empties at end-of-script and
+// Node flushes stdout fully before exiting with this code.
+process.exitCode = errors.length > 0 ? 1 : 0;

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -6411,6 +6411,51 @@ test('fresh init wiki passes lint (regression: observability scaffold vs B6)', (
   );
 });
 
+suite('lint.mjs --json large-output flush (ISSUE-16)');
+
+test('lint --json: large warn-heavy output survives the 64 KiB pipe boundary', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-big-'));
+  try {
+    writeFileSync(join(dir, 'SCHEMA.md'), VOCAB_SCHEMA);
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    // One frontmatter-valid page with many DISTINCT broken wikilinks → one W4 warn
+    // each. Enough to push --json stdout well past 64 KiB — the exact point where
+    // lint's old synchronous process.exit() cut stdout at 65536 bytes mid-string,
+    // making JSON.parse throw for every spawn-and-parse consumer (crystallize's
+    // runLint, the PreCompact gate).
+    const N = 3000;
+    let body = '---\ntitle: many\ntype: wiki\nupdated: 2026-06-08\n---\n\n# many\n\n';
+    for (let i = 0; i < N; i++) body += `- [[missing-target-${i}]]\n`;
+    writeFileSync(join(dir, 'pages', 'many.md'), body);
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${dir}`, '--json'],
+      {
+        encoding: 'utf-8',
+        maxBuffer: 64 * 1024 * 1024,
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    // Output must exceed the old 64 KiB cutoff AND parse cleanly (pre-fix it was
+    // truncated to exactly 65536 bytes and JSON.parse threw here). Don't assert an
+    // exact size — only that it crosses the boundary and every warn survived.
+    assert.ok(r.stdout.length > 64 * 1024, `expected >64 KiB stdout, got ${r.stdout.length}`);
+    const parsed = JSON.parse(r.stdout);
+    const broken = parsed.warns.filter((w) =>
+      /Broken wikilink: \[\[missing-target-/.test(w.message),
+    );
+    assert.equal(
+      broken.length,
+      N,
+      `expected all ${N} broken-link warns intact, got ${broken.length}`,
+    );
+    // exit code contract preserved: warns are not errors → clean exit 0.
+    assert.equal(r.status, 0, `warn-only lint must exit 0, got ${r.status}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ── Lane B: formatGrowthMetrics + growth echo regressions ─────────────────
 
 const { formatGrowthMetrics, computeSessionGrowth } = await import(join(HOOKS, 'hypo-shared.mjs'));


### PR DESCRIPTION
## Problem

`lint.mjs` called `process.exit()` immediately after `console.log()`-ing its JSON report. When stdout is a pipe the write is async, so a synchronous exit tears the process down before the OS pipe buffer (64 KiB) drains — truncating large `--json` output at exactly **65536 bytes**, mid-string.

Every consumer that spawns lint and `JSON.parse`es its stdout then crashes on the partial output:
- crystallize's preflight `runLint` **throws**, which on `--apply-session-close` aborts the whole close — even when the payload is clean and the only lint debt is in unrelated files.
- the PreCompact gate silently fails open.

This reproduces today: a `spawnSync` with `maxBuffer: 64 MiB` (so the buffer is not the limit) still gets `stdout.length === 65536`, `JSON.parse` throws. `maxBuffer` is irrelevant — the child dies before flushing.

## Fix

- **`lint.mjs`**: set `process.exitCode` and let Node exit naturally. No pending async handles (pure sync fs), so stdout flushes fully before exit. The exit-code contract (1=errors, 0=clean) is preserved.
- **`hypo-shared.mjs`** (PreCompact gate): raise the lint spawn `maxBuffer` to 64 MiB to match crystallize, and stop treating a spawn failure / timeout / empty stdout as a clean `{}` lint — those now route through the catch as a **visible** fail-open with a reason notice instead of silently dropping the check.
- **`crystallize.mjs`** `runLint`: on parse failure, report diagnostic metadata (stdout size, exit/signal, spawn error code, stderr tail) instead of dumping the whole, possibly truncated, stdout.

## Verification

On the real wiki: `stdout.length` 65536 (truncated, parse fails) → **73450 (full, parses clean)**.

Test added: a page with 3000 distinct broken wikilinks produces >64 KiB of `--json` that parses with **every warn intact** (`warns.length === 3000`), exit 0. 723 passed.

## Review

Two-stage codex cross-review (design + pre-commit), 1 worker each. Design pass surfaced that the PreCompact gate is a second lint consumer with a 1 MiB default that silently fails open (folded into this patch). Pre-commit pass caught that `JSON.parse(r.stdout || '{}')` still swallowed spawn errors/timeouts/crashes as a clean lint — now guarded to throw so the fail-open is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)