### PR TITLE
fix(close): apply commit-then-mark + demote git "ahead" to a notice (ADR 0056)

### DIFF
--- a/hooks/hypo-auto-commit.mjs
+++ b/hooks/hypo-auto-commit.mjs
@@ -6,8 +6,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { HYPO_DIR, loadHypoIgnore, isIgnored, appendSyncFailure } from './hypo-shared.mjs';
-import { join } from 'path';
+import { HYPO_DIR, appendSyncFailure, commitWikiChanges } from './hypo-shared.mjs';
 
 function git(...args) {
   return spawnSync('git', ['-C', HYPO_DIR, ...args], { encoding: 'utf-8', timeout: 30000 });
@@ -18,28 +17,13 @@ function hasRemote() {
   return (r.stdout || '').trim().length > 0;
 }
 
-// `.hypoignore` is the project privacy boundary. `git add -A` ignores it, so
-// enumerate changed paths, drop ignored ones, then stage explicitly.
-const ignorePatterns = loadHypoIgnore(HYPO_DIR);
-const porcelain = git('status', '--porcelain', '-uall');
-const paths = [];
-for (const line of (porcelain.stdout || '').split('\n')) {
-  if (!line) continue;
-  const file = line.slice(3).replace(/^"|"$/g, '').split(' -> ').pop().trim();
-  if (!file) continue;
-  if (ignorePatterns.length > 0 && isIgnored(join(HYPO_DIR, file), HYPO_DIR, ignorePatterns))
-    continue;
-  paths.push(file);
-}
-if (paths.length > 0) git('add', '--', ...paths);
-const staged = git('diff', '--cached', '--name-only').stdout?.trim() || '';
-if (staged) {
-  const today = new Date().toISOString().slice(0, 10);
-  const commit = git('commit', '-m', `auto: ${today} wiki update`);
-  if (commit.status !== 0) {
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
-    process.exit(0);
-  }
+// Stage + commit via the shared helper (same .hypoignore filter the apply path
+// uses — ADR 0056). A real commit failure short-circuits before sync, exactly as
+// the inline logic did; "nothing to commit" is success and falls through to sync.
+const result = commitWikiChanges(HYPO_DIR);
+if (!result.committed) {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  process.exit(0);
 }
 
 if (hasRemote()) {

--- a/hooks/hypo-compact-guard.mjs
+++ b/hooks/hypo-compact-guard.mjs
@@ -42,14 +42,17 @@ process.stdin.on('end', () => {
     const gitStatus = hypoIsClean();
     const hotStatus = hotMdIsClean();
 
-    if (hasSession && gitStatus.clean && hotStatus.clean) {
+    // ADR 0056: block on uncommitted (real unsaved work); unpushed commits (ahead)
+    // are a soft, auto-synced state and must not block /compact or /clear — mirrors
+    // the precompactGateStatus demote so the chat-side gate stays consistent.
+    if (hasSession && !gitStatus.uncommitted && hotStatus.clean) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
 
     const reasons = [
       !hasSession ? 'session log entry missing' : '',
-      !gitStatus.clean ? gitStatus.reason : '',
+      gitStatus.uncommitted ? gitStatus.reason : '',
       !hotStatus.clean ? hotStatus.reason : '',
     ].filter(Boolean);
 

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -128,22 +128,43 @@ export function lastSubstantialOpIsSession() {
   return /^## \[\d{4}-\d{2}-\d{2}\] session/.test(substantial[substantial.length - 1]);
 }
 
+// Returns the wiki's git state split into its two independent axes (ADR 0056):
+//   uncommitted — working-tree changes (real unsaved work; a human-fixable blocker)
+//   ahead       — committed-but-unpushed commits (a soft, auto-synced state: the
+//                 auto-commit Stop hook pushes, and push failures are non-fatal —
+//                 see hypo-auto-commit.mjs / appendSyncFailure)
+// `clean` stays `!uncommitted && !ahead` for back-compat with callers that only
+// read it. Callers that gate session-close / compact distinguish the two: they
+// block on `uncommitted` and demote `ahead` to a notice (precompactGateStatus,
+// hypo-compact-guard) so a committed-but-unpushed close is still "compact-ready".
 export function hypoIsClean(dir = HYPO_DIR) {
   try {
     const porcelain = spawnSync('git', ['-C', dir, 'status', '--porcelain'], {
       encoding: 'utf-8',
     });
-    if (porcelain.status !== 0) return { clean: false, reason: `git check failed in ${dir}` };
-    if (porcelain.stdout.trim() !== '')
-      return { clean: false, reason: `uncommitted changes in ${dir}` };
-    const ahead = spawnSync('git', ['-C', dir, 'status', '--branch', '--porcelain'], {
+    if (porcelain.status !== 0)
+      return {
+        clean: false,
+        uncommitted: true,
+        ahead: false,
+        reason: `git check failed in ${dir}`,
+      };
+    const uncommitted = porcelain.stdout.trim() !== '';
+    const aheadRes = spawnSync('git', ['-C', dir, 'status', '--branch', '--porcelain'], {
       encoding: 'utf-8',
     });
-    if (/\[ahead \d+\]/.test(ahead.stdout || ''))
-      return { clean: false, reason: `unpushed commits in ${dir}` };
-    return { clean: true };
+    const ahead = /\[ahead \d+\]/.test(aheadRes.stdout || '');
+    const reasons = [];
+    if (uncommitted) reasons.push(`uncommitted changes in ${dir}`);
+    if (ahead) reasons.push(`unpushed commits in ${dir}`);
+    return {
+      clean: !uncommitted && !ahead,
+      uncommitted,
+      ahead,
+      reason: reasons.length ? reasons.join('; ') : undefined,
+    };
   } catch {
-    return { clean: false, reason: `git check failed in ${dir}` };
+    return { clean: false, uncommitted: true, ahead: false, reason: `git check failed in ${dir}` };
   }
 }
 
@@ -844,6 +865,61 @@ export function appendSyncFailure(hypoDir, op, error) {
 }
 
 /**
+ * Stage + commit every non-.hypoignore change in the wiki. Does NOT pull/push —
+ * remote sync stays in the auto-commit Stop hook (commit is local + cheap; sync is
+ * network + soft-fail). Shared by hypo-auto-commit.mjs and crystallize.mjs's
+ * --apply-session-close path so the .hypoignore staging filter cannot diverge
+ * between the two commit loci (ADR 0056).
+ *
+ * "Nothing to commit" (clean tree, or only .hypoignore'd changes) is SUCCESS, not
+ * failure — the caller's tree is already in the committed state it wanted.
+ *
+ * @param {string} hypoDir
+ * @returns {{committed: boolean, reason?: string}} committed:true when a commit was
+ *   created OR nothing needed committing; committed:false (with reason) on a real
+ *   failure: not a git repo, or git status/add/commit erroring.
+ */
+export function commitWikiChanges(hypoDir) {
+  const git = (...args) =>
+    spawnSync('git', ['-C', hypoDir, ...args], { encoding: 'utf-8', timeout: 30000 });
+  if (git('rev-parse', '--is-inside-work-tree').status !== 0)
+    return { committed: false, reason: `not a git repository: ${hypoDir}` };
+  const porcelain = git('status', '--porcelain', '-uall');
+  if (porcelain.status !== 0)
+    return { committed: false, reason: `git status failed in ${hypoDir}` };
+  // `.hypoignore` is the project privacy boundary. `git add -A` ignores it, so
+  // enumerate changed paths, drop ignored ones, then stage explicitly.
+  const ignorePatterns = loadHypoIgnore(hypoDir);
+  const paths = [];
+  for (const line of (porcelain.stdout || '').split('\n')) {
+    if (!line) continue;
+    const file = line.slice(3).replace(/^"|"$/g, '').split(' -> ').pop().trim();
+    if (!file) continue;
+    if (ignorePatterns.length > 0 && isIgnored(join(hypoDir, file), hypoDir, ignorePatterns))
+      continue;
+    paths.push(file);
+  }
+  if (paths.length > 0) {
+    const add = git('add', '--', ...paths);
+    if (add.status !== 0)
+      return {
+        committed: false,
+        reason: `git add failed: ${(add.stderr || '').trim() || 'unknown'}`,
+      };
+  }
+  const staged = git('diff', '--cached', '--name-only').stdout?.trim() || '';
+  if (!staged) return { committed: true }; // nothing to commit = success (idempotent)
+  const today = new Date().toISOString().slice(0, 10);
+  const commit = git('commit', '-m', `auto: ${today} wiki update`);
+  if (commit.status !== 0)
+    return {
+      committed: false,
+      reason: `git commit failed: ${(commit.stderr || '').trim() || 'unknown'}`,
+    };
+  return { committed: true };
+}
+
+/**
  * Read sync-state entries.
  * @param {string} hypoDir
  * @returns {{entries: object[], parseError: boolean}}
@@ -1503,9 +1579,20 @@ export function precompactGateStatus(hypoDir, opts = {}) {
   const marker = opts.sessionId ? readSessionClosedMarker(hypoDir, opts.sessionId) : null;
   const logOnly = opts.logOnly === true || marker?.scope === 'log-only';
 
-  // 1. wiki git clean
+  // 1. wiki git state (ADR 0056). Uncommitted changes (real unsaved work) BLOCK —
+  //    they are human-fixable. Unpushed commits (ahead) DEMOTE to a notice: push is
+  //    automatic (auto-commit Stop hook) and its failures are already non-fatal, so
+  //    "ahead" is a transient sync state, not a human-fixable blocker. Demoting it
+  //    here (the shared gate) keeps the marker == compact-ready invariant (ADR 0047):
+  //    a committed-but-unpushed close marks AND compacts, instead of the close writer
+  //    committing its own payload and then being blocked by its own (unpushed) commit.
   const git = hypoIsClean(hypoDir);
-  if (!git.clean) blockers.push({ type: 'git', reason: git.reason });
+  if (git.uncommitted) blockers.push({ type: 'git', reason: git.reason });
+  else if (git.ahead)
+    notices.push({
+      type: 'git-sync',
+      reason: `unpushed commits in ${hypoDir} (push deferred to Stop hook)`,
+    });
 
   // 2. root hot.md structure
   const hot = hotMdIsClean(hypoDir);

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -87,6 +87,7 @@ import {
   sessionLogScopePath,
   resolveTranscriptBySessionId,
   hasUserCloseSignal,
+  commitWikiChanges,
 } from '../hooks/hypo-shared.mjs';
 
 const LINT_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'lint.mjs');
@@ -832,29 +833,53 @@ function applySessionClose(args) {
   // govern apply SUCCESS (exit code below), but the marker must additionally
   // clear feedback projection / W8 design-history / hot.md structure, else this
   // path could issue a marker the standalone path would refuse (the second
-  // divergence codex flagged). git-clean is subsumed by the gate's git blocker.
+  // divergence codex flagged).
+  //
+  // ADR 0056: apply just wrote the payload, so the tree is dirty by its OWN
+  // writes — the gate's `uncommitted` git blocker would always trip and the
+  // marker would be skipped, deferring the close to a manual --mark-session-closed
+  // (the ADR 0047 "done but still blocked" regression). Commit the payload HERE, via
+  // the SAME .hypoignore-aware helper the auto-commit Stop hook uses, so the gate sees
+  // a committed tree. Push stays deferred to the Stop hook; the resulting
+  // committed-but-unpushed state is a gate notice, not a blocker (ADR 0056), so
+  // this still marks. A commit failure (not a repo / pre-commit reject / git error)
+  // skips the marker WITH a surfaced reason — today's behavior was also "no marker",
+  // but silently.
   let markerWritten = false;
   let markerSkipReason = null;
   if (ok && args.sessionId) {
-    const closeTranscript = resolveTranscriptBySessionId(args.sessionId);
-    const markerGate = precompactGateStatus(
-      args.hypoDir,
-      closeTranscript ? { transcriptPath: closeTranscript } : {},
-    );
-    if (!markerGate.ok) {
-      // compact gate not ok → skip. Caller's `result.ok` already reflects the
-      // file/lint state; next Stop re-blocks until the remaining blocker
-      // (git/feedback/W8/hot/lint) is resolved.
-      markerSkipReason = 'compact-gate-not-ok';
-    } else if (!closeTranscript || !hasUserCloseSignal(closeTranscript)) {
-      // User-close hard gate (ADR 0055): apply succeeded (payload files written)
-      // but the user never signalled session close, so the marker — which attests
-      // "user closed" — is withheld. The wiki record stands; the session is simply
-      // not marked closed. Surfaced (not silent) so the caller knows.
-      markerSkipReason = closeTranscript ? 'no-user-close-signal' : 'transcript-unresolved';
+    const commitOutcome = commitWikiChanges(args.hypoDir);
+    if (!commitOutcome.committed) {
+      markerSkipReason = `commit-failed: ${commitOutcome.reason}`;
     } else {
-      writeSessionClosedMarker(args.hypoDir, args.sessionId, { project });
-      markerWritten = true;
+      const closeTranscript = resolveTranscriptBySessionId(args.sessionId);
+      const markerGate = precompactGateStatus(
+        args.hypoDir,
+        closeTranscript ? { transcriptPath: closeTranscript } : {},
+      );
+      if (!markerGate.ok) {
+        // compact gate not ok → skip. Caller's `result.ok` already reflects the
+        // file/lint state; next Stop re-blocks until the remaining blocker
+        // (feedback/W8/hot/lint — git is now committed) is resolved.
+        markerSkipReason = 'compact-gate-not-ok';
+      } else if (!closeTranscript || !hasUserCloseSignal(closeTranscript)) {
+        // User-close hard gate (ADR 0055): apply succeeded (payload files written)
+        // but the user never signalled session close, so the marker — which attests
+        // "user closed" — is withheld. The wiki record stands; the session is simply
+        // not marked closed. Surfaced (not silent) so the caller knows.
+        markerSkipReason = closeTranscript ? 'no-user-close-signal' : 'transcript-unresolved';
+      } else {
+        writeSessionClosedMarker(args.hypoDir, args.sessionId, { project });
+        // Codex CONCERN (ADR 0055/0056): the writer swallows IO errors (best-effort).
+        // Verify the file actually landed — mirroring the standalone path — instead of
+        // asserting markerWritten=true, so a .cache permission/disk problem surfaces
+        // rather than the caller reporting "closed" while the next Stop re-blocks.
+        if (existsSync(sessionClosedMarkerPath(args.hypoDir, args.sessionId))) {
+          markerWritten = true;
+        } else {
+          markerSkipReason = 'marker-did-not-land';
+        }
+      }
     }
   }
   const stage = ok

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -756,6 +756,9 @@ const {
   sessionLogShardPath,
   sessionLogReadCandidates,
   sessionCloseFileStatus,
+  hypoIsClean,
+  precompactGateStatus,
+  commitWikiChanges,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
@@ -1632,6 +1635,38 @@ test('/compact with clean wiki → pass-through', () => {
     const out = JSON.parse(r.stdout);
     assert.equal(out.continue, true);
     assert.equal(out.suppressOutput, true);
+  });
+});
+
+test('/compact with committed-but-unpushed (ahead) wiki → pass-through (ADR 0056)', () => {
+  // The 3rd hypoIsClean consumer: ahead-only must NOT block /compact (mirrors the
+  // precompactGateStatus demote — unpushed is a soft, auto-synced state).
+  withCleanWiki((dir) => {
+    const remote = mkdtempSync(join(tmpdir(), 'hypo-cg-remote-'));
+    spawnSync('git', ['init', '--bare', '-q', remote]);
+    spawnSync('git', ['-C', dir, 'remote', 'add', 'origin', remote]);
+    spawnSync('git', ['-C', dir, 'push', '-q', '-u', 'origin', 'HEAD']);
+    writeFileSync(join(dir, 'extra.md'), '# extra\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'unpushed']);
+    const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' }, { HYPO_DIR: dir });
+    rmSync(remote, { recursive: true, force: true });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true);
+    assert.equal(out.suppressOutput, true, `ahead-only must not block /compact: ${r.stdout}`);
+  });
+});
+
+test('/compact with uncommitted change → blocks (git axis still enforced, ADR 0056)', () => {
+  withCleanWiki((dir) => {
+    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' }, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true);
+    assert.ok(
+      /WIKI_AUTOCLOSE/.test(out.additionalContext || ''),
+      `uncommitted work must still block /compact: ${r.stdout}`,
+    );
   });
 });
 
@@ -8026,6 +8061,118 @@ test('replay-session-start-preserves-sync-state-when-ahead: unpushed commit keep
   });
 });
 
+// ── ADR 0056: git state split — uncommitted blocks, ahead (unpushed) is a notice ──
+
+suite('ADR 0056 — hypoIsClean axes + precompactGateStatus ahead-demote + commitWikiChanges');
+
+test('hypoIsClean: committed-but-unpushed → uncommitted:false, ahead:true, clean:false', () => {
+  withSyncedWiki((dir) => {
+    // a local commit not on the remote (the real-vault state after auto-commit
+    // commits but before/without a successful push)
+    writeFileSync(join(dir, 'ahead.md'), '# ahead\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'ahead']);
+    const st = hypoIsClean(dir);
+    assert.equal(st.uncommitted, false, 'tree is committed → not uncommitted');
+    assert.equal(st.ahead, true, 'commit is unpushed → ahead');
+    assert.equal(st.clean, false, 'clean stays false while ahead (back-compat)');
+  });
+});
+
+test('hypoIsClean: uncommitted working-tree change → uncommitted:true', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    const st = hypoIsClean(dir);
+    assert.equal(st.uncommitted, true, 'untracked file → uncommitted');
+    assert.equal(st.clean, false);
+  });
+});
+
+test('precompactGateStatus: ahead-only → NO git blocker, has git-sync notice', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'ahead.md'), '# ahead\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'ahead']);
+    const gate = precompactGateStatus(dir, { claudeHome: join(dir, '.claude-none') });
+    assert.ok(
+      !(gate.blockers || []).some((b) => b.type === 'git'),
+      `unpushed commits must NOT be a git blocker: ${JSON.stringify(gate.blockers)}`,
+    );
+    assert.ok(
+      (gate.notices || []).some((n) => n.type === 'git-sync'),
+      `ahead must surface a git-sync notice: ${JSON.stringify(gate.notices)}`,
+    );
+  });
+});
+
+test('precompactGateStatus: uncommitted change → git blocker (unchanged)', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    const gate = precompactGateStatus(dir, { claudeHome: join(dir, '.claude-none') });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `uncommitted work must still be a git blocker: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+test('commitWikiChanges: dirty tree → commits, leaves tree uncommitted-clean', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'new.md'), '# new\n');
+    const res = commitWikiChanges(dir);
+    assert.equal(res.committed, true, `expected commit: ${JSON.stringify(res)}`);
+    assert.equal(hypoIsClean(dir).uncommitted, false, 'no uncommitted work after commit');
+  });
+});
+
+test('commitWikiChanges: commits ALL non-ignored changes, not a subset (parity with auto-commit)', () => {
+  // codex round-2 CONCERN: apply commits the whole working tree, not just the
+  // payload it wrote. This is intentional — it is the SAME helper (and behavior)
+  // the auto-commit Stop hook has always used. Lock it so the parity is documented.
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'payload-like.md'), '# payload\n');
+    writeFileSync(join(dir, 'unrelated.md'), '# unrelated pre-existing edit\n');
+    const res = commitWikiChanges(dir);
+    assert.equal(res.committed, true);
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files'], { encoding: 'utf-8' }).stdout;
+    assert.ok(
+      /payload-like\.md/.test(tracked) && /unrelated\.md/.test(tracked),
+      `both the payload-like and unrelated files must be committed: ${tracked}`,
+    );
+    assert.equal(hypoIsClean(dir).uncommitted, false, 'tree fully committed');
+  });
+});
+
+test('commitWikiChanges: nothing to commit (clean tree) → committed:true (success)', () => {
+  withSyncedWiki((dir) => {
+    const res = commitWikiChanges(dir);
+    assert.equal(res.committed, true, `nothing-to-commit must be success: ${JSON.stringify(res)}`);
+  });
+});
+
+test('commitWikiChanges: not a git repo → committed:false with reason', () => {
+  withTmpDir((dir) => {
+    const res = commitWikiChanges(dir);
+    assert.equal(res.committed, false);
+    assert.ok(/not a git repository/.test(res.reason || ''), `reason: ${res.reason}`);
+  });
+});
+
+test('commitWikiChanges: respects .hypoignore (ignored file not staged)', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, '.hypoignore'), 'secret.md\n');
+    writeFileSync(join(dir, 'secret.md'), '# private\n');
+    writeFileSync(join(dir, 'public.md'), '# public\n');
+    const res = commitWikiChanges(dir);
+    assert.equal(res.committed, true);
+    // secret.md must remain uncommitted (ignored); the tree is therefore still
+    // "uncommitted" because of the ignored file — confirm secret.md was not staged.
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files'], { encoding: 'utf-8' }).stdout;
+    assert.ok(!/secret\.md/.test(tracked), `secret.md must not be committed: ${tracked}`);
+    assert.ok(/public\.md/.test(tracked), `public.md must be committed: ${tracked}`);
+  });
+});
+
 // ── hypo-session-end / clear-marker (ADR 0022 amendment) ────
 
 suite('hypo-session-end.mjs / hypo-session-start.mjs — clear-marker replay');
@@ -10329,9 +10476,12 @@ test('--mark-session-closed --transcript-path: lint error only in an UNTOUCHED f
   );
 });
 
-test('--apply-session-close --session-id leaves payload uncommitted → marker NOT written until git clean', () => {
+test('--apply-session-close --session-id with NO user-close signal → commits payload, marker withheld (ADR 0055/0056)', () => {
+  // ADR 0056: apply now commits its own payload before the marker gate, so the git
+  // axis no longer blocks. The marker is still withheld here — but because there is
+  // no resolvable close transcript (no user-close signal, ADR 0055 hard gate), NOT
+  // because the tree is dirty. The skip is surfaced, not silent.
   withWiki(null, (dir, today) => {
-    const ym = today.slice(0, 7);
     const payload = {
       project: 'test-project',
       date: today,
@@ -10357,18 +10507,61 @@ test('--apply-session-close --session-id leaves payload uncommitted → marker N
     assert.equal(r.status, 0, `apply failed: ${r.stdout}\n${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, true);
-    // After apply, payload writes leave .payload.json + new file content
-    // uncommitted — but the marker is written BEFORE that becomes a problem
-    // because the post-apply branch happens inside the same process. The
-    // assertion is just "marker file landed".
-    const markerPath = join(dir, '.cache', 'session-closed-s-apply.marker');
-    // git is "dirty" with payload bytes by the time hypoIsClean runs, so the
-    // marker is intentionally NOT written in that branch. Document the
-    // outcome rather than asserting marker presence.
+    // The payload was committed by apply (the .hypoignore-aware helper) — the tree
+    // has no uncommitted work left (the git axis is satisfied, ADR 0056).
+    assert.equal(hypoIsClean(dir).uncommitted, false, 'apply must commit its own payload');
+    // Marker withheld: no user-close signal, surfaced as markerSkipReason.
+    assert.equal(out.markerWritten, false, 'no close signal → marker not written');
     assert.equal(
-      existsSync(markerPath),
+      out.markerSkipReason,
+      'transcript-unresolved',
+      `skip reason must be the ADR 0055 user-close gate, not git: ${out.markerSkipReason}`,
+    );
+    assert.equal(
+      existsSync(join(dir, '.cache', 'session-closed-s-apply.marker')),
       false,
-      'apply leaves payload writes uncommitted → ADR Q2 git-clean gate skips marker until auto-commit lands',
+      'marker must not land without a user-close signal',
+    );
+  });
+});
+
+test('--apply-session-close --session-id WITH user-close signal → commits payload AND marker lands (ISSUE-27 fix, ADR 0056)', () => {
+  // The core regression fix: apply commits its payload (so the git axis clears) and
+  // then writes the marker in the SAME process — no manual --mark-session-closed.
+  withWiki(null, (dir, today) => {
+    const payload = {
+      project: 'test-project',
+      date: today,
+      sessionState: {
+        content: readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8'),
+      },
+      projectHot: {
+        content: readFileSync(join(dir, 'projects', 'test-project', 'hot.md'), 'utf-8'),
+      },
+      rootHot: { content: readFileSync(join(dir, 'hot.md'), 'utf-8') },
+      sessionLog: { entry: `## [${today}] auto-mark landed test\n` },
+      log: { entry: `## [${today}] session | test-project — auto-mark landed\n` },
+    };
+    const payloadPath = join(dir, '.payload.json');
+    writeFileSync(payloadPath, JSON.stringify(payload));
+    // Plant a transcript resolvable by session-id that carries a user-close signal.
+    const cleanup = seedCloseTranscript('s-apply-land');
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--apply-session-close',
+      `--payload=${payloadPath}`,
+      '--session-id=s-apply-land',
+      '--json',
+    ]);
+    cleanup();
+    assert.equal(r.status, 0, `apply failed: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.equal(out.markerWritten, true, `marker must land: ${JSON.stringify(out)}`);
+    assert.equal(out.markerSkipReason, null, `no skip reason expected: ${out.markerSkipReason}`);
+    assert.ok(
+      existsSync(join(dir, '.cache', 'session-closed-s-apply-land.marker')),
+      'marker file must exist after a verified close with a user-close signal',
     );
   });
 });


### PR DESCRIPTION
## What

`crystallize --apply-session-close --session-id` writes the close payload then issues the per-session `session-closed` marker, gated by `precompactGateStatus`. In the normal flow the marker was **never** written, so the caller reported `ok:true` while the next Stop re-blocked with "session-close incomplete" — forcing a manual `--mark-session-closed` (the ADR 0047 / "done but still blocked" regression).

Two compounding causes:
1. apply's own payload writes left the tree dirty, so the gate's git blocker tripped. The commit is deferred to the `hypo-auto-commit` Stop hook, which runs *after* apply — so at marker time the tree is always dirty.
2. Even after committing, `hypoIsClean` treated `[ahead N]` (unpushed) as not-clean. Push is also deferred to the Stop hook, so a **committed-but-unpushed** tree still failed the gate on any vault with a remote (the real user vault has one).

The round-1 codex design review caught cause (2): commit-only is insufficient because the gate also blocks on `ahead`.

## Fix (two parts)

1. **apply commit-then-mark.** When `ok && session-id`, apply commits its own tree before the marker gate via a new shared `commitWikiChanges(hypoDir)` helper — extracted from `hypo-auto-commit` so the `.hypoignore` staging filter cannot diverge between the two commit loci. Order: `verify(ok) → commit → precompactGateStatus → hasUserCloseSignal (ADR 0055) → write marker → verify landed`.
2. **demote git "ahead" to a notice, uniformly.** `hypoIsClean` now returns `{clean, uncommitted, ahead, reason}`. `precompactGateStatus` blocks on `uncommitted` but surfaces `ahead` as a `git-sync` notice; `hypo-compact-guard` (the chat-side `/compact` `/clear` gate, the 3rd consumer) mirrors it. Unpushed is a soft, auto-synced state — `hypo-auto-commit` already treats push failures as non-fatal — not a human-fixable blocker. Demoting in the **shared** gate (not just the marker path) preserves the ADR 0047 invariant that marker == compact-ready across both writers and `/compact`.

Also: apply verifies the marker actually landed (mirrors the standalone path) instead of asserting success after a best-effort write; "nothing to commit" is success; a real commit failure skips the marker with a surfaced `markerSkipReason`.

## Intentional, documented choices (ADR 0056)

- **commit-all is intentional.** `commitWikiChanges` commits every non-`.hypoignore` change, not just the payload — the same behavior `hypo-auto-commit` always had (now literally the same helper). `.hypoignore` is the privacy boundary. Locked by a test.
- **`git-sync` notice is not forwarded to the `/compact` UX (deliberate).** At `/compact` time the close just committed but push is deferred, so `ahead` is the normal transient state; nagging every `/compact` would be noise. Persistent push failures already surface via `sync-state` at session-start. The notice stays for programmatic `crystallize` consumers. (Reasoned override of a codex round-2 concern.)

## Validation

- **797 tests** (+12): both `hypoIsClean` axes; `precompactGateStatus` ahead-demote / uncommitted-still-blocks; `commitWikiChanges` (dirty / nothing-to-commit / not-a-repo / `.hypoignore` / commit-all parity); `hypo-compact-guard` ahead-pass-through / uncommitted-block; apply marker lands-with-signal / withheld-without-signal. The pre-existing apply-no-marker test is updated to the new behavior (commits, then withheld for no user-close signal).
- **advisor design + reconcile**: round-1 codex `[ahead]` BLOCKER resolved by uniform demote (tie-break: the goal — in-turn marker write — is structurally incompatible with `ahead` being a blocker, since push always lags the turn).
- **codex 2-stage review**: design (BLOCKER → adopted) + pre-commit (CONCERN ×3: commit-all / notice-forward / test-gap — addressed by tests, or overridden with rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)