### PR TITLE
fix(session-close): log-only first-class close path for non-project sessions

### DIFF
--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -69,6 +69,11 @@ function emitBlock(sessionId, transcriptPath, gate = null) {
   // /compact to immediately re-block on the same errors).
   const transcriptHint = transcriptPath ? ` --transcript-path=${transcriptPath}` : '';
   const markCmd = `crystallize --mark-session-closed --session-id=${sessionId}${transcriptHint}`;
+  // The log-only escape hatch for a non-project (wiki/tooling-only)
+  // session. Offered ONLY as an explicit alternative when a close blocker is
+  // present — never as the default recovery, so a real project session is not
+  // taught to bypass the ADR 0043 close invariant (codex design Finding 3).
+  const logOnlyCmd = `crystallize --mark-session-closed --log-only --session-id=${sessionId}${transcriptHint}`;
   // ADR 0047: refine the message with the read-only /compact gate result.
   // - gate green → the close is compact-ready and ONLY the marker is missing
   //   (the hand-edit close case: files Written + committed directly, bypassing
@@ -82,6 +87,12 @@ function emitBlock(sessionId, transcriptPath, gate = null) {
   } else if (gate && gate.blockers && gate.blockers.length > 0) {
     const blockers = gate.blockers.map((b) => b.reason).join('; ');
     reason = `[WIKI_AUTOCLOSE] session-close incomplete — resolve: ${blockers}. Then run \`${markCmd}\` (session_id=${sessionId}).`;
+    // Only when a project-close blocker is what's holding the session: a
+    // non-project session has nothing to close, so offer log-only as the way out
+    // (Claude decides whether this session is project-scoped — no auto-attribution).
+    if (gate.blockers.some((b) => b.type === 'close')) {
+      reason += ` If this was a non-project (wiki/tooling-only) session with no project to close, run \`${logOnlyCmd}\` instead (log-only close, no project attribution).`;
+    }
   } else {
     reason = `[WIKI_AUTOCLOSE] session-close 미완료 — /hypo:crystallize 실행으로 마무리 (session_id=${sessionId}${transcriptHint}).`;
   }

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -40,9 +40,14 @@ process.stdin.setEncoding('utf-8');
 process.stdin.on('data', (chunk) => (raw += chunk));
 process.stdin.on('end', () => {
   let transcriptPath = null;
+  let sessionId = null;
   try {
     const input = JSON.parse(raw || '{}');
     transcriptPath = input.transcript_path ?? null;
+    // A log-only marker for this session activates log-only gate
+    // semantics (no project attribution) so /compact does not block a closed
+    // non-project session on the active/phantom project's files.
+    sessionId = input.session_id ?? input.sessionId ?? null;
   } catch {
     /* fail-open */
   }
@@ -98,7 +103,10 @@ process.stdin.on('end', () => {
   // gate.driftTargets, a self-heal effect requirement we run as --write below.
   let gate;
   try {
-    gate = precompactGateStatus(HYPO_DIR, { transcriptPath });
+    gate = precompactGateStatus(HYPO_DIR, {
+      transcriptPath,
+      ...(sessionId ? { sessionId } : {}),
+    });
   } catch (err) {
     // Defense-in-depth: precompactGateStatus fails open per-check, but if it ever
     // throws, never crash the PreCompact hook — fail open (continue) so a tooling

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -277,6 +277,31 @@ export function hasLogEntry(content, date, project) {
 }
 
 /**
+ * True when log.md carries ANY `## [<freshDate>] session | <slug>` heading —
+ * project-agnostic. The minimum proof for a log-only close: a
+ * non-project (tooling/wiki-only) session has no project mandatory files, but it
+ * MUST still leave a today log.md trace so the close is not a content-free bypass.
+ * Uses the same canonical heading parser as hasLogEntry (not a loose substring —
+ * codex design review: keep the fresh-date/canonical-heading style) so a stray
+ * mention of the date elsewhere cannot satisfy it.
+ * @param {string} hypoDir
+ * @returns {boolean}
+ */
+export function hasAnyTodayLogEntry(hypoDir) {
+  const logPath = join(hypoDir, 'log.md');
+  if (!existsSync(logPath)) return false;
+  let content = '';
+  try {
+    content = readFileSync(logPath, 'utf-8');
+  } catch {
+    return false;
+  }
+  return freshDates().some((d) =>
+    new RegExp('^## \\[' + escapeRegExp(d) + '\\] session \\| \\S', 'm').test(content),
+  );
+}
+
+/**
  * Date strings that count as "today" for freshness checks. Both the local and
  * UTC dates are accepted: Claude writes file dates in the user's local zone,
  * while hypo-hot-rebuild stamps root hot.md with the UTC date. Accepting both
@@ -1083,19 +1108,25 @@ export function sessionClosedMarkerPath(hypoDir, sessionId) {
  *
  * @param {string} hypoDir
  * @param {string} sessionId
- * @param {{project?: string, transcript_path?: string}} info
+ * @param {{project?: string, scope?: string, transcript_path?: string}} info
  */
 export function writeSessionClosedMarker(hypoDir, sessionId, info = {}) {
   if (!sessionId) return;
   try {
     const cacheDir = join(hypoDir, '.cache');
     if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+    // scope distinguishes a project close (the 5 mandatory files were verified
+    // fresh) from a log-only close (a non-project session, no project
+    // attribution). Readers (precompactGateStatus / --check-session-close) key
+    // the gate semantics on this field, so it must be recorded.
+    const scope = info.scope === 'log-only' ? 'log-only' : 'project';
     const payload = {
       session_id: sessionId,
       project: info.project || null,
+      scope,
       transcript_path: info.transcript_path || null,
       closed_at: new Date().toISOString(),
-      verification: 'session-close-file-status:ok',
+      verification: scope === 'log-only' ? 'log-only-close:ok' : 'session-close-file-status:ok',
     };
     writeFileSync(sessionClosedMarkerPath(hypoDir, sessionId), JSON.stringify(payload) + '\n');
   } catch (err) {
@@ -1458,6 +1489,19 @@ export function precompactGateStatus(hypoDir, opts = {}) {
   const driftTargets = [];
   const skipped = { lint: false, feedback: false };
 
+  // log-only synthetic close mode. A non-project (tooling / wiki-only)
+  // session has no project to close. Activated either by the explicit writer flag
+  // (opts.logOnly, from `--mark-session-closed --log-only`) or by a log-only marker
+  // for opts.sessionId (the PreCompact / --check-session-close readers). In this
+  // mode the project-close invariant is replaced by a today log.md entry (minimum
+  // proof), and — critically — the active/phantom project is NEVER put in
+  // close.projects, because that set ALSO drives the lint scope and W8 ownership
+  // below. Exempting only the close blocker would still let an unrelated project's
+  // stale design-history / lint block the non-project session (codex design
+  // BLOCKER). git / hot / lint(self) / feedback all still apply — not a bypass.
+  const marker = opts.sessionId ? readSessionClosedMarker(hypoDir, opts.sessionId) : null;
+  const logOnly = opts.logOnly === true || marker?.scope === 'log-only';
+
   // 1. wiki git clean
   const git = hypoIsClean(hypoDir);
   if (!git.clean) blockers.push({ type: 'git', reason: git.reason });
@@ -1466,16 +1510,38 @@ export function precompactGateStatus(hypoDir, opts = {}) {
   const hot = hotMdIsClean(hypoDir);
   if (!hot.clean) blockers.push({ type: 'hot', reason: hot.reason });
 
-  // 3. session-close files (global invariant, ADR 0043)
-  const close = sessionCloseGlobalStatus(hypoDir);
-  if (!close.ok) {
-    blockers.push({
-      type: 'close',
-      reason: `memory files not updated this session: ${[
-        ...close.missing.map((f) => `${f} (missing)`),
-        ...close.stale.map((f) => `${f} (stale)`),
-      ].join(', ')}`,
-    });
+  // 3. session-close files (global invariant, ADR 0043) — or, in log-only mode,
+  //    the minimum proof (a today log.md entry) with NO project attribution.
+  let close;
+  if (logOnly) {
+    const hasLog = hasAnyTodayLogEntry(hypoDir);
+    close = {
+      ok: hasLog,
+      projects: [],
+      dates: freshDates(),
+      fallback: false,
+      primary: null,
+      project: null,
+      stale: [],
+      missing: hasLog ? [] : ['log.md (no today session entry)'],
+    };
+    if (!hasLog) {
+      blockers.push({
+        type: 'close',
+        reason: 'log-only close: log.md has no today session entry (minimum proof)',
+      });
+    }
+  } else {
+    close = sessionCloseGlobalStatus(hypoDir);
+    if (!close.ok) {
+      blockers.push({
+        type: 'close',
+        reason: `memory files not updated this session: ${[
+          ...close.missing.map((f) => `${f} (missing)`),
+          ...close.stale.map((f) => `${f} (stale)`),
+        ].join(', ')}`,
+      });
+    }
   }
 
   // 4. lint blockers + W8 design-history (scoped). Mirrors hypo-personal-check.
@@ -1512,7 +1578,14 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       const parsed = JSON.parse(r.stdout);
       const allErrors = parsed.errors || [];
       const allW8 = (parsed.warns || []).filter((w) => w.id === 'W8');
-      const scope = new Set(opts.lintScope || closeFileTargetsGlobal(hypoDir));
+      // log-only base scope = the shared root files only (hot.md / log.md) — NOT
+      // closeFileTargetsGlobal, which would fold the active/phantom project's
+      // mandatory files in and re-introduce the cross-project attribution. The
+      // session's own transcript-touched files are still added below (a log-only
+      // session is accountable for the wiki files it actually edited).
+      const scope = new Set(
+        opts.lintScope || (logOnly ? ['hot.md', 'log.md'] : closeFileTargetsGlobal(hypoDir)),
+      );
       if (opts.transcriptPath && existsSync(opts.transcriptPath)) {
         for (const f of extractTouchedWikiFiles(opts.transcriptPath, hypoDir)) scope.add(f);
       }
@@ -1526,11 +1599,25 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       for (const n of part.notice)
         notices.push({ type: 'lint', reason: `${n.file}${n.id ? ` (${n.id})` : ''}` });
       // W8 (design-history stale) is each today-active project's own close
-      // responsibility; others' are non-blocking notices (ADR 0043).
-      const activeSlugs = (close.projects || []).map((p) => p.project).filter(Boolean);
+      // responsibility; others' are non-blocking notices (ADR 0043). In log-only
+      // mode there is NO project this session is accountable for, so every W8 is a
+      // notice — a non-project session must never be blocked by some project's
+      // stale design-history (codex design BLOCKER: the attribution leak this fix
+      // closes).
+      const activeSlugs = logOnly
+        ? []
+        : (close.projects || []).map((p) => p.project).filter(Boolean);
       const mine = new Set(activeSlugs.map((s) => `projects/${s}/design-history.md`));
-      const w8Blocking = activeSlugs.length > 0 ? allW8.filter((w) => mine.has(w.file)) : allW8;
-      const w8Notice = activeSlugs.length > 0 ? allW8.filter((w) => !mine.has(w.file)) : [];
+      const w8Blocking = logOnly
+        ? []
+        : activeSlugs.length > 0
+          ? allW8.filter((w) => mine.has(w.file))
+          : allW8;
+      const w8Notice = logOnly
+        ? allW8
+        : activeSlugs.length > 0
+          ? allW8.filter((w) => !mine.has(w.file))
+          : [];
       if (w8Blocking.length > 0) {
         blockers.push({
           type: 'design-history',

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -131,6 +131,7 @@ function parseArgs(argv) {
     checkSessionClose: false,
     applySessionClose: false,
     markSessionClosed: false,
+    logOnly: false,
     sessionId: null,
     payload: null,
     force: false,
@@ -142,6 +143,7 @@ function parseArgs(argv) {
     else if (arg === '--check-session-close') args.checkSessionClose = true;
     else if (arg === '--apply-session-close') args.applySessionClose = true;
     else if (arg === '--mark-session-closed') args.markSessionClosed = true;
+    else if (arg === '--log-only') args.logOnly = true;
     else if (arg.startsWith('--session-id=')) args.sessionId = arg.slice(13);
     else if (arg.startsWith('--payload=')) args.payload = arg.slice(10);
     else if (arg.startsWith('--transcript-path=')) args.transcriptPath = expandHome(arg.slice(18));
@@ -163,7 +165,15 @@ function runSessionCloseCheck(args) {
   // won't block on a human-fixable issue. Pass --transcript-path to widen the
   // lint scope to the session's edited files exactly as the interactive hook
   // does (without it, the scope is the mandatory close files only).
-  const status = precompactGateStatus(args.hypoDir, { transcriptPath: args.transcriptPath });
+  // Pass --session-id so a log-only marker activates log-only gate
+  // semantics here too. Without it the check would read the marker as present
+  // (marker_present:true) while `ok` still reflected the stale active project —
+  // the completion-signal trio (PreCompact / --check / marker) would diverge
+  // (codex design Finding 2).
+  const status = precompactGateStatus(args.hypoDir, {
+    ...(args.transcriptPath ? { transcriptPath: args.transcriptPath } : {}),
+    ...(args.sessionId ? { sessionId: args.sessionId } : {}),
+  });
   const close = status.close;
 
   // ADR 0047: when a --session-id is supplied, report whether THIS session's
@@ -411,10 +421,15 @@ function runMarkSessionClosed(args) {
   // `git` blocker inside the gate. Pass --transcript-path to widen the lint
   // scope to this session's edited files exactly as the interactive hook does;
   // without it the scope is the mandatory close files only.
-  const gate = precompactGateStatus(
-    args.hypoDir,
-    args.transcriptPath ? { transcriptPath: args.transcriptPath } : {},
-  );
+  // --log-only marks a non-project (tooling / wiki-only) session as
+  // closed without attributing it to any project. The gate runs in log-only mode
+  // (project-close invariant → a today log.md entry; lint/W8 scoped to shared +
+  // touched files, never the active/phantom project), but git / hot / feedback
+  // still apply — log-only is NOT a global-gate bypass.
+  const gate = precompactGateStatus(args.hypoDir, {
+    ...(args.transcriptPath ? { transcriptPath: args.transcriptPath } : {}),
+    ...(args.logOnly ? { logOnly: true } : {}),
+  });
   const status = gate.close;
   if (!gate.ok) {
     const result = {
@@ -436,7 +451,10 @@ function runMarkSessionClosed(args) {
     }
     process.exit(1);
   }
-  writeSessionClosedMarker(args.hypoDir, args.sessionId, { project: status.project });
+  writeSessionClosedMarker(args.hypoDir, args.sessionId, {
+    project: status.project,
+    ...(args.logOnly ? { scope: 'log-only' } : {}),
+  });
   // Marker writer swallows IO errors (best-effort, see hypo-shared.mjs). Verify
   // the file actually landed before claiming success — otherwise CLI exits 0
   // while next Stop re-blocks, hiding a permission/disk problem.
@@ -454,6 +472,7 @@ function runMarkSessionClosed(args) {
     ok: true,
     session_id: args.sessionId,
     project: status.project,
+    scope: args.logOnly ? 'log-only' : 'project',
     date: status.dates[0],
     notices: gate.notices,
     // ADR 0047: pure feedback-projection drift is a non-blocker — the marker
@@ -466,7 +485,9 @@ function runMarkSessionClosed(args) {
     console.log(JSON.stringify(result, null, 2));
   } else {
     console.log(
-      `✓ session-closed marker written (session_id: ${args.sessionId}, project: ${status.project}).`,
+      args.logOnly
+        ? `✓ session-closed marker written (session_id: ${args.sessionId}, scope: log-only — no project attribution).`
+        : `✓ session-closed marker written (session_id: ${args.sessionId}, project: ${status.project}).`,
     );
     if (gate.driftTargets.length > 0) {
       console.log(

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -10519,6 +10519,173 @@ test('--check-session-close --session-id reports marker presence without alterin
   });
 });
 
+// ── ISSUE-10: --log-only first-class non-project close path ───────────────────
+suite('crystallize.mjs --mark-session-closed --log-only (ISSUE-10)');
+
+// A non-project (tooling / wiki-only) session leaves a today log.md entry but
+// closes NO project. The current marker gate resolves the active project via
+// sessionCloseGlobalStatus and demands its mandatory files — trapping the session
+// and pushing it to clobber an unrelated project's handoff. --log-only is the
+// first-class signal: exempt the project-close blocker, still require git/hot/lint
+// clean + a today log.md entry (the log-only minimum proof), record project:null.
+test('--log-only: active project not closed today → marker written, project:null, scope log-only', () => {
+  withWiki(
+    (dir) => {
+      // Backdate the project's mandatory files so sessionCloseGlobalStatus would
+      // block on them, but keep the today log.md entry (the log-only session's own
+      // trace) so the gate still has its minimum proof.
+      const stale = '2000-01-01';
+      const projDir = join(dir, 'projects', 'test-project');
+      writeFileSync(
+        join(projDir, 'session-state.md'),
+        `---\ntitle: session-state\ntype: session-state\nupdated: ${stale}\n---\n\n## 다음 작업\n\n- next\n`,
+      );
+      writeFileSync(
+        join(projDir, 'hot.md'),
+        `---\ntitle: hot\ntype: reference\nupdated: ${stale}\n---\n\n# Hot\n`,
+      );
+      const ym = todayLocal().slice(0, 7);
+      writeFileSync(
+        join(projDir, 'session-log', `${ym}.md`),
+        `---\ntitle: Session Log\ntype: session-log\nupdated: ${stale}\n---\n\n## [${stale}] old session\n`,
+      );
+    },
+    (dir) => {
+      const r = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--mark-session-closed',
+        '--log-only',
+        '--session-id=s-logonly',
+        '--json',
+      ]);
+      assert.equal(
+        r.status,
+        0,
+        `--log-only must close a non-project session despite a stale active project: ${r.stdout}\n${r.stderr}`,
+      );
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, true);
+      assert.equal(out.scope, 'log-only');
+      const markerPath = join(dir, '.cache', 'session-closed-s-logonly.marker');
+      assert.ok(existsSync(markerPath), 'log-only marker must be written');
+      const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+      assert.equal(
+        marker.project,
+        null,
+        'log-only marker must NOT attribute to a project (clobber-safe)',
+      );
+      assert.equal(marker.scope, 'log-only');
+    },
+  );
+});
+
+// log-only is NOT a global-gate bypass: git must still be clean.
+test('--log-only: dirty git still blocks (not a global bypass)', () => {
+  withWiki(null, (dir) => {
+    writeFileSync(join(dir, 'untracked.md'), 'dirty\n');
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--mark-session-closed',
+      '--log-only',
+      '--session-id=s-lo-dirty',
+      '--json',
+    ]);
+    assert.equal(r.status, 1, `log-only must still block on dirty git: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(
+      (out.blockers || []).some((b) => b.type === 'git'),
+      `dirty-git log-only result must carry a git blocker: ${JSON.stringify(out)}`,
+    );
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-lo-dirty.marker')),
+      'log-only marker must not land on dirty git',
+    );
+  });
+});
+
+// log-only requires its minimum proof: a today log.md entry. Without one the
+// session left no trace and the marker is refused.
+test('--log-only: no today log.md entry → marker refused (minimum proof)', () => {
+  withWiki(
+    (dir) => {
+      // Wipe log.md to its header so there is NO today session entry at all.
+      writeFileSync(join(dir, 'log.md'), '# Log\n');
+    },
+    (dir) => {
+      const r = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--mark-session-closed',
+        '--log-only',
+        '--session-id=s-lo-nolog',
+        '--json',
+      ]);
+      assert.equal(r.status, 1, `log-only with no today log entry must block: ${r.stdout}`);
+      assert.ok(
+        !existsSync(join(dir, '.cache', 'session-closed-s-lo-nolog.marker')),
+        'log-only marker must not land without a today log.md entry',
+      );
+    },
+  );
+});
+
+// Completion-signal trio coherence (codex design Finding 2): after a log-only
+// marker, --check-session-close --session-id must read the SAME log-only gate —
+// marker_present:true AND ok:true — even though the active project is stale.
+// Without passing sessionId into the gate it would report marker_present:true
+// while ok:false from the stale project (the divergence this guards).
+test('--check-session-close --session-id: log-only marker → ok:true, marker_present:true (trio coherence)', () => {
+  withWiki(
+    (dir) => {
+      const stale = '2000-01-01';
+      const projDir = join(dir, 'projects', 'test-project');
+      writeFileSync(
+        join(projDir, 'session-state.md'),
+        `---\ntitle: session-state\ntype: session-state\nupdated: ${stale}\n---\n\n## 다음 작업\n\n- next\n`,
+      );
+      writeFileSync(
+        join(projDir, 'hot.md'),
+        `---\ntitle: hot\ntype: reference\nupdated: ${stale}\n---\n\n# Hot\n`,
+      );
+      const ym = todayLocal().slice(0, 7);
+      writeFileSync(
+        join(projDir, 'session-log', `${ym}.md`),
+        `---\ntitle: Session Log\ntype: session-log\nupdated: ${stale}\n---\n\n## [${stale}] old session\n`,
+      );
+    },
+    (dir) => {
+      // First write the log-only marker, then commit it so git stays clean.
+      const m = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--mark-session-closed',
+        '--log-only',
+        '--session-id=s-trio',
+        '--json',
+      ]);
+      assert.equal(m.status, 0, `log-only marker write must succeed: ${m.stdout}\n${m.stderr}`);
+      spawnSync('git', ['add', '-A'], { cwd: dir });
+      spawnSync('git', ['commit', '-m', 'marker'], { cwd: dir });
+      const r = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--check-session-close',
+        '--session-id=s-trio',
+        '--json',
+      ]);
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.marker_present,
+        true,
+        `the log-only marker must be reported present: ${r.stdout}`,
+      );
+      assert.equal(
+        out.ok,
+        true,
+        `log-only check must be compact-ready despite the stale project: ${r.stdout}`,
+      );
+    },
+  );
+});
+
 test('--check-session-close --session-id: a STALE marker reports marker_present:false (matches the Stop hook reader, not raw existsSync)', () => {
   withWiki(null, (dir) => {
     // A marker file exists on disk but is stale → the Stop hook would reject and


### PR DESCRIPTION
## Problem

A non-project (tooling / wiki-only) session has no project mandatory files, but the per-session marker gate resolved the active project via `sessionCloseGlobalStatus` and demanded that project's 5 mandatory files — trapping the session and pushing it to clobber an unrelated project's handoff. The active/phantom project also drove **lint scope** (`closeFileTargetsGlobal`) and **W8 design-history ownership**, so exempting the close blocker alone would still leave the session blocked on another project's stale design-history / lint.

## Fix — `crystallize --mark-session-closed --log-only`

A synthetic close mode that:
- replaces the project-close invariant with a **today `log.md` entry** (minimum proof, canonical heading parser — not a loose substring),
- never attributes lint scope or W8 design-history to the active/phantom project (scope = shared root files + the session's own transcript-touched files),
- records the marker with `project: null, scope: 'log-only'`,

while git / hot.md / lint(self) / feedback projection **still apply** — log-only is not a global-gate bypass.

`precompactGateStatus` and `--check-session-close` read the log-only marker by `session_id` (PreCompact now forwards it) so `/compact`, the self-check, and the marker stay coherent. The Stop hook offers `--log-only` only when a project-close blocker is present — never as the default recovery, so a real project session is not taught to bypass the close invariant.

## Tests

Red-first repro confirmed the trap (a non-project session blocked on a stale active project via the main branch), then green after the fix:
- `--log-only`: active project stale → marker written, `project:null`, `scope:log-only`
- `--log-only` + dirty git → still blocks (not a bypass)
- `--log-only` + no today log.md entry → marker refused (minimum proof)
- `--check-session-close --session-id` with a log-only marker → `ok:true`, `marker_present:true` (completion-signal trio coherence)

734 passed, tracker-id check clean. Design-round cross-review caught the lint/W8 second-order attribution leak, which this PR closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)