### PR TITLE
fix(close-gate): exclude tool_result from close-intent extraction

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1760,7 +1760,9 @@ export function isCompactOrClearCommand(prompt) {
  * PreCompact gate and the Stop-chain Layer 3 hook share one close-intent
  * signal source. Claude Code transcript format: each line is
  * `{ type:"user", message:{ role:"user", content: ... } }`; the older
- * top-level `{ role, content }` shape is also accepted.
+ * top-level `{ role, content }` shape is also accepted. tool_result blocks
+ * (also role:'user') are excluded so tool output never feeds the close-intent
+ * gate — only top-level `type:'text'` blocks and string content count.
  *
  * @param {string} transcriptPath
  * @param {number} tailN  how many trailing lines to scan (default 30)
@@ -1778,7 +1780,19 @@ export function extractUserMessages(transcriptPath, tailN = 30) {
           const role = msg.role ?? obj.role ?? obj.type;
           if (role !== 'user') return '';
           const content = msg.content ?? obj.content;
-          return typeof content === 'string' ? content : JSON.stringify(content);
+          if (typeof content === 'string') return content;
+          if (Array.isArray(content)) {
+            // Only genuine user-typed text blocks. tool_result blocks are also
+            // recorded with role:'user' in the Claude Code transcript; slurping
+            // them via JSON.stringify let tool output (e.g. close-pattern example
+            // strings read out of code/docs) trip the close-intent gate.
+            // Do NOT recurse into tool_result.content, or the pollution returns.
+            return content
+              .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+              .map((b) => b.text)
+              .join('\n');
+          }
+          return '';
         } catch {
           return '';
         }
@@ -1800,7 +1814,12 @@ export function extractUserMessages(transcriptPath, tailN = 30) {
 export function isClosePattern(text) {
   if (!text || typeof text !== 'string') return false;
   const krPatterns = [
-    /세션\s*(끝|종료|마무리)/,
+    // 끝: bare terminal noun, but boundary-guarded so "세션 끝내는 방법" /
+    // "세션 끝나면" don't trip. 마무리/종료: require a verb ending (mirrors the
+    // 작업 마무리/종료 sibling below) so mentions/negations like
+    // "세션 마무리 할 때가 아닌데" are excluded. 임 is boundary-guarded so
+    // "세션 종료 임시 플래그" doesn't match.
+    /세션\s*(?:끝(?![가-힣])|(?:마무리|종료)\s*(?:하자|할게|하겠|했어|임(?![가-힣])))/,
     /오늘\s*은?\s*(여기|작업|세션).*(끝|마치|마무리|종료)/,
     // 여기까지: requires no continuation action word (e.g. 여기까지 구현해줘 is not a close signal)
     /여기(서)?까지(?!\s*(?:구현|작성|완성|수정|변경|추가|삭제|테스트|확인|검토|해줘|해야|하고|하면))/,

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -742,6 +742,7 @@ const {
   isGateSkipped,
   buildOutput,
   isClosePattern,
+  extractUserMessages,
   hasMutatingTranscriptActivity,
   isSubstantialSession,
   extractTouchedWikiFiles,
@@ -936,6 +937,13 @@ test('일반 작업 문장 → false (false-positive 방지)', () => {
   assert.equal(isClosePattern('wrapping up the investigation'), false);
   assert.equal(isClosePattern('wrap up the debugging'), false);
   assert.equal(isClosePattern('wrap up the audit'), false);
+  // ISSUE-29 부 fix: 세션 + 마무리/종료 needs a verb ending; bare 끝/임 are
+  // boundary-guarded so mentions/negations and noun-prefix forms don't trip.
+  assert.equal(isClosePattern('세션 마무리 할 때가 아닌데'), false);
+  assert.equal(isClosePattern('세션 종료 조건을 바꿔줘'), false);
+  assert.equal(isClosePattern('세션 종료 임시 플래그'), false);
+  assert.equal(isClosePattern('세션 끝내는 방법'), false);
+  assert.equal(isClosePattern('세션 끝나면 알려줘'), false);
   assert.equal(isClosePattern(''), false);
   assert.equal(isClosePattern(null), false);
 });
@@ -943,6 +951,71 @@ test('일반 작업 문장 → false (false-positive 방지)', () => {
 test('혼합 텍스트(트랜스크립트)에서도 패턴 감지', () => {
   const transcript = '이 PR 리뷰 마저 봐줘\n오늘은 여기까지 하자\n내일 다시 볼게';
   assert.equal(isClosePattern(transcript), true);
+});
+
+// ── ISSUE-29: extractUserMessages must not slurp tool_result content ──
+suite('extractUserMessages() — tool_result exclusion');
+
+test('tool_result carrying close-phrase examples is excluded → no false close', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      // tool_result (role:'user') carrying close-pattern example strings, as a
+      // Read of close logic/docs would produce — must NOT count as user text.
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'x',
+              content: '패턴 예시: "이만 마치자", "오늘 여기까지", "wrap up", "session close"',
+            },
+          ],
+        },
+      },
+      // a genuine, neutral user message in a text block
+      {
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'text', text: '이 close 로직 좀 봐줘' }] },
+      },
+    ]);
+    const text = extractUserMessages(p);
+    assert.equal(text.includes('이 close 로직'), true); // real text kept
+    assert.equal(text.includes('이만 마치자'), false); // tool_result dropped
+    assert.equal(isClosePattern(text), false); // the ISSUE-29 false-positive is dead
+  });
+});
+
+test('genuine close in a text block still fires', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'y', content: 'noise' }],
+        },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'text', text: '오늘은 여기까지 하자' }] },
+      },
+    ]);
+    assert.equal(isClosePattern(extractUserMessages(p)), true);
+  });
+});
+
+test('string content and legacy top-level shape still extracted', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      { type: 'user', message: { role: 'user', content: '세션 마무리하자' } },
+      { role: 'user', content: '추가 메모' }, // legacy top-level shape
+    ]);
+    const text = extractUserMessages(p);
+    assert.equal(text.includes('세션 마무리하자'), true);
+    assert.equal(text.includes('추가 메모'), true);
+  });
 });
 
 // ── 6a: substantial-session gate (read-only investigation volume) ──


### PR DESCRIPTION
## Problem

The Stop-chain close-intent gate fired spuriously on nearly every turn of a self-development session. `extractUserMessages` scanned `role:'user'` transcript records, but in the Claude Code transcript **tool_result blocks are also recorded with `role:'user'`** — and the old code `JSON.stringify`'d the whole content array. So any close-pattern example string read out of code or docs (via `Read`/`Grep`/`Bash`) landed in the close-intent input. A session that reads the close logic or its own issue docs (which literally contain phrases like "wrap up", "오늘 여기까지") matched the close gate without the user ever signalling a close.

This reproduced live in this very PR's authoring session: the `[WIKI_AUTOCLOSE]` block tripped while reading close-gate source.

## Fix

- **`extractUserMessages` (main fix):** collect only top-level `type:'text'` blocks (plus plain-string content and the legacy top-level `{role, content}` shape). `tool_result` blocks are excluded, and their `.content` is **not** recursed into (recursing would re-import the pollution). Same trailing-window semantics, just without tool output. The trailing-window order was deliberately **not** changed: recency is the right property for "did the user *just* signal close", and reordering to "last N user messages" would have reintroduced a stale-close-intent false-positive.
- **`isClosePattern` (secondary):** the `세션` pattern now requires a verb ending on `마무리`/`종료` (mirroring the existing `작업 마무리/종료` sibling), and `끝`/`임` are boundary-guarded. So `세션 마무리 할 때가 아닌데` (a negation), `세션 종료 임시 플래그`, and `세션 끝내는 방법` no longer match, while `세션 끝`, `세션 마무리하자`, `세션 종료할게` still do.

## Verification

- 766 tests pass (adds direct `extractUserMessages` tests — tool_result exclusion, genuine close still fires, string/legacy shapes — plus the new close-pattern negatives).
- Replayed against this session's real transcript with a 30-line sliding window: the old logic would block **160** windows, the new logic **30** — **130 windows where the old gate spuriously blocks but the new gate correctly passes** (the documented bug, eliminated).

## Scope (deliberately tight)

Two pre-existing, separate defects were surfaced during measurement but left for follow-up to keep the diff reviewable:
1. The English `end (the|this) (session|work|day)` pattern lacks a leading word boundary, so injected text like "Send **the work**er" substring-matches. Different vector (harness skill-body injection as `role:'user'` text), different root cause.
2. The `오늘\s*은?\s*(여기|작업|세션).*(끝|마치|마무리|종료)` sibling pattern is similarly broad.

## Review

Two-round codex cross-review (design + pre-commit) via `/teams`: design round returned CONCERN (caught that a tailN-reorder would introduce a stale-close-intent regression — dropped), pre-commit round returned CLEAR.

CHANGELOG entry deferred to the next release bundle, matching recent feature-PR precedent (#123/#125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
