### PR TITLE
feat(audit): stamp session_id/device on session-log shard + index.jsonl (PRAC-17)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,7 +115,7 @@ Hooks run automatically at Claude Code lifecycle events. They are deployed to `~
 | `hypo-personal-check` | PreCompact validation: lint blockers, uncommitted changes, missing session-log entries → block compact |
 | `hypo-auto-stage` | After Write/Edit on a wiki path, run `git add` (skips paths matching `.hypoignore`) |
 | `hypo-hot-rebuild` | At session stop, regenerate root `hot.md` from recent activity; emit growth metrics + cache for next SessionStart |
-| `hypo-session-record` | At session stop, append `{session_id, transcript_path, recorded_at, cwd}` to `.cache/sessions/index.jsonl` (primary source for the observability audit) |
+| `hypo-session-record` | At session stop, append `{session_id, transcript_path, recorded_at, cwd, device}` to `.cache/sessions/index.jsonl` (primary source for the observability audit) |
 | `hypo-auto-commit` | At session stop, filter changed paths through `.hypoignore`, commit non-ignored changes, `git pull --no-rebase` + `git push` (silent fail on missing remote) |
 | `hypo-cwd-change` | When working directory changes, re-resolve the active project and inject its `hot.md` |
 | `hypo-file-watch` | Notify on external wiki edits so the in-session view stays consistent |
@@ -335,7 +335,7 @@ journal/weekly/<YYYY-Www>.md               ← committed report (heuristic v0, s
 
 `session-audit.mjs` reads transcripts from two locations, in priority order:
 
-1. **Primary:** `<hypo-root>/.cache/sessions/index.jsonl` — written by the Stop hook `hypo-session-record.mjs`. Each line: `{ session_id, transcript_path, recorded_at, cwd }`.
+1. **Primary:** `<hypo-root>/.cache/sessions/index.jsonl` — written by the Stop hook `hypo-session-record.mjs`. Each line: `{ session_id, transcript_path, recorded_at, cwd, device }`. `device` (PRAC-17) is `os.hostname()` for multi-machine audit; the index lives under `.cache/` (gitignored in a normal vault) so it is a local-only per-session record.
 2. **Fallback:** `~/.claude/projects/<encoded>/*.jsonl` — scanned when the index is missing or empty (legacy / freshly-installed wikis).
 
 ### Classification
@@ -365,6 +365,8 @@ The score is a **proxy, not ground truth**. The four-week baseline plan (capture
 ### Privacy
 
 The observability pipeline reads but never republishes raw transcripts. Weekly reports only emit `session_id` plus aggregate counts — no transcript content, no URLs, no tool inputs. Transcripts themselves live under `~/.claude/projects/` or `.cache/sessions/` which `.hypoignore` already excludes from any sync.
+
+**PRAC-17 audit fields (`device`, `session_id`).** `device` (`os.hostname()`) is recorded in two places with different sync boundaries, by design. In `.cache/sessions/index.jsonl` it is per-session-accurate but **local-only** (`.cache/` is gitignored in a normal vault). In the seeded session-log daily-shard frontmatter it is an **intentional synced field** — a creator-only stamp (the session/machine that first created the day's shard), carried across machines so the wiki itself records which machine opened each day. `session_id` (the Claude session UUID) is seeded into that same synced frontmatter, but only on the Stop-chain close path that passes `--session-id`; on manual/skill closes it is omitted. This deliberately puts a hostname (and, on the automated path, the session UUID) into git-tracked, synced content; it is acceptable for a single-user private vault where multi-machine identification is the goal. Operators who do not want a hostname synced can override `os.hostname()` at the OS level or treat the field as a pseudonymous label.
 
 ### Growth metrics (Lane B)
 

--- a/hooks/hypo-session-record.mjs
+++ b/hooks/hypo-session-record.mjs
@@ -12,6 +12,7 @@
 
 import { existsSync, mkdirSync, appendFileSync } from 'fs';
 import { dirname, join } from 'path';
+import { hostname } from 'os';
 import { HYPO_DIR } from './hypo-shared.mjs';
 
 const INDEX_PATH = join(HYPO_DIR, '.cache', 'sessions', 'index.jsonl');
@@ -50,6 +51,10 @@ process.stdin.on('end', () => {
       transcript_path: transcriptPath,
       recorded_at: new Date().toISOString(),
       cwd: payload.cwd || process.cwd(),
+      // PRAC-17: machine identity for multi-machine audit. index.jsonl lives
+      // under .cache/ (gitignored in a normal vault), so this is a LOCAL-only
+      // per-session record — accurate for every session, no sync/privacy cost.
+      device: hostname() || 'unknown',
     };
     appendFileSync(INDEX_PATH, JSON.stringify(entry) + '\n');
   } catch (err) {

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -70,6 +70,7 @@ import {
   renameSync,
 } from 'fs';
 import { join, relative, extname, dirname } from 'path';
+import { hostname } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
@@ -756,9 +757,21 @@ function applySessionClose(args) {
       // otherwise mistake it for the evidence file. The dated `## [date] ...`
       // heading lives inside the entry, so freshness / derive / design-history
       // are unchanged.
+      // PRAC-17 audit fields. The shard frontmatter is git-tracked and synced, so
+      // `device` is an INTENTIONAL synced multi-machine identifier (privacy note:
+      // docs/ARCHITECTURE.md). It is a CREATOR-only stamp — only the session/
+      // machine that first seeds the daily shard is recorded; later same-day
+      // appends do not touch it. The per-session-accurate store is the LOCAL
+      // (.cache/, gitignored) index.jsonl written by hypo-session-record.mjs.
+      // `session_id` is honest naming: the value is the Claude session UUID, and
+      // it is present only on the Stop-chain close path that passes --session-id.
+      const device = String(hostname() || 'unknown').replace(/[\r\n]/g, '');
+      const auditFm =
+        (args.sessionId ? `session_id: ${String(args.sessionId).replace(/[\r\n]/g, '')}\n` : '') +
+        `device: ${device}\n`;
       const header =
         `---\ntitle: Session Log ${date} (${project})\n` +
-        `type: session-log\nupdated: ${date}\n---\n\n` +
+        `type: session-log\nupdated: ${date}\n${auditFm}---\n\n` +
         `# Session Log ${date} (${project})\n`;
       const entry = payload.sessionLog.entry;
       const body = entry.endsWith('\n') ? entry : `${entry}\n`;

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2342,7 +2342,7 @@ function payloadForCleanWiki(dir, today) {
   };
 }
 
-function runApply(dir, payload, { force = false } = {}) {
+function runApply(dir, payload, { force = false, sessionId = null } = {}) {
   // Fix #39 (option D): payload presence = explicit close intent → always runs
   // full apply. --force only matters for the no-payload probe path, so tests
   // that supply a payload do NOT need --force.
@@ -2355,6 +2355,7 @@ function runApply(dir, payload, { force = false } = {}) {
     '--json',
   ];
   if (force) flags.push('--force');
+  if (sessionId) flags.push(`--session-id=${sessionId}`);
   return run('crystallize.mjs', flags);
 }
 
@@ -2399,6 +2400,79 @@ test('idempotent: re-running same payload produces no new bytes (file mtimes unc
       'session-log must not grow on re-apply (idempotent append)',
     );
     assert.equal(logAfter, logBefore, 'log.md must not grow on re-apply (idempotent append)');
+  });
+});
+
+// PRAC-17: the test above measures the LEGACY MONTHLY shard path; the apply code
+// writes the DAILY shard for a distinct entry. This dedicated test targets the
+// daily shard and pins both (a) the new audit frontmatter (device present once,
+// no session_id when --session-id is not passed) and (b) byte-equal idempotency
+// on the daily shard — the gap the monthly-path test cannot catch.
+test('PRAC-17: daily shard seeds device frontmatter once + byte-equal on re-apply', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog = { entry: `## [${today}] prac17 daily entry\n\nbody\n` };
+    const r1 = runApply(dir, payload);
+    assert.equal(r1.status, 0, `first apply failed: ${r1.stdout}\n${r1.stderr}`);
+    const shard = join(dir, 'projects', 'test-project', 'session-log', `${today}.md`);
+    assert.ok(existsSync(shard), 'daily shard must be created');
+    const fm1 = readFileSync(shard, 'utf-8');
+    // device is always seeded; appears exactly once (in the seeded header).
+    assert.ok(/\ndevice: \S+\n/.test(fm1), `shard frontmatter must carry device: ${fm1}`);
+    assert.equal((fm1.match(/^device: /gm) || []).length, 1, 'device must appear exactly once');
+    // runApply does not pass --session-id, so session_id must be absent (not a
+    // dead/empty field) on the manual close path.
+    assert.ok(!/^session_id:/m.test(fm1), `session_id must be absent without --session-id: ${fm1}`);
+    // Post-apply lint stays clean with the extra fields (lint requires only title+type).
+    assert.equal(JSON.parse(r1.stdout).ok, true, `post-apply lint must be clean: ${r1.stdout}`);
+
+    const r2 = runApply(dir, payload);
+    assert.equal(r2.status, 0, `second apply failed: ${r2.stdout}\n${r2.stderr}`);
+    assert.equal(
+      readFileSync(shard, 'utf-8'),
+      fm1,
+      'daily shard must be byte-equal on re-apply (frontmatter not regenerated)',
+    );
+  });
+});
+
+test('PRAC-17: --session-id seeds the session_id frontmatter line on the daily shard', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog = { entry: `## [${today}] prac17 session-id entry\n\nbody\n` };
+    const sid = '0c9d1234-aaaa-bbbb-cccc-0123456789ab';
+    const r = runApply(dir, payload, { sessionId: sid });
+    assert.equal(r.status, 0, `apply failed: ${r.stdout}\n${r.stderr}`);
+    const shard = join(dir, 'projects', 'test-project', 'session-log', `${today}.md`);
+    const fm = readFileSync(shard, 'utf-8');
+    assert.ok(
+      new RegExp(`^session_id: ${sid}$`, 'm').test(fm),
+      `shard frontmatter must carry the passed session_id: ${fm}`,
+    );
+    assert.ok(/^device: \S+$/m.test(fm), `device must still be present: ${fm}`);
+    assert.equal(JSON.parse(r.stdout).ok, true, `post-apply lint must be clean: ${r.stdout}`);
+  });
+});
+
+// PRAC-17: the OTHER write site — the per-session index.jsonl. This store is
+// local-only (.cache/ gitignored) and accurate for every session, so it pins
+// that the Stop hook stamps `device` on every recorded entry.
+test('PRAC-17: hypo-session-record stamps device on the index.jsonl entry', () => {
+  withTmpDir((dir) => {
+    const r = runHook(
+      'hypo-session-record.mjs',
+      { session_id: 'rec-prac17', transcript_path: '/tmp/t.jsonl', cwd: '/tmp/work' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `hook failed: ${r.stderr}`);
+    const idx = join(dir, '.cache', 'sessions', 'index.jsonl');
+    assert.ok(existsSync(idx), 'index.jsonl must be written');
+    const entry = JSON.parse(readFileSync(idx, 'utf-8').trim().split('\n').pop());
+    assert.equal(entry.session_id, 'rec-prac17');
+    assert.ok(
+      typeof entry.device === 'string' && entry.device.length > 0,
+      `device must be recorded on the index entry: ${JSON.stringify(entry)}`,
+    );
   });
 });
 


### PR DESCRIPTION
## What

PRAC-17 — add machine/session audit fields so multi-machine, multi-session activity is identifiable (observability + foundation for per-contribution attribution, FEAT-5).

Two write sites, deliberately different sync boundaries:

| Site | Field(s) | Sync boundary |
|---|---|---|
| `hooks/hypo-session-record.mjs` → `.cache/sessions/index.jsonl` | `device` (always) | **Local-only** (`.cache/` gitignored in a normal vault), per-session-accurate |
| `scripts/crystallize.mjs` → session-log daily-shard frontmatter | `device` (always) + `session_id` (only on the `--session-id` Stop-chain close path) | **Synced** (git-tracked), creator-only stamp |

## Decisions

- Field name is `session_id` (honest — the value is the Claude session UUID), not `agent_id`.
- Shard frontmatter is a **creator-only** stamp (only the session/machine that first creates the day's shard); the per-session-accurate record is the local index.jsonl. Documented as intentional scope.
- `device` in synced frontmatter deliberately crosses the hostname-privacy boundary; documented in `docs/ARCHITECTURE.md` as an intentional synced multi-machine identifier, acceptable for a single-user private vault.
- lint requires only `title`+`type`, so the extra fields stay lint-clean; the shard is seeded once (`existsSync` guard) so re-apply is byte-equal.

## Review trail (codex 2-stage + advisor)

- **Design review (codex):** `**CONCERN**` — hostname privacy boundary in synced content. Resolved by documenting it as an intentional synced field + keeping the accurate store local-only.
- **Pre-commit review (codex):** `**NIT**` ×2 — byte-equal assertion strengthened to full-string compare; added a positive `--session-id` frontmatter test.
- **advisor follow-ups:** added an index.jsonl `device` unit test (the previously-untested write site); filled the doc gap so the privacy note also covers the synced `session_id` line.

## Tests

816 → 819, all green. 3 new tests: frontmatter `device` once + byte-equal re-apply, `--session-id` seeds `session_id`, Stop hook stamps `device` on the index entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)