### PR TITLE
fix(catalog): dedup template injection + scan-exclude generated root artifacts

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -73,7 +73,7 @@ import { join, relative, extname, dirname } from 'path';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import {
   sessionCloseFileStatus,
   sessionCloseGlobalStatus,
@@ -949,7 +949,7 @@ function collectPages(dir, root, acc = [], ignorePatterns = []) {
   for (const entry of readdirSync(dir)) {
     if (entry.startsWith('.')) continue;
     const full = join(dir, entry);
-    if (isIgnored(full, root, ignorePatterns)) continue;
+    if (isScanIgnored(full, root, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) collectPages(full, root, acc, ignorePatterns);
     else if (extname(entry) === '.md') {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -18,7 +18,7 @@ import { homedir } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import { readSyncState, projectSuggestionsPath } from '../hooks/hypo-shared.mjs';
 import {
@@ -443,7 +443,7 @@ function collectMdFiles(dir, acc = [], hypoDir = '', ignorePatterns = []) {
   for (const entry of readdirSync(dir)) {
     if (entry.startsWith('.')) continue;
     const full = join(dir, entry);
-    if (hypoDir && isIgnored(full, hypoDir, ignorePatterns)) continue;
+    if (hypoDir && isScanIgnored(full, hypoDir, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) collectMdFiles(full, acc, hypoDir, ignorePatterns);
     else if (extname(entry) === '.md') acc.push(full);

--- a/scripts/graph.mjs
+++ b/scripts/graph.mjs
@@ -17,7 +17,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, extname, basename } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ───────────────────────────────────────────────────────────────
 
@@ -38,7 +38,7 @@ function collectPages(dir, root, pages = [], ignorePatterns = []) {
   if (!existsSync(dir)) return pages;
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
-    if (isIgnored(full, root, ignorePatterns)) continue;
+    if (isScanIgnored(full, root, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) {
       collectPages(full, root, pages, ignorePatterns);

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -32,7 +32,7 @@ import {
   renameSync,
   unlinkSync,
 } from 'fs';
-import { join, basename } from 'path';
+import { join, basename, dirname } from 'path';
 import { homedir } from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -171,7 +171,19 @@ docstring at the top of scripts/<command>.mjs.`);
 
 // ── result tracking ──────────────────────────────────────────────────────────
 
-const results = { created: [], skipped: [], merged: [], errors: [] };
+const results = { created: [], skipped: [], merged: [], deduped: [], errors: [] };
+
+// Stock template basename → legacy hand-authored equivalents to honor instead of
+// injecting a duplicate. The hypo-/wiki- namespace split (the rename that
+// produced hypo-guide from wiki-guide, etc.) means an exact-filename check misses
+// a user's existing page and drops a 0-reference duplicate orphan beside it.
+// Mirrors the explicit HOOK_RENAMES idiom in upgrade.mjs. hypo-guide.md is
+// intentionally absent: the runtime reads it by name, so a mid-migration vault
+// must still receive it even when wiki-guide.md is present.
+const PAGE_EQUIVALENTS = {
+  'hypo-automation.md': ['wiki-automation.md'],
+  'hypo-help.md': ['wiki-help.md'],
+};
 
 function log(action, path) {
   results[action].push(path);
@@ -211,6 +223,19 @@ function copyTemplate(srcName, destPath, dryRun, transform) {
   }
   if (existsSync(destPath)) {
     log('skipped', destPath);
+    return;
+  }
+  // If a legacy hand-authored equivalent already exists, do NOT inject the stock
+  // page — that is exactly what produced a duplicate orphan. Skip LOUDLY (own
+  // bucket, ⚠ in the summary) so the user can merge manually. Fires in --dry-run
+  // too, so a dry run previews the suppression.
+  const equivalents = PAGE_EQUIVALENTS[basename(srcName)] || [];
+  const existingEquivalent = equivalents.find((name) => existsSync(join(dirname(destPath), name)));
+  if (existingEquivalent) {
+    log(
+      'deduped',
+      `${destPath} — kept existing ${existingEquivalent}; stock ${basename(srcName)} not installed (merge manually if you want the template content)`,
+    );
     return;
   }
   if (!dryRun) {
@@ -1017,6 +1042,10 @@ if (results.skipped.length)
   );
 if (results.merged.length)
   lines.push(`↪ Merged into settings.json:\n${results.merged.map((p) => `  ${p}`).join('\n')}`);
+if (results.deduped.length)
+  lines.push(
+    `⚠ Skipped to avoid a duplicate — an equivalent page already exists (${results.deduped.length}):\n${results.deduped.map((p) => `  ${p}`).join('\n')}`,
+  );
 if (results.errors.length)
   lines.push(`✗ Errors:\n${results.errors.map((p) => `  ${p}`).join('\n')}`);
 

--- a/scripts/lib/hypo-ignore.mjs
+++ b/scripts/lib/hypo-ignore.mjs
@@ -23,6 +23,30 @@ function globToRegex(glob) {
   );
 }
 
+// Generated, regenerable tool artifacts that live at the WIKI ROOT and must not
+// pollute the knowledge catalog. These are intentionally NOT added to
+// .hypoignore: that list also drives the pre-commit secret gate
+// (hooks/hypo-pre-commit.mjs), so listing them there would block the report's
+// commit and freeze every auto-commit while it sits at root. Instead they are
+// excluded from catalog/scan only, via isScanIgnored(). The patterns are
+// anchored to the root-relative path (no '/'), so an equivalent name nested
+// under pages/, projects/, or sources/ is left untouched.
+const GENERATED_ARTIFACT_RES = [/^MIGRATION-v[^/]*\.md$/, /^GRAPH_REPORT\.md$/];
+
+export function isGeneratedArtifact(filePath, hypoDir) {
+  const rel = relative(hypoDir, filePath).replace(/\\/g, '/');
+  return GENERATED_ARTIFACT_RES.some((re) => re.test(rel));
+}
+
+// Catalog/scan exclusion = privacy/.hypoignore patterns PLUS generated root
+// artifacts. Use this in tools that build the knowledge catalog (lint, graph,
+// stats, query, verify, crystallize, rename, doctor broken-links). Do NOT use it
+// in the pre-commit gate or ingest --check, which are privacy boundaries that
+// must stay on isIgnored()/.hypoignore alone.
+export function isScanIgnored(filePath, hypoDir, patterns) {
+  return isIgnored(filePath, hypoDir, patterns) || isGeneratedArtifact(filePath, hypoDir);
+}
+
 export function isIgnored(filePath, hypoDir, patterns) {
   const rel = relative(hypoDir, filePath).replace(/\\/g, '/');
   const base = basename(filePath);

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -20,7 +20,7 @@ import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from '
 import { join, relative, extname, basename } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import { parseSchemaVocab, checkForbidden, parseSchemaPageDirs } from './lib/schema-vocab.mjs';
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
@@ -117,7 +117,7 @@ function collectPages(dir, root, pages = [], ignorePatterns = []) {
   if (!existsSync(dir)) return pages;
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
-    if (isIgnored(full, root, ignorePatterns)) continue;
+    if (isScanIgnored(full, root, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) {
       // `_`-prefixed dirs (e.g. pages/feedback/_drafts) hold scaffolds / scratch
@@ -164,13 +164,14 @@ function collectLinkTargets(hypoDir, ignorePatterns = []) {
   if (existsSync(hypoDir)) {
     for (const entry of readdirSync(hypoDir)) {
       const full = join(hypoDir, entry);
-      // root-level *.md FILES only (no recursion), honoring .hypoignore exactly
-      // like collectPages — otherwise an ignored root file (e.g. a secret) would
-      // resolve [[its-slug]] as valid, a false negative.
+      // root-level *.md FILES only (no recursion), honoring .hypoignore plus the
+      // scan-only generated-artifact exclusions (isScanIgnored) like collectPages
+      // — otherwise an ignored root file (e.g. a secret) or a regenerable report
+      // would resolve [[its-slug]] as valid, a false negative.
       if (
         extname(entry) === '.md' &&
         !entry.startsWith('.') &&
-        !isIgnored(full, hypoDir, ignorePatterns) &&
+        !isScanIgnored(full, hypoDir, ignorePatterns) &&
         statSync(full).isFile()
       ) {
         targets.push(entry.replace(/\.md$/, ''));

--- a/scripts/query.mjs
+++ b/scripts/query.mjs
@@ -19,7 +19,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, extname } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -42,7 +42,7 @@ function collectMdFiles(dir, root, acc = [], ignorePatterns = []) {
   for (const entry of readdirSync(dir)) {
     if (entry.startsWith('.')) continue;
     const full = join(dir, entry);
-    if (isIgnored(full, root, ignorePatterns)) continue;
+    if (isScanIgnored(full, root, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) collectMdFiles(full, root, acc, ignorePatterns);
     else if (extname(entry) === '.md') acc.push({ path: full, rel: relative(root, full) });

--- a/scripts/rename.mjs
+++ b/scripts/rename.mjs
@@ -49,7 +49,7 @@ import {
 } from 'fs';
 import { join, relative, extname, basename, dirname, normalize, isAbsolute, sep } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ───────────────────────────────────────────────────────────────
 
@@ -72,7 +72,7 @@ function collectPages(dir, root, pages = [], ignorePatterns = []) {
   if (!existsSync(dir)) return pages;
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
-    if (isIgnored(full, root, ignorePatterns)) continue;
+    if (isScanIgnored(full, root, ignorePatterns)) continue;
     // lstat (never follow): a symlinked dir or file is skipped entirely so the
     // whole-vault scan can never traverse out of the vault via a symlink.
     const st = lstatSync(full);

--- a/scripts/stats.mjs
+++ b/scripts/stats.mjs
@@ -16,7 +16,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, extname } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isIgnored, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -37,7 +37,7 @@ function collectMdFiles(dir, acc = [], hypoDir = '', ignorePatterns = []) {
   for (const entry of readdirSync(dir)) {
     if (entry.startsWith('.')) continue;
     const full = join(dir, entry);
-    if (hypoDir && isIgnored(full, hypoDir, ignorePatterns)) continue;
+    if (hypoDir && isScanIgnored(full, hypoDir, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) collectMdFiles(full, acc, hypoDir, ignorePatterns);
     else if (extname(entry) === '.md') acc.push(full);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -18,7 +18,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, extname } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -40,7 +40,7 @@ function collectMdFiles(dir, acc = [], hypoDir = '', ignorePatterns = []) {
   for (const entry of readdirSync(dir)) {
     if (entry.startsWith('.')) continue;
     const full = join(dir, entry);
-    if (hypoDir && isIgnored(full, hypoDir, ignorePatterns)) continue;
+    if (hypoDir && isScanIgnored(full, hypoDir, ignorePatterns)) continue;
     const st = statSync(full);
     if (st.isDirectory()) collectMdFiles(full, acc, hypoDir, ignorePatterns);
     else if (extname(entry) === '.md') acc.push(full);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -281,6 +281,74 @@ test('init creates .gitignore with .cache/ entry', () => {
   });
 });
 
+suite('init.mjs — duplicate-orphan dedup (hypo-/wiki- namespace split)');
+
+test('skips stock hypo-automation.md when a legacy wiki-automation.md exists', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    writeFileSync(join(hypoDir, 'wiki-automation.md'), '# my hand-authored automation\n');
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !existsSync(join(hypoDir, 'hypo-automation.md')),
+      'stock hypo-automation.md must NOT be injected beside the user page',
+    );
+    assert.ok(existsSync(join(hypoDir, 'wiki-automation.md')), 'user page must be preserved');
+    assert.match(
+      r.stdout,
+      /kept existing wiki-automation\.md/,
+      `dedup must warn LOUDLY: ${r.stdout}`,
+    );
+  });
+});
+
+test('injects hypo-automation.md normally when no equivalent exists', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      existsSync(join(hypoDir, 'hypo-automation.md')),
+      'hypo-automation.md should be created when there is nothing to dedup against',
+    );
+  });
+});
+
+test('hypo-guide.md is still injected even when wiki-guide.md exists (runtime-required)', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    writeFileSync(join(hypoDir, 'wiki-guide.md'), '# legacy guide\n');
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      existsSync(join(hypoDir, 'hypo-guide.md')),
+      'core hypo-guide.md must still be installed (runtime reads it by name)',
+    );
+  });
+});
+
+test('--dry-run previews the dedup suppression and writes nothing', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    writeFileSync(join(hypoDir, 'wiki-automation.md'), '# my automation\n');
+    const r = run('init.mjs', [
+      `--hypo-dir=${hypoDir}`,
+      '--no-hooks',
+      '--no-git-init',
+      '--dry-run',
+    ]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stdout, /kept existing wiki-automation\.md/, `dry-run must warn: ${r.stdout}`);
+    assert.ok(
+      !existsSync(join(hypoDir, 'hypo-automation.md')),
+      'dry-run must not write hypo-automation.md',
+    );
+  });
+});
+
 // init-creates-extensions-baseline (§8.12, ADR 0024)
 test('init-creates-extensions-baseline', () => {
   withTmpDir((dir) => {
@@ -6795,6 +6863,46 @@ test('lint --json: large warn-heavy output survives the 64 KiB pipe boundary', (
   }
 });
 
+suite('lib/hypo-ignore.mjs — generated-artifact catalog exclusion');
+
+const {
+  isGeneratedArtifact,
+  isScanIgnored,
+  isIgnored: isHypoIgnored,
+} = await import(`${SCRIPTS}/lib/hypo-ignore.mjs`);
+const GA_ROOT = '/tmp/ga-vault';
+
+test('root MIGRATION-v*.md and GRAPH_REPORT.md are generated artifacts', () => {
+  assert.ok(isGeneratedArtifact(join(GA_ROOT, 'MIGRATION-v2.0.md'), GA_ROOT));
+  assert.ok(isGeneratedArtifact(join(GA_ROOT, 'MIGRATION-v1.3.4.md'), GA_ROOT));
+  assert.ok(isGeneratedArtifact(join(GA_ROOT, 'GRAPH_REPORT.md'), GA_ROOT));
+});
+
+test('exclusion is root-anchored — a same-named nested file is NOT an artifact', () => {
+  assert.ok(!isGeneratedArtifact(join(GA_ROOT, 'pages', 'MIGRATION-v2.0.md'), GA_ROOT));
+  assert.ok(!isGeneratedArtifact(join(GA_ROOT, 'projects', 'x', 'GRAPH_REPORT.md'), GA_ROOT));
+  assert.ok(!isGeneratedArtifact(join(GA_ROOT, 'sources', 'MIGRATION-v2.0.md'), GA_ROOT));
+});
+
+test('lookalike root names are NOT artifacts', () => {
+  assert.ok(!isGeneratedArtifact(join(GA_ROOT, 'MIGRATION.md'), GA_ROOT)); // no -v segment
+  assert.ok(!isGeneratedArtifact(join(GA_ROOT, 'GRAPH_REPORT_NOTES.md'), GA_ROOT));
+  assert.ok(!isGeneratedArtifact(join(GA_ROOT, 'hot.md'), GA_ROOT));
+});
+
+test('isScanIgnored hides a generated root artifact but isIgnored does NOT', () => {
+  // The split matters: pre-commit runs isIgnored() — if it hid the report, the
+  // commit (and every auto-commit) would be blocked while it sits at root.
+  const report = join(GA_ROOT, 'MIGRATION-v2.0.md');
+  assert.equal(isHypoIgnored(report, GA_ROOT, []), false, 'pre-commit must still commit it');
+  assert.equal(isScanIgnored(report, GA_ROOT, []), true, 'catalog scan must skip it');
+});
+
+test('isScanIgnored still honors .hypoignore patterns (secret-block preserved)', () => {
+  const secret = join(GA_ROOT, 'my-token.md');
+  assert.equal(isScanIgnored(secret, GA_ROOT, ['*token*']), true);
+});
+
 suite('lint.mjs wikilink resolution (ISSUE-21)');
 
 // Build a multi-file vault, run lint --json, return broken-wikilink targets plus
@@ -6902,6 +7010,52 @@ test('table-escaped alias [[a/b\\|label]] yields the clean target a/b', () => {
   assert.ok(
     !broken.some((b) => b && b.includes('\\')),
     `no target should carry a trailing backslash: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('generated root artifact MIGRATION-v*.md is NOT a valid link target', () => {
+  // A regenerable upgrade report at the root must not pollute the catalog: a
+  // stale [[MIGRATION-v9.9]] reads as broken instead of silently resolving.
+  const { broken } = lintWiki({
+    'MIGRATION-v9.9.md': '---\nupdated: 2026-06-08\n---\n# one-time upgrade report\n',
+    'pages/index.md': wlPage('reference', 'stale [[MIGRATION-v9.9]]'),
+  });
+  assert.ok(
+    broken.includes('MIGRATION-v9.9'),
+    `a generated root artifact must NOT resolve as a link target: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('generated root artifact GRAPH_REPORT.md is NOT a valid link target', () => {
+  const { broken } = lintWiki({
+    'GRAPH_REPORT.md': '---\nupdated: 2026-06-08\n---\n# regenerable graph dump\n',
+    'pages/index.md': wlPage('reference', 'stale [[GRAPH_REPORT]]'),
+  });
+  assert.ok(
+    broken.includes('GRAPH_REPORT'),
+    `GRAPH_REPORT.md must NOT resolve as a link target: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('a real root operational file is still a valid target (no over-exclusion)', () => {
+  const { broken } = lintWiki({
+    'hot.md': '---\nupdated: 2026-06-08\n---\n# hot\n',
+    'pages/index.md': wlPage('reference', 'see [[hot]]'),
+  });
+  assert.ok(
+    !broken.includes('hot'),
+    `a non-artifact root file must still resolve: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('only ROOT artifacts are excluded — a nested same-named page still resolves', () => {
+  const { broken } = lintWiki({
+    'pages/MIGRATION-v9.9.md': wlPage('reference', '# a real page that happens to share the name'),
+    'pages/index.md': wlPage('reference', 'see [[MIGRATION-v9.9]]'),
+  });
+  assert.ok(
+    !broken.includes('MIGRATION-v9.9'),
+    `a nested page must NOT be treated as a generated artifact: ${JSON.stringify(broken)}`,
   );
 });
 


### PR DESCRIPTION
## What

Two wiki-hygiene defects. In both, the symptom was hand-cleaned earlier; this PR adds the recurrence-prevention tooling.

### 1. Duplicate-orphan from template injection (ADR 0058)
`init.mjs copyTemplate` checked only the exact destination filename, so it would drop a stock `hypo-automation.md` beside a user's hand-authored `wiki-automation.md` (the `hypo-`/`wiki-` namespace split), creating a 0-reference duplicate orphan.

- Explicit `PAGE_EQUIVALENTS` map (mirrors the existing `HOOK_RENAMES` idiom): when a legacy `wiki-*` equivalent exists, skip the stock page and warn **loudly** via a new `deduped` results bucket (⚠ in the summary).
- `hypo-guide.md` is deliberately excluded from the map — the runtime reads it by name, so a mid-migration vault must still receive it.
- Fires in `--dry-run` too (previews the suppression).

### 2. Generated root artifacts pollute the catalog (ADR 0059)
`MIGRATION-v*.md` (the upgrade report) and `GRAPH_REPORT.md` (a regenerable graph dump) live at the wiki root and were treated as knowledge by catalog scans (lint link-targets, rename, doctor broken-links).

They **cannot** go in `.hypoignore`: that list also drives the pre-commit secret gate (`hypo-pre-commit.mjs`), so listing them there would block the report's commit and freeze every auto-commit while it sits at root.

- New **root-anchored** `isGeneratedArtifact()` predicate + `isScanIgnored()` = `isIgnored()` OR generated-artifact.
- Catalog-scan consumers switch `isIgnored` → `isScanIgnored`. The pre-commit gate and `ingest --check` stay on `isIgnored()` so the report remains committable (enters git history) but is invisible to the catalog.
- Patterns are root-anchored, so a nested same-named page is untouched.

## Review & tests

- Two-stage codex cross-review (design stage + pre-commit), both **CLEAR** after addressing a design-stage BLOCKER (root-anchored matching instead of basename; do not switch `ingest --check`).
- **813 tests green** (13 new): init dedup incl. `--dry-run` + runtime-required guide, root-anchored predicate, `isScanIgnored` vs `isIgnored` split (commit stays unblocked), lint link-target exclusion, root-only anchoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)