### PR TITLE
refactor(lib): extract shared wikilink resolver (IMPR-13)

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -60,21 +60,14 @@
  *     hard-fails regardless of scope.
  */
 
-import {
-  existsSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-  mkdirSync,
-  renameSync,
-} from 'fs';
-import { join, relative, extname, dirname } from 'path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
+import { join, dirname } from 'path';
 import { hostname } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
+import { collectPagesCrystallize, extractWikilinks } from './lib/wikilink.mjs';
 import {
   sessionCloseFileStatus,
   sessionCloseGlobalStatus,
@@ -957,21 +950,6 @@ function applySessionClose(args) {
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-function collectPages(dir, root, acc = [], ignorePatterns = []) {
-  if (!existsSync(dir)) return acc;
-  for (const entry of readdirSync(dir)) {
-    if (entry.startsWith('.')) continue;
-    const full = join(dir, entry);
-    if (isScanIgnored(full, root, ignorePatterns)) continue;
-    const st = statSync(full);
-    if (st.isDirectory()) collectPages(full, root, acc, ignorePatterns);
-    else if (extname(entry) === '.md') {
-      acc.push({ path: full, rel: relative(root, full) });
-    }
-  }
-  return acc;
-}
-
 function parseFrontmatter(content) {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!m) return null;
@@ -996,10 +974,6 @@ function parseTags(fm) {
     .filter(Boolean);
 }
 
-function extractWikilinks(content) {
-  return [...content.matchAll(/\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]/g)].map((m) => m[1].trim());
-}
-
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
@@ -1018,7 +992,7 @@ if (args.checkSessionClose) {
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const pagesDir = join(args.hypoDir, 'pages');
-const pages = collectPages(pagesDir, args.hypoDir, [], ignorePatterns);
+const pages = collectPagesCrystallize(pagesDir, args.hypoDir, ignorePatterns);
 
 const tagGroups = {}; // tag → [{ slug, title }]
 const unlinked = []; // pages with no outbound wikilinks

--- a/scripts/graph.mjs
+++ b/scripts/graph.mjs
@@ -14,10 +14,11 @@
  *   --min-edges=<n>     Only include nodes with at least N edges (default: 0)
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { join, relative, extname, basename } from 'path';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
+import { collectPagesGraph, extractWikilinks } from './lib/wikilink.mjs';
 
 // ── arg parsing ───────────────────────────────────────────────────────────────
 
@@ -32,24 +33,6 @@ function parseArgs(argv) {
   return args;
 }
 
-// ── page collector ────────────────────────────────────────────────────────────
-
-function collectPages(dir, root, pages = [], ignorePatterns = []) {
-  if (!existsSync(dir)) return pages;
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (isScanIgnored(full, root, ignorePatterns)) continue;
-    const st = statSync(full);
-    if (st.isDirectory()) {
-      collectPages(full, root, pages, ignorePatterns);
-    } else if (extname(entry) === '.md' && !entry.startsWith('.')) {
-      const slug = relative(root, full).replace(/\.md$/, '').replace(/\\/g, '/');
-      pages.push({ path: full, slug, bare: basename(full, '.md') });
-    }
-  }
-  return pages;
-}
-
 // ── slug resolver ─────────────────────────────────────────────────────────────
 
 function buildSlugIndex(pages) {
@@ -59,16 +42,6 @@ function buildSlugIndex(pages) {
     if (!index.has(p.bare)) index.set(p.bare, p.slug);
   }
   return index;
-}
-
-// ── wikilink extractor ────────────────────────────────────────────────────────
-
-function extractWikilinks(content) {
-  const links = [];
-  for (const m of content.matchAll(/\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]/g)) {
-    links.push(m[1].trim());
-  }
-  return links;
 }
 
 // ── graph builder ─────────────────────────────────────────────────────────────
@@ -180,7 +153,7 @@ const args = parseArgs(process.argv);
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects'].map((d) => join(args.hypoDir, d));
-const pages = scanDirs.flatMap((d) => collectPages(d, args.hypoDir, [], ignorePatterns));
+const pages = scanDirs.flatMap((d) => collectPagesGraph(d, args.hypoDir, ignorePatterns));
 const slugIndex = buildSlugIndex(pages);
 const graph = buildGraph(pages, slugIndex);
 

--- a/scripts/lib/wikilink.mjs
+++ b/scripts/lib/wikilink.mjs
@@ -1,0 +1,156 @@
+// Shared wikilink primitives — the ONE source of truth for vault traversal,
+// slug-form generation, and bare wikilink extraction.
+//
+// Consumed by:
+//   - scripts/lint.mjs        (slug map, page collection, link-target scan)
+//   - scripts/rename.mjs      (form index with collision detection, page scan)
+//   - scripts/graph.mjs       (slug index, page collection, link extraction)
+//   - scripts/crystallize.mjs (page collection, link extraction)
+//
+// IMPR-13 consolidation. Before this lib, each script carried its own copy of
+// collectPages + a slug-form deriver, drifting in subtle ways. The four
+// collectPages variants are NOT interchangeable — they differ deliberately in
+// traversal/security/output-shape policy (codex design review, CONCERN):
+//
+//   - rename uses lstat + skips symlinks   → a vault scan can never escape via a
+//     symlinked dir/file (security boundary).
+//   - lint skips `_`-prefixed DIRECTORIES  → pages/feedback/_drafts scaffolds
+//     stay out of the lint set, while `_`-prefixed FILES (e.g. _index.md) lint.
+//   - crystallize skips ANY `.`-prefixed entry (dir AND file).
+//   - graph/lint/rename skip only `.`-prefixed FILES.
+//   - graph/crystallize emit raw `rel`/`slug`; lint keeps OS-native `rel`
+//     (its own buildSlugMap POSIX-normalizes downstream); rename/graph
+//     POSIX-normalize the slug at scan time.
+//
+// So this lib exposes ONE walker core plus four NAMED PRESETS, not a pile of
+// boolean flags — each preset pins exactly one caller's historical behavior and
+// is fixed by a unit test. readdirSync order is preserved verbatim (NO sort):
+// graph's bare-first slug index is order-sensitive (first page wins a shared
+// bare form), so adding a sort would silently change resolution.
+//
+// Collision RESOLUTION is intentionally NOT shared: lint dedups into a Set
+// (membership), rename detects ambiguity to refuse unsafe auto-rewrites, graph
+// is first-wins. Each caller builds its own structure from slugForms(); only the
+// form GENERATION lives here.
+
+import { existsSync, readdirSync, statSync, lstatSync } from 'fs';
+import { join, relative, extname, basename } from 'path';
+import { isScanIgnored } from './hypo-ignore.mjs';
+
+// ── markdown page walker (shared core) ─────────────────────────────────────────
+// `policy` keys (all optional):
+//   lstat            — stat with lstatSync and skip symlinks (rename's security
+//                      boundary). Default: statSync, symlinks followed.
+//   skipDotEntry     — skip ANY entry (dir or file) whose name starts with `.`
+//                      BEFORE the ignore check (crystallize).
+//   skipUnderscoreDir— skip directories whose name starts with `_` (lint).
+//   skipDotFile      — among `.md` files, skip names starting with `.`.
+//   shape(full)      — build the per-page record pushed onto the accumulator.
+function walkMarkdown(dir, root, ignorePatterns, policy, acc) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (policy.skipDotEntry && entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    if (isScanIgnored(full, root, ignorePatterns)) continue;
+    const st = policy.lstat ? lstatSync(full) : statSync(full);
+    if (policy.lstat && st.isSymbolicLink()) continue;
+    if (st.isDirectory()) {
+      if (policy.skipUnderscoreDir && entry.startsWith('_')) continue;
+      walkMarkdown(full, root, ignorePatterns, policy, acc);
+    } else if (extname(entry) === '.md' && !(policy.skipDotFile && entry.startsWith('.'))) {
+      acc.push(policy.shape(full));
+    }
+  }
+  return acc;
+}
+
+const posixSlug = (full, root) => relative(root, full).replace(/\.md$/, '').replace(/\\/g, '/');
+
+// lint: `_`-dir skip + `_`-file kept; OS-native `rel` (buildSlugMap normalizes).
+export function collectPagesLint(dir, root, ignorePatterns = []) {
+  return walkMarkdown(
+    dir,
+    root,
+    ignorePatterns,
+    {
+      skipDotFile: true,
+      skipUnderscoreDir: true,
+      shape: (full) => ({ path: full, rel: relative(root, full) }),
+    },
+    [],
+  );
+}
+
+// graph: POSIX slug + bare, no `rel`.
+export function collectPagesGraph(dir, root, ignorePatterns = []) {
+  return walkMarkdown(
+    dir,
+    root,
+    ignorePatterns,
+    {
+      skipDotFile: true,
+      shape: (full) => ({ path: full, slug: posixSlug(full, root), bare: basename(full, '.md') }),
+    },
+    [],
+  );
+}
+
+// rename: lstat + symlink skip (security); POSIX rel/slug/bare.
+export function collectPagesRename(dir, root, ignorePatterns = []) {
+  return walkMarkdown(
+    dir,
+    root,
+    ignorePatterns,
+    {
+      lstat: true,
+      skipDotFile: true,
+      shape: (full) => {
+        const rel = relative(root, full).replace(/\\/g, '/');
+        return { path: full, rel, slug: rel.replace(/\.md$/, ''), bare: basename(full, '.md') };
+      },
+    },
+    [],
+  );
+}
+
+// crystallize: skip ANY `.`-prefixed entry; OS-native `rel`.
+export function collectPagesCrystallize(dir, root, ignorePatterns = []) {
+  return walkMarkdown(
+    dir,
+    root,
+    ignorePatterns,
+    { skipDotEntry: true, shape: (full) => ({ path: full, rel: relative(root, full) }) },
+    [],
+  );
+}
+
+// ── slug-form generation ───────────────────────────────────────────────────────
+// From a POSIX no-extension slug (e.g. `pages/learnings/foo`), derive the three
+// link forms a [[wikilink]] may use:
+//   full   — the whole slug                       [[pages/learnings/foo]]
+//   bare   — the basename                         [[foo]]
+//   dirRel — slug minus the leading scan-dir seg  [[learnings/foo]]  (null if the
+//            slug has no `/`, i.e. nothing to drop)
+// Callers pick which forms to register and own their own collision policy. Do NOT
+// apply this to link-target-only slugs (lint's root-md/sources extraTargets,
+// rename's sources/*) — those resolve VERBATIM, with no derived alias, so a bare
+// form can't mask an unrelated broken link or block a safe rewrite.
+export function slugForms(slug) {
+  const slash = slug.indexOf('/');
+  return { full: slug, bare: basename(slug), dirRel: slash === -1 ? null : slug.slice(slash + 1) };
+}
+
+// ── bare wikilink extraction (graph/crystallize variant) ───────────────────────
+// Raw extraction: matches [[target]] / [[target|alias]] / [[target#anchor]]
+// anywhere, INCLUDING inside code fences (graph counts those as edges, and
+// crystallize counts them for unlinked-page detection — preserving that is
+// behavior-stable). lint uses a DIFFERENT extractor (strips code regions and
+// handles table-escaped `\|`); rename uses length-preserving masking. Neither
+// shares this one.
+export function extractWikilinks(content) {
+  const links = [];
+  for (const m of content.matchAll(/\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]/g)) {
+    links.push(m[1].trim());
+  }
+  return links;
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -17,13 +17,14 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
-import { join, relative, extname, basename } from 'path';
+import { join, extname, basename } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import { parseSchemaVocab, checkForbidden, parseSchemaPageDirs } from './lib/schema-vocab.mjs';
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
+import { collectPagesLint, slugForms } from './lib/wikilink.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -113,26 +114,6 @@ const TYPE_ENUM_FIELDS = {
 
 // ── page collector ────────────────────────────────────────────────────────────
 
-function collectPages(dir, root, pages = [], ignorePatterns = []) {
-  if (!existsSync(dir)) return pages;
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (isScanIgnored(full, root, ignorePatterns)) continue;
-    const st = statSync(full);
-    if (st.isDirectory()) {
-      // `_`-prefixed dirs (e.g. pages/feedback/_drafts) hold scaffolds / scratch
-      // not yet promoted to content — skip so incomplete frontmatter never errors
-      // (mirrors loadFeedbackPages in feedback-sync.mjs). `_`-prefixed *files*
-      // (e.g. _index.md) are still linted.
-      if (entry.startsWith('_')) continue;
-      collectPages(full, root, pages, ignorePatterns);
-    } else if (extname(entry) === '.md' && !entry.startsWith('.')) {
-      pages.push({ path: full, rel: relative(root, full) });
-    }
-  }
-  return pages;
-}
-
 // ── slug map ─────────────────────────────────────────────────────────────────
 
 // `extraTargets` are link-target-only slugs (root *.md, sources/*) that resolve
@@ -142,13 +123,14 @@ function buildSlugMap(pages, extraTargets = []) {
   const map = new Set();
   for (const { rel } of pages) {
     const noExt = rel.replace(/\.md$/, '').replace(/\\/g, '/');
-    map.add(noExt);
-    map.add(basename(rel, '.md'));
-    // Dir-relative alias: drop the leading scan-dir segment so the vault's
-    // convention link [[learnings/foo]] resolves to pages/learnings/foo.md.
-    // (A page directly under a scan dir has no extra segment to drop.)
-    const slash = noExt.indexOf('/');
-    if (slash !== -1) map.add(noExt.slice(slash + 1));
+    // full slug + bare basename + dir-relative alias (drop the leading scan-dir
+    // segment so the convention link [[learnings/foo]] resolves to
+    // pages/learnings/foo.md). slugForms returns dirRel=null when the slug has no
+    // `/` (a page directly under a scan dir has no extra segment to drop).
+    const { full, bare, dirRel } = slugForms(noExt);
+    map.add(full);
+    map.add(bare);
+    if (dirRel) map.add(dirRel);
   }
   for (const t of extraTargets) map.add(t);
   return map;
@@ -165,7 +147,7 @@ function collectLinkTargets(hypoDir, ignorePatterns = []) {
     for (const entry of readdirSync(hypoDir)) {
       const full = join(hypoDir, entry);
       // root-level *.md FILES only (no recursion), honoring .hypoignore plus the
-      // scan-only generated-artifact exclusions (isScanIgnored) like collectPages
+      // scan-only generated-artifact exclusions (isScanIgnored) like collectPagesLint
       // — otherwise an ignored root file (e.g. a secret) or a regenerable report
       // would resolve [[its-slug]] as valid, a false negative.
       if (
@@ -180,7 +162,7 @@ function collectLinkTargets(hypoDir, ignorePatterns = []) {
   }
   // sources/*: linkable as the full 'sources/<name>' slug only — deliberately no
   // bare basename, so a stale [[name]] can't silently resolve to a source file.
-  for (const { rel } of collectPages(join(hypoDir, 'sources'), hypoDir, [], ignorePatterns)) {
+  for (const { rel } of collectPagesLint(join(hypoDir, 'sources'), hypoDir, ignorePatterns)) {
     targets.push(rel.replace(/\.md$/, '').replace(/\\/g, '/'));
   }
   return targets;
@@ -413,7 +395,7 @@ const args = parseArgs(process.argv);
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects', 'journal'].map((d) => join(args.hypoDir, d));
-const pages = scanDirs.flatMap((d) => collectPages(d, args.hypoDir, [], ignorePatterns));
+const pages = scanDirs.flatMap((d) => collectPagesLint(d, args.hypoDir, ignorePatterns));
 const linkTargets = collectLinkTargets(args.hypoDir, ignorePatterns);
 const slugMap = buildSlugMap(pages, linkTargets);
 const tagVocab = parseSchemaVocab(args.hypoDir);

--- a/scripts/rename.mjs
+++ b/scripts/rename.mjs
@@ -47,9 +47,10 @@ import {
   lstatSync,
   realpathSync,
 } from 'fs';
-import { join, relative, extname, basename, dirname, normalize, isAbsolute, sep } from 'path';
+import { join, basename, dirname, normalize, isAbsolute, sep } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
+import { collectPagesRename, slugForms } from './lib/wikilink.mjs';
 
 // ── arg parsing ───────────────────────────────────────────────────────────────
 
@@ -64,28 +65,6 @@ function parseArgs(argv) {
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;
-}
-
-// ── page collection (mirrors graph.mjs / crystallize.mjs collectPages) ──────────
-
-function collectPages(dir, root, pages = [], ignorePatterns = []) {
-  if (!existsSync(dir)) return pages;
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (isScanIgnored(full, root, ignorePatterns)) continue;
-    // lstat (never follow): a symlinked dir or file is skipped entirely so the
-    // whole-vault scan can never traverse out of the vault via a symlink.
-    const st = lstatSync(full);
-    if (st.isSymbolicLink()) {
-      continue;
-    } else if (st.isDirectory()) {
-      collectPages(full, root, pages, ignorePatterns);
-    } else if (extname(entry) === '.md' && !entry.startsWith('.')) {
-      const rel = relative(root, full).replace(/\\/g, '/');
-      pages.push({ path: full, rel, slug: rel.replace(/\.md$/, ''), bare: basename(full, '.md') });
-    }
-  }
-  return pages;
 }
 
 // ── preservation class of a link-source path ───────────────────────────────────
@@ -123,10 +102,7 @@ function isPreservedSource(rel) {
 // needs to KNOW when a form is shared, so it maps each form → the set of page
 // rels that expose it. precedence forms per page: full noExt slug, bare
 // basename, dir-relative (drop the leading scan-dir segment).
-function dirRelForm(slug) {
-  const slash = slug.indexOf('/');
-  return slash === -1 ? null : slug.slice(slash + 1);
-}
+const dirRelForm = (slug) => slugForms(slug).dirRel;
 
 function buildFormIndex(pages) {
   const index = new Map(); // form → Set<rel>
@@ -473,7 +449,7 @@ function runDirectory(args, fromDirRel, ignorePatterns) {
     fail(args, `--from subtree contains a symlink — refusing (move could escape the vault)`);
   }
 
-  const pages = collectPages(args.hypoDir, args.hypoDir, [], ignorePatterns);
+  const pages = collectPagesRename(args.hypoDir, args.hypoDir, ignorePatterns);
   const formIndex = buildFormIndex(pages);
 
   // The moving pages: every collected page whose rel is under the from-directory.
@@ -676,7 +652,7 @@ function run(args) {
     return runDirectory(args, fromNorm, ignorePatterns);
   }
 
-  const pages = collectPages(args.hypoDir, args.hypoDir, [], ignorePatterns);
+  const pages = collectPagesRename(args.hypoDir, args.hypoDir, ignorePatterns);
   const formIndex = buildFormIndex(pages);
 
   const fromPage = resolveArgToPage(args.from, pages, formIndex);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -22,7 +22,7 @@ import {
   cpSync,
   realpathSync,
 } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 // static import (no top-level await) — feedback-sync.mjs guards main() behind an
@@ -45,6 +45,14 @@ import {
   BLOCKED_PATTERNS,
   USER_FACING_PATTERNS,
 } from '../scripts/lib/check-tracker-ids.mjs';
+import {
+  collectPagesLint,
+  collectPagesGraph,
+  collectPagesRename,
+  collectPagesCrystallize,
+  slugForms,
+  extractWikilinks,
+} from '../scripts/lib/wikilink.mjs';
 
 const HOME = homedir();
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -18049,6 +18057,80 @@ test('marketplace name mismatch → exit 1', () => {
     );
     const r = run('smoke-plugin.mjs', ['--root', dir]);
     assert.equal(r.status, 1, 'name parity must be enforced');
+  });
+});
+
+// ── wikilink.mjs — shared resolver (IMPR-13) ──────────────────────────────────
+
+suite('wikilink.mjs — shared resolver (IMPR-13)');
+
+test('slugForms derives full / bare / dirRel', () => {
+  assert.deepEqual(slugForms('pages/learnings/foo'), {
+    full: 'pages/learnings/foo',
+    bare: 'foo',
+    dirRel: 'learnings/foo',
+  });
+  // no `/` → nothing to drop, dirRel is null (a page directly under a scan dir)
+  assert.deepEqual(slugForms('hot'), { full: 'hot', bare: 'hot', dirRel: null });
+});
+
+test('extractWikilinks: target from [[t]] / [[t|alias]] / [[t#anchor]], code fences included (raw)', () => {
+  // graph/crystallize variant is intentionally RAW — a [[link]] inside a fence
+  // still counts (preserves pre-IMPR-13 edge/unlinked behavior). lint/rename use
+  // their own strippers, so this must NOT strip.
+  const md = 'x [[foo]] y [[bar/baz|label]] z [[qux#sec]]\n```\n[[in-fence]]\n```\n';
+  assert.deepEqual(extractWikilinks(md), ['foo', 'bar/baz', 'qux', 'in-fence']);
+});
+
+test('collectPages presets enforce distinct traversal policy', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'sub'));
+    mkdirSync(join(dir, '_drafts'));
+    mkdirSync(join(dir, '.hidden'));
+    writeFileSync(join(dir, 'a.md'), '');
+    writeFileSync(join(dir, '_keep.md'), ''); // `_`-FILE: lint keeps it
+    writeFileSync(join(dir, '.secret.md'), ''); // `.`-file: all skip
+    writeFileSync(join(dir, 'sub', 'b.md'), '');
+    writeFileSync(join(dir, '_drafts', 'c.md'), ''); // `_`-DIR: only lint skips
+    writeFileSync(join(dir, '.hidden', 'h.md'), ''); // `.`-DIR: only crystallize skips
+    symlinkSync(join(dir, 'a.md'), join(dir, 'link.md')); // symlink: only rename skips
+
+    const names = (pages) =>
+      pages.map((p) => basename((p.slug ?? p.rel).replace(/\\/g, '/'), '.md')).sort();
+
+    // lint: `_`-dir skipped (no c), `_`-file kept, symlink + `.`-dir followed
+    assert.deepEqual(names(collectPagesLint(dir, dir, [])), ['_keep', 'a', 'b', 'h', 'link']);
+    // graph: most permissive — `_`-dir and `.`-dir and symlink all followed
+    assert.deepEqual(names(collectPagesGraph(dir, dir, [])), ['_keep', 'a', 'b', 'c', 'h', 'link']);
+    // rename: symlink skipped (security boundary), no link
+    assert.deepEqual(names(collectPagesRename(dir, dir, [])), ['_keep', 'a', 'b', 'c', 'h']);
+    // crystallize: `.`-dir skipped (no h), `.`-file skipped
+    assert.deepEqual(names(collectPagesCrystallize(dir, dir, [])), [
+      '_keep',
+      'a',
+      'b',
+      'c',
+      'link',
+    ]);
+  });
+});
+
+test('collectPages presets emit the historical output shape', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'sub'));
+    writeFileSync(join(dir, 'sub', 'b.md'), '');
+    const norm = (s) => s.replace(/\\/g, '/');
+    const [r] = collectPagesRename(dir, dir, []);
+    assert.equal(norm(r.slug), 'sub/b');
+    assert.equal(norm(r.rel), 'sub/b.md');
+    assert.equal(r.bare, 'b');
+    const [g] = collectPagesGraph(dir, dir, []);
+    assert.equal(norm(g.slug), 'sub/b');
+    assert.equal(g.bare, 'b');
+    // lint/crystallize emit only { path, rel } (no slug/bare)
+    const [l] = collectPagesLint(dir, dir, []);
+    assert.equal(norm(l.rel), 'sub/b.md');
+    assert.equal(l.slug, undefined);
   });
 });
 


### PR DESCRIPTION
## 요약
lint/rename/graph/crystallize에 흩어진 wikilink 처리 중복(collectPages 4종, extractWikilinks, slug-form 파생)을 공유 `scripts/lib/wikilink.mjs`로 통합한다. 순수 리팩터.

## 왜 단순 통합이 아닌가
네 collectPages는 표면상 비슷하지만 traversal 정책이 의도적으로 다르다:
- rename: lstat + symlink skip (볼트 밖 traverse 방어, 보안 경계)
- lint: `_`-dir skip, `_`-file 유지
- crystallize: `.`-entry(dir+file) skip
- graph: 가장 포괄

그래서 boolean flag 더미가 아니라 공유 walker 코어 + 4개 named preset으로 노출하고, 각 preset을 단위 테스트로 고정했다. readdirSync 순서는 그대로 보존한다(graph의 bare-first slug index가 순서 의존).

## 무엇을 공유하고 무엇을 안 하나
- 공유: collectPages(named preset), slugForms(full/bare/dirRel), extractWikilinks(graph/crystallize raw 변형)
- caller 소유 유지: 충돌 resolution(lint Set membership / rename ambiguity / graph first-wins), extraTargets verbatim 정책, lint·rename의 자체 정규식/마스킹

## 검증
- 845 테스트 통과(기존 841 + preset 정책/shape 단위 테스트 4 신규)
- 실제 볼트 lint/graph 출력 리팩터 전후 byte-identical
- codex 2단계 교차검토: 설계 verdict CONCERN(named preset·extract 분리·정렬 금지 반영) → commit verdict NIT(행동 회귀 없음, symlink 경계·TDZ·import 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012v5JKxfX7dxDiYL7rSepp6