### PR TITLE
chore(commands): make hypo:* descriptions trigger-rich

### DIFF
--- a/commands/audit.md
+++ b/commands/audit.md
@@ -1,5 +1,5 @@
 ---
-description: Run the observability audit on recent sessions and (optionally) write the weekly report
+description: Audit recent sessions for observability gaps and optionally write the weekly report. Use when the user asks to review session quality, find tracking gaps, or generate the weekly summary.
 ---
 
 You are running `/hypo:audit`. Inspect recent Claude Code sessions to see how much of the wiki's value motion is actually happening (search, ingest, citation, feedback), then either show the result inline or write a weekly observability page.

--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -1,5 +1,5 @@
 ---
-description: Crystallize draft notes into stable knowledge — also the session-close alias
+description: Crystallize draft notes into stable wiki knowledge; also the session-close path. Use when the user is wrapping up a session, asks to save or consolidate notes, or before a /compact.
 ---
 
 You are running `/hypo:crystallize`. This command serves two purposes:

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-description: Health check for a Hypomnema wiki installation
+description: Run a health check on a Hypomnema wiki installation (hooks, settings, structure). Use when the user reports the wiki misbehaving, after an install or upgrade, or to diagnose setup problems.
 ---
 
 You are running `/hypo:doctor`. Verify the health of the current Hypomnema wiki installation.

--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -1,5 +1,5 @@
 ---
-description: Record an AI behavior correction or preference into the wiki
+description: Record an AI behavior correction or preference into the wiki. Use when the user corrects how you work or states a lasting preference to remember.
 ---
 
 You are running `/hypo:feedback`. Capture a behavior correction or preference into `pages/feedback/` — the **single source of truth** for learned behaviors (ADR 0031).

--- a/commands/graph.md
+++ b/commands/graph.md
@@ -1,5 +1,5 @@
 ---
-description: Generate a wikilink dependency graph for the wiki
+description: Generate a wikilink dependency graph from wiki pages (json, mermaid, or dot). Use when the user asks to visualize wiki structure or find orphan and hub pages.
 ---
 
 You are running `/hypo:graph`. Generate a link dependency graph from wiki pages.

--- a/commands/ingest.md
+++ b/commands/ingest.md
@@ -1,5 +1,5 @@
 ---
-description: Ingest an external source into the wiki
+description: Ingest an external source (URL, doc, article, command output) into the wiki as a citable page. Use when the user shares a source to capture or wants external knowledge saved for reuse.
 ---
 
 You are running `/hypo:ingest`. Save a raw source and synthesize it into wiki pages.

--- a/commands/init.md
+++ b/commands/init.md
@@ -1,5 +1,5 @@
 ---
-description: Initialize a new Hypomnema wiki
+description: Initialize a new Hypomnema wiki (structure, config, hooks). Use when the user is setting up a wiki for the first time or starting a fresh vault.
 ---
 
 You are running `/hypo:init`. Set up a new personal wiki powered by Hypomnema.

--- a/commands/lint.md
+++ b/commands/lint.md
@@ -1,5 +1,5 @@
 ---
-description: Validate wiki pages for frontmatter correctness and broken wikilinks
+description: Validate wiki pages for frontmatter correctness and broken wikilinks. Use when the user asks to check wiki health, before a commit, or after bulk edits or renames.
 ---
 
 You are running `/hypo:lint`. Validate all wiki pages for frontmatter correctness and broken `[[wikilink]]` references.

--- a/commands/query.md
+++ b/commands/query.md
@@ -1,5 +1,5 @@
 ---
-description: Query the wiki and synthesize an answer from relevant pages
+description: Query the wiki and synthesize an answer from the relevant pages. Use when the user asks what the wiki knows, wants to recall a past decision, or needs prior context before starting work.
 ---
 
 You are running `/hypo:query`. Answer a question by searching the wiki and synthesizing from relevant pages.

--- a/commands/rename.md
+++ b/commands/rename.md
@@ -1,5 +1,5 @@
 ---
-description: Rename a wiki page or directory and rewrite inbound wikilinks
+description: Rename a wiki page or directory and rewrite the inbound wikilinks so live links survive. Use when the user wants to move or rename a page or folder without breaking references.
 ---
 
 You are running `/hypo:rename`. Move a page or directory and content-aware rewrite every inbound `[[wikilink]]` across the vault so the rename never breaks a link.

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -1,5 +1,5 @@
 ---
-description: Resume the most recent session for an active project
+description: Resume an active project and pick up where you left off. Use when the user asks to continue prior work or what they were working on.
 ---
 
 You are running `/hypo:resume`. Load the session state for an active project and pick up where you left off.

--- a/commands/stats.md
+++ b/commands/stats.md
@@ -1,5 +1,5 @@
 ---
-description: Show statistics about the wiki
+description: Show statistics about the wiki (page counts, link density, growth). Use when the user asks how big the wiki is, how it has grown, or its overall shape.
 ---
 
 You are running `/hypo:stats`. Display a summary of wiki health and activity.

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -1,5 +1,5 @@
 ---
-description: Remove Hypomnema hooks and clean up settings.json
+description: Remove Hypomnema hooks and clean up settings.json. Use when the user wants to uninstall or disable the wiki integration.
 ---
 
 You are running `/hypo:uninstall`. Remove Hypomnema from this machine.

--- a/commands/upgrade.md
+++ b/commands/upgrade.md
@@ -1,5 +1,5 @@
 ---
-description: Check for Hypomnema updates and optionally apply them
+description: Check for Hypomnema updates and optionally apply them. Use when the user asks to update Hypomnema or sees an update-available notice.
 ---
 
 You are running `/hypo:upgrade`. Check if the installed Hypomnema wiki is out of date and offer to apply updates.

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -1,5 +1,5 @@
 ---
-description: Check verify_by fields and surface overdue or missing verifications
+description: Check verify_by fields and surface overdue or missing verifications. Use when the user asks what wiki knowledge needs re-checking or wants to audit freshness.
 ---
 
 You are running `/hypo:verify`. Audit wiki pages for overdue or missing `verify_by` fields.

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Close a session (steps 1~6) and, on request, consolidate scattered wiki knowledge into stable pages (steps 7~11)
+description: Close a session by capturing what happened into the wiki (steps 1-6), and on request consolidate scattered notes into stable pages (steps 7-11). Use when the user signals they are wrapping up, asks to save or crystallize the session, or before a /compact.
 ---
 
 You are running `/hypo:crystallize`. The command serves two modes (spec §5.2.7 / §8.3):

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Generate a wikilink dependency graph from wiki pages
+description: Generate a wikilink dependency graph from wiki pages (json, mermaid, or dot). Use when the user asks to visualize wiki structure, find orphan or hub pages, or map how notes link together.
 ---
 
 You are running `/hypo:graph`. Build a wikilink dependency graph from all pages under `pages/` and `projects/` and output it in the requested format.

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Add a source document to the wiki and synthesize a source-summary page
+description: Add an external source (URL, doc, article, command output) to the wiki and synthesize a citable summary page. Use when the user shares a source to capture, asks to ingest something, or wants reliable external knowledge saved for reuse.
 ---
 
 You are running `/hypo:ingest`. Add a new source document to `sources/` and create (or update) its corresponding `source-summary` page under `pages/`.

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Lint wiki pages for frontmatter and broken wikilinks
+description: Lint wiki pages for frontmatter errors and broken wikilinks. Use when the user asks to check or validate the wiki health, before a commit, or after bulk edits or renames.
 ---
 
 You are running `/hypo:lint`. Validate all wiki pages for frontmatter correctness and broken `[[wikilink]]` references.

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Search wiki pages by keyword and retrieve relevant knowledge
+description: Search the wiki by keyword and synthesize an answer from the relevant pages. Use when the user asks what the wiki knows about a topic, wants to recall a past decision, or needs prior context before starting work.
 ---
 
 You are running `/hypo:query`. Full-text search across all wiki pages and projects, then synthesize an answer from the matching pages.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Check wiki pages for stale or unverified knowledge and prompt review
+description: Surface wiki knowledge that is stale or past its verify-by date and prompt review. Use when the user asks what needs re-checking, wants to audit knowledge freshness, or is reviewing the wiki for rot.
 ---
 
 You are running `/hypo:verify`. Check all wiki pages for `verify_by` and `verify_by_date` fields, surface overdue pages, and guide a review pass.


### PR DESCRIPTION
## Problem

Every `hypo:*` slash-command and skill description stated only **what** the command does, never **when** to invoke it. With no trigger conditions, the model can pass over the right command rather than reach for it, so a wiki action that should fire proactively (query before starting work, crystallize at session wrap-up, ingest a shared source) is easy to miss.

Separately, the six commands that also exist as skills (`crystallize`, `graph`, `ingest`, `lint`, `query`, `verify`) had drifted to different wording across the two surfaces.

## Change

- **All 15 command descriptions and 6 skill descriptions** now add an accurate `Use when ...` clause naming the real conditions for invoking the command. Calibrated to *precise* triggers, not maximal pushiness (over-eager descriptions cause false invocation).
- **The six command/skill pairs are reconciled** to a consistent meaning, with the skill side kept slightly richer since it drives auto-invocation.
- **English-only**, matching the existing descriptions and the npm audience; localization stays in `README.ko.md`. No body or behavior change, only frontmatter `description:` lines.

## Verification

- 766 tests pass; `check-tracker-ids` clean; no em/en dashes in any description; `Init`/`Upgrade` snapshot jobs are unaffected (they assert structure and JSON fields, not description content).
- 21 files changed, one `description:` line each.

## Review

One codex pre-commit pass via `/teams` returned CLEAR. A single round is proportionate for a pure-copy change with no logic or regression surface (design was fixed by the tracker spec and an advisor consult).

CHANGELOG entry deferred to the next release bundle, matching recent feature-PR precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
