### PR TITLE
fix(lint): resolve vault-convention wikilinks instead of false-flagging them

### DIFF
--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -135,13 +135,54 @@ function collectPages(dir, root, pages = [], ignorePatterns = []) {
 
 // ── slug map ─────────────────────────────────────────────────────────────────
 
-function buildSlugMap(pages) {
+// `extraTargets` are link-target-only slugs (root *.md, sources/*) that resolve
+// wikilinks but are not themselves linted — added verbatim, with NO derived
+// basename/dir-relative aliases, so they can't mask an unrelated broken link.
+function buildSlugMap(pages, extraTargets = []) {
   const map = new Set();
   for (const { rel } of pages) {
-    map.add(rel.replace(/\.md$/, '').replace(/\\/g, '/'));
+    const noExt = rel.replace(/\.md$/, '').replace(/\\/g, '/');
+    map.add(noExt);
     map.add(basename(rel, '.md'));
+    // Dir-relative alias: drop the leading scan-dir segment so the vault's
+    // convention link [[learnings/foo]] resolves to pages/learnings/foo.md.
+    // (A page directly under a scan dir has no extra segment to drop.)
+    const slash = noExt.indexOf('/');
+    if (slash !== -1) map.add(noExt.slice(slash + 1));
   }
+  for (const t of extraTargets) map.add(t);
   return map;
+}
+
+// Link-target-only slugs: files that are valid wikilink destinations but are
+// NOT linted themselves. Root-level *.md (hot.md / log.md / hypo-guide.md /
+// SCHEMA.md — special operational files whose types sit outside VALID_TYPES)
+// and sources/* (immutable captured sources). Returned as verbatim slugs so
+// buildSlugMap adds no derived aliases for them.
+function collectLinkTargets(hypoDir, ignorePatterns = []) {
+  const targets = [];
+  if (existsSync(hypoDir)) {
+    for (const entry of readdirSync(hypoDir)) {
+      const full = join(hypoDir, entry);
+      // root-level *.md FILES only (no recursion), honoring .hypoignore exactly
+      // like collectPages — otherwise an ignored root file (e.g. a secret) would
+      // resolve [[its-slug]] as valid, a false negative.
+      if (
+        extname(entry) === '.md' &&
+        !entry.startsWith('.') &&
+        !isIgnored(full, hypoDir, ignorePatterns) &&
+        statSync(full).isFile()
+      ) {
+        targets.push(entry.replace(/\.md$/, ''));
+      }
+    }
+  }
+  // sources/*: linkable as the full 'sources/<name>' slug only — deliberately no
+  // bare basename, so a stale [[name]] can't silently resolve to a source file.
+  for (const { rel } of collectPages(join(hypoDir, 'sources'), hypoDir, [], ignorePatterns)) {
+    targets.push(rel.replace(/\.md$/, '').replace(/\\/g, '/'));
+  }
+  return targets;
 }
 
 // ── wikilink extractor ────────────────────────────────────────────────────────
@@ -168,7 +209,12 @@ function stripNonWikilinkRegions(content) {
 function extractWikilinks(content) {
   const stripped = stripNonWikilinkRegions(content);
   const links = [];
-  for (const m of stripped.matchAll(/\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]/g)) {
+  // Target capture excludes `\` and stops before an optional `\` preceding the
+  // alias/anchor delimiter, so a markdown-table-escaped alias
+  // `[[a/b\|label]]` (the `\|` is a literal pipe inside a table cell) yields the
+  // clean target `a/b`, not `a/b\`. A bare `[[a\]]` (no delimiter) simply fails
+  // to match rather than being mis-read as `[[a]]`.
+  for (const m of stripped.matchAll(/\[\[([^\]|#\\]+?)(?:\\?[|#][^\]]*?)?\]\]/g)) {
     links.push(m[1].trim());
   }
   return links;
@@ -367,7 +413,8 @@ const args = parseArgs(process.argv);
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects', 'journal'].map((d) => join(args.hypoDir, d));
 const pages = scanDirs.flatMap((d) => collectPages(d, args.hypoDir, [], ignorePatterns));
-const slugMap = buildSlugMap(pages);
+const linkTargets = collectLinkTargets(args.hypoDir, ignorePatterns);
+const slugMap = buildSlugMap(pages, linkTargets);
 const tagVocab = parseSchemaVocab(args.hypoDir);
 const pageDirs = parseSchemaPageDirs(args.hypoDir);
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -6456,6 +6456,145 @@ test('lint --json: large warn-heavy output survives the 64 KiB pipe boundary', (
   }
 });
 
+suite('lint.mjs wikilink resolution (ISSUE-21)');
+
+// Build a multi-file vault, run lint --json, return broken-wikilink targets plus
+// the error count and exit status (so a test can assert target-only files are NOT
+// linted). `files` maps relPath → content; SCHEMA.md is auto-seeded unless given.
+function lintWiki(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-wl-'));
+  try {
+    if (!files['SCHEMA.md']) writeFileSync(join(dir, 'SCHEMA.md'), VOCAB_SCHEMA);
+    for (const [rel, content] of Object.entries(files)) {
+      const full = join(dir, rel);
+      mkdirSync(dirname(full), { recursive: true });
+      writeFileSync(full, content);
+    }
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${dir}`, '--json'],
+      {
+        encoding: 'utf-8',
+        maxBuffer: 64 * 1024 * 1024,
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    const out = JSON.parse(r.stdout);
+    const broken = out.warns
+      .filter((w) => /Broken wikilink/.test(w.message))
+      .map((w) => (w.message.match(/\[\[(.+?)\]\]/) || [])[1]);
+    return { broken, errors: out.errors, status: r.status };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const wlPage = (type, body) =>
+  `---\ntitle: T\ntype: ${type}\nupdated: 2026-06-08\n---\n\n${body}\n`;
+
+test('dir-relative link [[learnings/foo]] resolves to pages/learnings/foo.md', () => {
+  const { broken } = lintWiki({
+    'pages/learnings/foo.md': wlPage('learning', '# foo'),
+    'pages/index.md': wlPage('reference', 'see [[learnings/foo]]'),
+  });
+  assert.ok(
+    !broken.includes('learnings/foo'),
+    `dir-relative link must resolve, broken=${JSON.stringify(broken)}`,
+  );
+});
+
+test('root *.md and sources are target-only — linkable but NOT linted', () => {
+  // Each target file OMITS the required title/type frontmatter, which is an
+  // ERROR if the file is linted. As pure link targets they must resolve AND
+  // raise zero errors — so if a future change widens scanDirs to include root or
+  // sources, the missing-field error fires and this test fails (it would pass
+  // with valid-frontmatter fixtures, the weakness codex flagged).
+  const { broken, errors, status } = lintWiki({
+    'log.md': '---\nupdated: 2026-06-08\n---\n# operational log, no title/type\n',
+    'hypo-guide.md': '---\nupdated: 2026-06-08\n---\n# guide, no title/type\n',
+    'sources/2026-01-01-x.md': '---\nupdated: 2026-06-08\n---\n# source, no title/type\n',
+    'pages/index.md': wlPage('reference', 'see [[log]], [[hypo-guide]], [[sources/2026-01-01-x]]'),
+  });
+  assert.equal(
+    errors.length,
+    0,
+    `target-only files must NOT be linted (got errors): ${JSON.stringify(errors)}`,
+  );
+  assert.equal(status, 0, `clean exit expected, got ${status}`);
+  for (const t of ['log', 'hypo-guide', 'sources/2026-01-01-x']) {
+    assert.ok(!broken.includes(t), `target "${t}" must resolve: ${JSON.stringify(broken)}`);
+  }
+});
+
+test('root .md honors .hypoignore — an ignored root file is NOT a valid target', () => {
+  // collectLinkTargets must skip .hypoignore'd root files; otherwise [[secret]]
+  // would resolve to an ignored file (the false negative codex reproduced).
+  const { broken } = lintWiki({
+    '.hypoignore': 'secret.md\n',
+    'secret.md': '---\ntitle: S\ntype: reference\nupdated: 2026-06-08\n---\n# secret\n',
+    'pages/index.md': wlPage('reference', 'leak [[secret]]'),
+  });
+  assert.ok(
+    broken.includes('secret'),
+    `an ignored root file must NOT resolve as a link target: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('sources is target-only by full slug, NOT bare basename (no false negative)', () => {
+  const { broken } = lintWiki({
+    'sources/2026-01-01-x.md': '---\ntitle: S\ntype: source\nupdated: 2026-06-08\n---\n# s\n',
+    'pages/index.md': wlPage('reference', 'stale [[2026-01-01-x]]'), // bare basename
+  });
+  assert.ok(
+    broken.includes('2026-01-01-x'),
+    `a bare basename must NOT resolve to a source file: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('table-escaped alias [[a/b\\|label]] yields the clean target a/b', () => {
+  const { broken } = lintWiki({
+    'projects/p/issue.md': wlPage('reference', '# issue'),
+    'pages/index.md': wlPage('reference', '| x | [[projects/p/issue\\|issue.md]] |'),
+  });
+  assert.ok(
+    !broken.includes('projects/p/issue'),
+    `escaped-pipe alias must resolve: ${JSON.stringify(broken)}`,
+  );
+  assert.ok(
+    !broken.some((b) => b && b.includes('\\')),
+    `no target should carry a trailing backslash: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('genuinely missing links are still W4 broken (no false negative)', () => {
+  const { broken } = lintWiki({
+    'pages/index.md': wlPage('reference', 'see [[learnings/does-not-exist]] and [[nope]]'),
+  });
+  assert.ok(
+    broken.includes('learnings/does-not-exist'),
+    `missing dir-relative must stay broken: ${JSON.stringify(broken)}`,
+  );
+  assert.ok(
+    broken.includes('nope'),
+    `missing bare slug must stay broken: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('dir-relative collision across scan dirs resolves when a real file matches', () => {
+  // pages/x/foo.md and projects/x/foo.md both yield the dir-relative key x/foo.
+  // The Set semantics resolve [[x/foo]] because a real file backs the key — this
+  // pins the collision behavior codex flagged so a future change can't regress it.
+  const { broken } = lintWiki({
+    'pages/x/foo.md': wlPage('learning', '# pf'),
+    'projects/x/foo.md': wlPage('reference', '# pjf'),
+    'pages/index.md': wlPage('reference', 'see [[x/foo]]'),
+  });
+  assert.ok(
+    !broken.includes('x/foo'),
+    `collision key must resolve when a real file exists: ${JSON.stringify(broken)}`,
+  );
+});
+
 // ── Lane B: formatGrowthMetrics + growth echo regressions ─────────────────
 
 const { formatGrowthMetrics, computeSessionGrowth } = await import(join(HOOKS, 'hypo-shared.mjs'));


### PR DESCRIPTION
## Problem

`lint.mjs` reported **361 broken wikilinks** on the real vault, but **228 were false positives** — real files the resolver couldn't see — which buried the ~133 genuine dangling links and made the broken count untrustworthy.

Three resolution gaps:

1. **Directory-relative links (196 FP)**: the vault convention writes `[[learnings/foo]]` (e.g. `hypo-guide.md`) for `pages/learnings/foo.md`, but `buildSlugMap` only keyed the full path (`pages/learnings/foo`) and the bare basename (`foo`) — never the `pages/`-omitted middle form.
2. **Root `*.md` and `sources/*` (28 FP)**: `scanDirs` is `['pages','projects','journal']` only, so `[[hypo-guide]]`, `[[SCHEMA]]`, `[[sources/x]]` flagged broken though the files exist.
3. **Table-escaped aliases (15 FP)**: a markdown-table cell `[[a/b\|label]]` (the `\|` is an escaped pipe) captured `a/b\` with a trailing backslash and never matched.

## Fix

- Add a **dir-relative alias** in `buildSlugMap` (scan-dir segment stripped) so the convention link resolves to the real file.
- Add a separate **link-target collector** for root `*.md` and `sources/*` that makes them valid destinations **without linting them** (they're special operational / immutable files). It honors `.hypoignore`, is files-only, and keys sources by full slug (no bare basename) so a stale `[[name]]` can't silently resolve.
- The extractor now **excludes the backslash** from the target and treats an optional `\` before the `|`/`#` delimiter as the escape. A bare `[[a\]]` fails to match rather than being mis-read.

## Result

Real vault: **361 → 133 broken**, errors 0, exit 0. The remaining 133 are genuine missing pages (rename residue, uncreated targets) for separate content triage.

## Tests

730 passed. Added: dir-relative resolution, root/sources target-only (asserting they raise **no lint errors** — a strong check that they aren't linted), `.hypoignore` honored on root targets, table-escaped alias, scan-dir collision, and that genuinely missing links stay W4 (no false negative).

## Review

Two-stage codex cross-review (design + pre-commit), 1 worker each. Design pass tightened the Set-collision handling, the target-only separation, and the conditional backslash strip. Pre-commit pass caught two real gaps — root targets bypassing `.hypoignore` (a reproduced false negative) and the target-only test being too weak to lock the not-linted property — both fixed here.

> Note: `graph.mjs` and `crystallize.mjs` carry a copy of the wikilink regex; keeping them in sync with this resolver is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)