### PR TITLE
feat(sync): abort merge conflicts to never leave a half-merged tree (FEAT-17)

### DIFF
--- a/hooks/hypo-auto-commit.mjs
+++ b/hooks/hypo-auto-commit.mjs
@@ -6,14 +6,10 @@
  */
 
 import { spawnSync } from 'child_process';
-import { HYPO_DIR, appendSyncFailure, commitWikiChanges } from './hypo-shared.mjs';
-
-function git(...args) {
-  return spawnSync('git', ['-C', HYPO_DIR, ...args], { encoding: 'utf-8', timeout: 30000 });
-}
+import { HYPO_DIR, syncRemote, commitWikiChanges } from './hypo-shared.mjs';
 
 function hasRemote() {
-  const r = git('remote');
+  const r = spawnSync('git', ['-C', HYPO_DIR, 'remote'], { encoding: 'utf-8', timeout: 30000 });
   return (r.stdout || '').trim().length > 0;
 }
 
@@ -28,12 +24,10 @@ if (!result.committed) {
 
 if (hasRemote()) {
   // pull/push failures must not stop the session, but they can no longer be
-  // swallowed silently — record each to .cache/sync-state.json so session-start
-  // and doctor can surface them next session.
-  const pull = git('pull', '--no-rebase', '-q');
-  if (pull.status !== 0) appendSyncFailure(HYPO_DIR, 'pull', pull.stderr || pull.stdout);
-  const push = git('push');
-  if (push.status !== 0) appendSyncFailure(HYPO_DIR, 'push', push.stderr || push.stdout);
+  // swallowed silently — syncRemote records each to .cache/sync-state.json and,
+  // on a merge conflict, aborts the merge so the tree is never left half-merged
+  // (FEAT-17 hardening). session-start + doctor surface the result next session.
+  syncRemote(HYPO_DIR);
 }
 
 console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -243,6 +243,13 @@ function syncStateNotice(pullOk) {
     return '';
   }
   const last = entries[entries.length - 1];
+  if (last.op === 'conflict') {
+    return (
+      `[WIKI: remote diverged — auto-merge was aborted to protect your edits ` +
+      `(your local work is committed and safe; the other machine's version is on the remote). ` +
+      `Resolve manually: \`git -C ${HYPO_DIR} pull --no-rebase\`, fix conflicts, then push.]`
+    );
+  }
   return `[WIKI: last sync failed: ${last.op || '?'} — ${last.error || 'unknown'}]`;
 }
 const GLOBAL_HOT = join(HYPO_DIR, 'hot.md');

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -846,7 +846,10 @@ function syncStatePath(hypoDir) {
  * failure-log must not break the Stop hook that calls it.
  *
  * @param {string} hypoDir
- * @param {'pull'|'push'} op
+ * @param {'pull'|'push'|'conflict'|'conflict-unresolved'} op  'conflict' = a
+ *   merge conflict was detected and aborted (the tree was left clean at the
+ *   local commit); 'conflict-unresolved' = the abort itself failed and the tree
+ *   may still be half-merged (rare). See syncRemote.
  * @param {string} error  raw stderr/stdout; first non-empty line is kept
  */
 export function appendSyncFailure(hypoDir, op, error) {
@@ -868,6 +871,70 @@ export function appendSyncFailure(hypoDir, op, error) {
   } catch {
     // best-effort
   }
+}
+
+/**
+ * Pull + push the wiki against its remote, guaranteeing the working tree is
+ * never left half-merged. Called by the auto-commit Stop hook after a local
+ * commit succeeds.
+ *
+ * Failure policy (v1.4 "sync hardening", tracker FEAT-17):
+ *   - clean fast-forward / conflict-free merge → push.
+ *   - MERGE CONFLICT (`git pull --no-rebase` leaves unmerged paths): abort the
+ *     merge so the tree returns to the just-committed local state ("ours"),
+ *     record op='conflict', and do NOT push (a diverged branch cannot
+ *     fast-forward, so the push would only add a noisy second failure). No data
+ *     is lost: ours stays committed locally, "theirs" stays on the remote, and
+ *     the divergence is surfaced by session-start + doctor until the user merges
+ *     manually. Inline auto-resolution (preserving the losing version as a
+ *     `.conflict-*` sibling) is deferred — see tracker PRAC-18.
+ *   - non-conflict pull failure (network/auth: no unmerged paths) → record
+ *     op='pull', then still attempt push (a transient pull blip should not block
+ *     an otherwise-pushable commit); record op='push' if that also fails.
+ *
+ * Best-effort: never throws — a sync failure must not break the Stop hook.
+ *
+ * @param {string} hypoDir
+ * @returns {{pulled: boolean, pushed: boolean, conflict: boolean}}
+ */
+export function syncRemote(hypoDir) {
+  const git = (...args) =>
+    spawnSync('git', ['-C', hypoDir, ...args], { encoding: 'utf-8', timeout: 30000 });
+  const result = { pulled: false, pushed: false, conflict: false };
+  try {
+    const pull = git('pull', '--no-rebase', '-q');
+    if (pull.status === 0) {
+      result.pulled = true;
+    } else {
+      // A merge conflict leaves unmerged index entries; a network/auth failure
+      // leaves none. Only the former must be aborted to keep the tree clean.
+      const unmerged = git('ls-files', '-u');
+      const hasConflict = unmerged.status === 0 && (unmerged.stdout || '').trim().length > 0;
+      if (hasConflict) {
+        // Abort to return the tree to the just-committed local state. Verify the
+        // abort actually cleaned up: if it fails (filesystem/concurrent-mutation
+        // edge), the tree may still be half-merged, so record that distinctly
+        // ('conflict-unresolved') rather than masking it as a clean abort.
+        const abort = git('merge', '--abort');
+        const stillUnmerged = git('ls-files', '-u');
+        const aborted = abort.status === 0 && (stillUnmerged.stdout || '').trim().length === 0;
+        appendSyncFailure(
+          hypoDir,
+          aborted ? 'conflict' : 'conflict-unresolved',
+          pull.stderr || pull.stdout,
+        );
+        result.conflict = true;
+        return result; // do not push from a diverged branch
+      }
+      appendSyncFailure(hypoDir, 'pull', pull.stderr || pull.stdout);
+    }
+    const push = git('push');
+    if (push.status === 0) result.pushed = true;
+    else appendSyncFailure(hypoDir, 'push', push.stderr || push.stdout);
+  } catch {
+    // best-effort — never break the Stop hook
+  }
+  return result;
 }
 
 /**

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -528,10 +528,19 @@ function checkSyncState(hypoDir) {
     pass('Sync state', 'No unresolved sync failures');
   } else {
     const last = entries[entries.length - 1];
-    warn(
-      'Sync state',
-      `${entries.length} unresolved failure(s) — last: ${last.op || '?'} at ${last.timestamp || '?'}. Inspect .cache/sync-state.json or push/pull manually to clear.`,
-    );
+    // A merge conflict needs a real manual merge, not a plain push/pull — give
+    // the same explicit guidance session-start does instead of the generic hint.
+    if (String(last.op || '').startsWith('conflict')) {
+      warn(
+        'Sync state',
+        `${entries.length} unresolved sync issue(s) — last: remote diverged (merge conflict). Your local work is committed; the other machine's version is on the remote. Resolve with \`git pull --no-rebase\`, fix conflicts, then push.`,
+      );
+    } else {
+      warn(
+        'Sync state',
+        `${entries.length} unresolved failure(s) — last: ${last.op || '?'} at ${last.timestamp || '?'}. Inspect .cache/sync-state.json or push/pull manually to clear.`,
+      );
+    }
   }
 }
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -669,6 +669,34 @@ test('doctor-sync-state-warn: open sync-state.json entries → warn', () => {
   });
 });
 
+test('doctor-sync-state-warn: conflict entry → manual-merge guidance, not generic hint', () => {
+  withTmpDir((dir) => {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'projects'), { recursive: true });
+    mkdirSync(join(dir, 'sources'), { recursive: true });
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-06-19T00:00:00Z',
+        op: 'conflict',
+        error: 'CONFLICT (content): Merge conflict in page.md',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+    assert.ok(
+      /diverged|pull --no-rebase/.test(check.detail),
+      `conflict must get manual-merge guidance, not the generic hint: ${check.detail}`,
+    );
+  });
+});
+
 // fix #23: doctor-project-suggestions skip-persistence schema check
 suite('doctor.mjs — fix #23: auto-project skip-persistence');
 
@@ -827,6 +855,7 @@ const {
   hypoIsClean,
   precompactGateStatus,
   commitWikiChanges,
+  syncRemote,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
@@ -8212,6 +8241,106 @@ test('replay-session-start-preserves-sync-state-when-ahead: unpushed commit keep
       `unresolved push failure must stay surfaced: ${ctx}`,
     );
     assert.ok(existsSync(p), 'sync-state.json must not be cleared while local is ahead of remote');
+  });
+});
+
+// ── FEAT-17: no-data-loss on a merge conflict (syncRemote) ──────────────────────
+//
+// Deterministic two-clone regression for the data-integrity hole: a Stop-hook
+// `pull --no-rebase` that hits a merge conflict must NOT leave the tree with
+// `<<<<<<<` markers (which the next session would read as corrupted pages).
+// ADR 0055 live QA cannot run in CI, so this is the machine-enforced guard.
+//
+// Sets up: bare remote ← clone A (pushes a divergent edit) + clone B (commits a
+// conflicting edit to the same file, then runs syncRemote).
+function withConflictingClones(fn) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-conflict-'));
+  const remote = join(base, 'remote.git');
+  const a = join(base, 'a');
+  const b = join(base, 'b');
+  const gitq = (dir, ...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf-8' });
+  try {
+    spawnSync('git', ['init', '--bare', '-q', remote]);
+    spawnSync('git', ['init', '-q', a]);
+    gitq(a, 'config', 'user.email', 'a@test.com');
+    gitq(a, 'config', 'user.name', 'A');
+    writeFileSync(join(a, 'page.md'), '---\ntitle: Page\n---\nbase line\n');
+    gitq(a, 'add', '-A');
+    gitq(a, 'commit', '-q', '-m', 'init');
+    gitq(a, 'remote', 'add', 'origin', remote);
+    gitq(a, 'push', '-q', '-u', 'origin', 'HEAD');
+    // clone B from the shared remote, on the same base commit
+    spawnSync('git', ['clone', '-q', remote, b]);
+    gitq(b, 'config', 'user.email', 'b@test.com');
+    gitq(b, 'config', 'user.name', 'B');
+    // A edits the line and pushes first → remote now ahead of B
+    writeFileSync(join(a, 'page.md'), '---\ntitle: Page\n---\nedit from A\n');
+    gitq(a, 'add', '-A');
+    gitq(a, 'commit', '-q', '-m', 'A edit');
+    gitq(a, 'push', '-q');
+    // B commits a conflicting edit to the same line (not yet pushed)
+    writeFileSync(join(b, 'page.md'), '---\ntitle: Page\n---\nedit from B\n');
+    gitq(b, 'add', '-A');
+    gitq(b, 'commit', '-q', '-m', 'B edit');
+    fn({ a, b, remote, gitq });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+suite('FEAT-17 — syncRemote no-data-loss on merge conflict');
+
+test('syncRemote aborts a conflicting merge and leaves the tree clean (no markers, ours kept)', () => {
+  withConflictingClones(({ b, remote, gitq }) => {
+    const res = syncRemote(b);
+
+    // 1. the conflict was detected and reported, not silently swallowed
+    assert.equal(res.conflict, true, `expected conflict result, got ${JSON.stringify(res)}`);
+    assert.equal(res.pushed, false, 'must not push from a diverged branch');
+
+    // 2. the tree is NOT left half-merged: no unmerged index entries…
+    const unmerged = gitq(b, 'ls-files', '-u').stdout || '';
+    assert.equal(unmerged.trim(), '', `unmerged index entries remain: ${unmerged}`);
+    // …and no conflict markers written into the page
+    const page = readFileSync(join(b, 'page.md'), 'utf-8');
+    assert.ok(!page.includes('<<<<<<<'), 'conflict markers must not survive in the working tree');
+    assert.ok(!page.includes('>>>>>>>'), 'conflict markers must not survive in the working tree');
+
+    // 3. no data lost: ours stays canonical locally, theirs stays on the remote
+    assert.ok(page.includes('edit from B'), `local (ours) edit must be preserved: ${page}`);
+    const remoteHead = spawnSync('git', ['-C', remote, 'show', 'HEAD:page.md'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(
+      remoteHead.includes('edit from A'),
+      `remote (theirs) edit must remain recoverable: ${remoteHead}`,
+    );
+
+    // 4. the divergence is surfaced for the user
+    const entries = readSyncEntries(b);
+    assert.ok(
+      entries.some((e) => e.op === 'conflict'),
+      `a conflict entry must be recorded: ${JSON.stringify(entries)}`,
+    );
+  });
+});
+
+test('session-start surfaces a conflict entry with manual-merge guidance', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-06-19T00:00:00Z',
+        op: 'conflict',
+        error: 'CONFLICT (content): Merge conflict in page.md',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = runStart(dir);
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(ctx.includes('remote diverged'), `conflict notice missing: ${ctx}`);
+    assert.ok(ctx.includes('pull --no-rebase'), `manual-merge guidance missing: ${ctx}`);
   });
 });
 


### PR DESCRIPTION
## 한글 요약

세션 종료 시 위키를 원격과 동기화하는 auto-commit Stop hook의 `git pull --no-rebase`가 **머지 충돌을 만나면 working tree에 `<<<<<<<` 마커와 반쯤 끝난 머지가 남고**, 다음 세션이 그 깨진 `.md`를 그대로 읽는 무결성 구멍이 있었습니다.

새 `syncRemote()` primitive가 **진짜 머지 충돌**(unmerged 인덱스 엔트리 존재)과 단순 네트워크/인증 pull 실패를 구분하고, 충돌 시 `git merge --abort`로 tree를 직전 로컬 커밋 상태(ours)로 되돌린 뒤 `op='conflict'`를 기록하고 push를 생략합니다(분기된 브랜치는 fast-forward 불가). **데이터 무손실**: ours는 로컬에 커밋되어 있고, theirs는 원격에 그대로 있으며, 분기는 session-start와 doctor가 수동 머지 안내와 함께 surface합니다.

inline 자동 해소(패배본을 `.conflict-*` sibling으로 보존)는 codex 설계리뷰 판단에 따라 **deferred**(tracker PRAC-18).

## What

- `hooks/hypo-shared.mjs`: `syncRemote()` 신설 + `appendSyncFailure` op에 `conflict`/`conflict-unresolved` 추가. abort 실패(드묾) 시 `conflict-unresolved`로 distinct 기록.
- `hooks/hypo-auto-commit.mjs`: 인라인 pull/push를 `syncRemote()` 호출로 교체.
- `hooks/hypo-session-start.mjs` + `scripts/doctor.mjs`: `conflict` 항목에 "remote diverged → `pull --no-rebase` 후 수동 해결" 전용 안내.
- `tests/runner.mjs`: 결정적 2-클론 충돌 회귀 테스트(마커 0·`ls-files -u` 빔·ours 보존·theirs 원격 복구 가능·`conflict` 기록) + doctor 충돌 메시지 테스트.

## Test

`node tests/runner.mjs` → **816 passed, 0 failed** (기존 813 +3).

## Review

codex 2-stage review (`/teams 1:codex`):
- 설계리뷰: inline 트리 재작성(A) vs abort+surface(B) → **B 채택**. `git ls-files -u`가 both-modified·modify/delete·rename/delete 전 충돌 유형을 잡음을 실제 git probe로 확인.
- pre-commit리뷰(CONCERN): doctor 충돌 메시지 + `merge --abort` 상태 검증 2건 반영.

## English summary

The auto-commit Stop hook's `git pull --no-rebase` could hit a merge conflict, leaving the tree with `<<<<<<<` markers and a half-finished merge that the next session would read as corrupted pages. New `syncRemote()` detects a true merge conflict (unmerged index entries) vs a network/auth pull failure, and on conflict aborts the merge (tree back to ours), records `op='conflict'`, and skips the push. No data lost: ours committed locally, theirs on the remote, divergence surfaced by session-start + doctor with manual-merge guidance. Inline `.conflict-*` sibling auto-resolution is deferred (tracker PRAC-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)