### PR TITLE
feat(release): assert version consistency + plugin-path smoke (IMPR-12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,19 @@ jobs:
       - name: No wiki-internal tracker ids in public artifacts
         run: npm run check:tracker-ids
 
+  plugin-channel:
+    name: Plugin channel (versions + smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - name: All version-carrying files agree (drift caught pre-release)
+        run: npm run check:versions
+      - name: Plugin surfaces load-valid (manifest, hooks, commands/skills)
+        run: npm run smoke:plugin
+
   init-snapshot:
     name: Init snapshot
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,19 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Validate tag matches package version
-        run: |
-          PKG_VERSION="v$(node -p "require('./package.json').version")"
-          TAG_VERSION="${GITHUB_REF_NAME}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Tag ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
+      - name: Validate version consistency (tag + all release channels)
+        # Supersedes the old package.json-only tag check (IMPR-12). Asserts the tag
+        # AND every version-carrying file agree — package.json, package-lock.json,
+        # .claude-plugin/{plugin,marketplace}.json, templates/hypo-config.md — so a
+        # forgotten plugin/marketplace/lockfile bump hard-fails the release instead
+        # of publishing a split-version plugin.
+        run: node scripts/check-versions.mjs --tag "${GITHUB_REF_NAME}"
+
+      - name: Plugin path smoke
+        # The repo is dual-channel (npm + Claude Code plugin). Smoke the plugin
+        # surfaces (manifest, hooks/hooks.json targets, command/skill files,
+        # marketplace parity) so a broken plugin channel cannot ship green.
+        run: node scripts/smoke-plugin.mjs
 
       - name: Validate bilingual release docs (CHANGELOG + annotated tag)
         run: |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -242,15 +242,21 @@ a missing `### 한글 요약` section will block `npm publish`.
 #    and templates/hypo-config.md. Takes a concrete semver (not patch/minor/major).
 node scripts/bump-version.mjs <new-semver>   # e.g. 1.2.2 or 1.3.0-rc.1
 
+# 1b. bump-version does NOT touch package-lock.json — sync it so `npm ci` and the
+#     version-consistency gate stay green (the lock carries the version twice).
+npm install --package-lock-only
+
 # 2. Edit CHANGELOG.md — the new section MUST include a "### 한글 요약"
 #    sub-section with at least 10 Hangul characters of real summary text.
 $EDITOR CHANGELOG.md
 
-# 3. Verify locally before tagging (same check that runs in CI)
+# 3. Verify locally before tagging (same checks that run in CI)
 node scripts/check-bilingual.mjs --changelog
+npm run check:versions   # all version-carrying files (incl. package-lock) agree
+npm run smoke:plugin     # plugin manifest + hooks/commands/skills load-valid
 
-# 4. Commit
-git add package.json CHANGELOG.md
+# 4. Commit — include EVERY file the bump touched, not just package.json.
+git add package.json package-lock.json .claude-plugin/ templates/hypo-config.md CHANGELOG.md
 git commit -m "chore: release v<version>"
 
 # 5. Tag with an ANNOTATED tag — never a lightweight tag.
@@ -278,11 +284,15 @@ git push origin main --tags
 
 The `release.yml` workflow then:
 
-1. Verifies the tag matches `package.json` version.
-2. Validates the CHANGELOG section AND the tag annotation are bilingual
+1. Verifies the tag matches the version in EVERY version-carrying file —
+   `package.json`, `package-lock.json`, `.claude-plugin/{plugin,marketplace}.json`,
+   and `templates/hypo-config.md` (`scripts/check-versions.mjs --tag`).
+2. Smokes the plugin channel — manifest, `hooks/hooks.json` targets, and
+   command/skill component files (`scripts/smoke-plugin.mjs`).
+3. Validates the CHANGELOG section AND the tag annotation are bilingual
    (`scripts/check-bilingual.mjs`).
-3. Runs `npm test` and `npm run lint`.
-4. Publishes to npm with `npm publish --access public --provenance`.
+4. Runs `npm test` and `npm run lint`.
+5. Publishes to npm with `npm publish --access public --provenance`.
 
 `NPM_TOKEN` must be set as a repository secret.
 

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "fix:verify": "node scripts/fix-status-verify.mjs",
     "graph": "node scripts/graph.mjs",
     "smoke-pack": "node scripts/smoke-pack.mjs",
+    "check:versions": "node scripts/check-versions.mjs",
+    "smoke:plugin": "node scripts/smoke-plugin.mjs",
     "check:bilingual": "node scripts/check-bilingual.mjs --changelog",
     "check:tracker-ids": "node scripts/check-tracker-ids.mjs --all",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "node scripts/install-git-hooks.mjs",
-    "prepublishOnly": "npm test && npm run lint && npm run smoke-pack && npm run check:bilingual && npm run check:tracker-ids"
+    "prepublishOnly": "npm test && npm run lint && npm run check:versions && npm run smoke:plugin && npm run smoke-pack && npm run check:bilingual && npm run check:tracker-ids"
   },
   "devDependencies": {
     "prettier": "^3.8.3"

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// check-versions.mjs — assert every version-carrying file in the repo agrees, and
+// (with --tag) that they all match the release tag. This makes the release pipeline
+// OWN the plugin channel: a forgotten plugin.json / marketplace.json / hypo-config /
+// lockfile bump hard-fails the release instead of publishing a split-version plugin.
+//
+// The set mirrors scripts/bump-version.mjs (package.json, .claude-plugin/plugin.json,
+// .claude-plugin/marketplace.json, templates/hypo-config.md) PLUS package-lock.json,
+// which npm — not bump-version — manages, so it can lag a bump and silently break
+// `npm ci`. README/CHANGELOG carry prose version HISTORY (every past vX.Y.Z), not a
+// single release authority, so they are intentionally excluded (covered by the
+// bilingual + README-reconcile checklist instead).
+//
+// Usage:
+//   node scripts/check-versions.mjs               # assert all files agree
+//   node scripts/check-versions.mjs --tag v1.4.0  # also assert they equal the tag
+//   node scripts/check-versions.mjs --root <dir>  # point at a fixture (tests)
+//   node scripts/check-versions.mjs --json
+//
+// Exit 0 = consistent (and, with --tag, matches). Exit 1 = drift / unreadable / mismatch.
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+function parseArgs(argv) {
+  const args = { root: null, tag: null, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--root=')) args.root = a.slice(7);
+    else if (a === '--root') args.root = argv[++i];
+    else if (a.startsWith('--tag=')) args.tag = a.slice(6);
+    else if (a === '--tag') args.tag = argv[++i];
+    else if (a === '--json') args.json = true;
+  }
+  return args;
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readJson(abs) {
+  return JSON.parse(readFileSync(abs, 'utf-8'));
+}
+
+// Collect {label, version} for every authoritative location. A location that
+// cannot be read or whose field is missing becomes {label, version: null, error}.
+function collectVersions(root) {
+  const sources = [];
+  const push = (label, fn) => {
+    try {
+      const v = fn();
+      if (typeof v !== 'string' || v.length === 0) {
+        sources.push({ label, version: null, error: 'version field missing or empty' });
+      } else {
+        sources.push({ label, version: v });
+      }
+    } catch (err) {
+      sources.push({ label, version: null, error: err?.message ?? String(err) });
+    }
+  };
+
+  push('package.json', () => readJson(join(root, 'package.json')).version);
+
+  // package-lock.json carries the version in TWO top-level spots (lockfileVersion 3):
+  // the root `.version` and `.packages[""].version`. Dependency versions deeper in
+  // the tree are NOT release authorities and must not be read.
+  push('package-lock.json (root)', () => readJson(join(root, 'package-lock.json')).version);
+  push('package-lock.json (packages[""])', () => {
+    const lock = readJson(join(root, 'package-lock.json'));
+    return lock.packages && lock.packages[''] ? lock.packages[''].version : undefined;
+  });
+
+  const pluginName = (() => {
+    try {
+      return readJson(join(root, '.claude-plugin', 'plugin.json')).name;
+    } catch {
+      return null;
+    }
+  })();
+
+  push(
+    '.claude-plugin/plugin.json',
+    () => readJson(join(root, '.claude-plugin', 'plugin.json')).version,
+  );
+
+  // Select the marketplace entry BY NAME (matching plugin.json), not by position:
+  // Claude Code's runtime resolves plugins by name (hooks/version-check.mjs), and a
+  // future second marketplace entry would make plugins[0] the wrong authority.
+  push('.claude-plugin/marketplace.json (entry: ' + (pluginName ?? '?') + ')', () => {
+    const mp = readJson(join(root, '.claude-plugin', 'marketplace.json'));
+    const plugins = Array.isArray(mp.plugins) ? mp.plugins : [];
+    if (!pluginName)
+      throw new Error('plugin.json name unreadable — cannot match marketplace entry');
+    const matches = plugins.filter((p) => p && p.name === pluginName);
+    if (matches.length !== 1) {
+      throw new Error(
+        `expected exactly one marketplace entry named "${pluginName}", found ${matches.length}`,
+      );
+    }
+    return matches[0].version;
+  });
+
+  // hypo-config.md frontmatter: version: "X.Y.Z"
+  push('templates/hypo-config.md', () => {
+    const text = readFileSync(join(root, 'templates', 'hypo-config.md'), 'utf-8');
+    const m = text.match(/^version:\s*"?([^"\n]+)"?/m);
+    return m ? m[1].trim() : undefined;
+  });
+
+  return sources;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const root = args.root || REPO_ROOT;
+  const sources = collectVersions(root);
+
+  const errored = sources.filter((s) => s.error);
+  const versions = [...new Set(sources.filter((s) => s.version).map((s) => s.version))];
+
+  // Normalize the tag by stripping exactly one leading `v` (release tags are vX.Y.Z,
+  // file versions are X.Y.Z). Track tag PRESENCE separately from the normalized
+  // value: a bare `v` (or any tag that normalizes to empty / non-semver) must HARD
+  // FAIL, not be mistaken for "no tag supplied" — otherwise a `git tag v` push would
+  // bypass the release gate. This preserves the old "Validate tag matches package
+  // version" guarantee while widening it to every channel.
+  const hasTag = args.tag != null;
+  const tagVersion = hasTag ? args.tag.replace(/^v/, '') : null;
+  const tagValid = hasTag && /^\d+\.\d+\.\d+(-[\w.]+)?$/.test(tagVersion);
+
+  const consistent = errored.length === 0 && versions.length === 1;
+  const tagOk = !hasTag || (tagValid && consistent && versions[0] === tagVersion);
+  const ok = consistent && tagOk;
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        { ok, consistent, hasTag, tagVersion, tagValid, distinctVersions: versions, sources },
+        null,
+        2,
+      ),
+    );
+  } else {
+    const width = Math.max(...sources.map((s) => s.label.length));
+    for (const s of sources) {
+      const val = s.error ? `ERROR: ${s.error}` : s.version;
+      console.log(`  ${s.label.padEnd(width)}  ${val}`);
+    }
+    if (errored.length) {
+      console.error(`\n✗ ${errored.length} version source(s) unreadable.`);
+    } else if (!consistent) {
+      console.error(
+        `\n✗ version drift — ${versions.length} distinct versions: ${versions.join(', ')}`,
+      );
+    } else if (hasTag && !tagValid) {
+      console.error(`\n✗ tag "${args.tag}" does not normalize to a valid semver version`);
+    } else if (!tagOk) {
+      console.error(
+        `\n✗ tag ${args.tag} (→ ${tagVersion}) does not match the file version ${versions[0]}`,
+      );
+    } else {
+      console.log(
+        `\n✓ all version-carrying files agree on ${versions[0]}${tagVersion ? ` (matches tag ${args.tag})` : ''}`,
+      );
+    }
+  }
+
+  process.exit(ok ? 0 : 1);
+}
+
+main();

--- a/scripts/smoke-plugin.mjs
+++ b/scripts/smoke-plugin.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// smoke-plugin.mjs — a cheap, LOCAL structural check that the Claude Code plugin
+// would load, with no network and no Claude CLI dependency (so it runs in CI). It
+// validates the three surfaces Claude Code actually reads:
+//   1. .claude-plugin/plugin.json  — manifest (name, version, commands/skills paths)
+//   2. hooks/hooks.json            — every `${CLAUDE_PLUGIN_ROOT}/...` target must exist
+//   3. component files             — commands/*.md and skills/*/SKILL.md must be REAL
+//      (a .gitkeep alone is not a surface — a plugin with zero commands/skills must fail)
+// plus marketplace↔plugin name parity and that the marketplace `source` resolves to a
+// dir holding .claude-plugin/plugin.json.
+//
+// For a deep, real load check on a dev machine: `claude --plugin-dir . plugin list`.
+// That needs Claude Code installed, so it is NOT used here; this is the CI floor.
+//
+// Usage:
+//   node scripts/smoke-plugin.mjs               # smoke the repo's plugin
+//   node scripts/smoke-plugin.mjs --root <dir>  # point at a fixture (tests)
+//
+// Exit 0 = plugin surfaces are structurally valid. Exit 1 = a load-blocking problem.
+
+import { readFileSync, existsSync, statSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+function parseArgs(argv) {
+  const args = { root: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--root=')) args.root = a.slice(7);
+    else if (a === '--root') args.root = argv[++i];
+  }
+  return args;
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function isDir(p) {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(p) {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function smoke(root) {
+  const errors = [];
+  const notes = [];
+  const fail = (msg) => errors.push(msg);
+
+  // 1. plugin.json manifest.
+  let plugin = null;
+  const pluginPath = join(root, '.claude-plugin', 'plugin.json');
+  try {
+    plugin = JSON.parse(readFileSync(pluginPath, 'utf-8'));
+  } catch (err) {
+    fail(`.claude-plugin/plugin.json: ${err?.message ?? err}`);
+  }
+  if (plugin) {
+    if (typeof plugin.name !== 'string' || !plugin.name) fail('plugin.json: missing "name"');
+    if (typeof plugin.version !== 'string' || !plugin.version)
+      fail('plugin.json: missing "version"');
+    // commands/skills are declared as relative dir paths; if declared they must resolve.
+    for (const key of ['commands', 'skills']) {
+      if (plugin[key] != null) {
+        const rel = String(plugin[key]).replace(/^\.\//, '');
+        if (!isDir(join(root, rel)))
+          fail(`plugin.json: "${key}" path "${plugin[key]}" is not a directory`);
+      }
+    }
+  }
+
+  // 2. Component files must be REAL regular files, not just a .gitkeep placeholder
+  // (or a directory that happens to be named like a component — isFile, not exists).
+  const commandsMd = isDir(join(root, 'commands'))
+    ? readdirSync(join(root, 'commands')).filter(
+        (f) => f.endsWith('.md') && isFile(join(root, 'commands', f)),
+      )
+    : [];
+  if (commandsMd.length === 0) fail('commands/: no *.md command files (only a placeholder?)');
+  else notes.push(`commands: ${commandsMd.length}`);
+
+  let skillCount = 0;
+  if (isDir(join(root, 'skills'))) {
+    for (const entry of readdirSync(join(root, 'skills'))) {
+      if (isFile(join(root, 'skills', entry, 'SKILL.md'))) skillCount++;
+    }
+  }
+  if (skillCount === 0) fail('skills/: no */SKILL.md skills (only a placeholder?)');
+  else notes.push(`skills: ${skillCount}`);
+
+  // 3. hooks/hooks.json — every command target AND every `shared` file must be a
+  // real regular file on disk. hooks.json is the hook source of truth, so a missing
+  // hypo-shared.mjs / version-check.mjs would pass a manifest-only check but break
+  // hook imports at runtime.
+  const hooksPath = join(root, 'hooks', 'hooks.json');
+  if (!existsSync(hooksPath)) {
+    fail('hooks/hooks.json: missing');
+  } else {
+    let hooksJson = null;
+    try {
+      hooksJson = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+    } catch (err) {
+      fail(`hooks/hooks.json: ${err?.message ?? err}`);
+    }
+    if (hooksJson) {
+      if (!hooksJson.hooks || typeof hooksJson.hooks !== 'object') {
+        fail('hooks/hooks.json: missing top-level "hooks" object');
+      } else {
+        const targets = new Set();
+        for (const groups of Object.values(hooksJson.hooks)) {
+          for (const group of groups || []) {
+            for (const hk of group?.hooks || []) {
+              if (hk?.command) {
+                // command looks like `node ${CLAUDE_PLUGIN_ROOT}/hooks/foo.mjs [args]`
+                const m = String(hk.command).match(/\$\{CLAUDE_PLUGIN_ROOT\}\/(\S+)/);
+                if (m) targets.add(m[1]);
+              }
+            }
+          }
+        }
+        if (targets.size === 0)
+          fail('hooks/hooks.json: no ${CLAUDE_PLUGIN_ROOT} command targets found');
+        for (const rel of targets) {
+          if (!isFile(join(root, rel))) fail(`hooks/hooks.json: target "${rel}" is not a file`);
+        }
+        notes.push(`hook targets: ${targets.size}`);
+      }
+      // `shared` lists hook-relative support files that the targets import.
+      if (Array.isArray(hooksJson.shared)) {
+        for (const shared of hooksJson.shared) {
+          if (!isFile(join(root, 'hooks', shared)))
+            fail(`hooks/hooks.json: shared file "hooks/${shared}" is not a file`);
+        }
+        notes.push(`shared: ${hooksJson.shared.length}`);
+      }
+    }
+  }
+
+  // 4. marketplace.json — name parity + source resolves.
+  const mpPath = join(root, '.claude-plugin', 'marketplace.json');
+  let mp = null;
+  try {
+    mp = JSON.parse(readFileSync(mpPath, 'utf-8'));
+  } catch (err) {
+    fail(`.claude-plugin/marketplace.json: ${err?.message ?? err}`);
+  }
+  if (mp) {
+    const plugins = Array.isArray(mp.plugins) ? mp.plugins : [];
+    if (plugins.length === 0) fail('marketplace.json: "plugins" is empty');
+    const name = plugin?.name;
+    if (name) {
+      const matches = plugins.filter((p) => p && p.name === name);
+      if (matches.length !== 1) {
+        fail(
+          `marketplace.json: expected exactly one entry named "${name}", found ${matches.length}`,
+        );
+      } else {
+        const src = matches[0].source ?? './';
+        const srcDir = join(root, String(src).replace(/^\.\//, ''));
+        if (!existsSync(join(srcDir, '.claude-plugin', 'plugin.json'))) {
+          fail(
+            `marketplace.json: source "${src}" does not resolve to a dir containing .claude-plugin/plugin.json`,
+          );
+        }
+      }
+    }
+  }
+
+  return { errors, notes };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const root = args.root || REPO_ROOT;
+  const { errors, notes } = smoke(root);
+
+  if (errors.length) {
+    for (const e of errors) console.error(`  ✗ ${e}`);
+    console.error(`\n✗ plugin smoke failed (${errors.length} problem(s)).`);
+    process.exit(1);
+  }
+  console.log(`✓ plugin surfaces valid (${notes.join(', ')}).`);
+  process.exit(0);
+}
+
+main();

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -17666,6 +17666,240 @@ test('directory move: dry-run reports but writes nothing', () => {
   });
 });
 
+// ── IMPR-12: release-channel version assert + plugin smoke ────────────────────
+suite('check-versions.mjs (IMPR-12)');
+
+// Build a minimal repo-shaped fixture where every version-carrying location holds
+// `v`. Tests mutate one location to prove drift is caught.
+function buildVersionFixture(dir, v) {
+  mkdirSync(join(dir, '.claude-plugin'), { recursive: true });
+  mkdirSync(join(dir, 'templates'), { recursive: true });
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: 'hypomnema', version: v }, null, 2),
+  );
+  writeFileSync(
+    join(dir, 'package-lock.json'),
+    JSON.stringify(
+      {
+        name: 'hypomnema',
+        version: v,
+        lockfileVersion: 3,
+        packages: { '': { name: 'hypomnema', version: v } },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(dir, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({ name: 'hypo', version: v }, null, 2),
+  );
+  writeFileSync(
+    join(dir, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify(
+      { name: 'hypomnema', plugins: [{ name: 'hypo', source: './', version: v }] },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(dir, 'templates', 'hypo-config.md'),
+    `---\ntitle: cfg\ntype: config\nversion: "${v}"\n---\n`,
+  );
+}
+
+test('all files agree → exit 0', () => {
+  withTmpDir((dir) => {
+    buildVersionFixture(dir, '1.4.0');
+    const r = run('check-versions.mjs', ['--root', dir]);
+    assert.equal(r.status, 0, `expected 0: ${r.stdout}\n${r.stderr}`);
+  });
+});
+
+test('one file drifts → exit 1 (drift caught)', () => {
+  withTmpDir((dir) => {
+    buildVersionFixture(dir, '1.4.0');
+    // bump-version does NOT touch the lockfile, so a stale lock is the realistic drift.
+    writeFileSync(
+      join(dir, 'package-lock.json'),
+      JSON.stringify(
+        {
+          name: 'hypomnema',
+          version: '1.3.9',
+          lockfileVersion: 3,
+          packages: { '': { version: '1.3.9' } },
+        },
+        null,
+        2,
+      ),
+    );
+    const r = run('check-versions.mjs', ['--root', dir]);
+    assert.equal(r.status, 1, `expected 1 on drift: ${r.stdout}`);
+    assert.ok(/drift/.test(r.stderr + r.stdout), 'should report drift');
+  });
+});
+
+test('--tag matching the files → exit 0; mismatch → exit 1', () => {
+  withTmpDir((dir) => {
+    buildVersionFixture(dir, '1.4.0');
+    assert.equal(
+      run('check-versions.mjs', ['--root', dir, '--tag', 'v1.4.0']).status,
+      0,
+      'tag match → 0',
+    );
+    const bad = run('check-versions.mjs', ['--root', dir, '--tag', 'v1.4.1']);
+    assert.equal(bad.status, 1, 'tag mismatch → 1');
+    assert.ok(/does not match/.test(bad.stderr + bad.stdout), 'should report tag mismatch');
+  });
+});
+
+test('marketplace entry selected by name, not position (parity enforced)', () => {
+  withTmpDir((dir) => {
+    buildVersionFixture(dir, '1.4.0');
+    // A first entry with a DIFFERENT name must not be treated as the authority.
+    writeFileSync(
+      join(dir, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify(
+        {
+          plugins: [
+            { name: 'other', source: './x', version: '9.9.9' },
+            { name: 'hypo', source: './', version: '1.4.0' },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    const r = run('check-versions.mjs', ['--root', dir]);
+    assert.equal(
+      r.status,
+      0,
+      `name-matched entry (1.4.0) should win over positional 9.9.9: ${r.stdout}\n${r.stderr}`,
+    );
+  });
+});
+
+test('--tag bare "v" (normalizes to empty) → exit 1 (gate not bypassed)', () => {
+  withTmpDir((dir) => {
+    buildVersionFixture(dir, '1.4.0');
+    const r = run('check-versions.mjs', ['--root', dir, '--tag', 'v']);
+    assert.equal(r.status, 1, 'a bare v tag must hard-fail, not be read as "no tag"');
+    assert.ok(/valid semver/.test(r.stderr + r.stdout), 'should report invalid tag');
+  });
+});
+
+test('an unreadable version file → exit 1 (no silent pass)', () => {
+  withTmpDir((dir) => {
+    buildVersionFixture(dir, '1.4.0');
+    rmSync(join(dir, 'templates', 'hypo-config.md'));
+    const r = run('check-versions.mjs', ['--root', dir]);
+    assert.equal(r.status, 1, 'a missing version source must fail');
+    assert.ok(/unreadable/.test(r.stderr + r.stdout), 'should report unreadable source');
+  });
+});
+
+suite('smoke-plugin.mjs (IMPR-12)');
+
+function buildPluginFixture(dir) {
+  mkdirSync(join(dir, '.claude-plugin'), { recursive: true });
+  mkdirSync(join(dir, 'commands'), { recursive: true });
+  mkdirSync(join(dir, 'skills', 'demo'), { recursive: true });
+  mkdirSync(join(dir, 'hooks'), { recursive: true });
+  writeFileSync(
+    join(dir, '.claude-plugin', 'plugin.json'),
+    JSON.stringify(
+      { name: 'hypo', version: '1.4.0', commands: './commands/', skills: './skills/' },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(dir, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify({ plugins: [{ name: 'hypo', source: './', version: '1.4.0' }] }, null, 2),
+  );
+  writeFileSync(join(dir, 'commands', 'foo.md'), '# foo\n');
+  writeFileSync(join(dir, 'skills', 'demo', 'SKILL.md'), '# demo\n');
+  writeFileSync(join(dir, 'hooks', 'h.mjs'), '// hook\n');
+  writeFileSync(join(dir, 'hooks', 'shared-lib.mjs'), '// shared\n');
+  writeFileSync(
+    join(dir, 'hooks', 'hooks.json'),
+    JSON.stringify(
+      {
+        hooks: {
+          SessionStart: [
+            { hooks: [{ type: 'command', command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/h.mjs' }] },
+          ],
+        },
+        shared: ['shared-lib.mjs'],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+test('valid plugin surfaces → exit 0', () => {
+  withTmpDir((dir) => {
+    buildPluginFixture(dir);
+    const r = run('smoke-plugin.mjs', ['--root', dir]);
+    assert.equal(r.status, 0, `expected 0: ${r.stdout}\n${r.stderr}`);
+  });
+});
+
+test('missing hook target → exit 1', () => {
+  withTmpDir((dir) => {
+    buildPluginFixture(dir);
+    rmSync(join(dir, 'hooks', 'h.mjs')); // hooks.json still references it
+    const r = run('smoke-plugin.mjs', ['--root', dir]);
+    assert.equal(r.status, 1, `expected 1 on missing hook target: ${r.stdout}`);
+    assert.ok(/is not a file/.test(r.stderr + r.stdout), 'should report missing target');
+  });
+});
+
+test('empty commands (.gitkeep only) → exit 1', () => {
+  withTmpDir((dir) => {
+    buildPluginFixture(dir);
+    rmSync(join(dir, 'commands', 'foo.md'));
+    writeFileSync(join(dir, 'commands', '.gitkeep'), '');
+    const r = run('smoke-plugin.mjs', ['--root', dir]);
+    assert.equal(r.status, 1, 'a placeholder-only commands/ must fail');
+    assert.ok(/command files/.test(r.stderr + r.stdout), 'should report no command files');
+  });
+});
+
+test('empty skills (.gitkeep only) → exit 1', () => {
+  withTmpDir((dir) => {
+    buildPluginFixture(dir);
+    rmSync(join(dir, 'skills', 'demo', 'SKILL.md'));
+    const r = run('smoke-plugin.mjs', ['--root', dir]);
+    assert.equal(r.status, 1, 'a placeholder-only skills/ must fail');
+    assert.ok(/SKILL\.md/.test(r.stderr + r.stdout), 'should report no skills');
+  });
+});
+
+test('missing shared hook file → exit 1', () => {
+  withTmpDir((dir) => {
+    buildPluginFixture(dir);
+    rmSync(join(dir, 'hooks', 'shared-lib.mjs')); // hooks.json.shared still lists it
+    const r = run('smoke-plugin.mjs', ['--root', dir]);
+    assert.equal(r.status, 1, 'a missing shared file must fail');
+    assert.ok(/shared/.test(r.stderr + r.stdout), 'should report missing shared file');
+  });
+});
+
+test('marketplace name mismatch → exit 1', () => {
+  withTmpDir((dir) => {
+    buildPluginFixture(dir);
+    writeFileSync(
+      join(dir, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({ plugins: [{ name: 'WRONG', source: './', version: '1.4.0' }] }, null, 2),
+    );
+    const r = run('smoke-plugin.mjs', ['--root', dir]);
+    assert.equal(r.status, 1, 'name parity must be enforced');
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
## What

IMPR-12 (v1.4 slice) — make the release pipeline OWN the Claude Code plugin channel, not just npm. Today `release.yml` validates only the tag vs `package.json` and never checks the plugin/marketplace versions or that the plugin would load.

## New scripts (both `--root`-isolatable for tests)

- **`scripts/check-versions.mjs`** — assert every version-carrying location agrees: `package.json`, `package-lock.json` (root + `packages[""]`), `.claude-plugin/{plugin,marketplace}.json`, `templates/hypo-config.md`. With `--tag`, also assert they equal the release tag (strip one leading `v`; a bare/non-semver tag hard-fails rather than being read as "no tag"). The marketplace entry is selected **by name** matching `plugin.json`, not positionally.
- **`scripts/smoke-plugin.mjs`** — structural, network-free load check of the plugin surfaces: manifest, `hooks/hooks.json` command targets **and `shared` files** (real regular files), `commands/*.md` + `skills/*/SKILL.md` component files (a `.gitkeep` alone fails), plus marketplace↔plugin name parity + `source` resolution.

## Wiring

- `package.json`: `check:versions` + `smoke:plugin` scripts; both added **early** in `prepublishOnly` (before the expensive pack smoke).
- `release.yml`: the package.json-only tag check is superseded by `check-versions.mjs --tag`; a "Plugin path smoke" step runs before Publish.
- `ci.yml`: a new **Plugin channel** job runs both on every PR so version drift and a broken plugin are caught pre-release, not at tag push.
- `docs/CONTRIBUTING.md`: release steps now sync `package-lock`, run the new gates, and `git add` every bumped file; the workflow summary is updated.

## Review trail (codex 2-stage + advisor)

- **Design (codex):** `**CONCERN**` — hooks.json validation depth, `.gitkeep` false-pass, positional marketplace selection → all addressed in the initial implementation.
- **Pre-commit (codex):** `**CONCERN**` — bare `v` tag bypass, `exists` vs `isFile`, unsmoked `shared` list; `**NIT**` — stale doc summary → all fixed with pinning tests.
- **advisor:** verified the tag logic directly; flagged that `release.yml`'s `--tag` path first runs for real at the v1.4.0 tag push (CI exercises the no-`--tag` path on every PR).

## Tests

819 → 831, all green. 12 new tests across both scripts (consistency, drift, tag match/mismatch, bare-`v` reject, unreadable-file fail, name-parity, missing hook target, empty commands/skills, missing shared file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)