### PR TITLE
fix(close): scope proactive-offer to offer-only, never self-close

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -1,5 +1,5 @@
 ---
-description: Crystallize draft notes into stable wiki knowledge; also the session-close path. Use when the user is wrapping up a session, asks to save or consolidate notes, or before a /compact.
+description: Crystallize draft notes into stable wiki knowledge; also the session-close path. Use when the user explicitly signals session end (종료/마무리/wrap up), asks to save or consolidate notes, or before a /compact. Task completion alone is not a close signal.
 ---
 
 You are running `/hypo:crystallize`. This command serves two purposes:
@@ -11,7 +11,7 @@ You are running `/hypo:crystallize`. This command serves two purposes:
 
 ## Step 1 — Detect context
 
-If the user invoked `/hypo:crystallize` to close a session (phrases like "세션 종료", "오늘 작업 마무리", "session close", or "wrap up"), run Step 1a (advisory reflections) then Steps 2–4 (session-close mechanical apply + recovery) **before** the synthesis scan. Otherwise skip to Step 5.
+If `/hypo:crystallize` was invoked to close a session (via an explicit close signal like "세션 종료" / "오늘 작업 마무리" / "session close" / "wrap up", an accepted proactive-offer [세션 마무리], or `/compact`), run Step 1a (advisory reflections) then Steps 2–4 (session-close mechanical apply + recovery) **before** the synthesis scan. Task completion alone does not put you in close mode. Otherwise skip to Step 5.
 
 ---
 

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Close a session by capturing what happened into the wiki (steps 1-6), and on request consolidate scattered notes into stable pages (steps 7-11). Use when the user signals they are wrapping up, asks to save or crystallize the session, or before a /compact.
+description: Close a session by capturing what happened into the wiki (steps 1-6), and on request consolidate scattered notes into stable pages (steps 7-11). Use when the user explicitly signals session end, asks to save or crystallize the session, or before a /compact. Task completion alone is not a close signal.
 ---
 
 You are running `/hypo:crystallize`. The command serves two modes (spec §5.2.7 / §8.3):
@@ -7,7 +7,7 @@ You are running `/hypo:crystallize`. The command serves two modes (spec §5.2.7 
 1. **Session close (steps 1~6)** — gate the 5 mandatory memory files plus open-questions (conditional) so `/compact` can pass.
 2. **Synthesis (steps 7~11)** — surface tag clusters, orphan pages, and drafts that are ready to consolidate.
 
-When invoked at the end of a session (or with phrases like "세션 종료", "wrap up"), run the session-close checklist first. The synthesis scan only runs after close is confirmed and the user agrees.
+When invoked to close a session — via an explicit close signal ("세션 종료", "wrap up"), an accepted proactive-offer [세션 마무리], or `/compact` — run the session-close checklist first. Task completion alone does not put you in close mode. The synthesis scan only runs after close is confirmed and the user agrees.
 
 ## What this does
 

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -74,6 +74,8 @@ Trigger: explicit close mention, `/compact` request, or context limit approachin
 
 Do **not** treat these as completion: plan approvals, clarification answers, permission grants, progress updates, partial findings, or mid-task checkpoints. A "좋아요" / "감사합니다" / "ok" following any of those is *not* a close signal — only offer after a genuine final completion/verification report.
 
+**Proactive offer means offer, not close.** In this path (task done, no close signal) do not run the close checklist, write the `session-closed` marker, or declare the session ended on your own. Fire `AskUserQuestion` and proceed only after the user picks [세션 마무리]. Task completion is not a close trigger; closing without asking violates this procedure. This scopes the proactive path only: a real close signal, `/compact`, or context limit still closes via the triggers above.
+
 Ask: *"이 작업이 마무리되었나요? 세션을 정리(crystallize)할까요?"* with options **[세션 마무리 / 계속 작업]**. On **세션 마무리** → run the session close checklist (or invoke `/hypo:crystallize`). On **계속 작업** → continue and do not re-ask until the next task completes. Ask at most once per completed task; never loop. (Decline simply ends the turn — Layer 3's Stop-chain only blocks on an explicit close signal, so no repeated prompts occur.)
 
 1. Update `projects/<name>/session-state.md` (next tasks, overwrite)

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -15717,6 +15717,56 @@ test('hypo-guide.md intentionally excluded from advisory surfaces (#47 follow-up
   );
 });
 
+// ── over-close guard (ISSUE-31) — proactive-offer path scoping ──────────────
+// Forensic (session d8d6ecd0): the model self-ran close (session-closed marker
+// write + "session ended" declaration) with NO user close signal — it skipped
+// the AskUserQuestion gate, pushed by a competing global instruction. The fix
+// is prose-only on shipped surfaces, so the defect class is "guard text drifts
+// out and a surface silently permits self-close again". Pin the scoping phrases
+// per surface, and pin REMOVAL of the over-trigger "wrapping up a session"
+// description wording that PR #127 introduced (which read as task-wrap-up).
+suite('over-close guard (ISSUE-31) — proactive path scoping on shipped surfaces');
+
+const OVERCLOSE_SURFACES = [
+  {
+    file: join(REPO, 'templates', 'hypo-guide.md'),
+    present: ['Proactive offer means offer, not close', 'Task completion is not a close trigger'],
+    absent: [],
+  },
+  {
+    file: join(REPO, 'commands', 'crystallize.md'),
+    present: [
+      'Task completion alone is not a close signal', // description
+      'Task completion alone does not put you in close mode', // body trigger
+    ],
+    absent: ['Use when the user is wrapping up a session'], // PR #127 over-trigger wording
+  },
+  {
+    file: join(REPO, 'skills', 'crystallize', 'SKILL.md'),
+    present: [
+      'Task completion alone is not a close signal',
+      'Task completion alone does not put you in close mode',
+    ],
+    absent: ['Use when the user signals they are wrapping up'],
+  },
+];
+
+for (const { file, present, absent } of OVERCLOSE_SURFACES) {
+  const rel = file.slice(REPO.length + 1);
+  test(`${rel}: over-close scoping present, over-trigger wording absent`, () => {
+    const txt = readFileSync(file, 'utf-8');
+    for (const needle of present) {
+      assert.ok(txt.includes(needle), `${rel} missing over-close guard: ${JSON.stringify(needle)}`);
+    }
+    for (const needle of absent) {
+      assert.ok(
+        !txt.includes(needle),
+        `${rel} still has over-trigger wording (PR #127 regression): ${JSON.stringify(needle)}`,
+      );
+    }
+  });
+}
+
 // ── tracker-id gate (no-internal-tracker-ids-in-oss-artifacts) ───────────────
 suite('tracker-id gate (check-tracker-ids)');
 


### PR DESCRIPTION
## Problem

The proactive close-offer path could slide from "offer to wrap up" into actually closing: running the close checklist, writing the `session-closed` marker, and declaring the session ended, all with no user close signal.

Transcript forensics on a real session confirmed the mechanism:
- The Stop hook never blocked (0 real close-gate blocks) — its close-intent gate worked correctly.
- The model called `AskUserQuestion` 0 times before writing the marker — it skipped the proactive-offer gate entirely.
- The last user message before the self-close was 1200+ lines earlier; no close signal followed.
- The model self-judged "gate green" and ran `--mark-session-closed` on its own, pushed by a competing always-on instruction the prose gate did not override.

## Fix (prose-only on shipped surfaces)

- **hypo-guide**: scope the proactive path to offer-only. Never run the checklist, write the marker, or declare the session ended on your own; proceed only after the user picks [세션 마무리]. The explicit triggers (close signal, `/compact`, context limit) are unchanged and still close as before.
- **crystallize description + body trigger** (command and skill): require an explicit close signal, an accepted offer, or `/compact`. Task completion alone is not a close signal. This reverses an over-trigger description wording that read as task-wrap-up.
- **tests**: a surface-drift guard pins the scoping phrases and the absence of the over-trigger wording across all three shipped surfaces.

## Out of scope (follow-up)

The marker writers (`crystallize.mjs --mark-session-closed` / `--apply-session-close`) still gate only on the compact gate, not on evidence of user confirmation. A transcript-backed hard gate is tracked as a separate follow-up; this PR is the prose-layer defense in depth.

## Verification

- `node tests/runner.mjs` → 769 passed, 0 failed (3 new surface-drift tests).
- codex two-stage cross-review: design (CONCERN, addressed: scope wording so it does not collide with the explicit triggers, sync the command/skill body) → commit (CLEAR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)