### PR TITLE
fix(close-gate): whitelist close-activity to authoritative artifacts (ADR 0057)

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -553,8 +553,11 @@ export function sessionCloseFileStatus(hypoDir, { projectOverride = null } = {})
 // but the resume.mjs copy adds an mtime fallback this one omits — see resume.mjs.
 
 // Root hot.md Active-Projects rows as {slug, date}. The per-row date column is
-// project-scoped (unlike the shared frontmatter `updated:`), so a today-dated
-// row is a legitimate close-activity signal. Mirrors resolveActiveProject's regex.
+// project-scoped (unlike the shared frontmatter `updated:`). Used for candidate
+// DISCOVERY in closeCandidateSlugs — NOT as close-activity evidence: ADR 0057
+// dropped the row date as an activity signal because project-create and
+// hypo-hot-rebuild both stamp rows today without a real session. Mirrors
+// resolveActiveProject's regex.
 function rootHotRows(hypoDir) {
   const hotPath = join(hypoDir, 'hot.md');
   if (!existsSync(hotPath)) return [];
@@ -610,23 +613,29 @@ function closeCandidateSlugs(hypoDir, dates) {
   return slugs;
 }
 
-// True when project P shows ANY today close-activity signal: session-state or
-// project hot.md frontmatter `updated:` today, a today-dated session-log heading,
-// a today log.md `session | P` entry, or a today-dated root hot.md row for P.
-// (Root hot.md *frontmatter* is shared and is NOT a signal; the per-project ROW
-// date is.)
+// True when project P shows an AUTHORITATIVE today close-activity signal: a
+// today-dated session-log heading, or a today-dated `## [today] session | P`
+// log.md entry. These are written ONLY by a real session close (apply, or its
+// auto-derived root log — ADR 0049).
+//
+// ADR 0057: soft state files are EXCLUDED, because each is bumped to today by
+// non-session tooling and is therefore indistinguishable from a real close:
+//   - session-state.md `updated:`  — tracker bookkeeping mirrors a new item into
+//     the "next tasks" section (a cross-block incident: editing one project's
+//     tracker bumped session-state and blocked an unrelated project's /compact).
+//   - project hot.md `updated:`    — project-create stamps the template `updated: today`.
+//   - root hot.md ROW date         — project-create inserts a today-dated row, and
+//     hypo-hot-rebuild defaults a row to today when a project hot.md is missing.
+// (Root hot.md *frontmatter* was already never a signal — it is shared and
+// hypo-hot-rebuild stamps it today every session.)
+//
+// Tradeoff (documented, accepted): apply writes session-state.md FIRST, then the
+// project files, then the session-log + log entry. A process crash before the
+// session-log write leaves a torn close that this gate no longer flags. Accepted:
+// a torn close never reached apply's ok=true so it wrote no marker (ADR 0055/0056);
+// the surviving session-state is the resume pointer the next session overwrites;
+// what is lost is a narrative log entry, not continuity.
 function hasTodayCloseActivity(hypoDir, project, dates) {
-  const fresh = (rel) => {
-    const full = join(hypoDir, rel);
-    if (!existsSync(full)) return false;
-    try {
-      return dates.includes(frontmatterUpdated(readFileSync(full, 'utf-8')));
-    } catch {
-      return false;
-    }
-  };
-  if (fresh(join('projects', project, 'session-state.md'))) return true;
-  if (fresh(join('projects', project, 'hot.md'))) return true;
   for (const d of dates) {
     for (const rel of sessionLogReadCandidates(project, d)) {
       const sl = join(hypoDir, rel);
@@ -646,9 +655,6 @@ function hasTodayCloseActivity(hypoDir, project, dates) {
     } catch {
       /* skip */
     }
-  }
-  for (const r of rootHotRows(hypoDir)) {
-    if (r.slug === project && r.date && dates.includes(r.date)) return true;
   }
   return false;
 }

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -9624,11 +9624,13 @@ test('project-dir-only candidate is gated (readdirSync leg) — guards the swall
   withTmpDir((dir) => {
     const today = todayLocal();
     // alpha is fully closed and visible via root hot.md row + log.md entry.
-    // gamma has today activity ONLY in its own session-state.md — it is absent
-    // from both the root hot.md rows and log.md, so ONLY the project-dirs leg
-    // (readdirSync over projects/*) can surface it. If that leg silently drops
-    // (e.g. an unimported readdirSync swallowed by the try/catch), gamma's
-    // dangling close is missed and the gate false-passes.
+    // gamma's only authoritative today signal is its own session-log heading
+    // (ADR 0057); it is absent from both the root hot.md rows and log.md, so ONLY
+    // the project-dirs leg (readdirSync over projects/* for session-state.md) can
+    // surface it as a candidate. If that leg silently drops (e.g. an unimported
+    // readdirSync swallowed by the try/catch), gamma's dangling close is missed
+    // and the gate false-passes. (session-state exists but is stale — it is the
+    // discovery handle, not the activity signal.)
     makeMultiProjectWiki(dir, today, [
       { slug: 'alpha', date: today },
       {
@@ -9636,7 +9638,7 @@ test('project-dir-only candidate is gated (readdirSync leg) — guards the swall
         date: today,
         hotRow: false,
         logEntry: false,
-        sessionLog: false,
+        sessionState: '2020-01-01',
         projectHot: '2020-01-01',
       },
     ]);
@@ -9646,6 +9648,97 @@ test('project-dir-only candidate is gated (readdirSync leg) — guards the swall
       `gamma must be found via the project-dirs leg: ${JSON.stringify(s.projects.map((p) => p.project))}`,
     );
     assert.equal(s.ok, false, 'gamma has a dangling close → block (must not false-pass)');
+  });
+});
+
+test('ADR 0057: bookkeeping-only freshness is NOT today close-activity (session-state bump must not cross-block)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha: a real, fully-closed session today. beta: ONLY soft state is fresh —
+    // session-state.md bumped today by tracker bookkeeping; no session-log heading,
+    // no log.md `session | beta` entry, stale hot.md + root row. beta must NOT be
+    // today-active, so alpha's completed close passes instead of cross-blocking.
+    // (Before ADR 0057 this asserted false — session-state freshness false-blocked.)
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      {
+        slug: 'beta',
+        date: today,
+        projectHot: '2020-01-01',
+        hotRow: '2020-01-01',
+        sessionLog: false,
+        logEntry: false,
+        // sessionState defaults to today — the bookkeeping bump
+      },
+    ]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, true, `beta is bookkeeping-only → not today-active: ${JSON.stringify(s)}`);
+    assert.deepEqual(
+      s.projects.map((p) => p.project),
+      ['alpha'],
+      'only alpha is today-active; beta (session-state-only) excluded',
+    );
+  });
+});
+
+test('ADR 0057: project-create artifacts are NOT today close-activity (soft state + non-session log entry)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // newproj looks fresh the way project-create leaves a project — today hot.md +
+    // today root row + a `## [today] project-create | newproj` log entry (NOT a
+    // `session | …` close entry) + no session-log heading. None is authoritative.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      {
+        slug: 'newproj',
+        date: today,
+        sessionLog: false,
+        logEntry: false,
+        // session-state + project hot + root row default to today (project-create stamps)
+      },
+    ]);
+    const logPath = join(dir, 'log.md');
+    writeFileSync(
+      logPath,
+      readFileSync(logPath, 'utf-8') + `## [${today}] project-create | newproj\n`,
+    );
+    const s = sessionCloseGlobalStatus(dir);
+    assert.deepEqual(
+      s.projects.map((p) => p.project),
+      ['alpha'],
+      'project-create (non-session log entry) must not make newproj today-active',
+    );
+    assert.equal(s.ok, true);
+  });
+});
+
+test('ADR 0057 no-regress: a real incomplete close still blocks (session-log heading present, log.md gap)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // beta had a genuine session (today session-log heading) but the root log.md
+    // entry is missing and session-state is stale. Still today-active via the
+    // session-log heading → still blocks. Dropping the soft-state signals (ISSUE-14
+    // family) must not lose this.
+    makeMultiProjectWiki(dir, today, [
+      {
+        slug: 'beta',
+        date: today,
+        sessionState: '2020-01-01',
+        projectHot: '2020-01-01',
+        hotRow: '2020-01-01',
+        logEntry: false,
+      },
+    ]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(
+      s.ok,
+      false,
+      'real incomplete close (session-log present, log.md gap) must still block',
+    );
+    assert.ok(
+      s.projects.some((p) => p.project === 'beta' && !p.ok),
+      'beta detected as today-active via its session-log heading despite stale soft state',
+    );
   });
 });
 


### PR DESCRIPTION
## What

`hasTodayCloseActivity(hypoDir, project, dates)` decides whether a project had a session close today; the ADR 0043 global invariant then forces that project to be **fully closed** before ANY project's `/compact`. Routine tracker bookkeeping — mirroring a new tracker item into `session-state.md`'s "next tasks" — bumps `session-state.md` `updated:` to today **with no real session**, so an unrelated project's `/compact` was cross-blocked, demanding the bookkept project's full close.

## The fix: blacklist → whitelist

The predicate returned true on ANY of five signals. A round-1 design review found that three are bumped by **non-session tooling** and so cannot distinguish a real close from scaffolding:

| signal | bumped by |
|---|---|
| `session-state.md` `updated:` | tracker bookkeeping mirror (the incident) |
| project `hot.md` `updated:` | `project-create` stamps the template `updated: today` |
| root `hot.md` row date | `project-create` inserts a today row; `hypo-hot-rebuild` defaults a row to today when a project `hot.md` is missing |

So flip to a **whitelist**: today-active iff a **today session-log heading** OR a **today `## [today] session | P` log.md entry** exists — the artifacts only a real close writes (`crystallize` apply, or its ADR 0049 auto-derived root log). `project-create` writes `## [today] project-create | P`, which does not match the `session | P` signal. This also closes the **project-create** and **hot-rebuild-default** false-positive vectors that a "drop session-state only" fix would have left.

## No regression (real-but-incomplete close family, ADR 0049)

A hand-edit close that skipped root `log.md` still has a session-log heading → still today-active → still blocks. And ADR 0049 auto-derives root `log.md`, so the original failure is structurally gone.

## Tradeoff (documented, accepted — ADR 0057)

apply writes `session-state.md` first, then project files, then the session-log + log entry. A process crash before the session-log write leaves a "torn close" this gate no longer flags. Accepted because: a torn close never reached apply `ok=true`, so it wrote **no session-closed marker** (ADR 0055/0056); the surviving `session-state` is the resume pointer the next session overwrites; what is lost is a narrative log entry, not continuity.

## Validation

- **800 tests** (+3): bookkeeping-only freshness → not today-active (incident regression guard — asserted the opposite before this change); `project-create` artifacts (soft state + non-session log entry) → not today-active; real incomplete close (session-log heading + `log.md` gap) → still blocks. The existing `project-dir-only candidate` readdirSync-leg guard now triggers via a session-log heading (session-state is the discovery handle, not the activity signal).
- **codex 2-stage review**: design (CONCERN: signals 2/5 also bumpable → widened to whitelist; torn-close window) + pre-commit (NIT: stale `rootHotRows` comment — fixed). Confirmed: whitelist coherent/complete, complete apply always writes the session-log heading, the three callers interact correctly, no dead symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)