### PR TITLE
feat(lint): reject invalid-YAML frontmatter + reconcile types with SCHEMA (IMPR-3)

### DIFF
--- a/scripts/lib/frontmatter.mjs
+++ b/scripts/lib/frontmatter.mjs
@@ -1,14 +1,35 @@
+// A YAML block sequence entry: `-` followed by whitespace or end-of-line.
+// Narrower than `startsWith('-')` so a (nonstandard) plain key like `-key:` is
+// still read rather than mistaken for a list item.
+export const SEQUENCE_ENTRY_RE = /^-(\s|$)/;
+
+// Lenient, top-level-only frontmatter field extractor (NOT a YAML parser).
+// Reads only unindented `key: value` lines, skipping indented lines and list
+// items, so a nested mapping (e.g. a `type:` inside a `relations:` list) cannot
+// clobber the page's real top-level field. Without this a `learning` page
+// carrying a relations block was mis-read as `type: depends_on` and silently
+// dropped by type-routed consumers (doctor's verify-freshness scan, lint's
+// type check). First-wins on a repeated top-level key. Assumes the Hypomnema
+// convention of unindented root fields (templates/SCHEMA.md §3). scripts/lint.mjs
+// imports this and adds a separate W9 pass for invalid-YAML classes a real
+// parser would reject.
 export function parseFrontmatter(content) {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!m) return null;
   const fm = {};
   for (const line of m[1].split(/\r?\n/)) {
+    if (/^\s/.test(line) || SEQUENCE_ENTRY_RE.test(line)) continue; // nested / list item
     const idx = line.indexOf(':');
     if (idx < 0) continue;
-    fm[line.slice(0, idx).trim()] = line
+    const key = line.slice(0, idx).trim();
+    if (!key || Object.hasOwn(fm, key)) continue; // first-wins
+    fm[key] = line
       .slice(idx + 1)
       .trim()
-      .replace(/\s*#.*$/, '')
+      // strip a trailing YAML comment: `#` must follow whitespace to start one,
+      // so `concept#bad` stays literal (and still trips lint's unknown-type W2)
+      // while `concept # note` loses the comment.
+      .replace(/\s+#.*$/, '')
       .replace(/^["']|["']$/g, '');
   }
   return fm;

--- a/scripts/lib/schema-vocab.mjs
+++ b/scripts/lib/schema-vocab.mjs
@@ -94,3 +94,38 @@ export function parseSchemaPageDirs(hypoDir) {
   }
   return dirs;
 }
+
+// Type-token shape: lowercase identifier (a-z, digits, hyphen). Excludes
+// memory-layer rows whose first cell is a filename (`hot.md`, `log.md`) — those
+// carry a `.` and never match — so only real type names survive.
+const TYPE_TOKEN_RE = /^[a-z][a-z0-9-]+$/;
+
+// Derive the set of valid page `type` values from the SCHEMA "Page Type
+// Taxonomy" table — the FIRST backticked cell of each table row (the type
+// column). Single source of truth, mirroring parseSchemaPageDirs: adding a type
+// row to a vault's SCHEMA automatically widens the accepted types, so a
+// vault-local extension (e.g. working-doc / draft / qa-run) stops tripping the
+// W2 unknown-type warning without editing lint. Returns an empty Set when
+// SCHEMA.md or the table is absent — callers union this with a hardcoded core so
+// the core types never depend on a present/complete SCHEMA.
+export function parseSchemaTypes(hypoDir) {
+  const path = join(hypoDir, 'SCHEMA.md');
+  if (!existsSync(path)) return new Set();
+  const content = readFileSync(path, 'utf-8');
+
+  const headerMatch = TYPE_TAXONOMY_HEADER_RE.exec(content);
+  if (!headerMatch) return new Set();
+
+  const sectionStart = headerMatch.index + headerMatch[0].length;
+  const rest = content.slice(sectionStart);
+  const nextH2 = NEXT_H2_RE.exec(rest);
+  const section = nextH2 ? rest.slice(0, nextH2.index) : rest;
+
+  const types = new Set();
+  for (const rawLine of section.split('\n')) {
+    if (!rawLine.trimStart().startsWith('|')) continue;
+    const m = rawLine.match(/`([^`]+)`/); // first backtick token = type column
+    if (m && TYPE_TOKEN_RE.test(m[1].trim())) types.add(m[1].trim());
+  }
+  return types;
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -21,10 +21,16 @@ import { join, extname, basename } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
-import { parseSchemaVocab, checkForbidden, parseSchemaPageDirs } from './lib/schema-vocab.mjs';
+import {
+  parseSchemaVocab,
+  checkForbidden,
+  parseSchemaPageDirs,
+  parseSchemaTypes,
+} from './lib/schema-vocab.mjs';
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
 import { collectPagesLint, slugForms } from './lib/wikilink.mjs';
+import { parseFrontmatter, SEQUENCE_ENTRY_RE } from './lib/frontmatter.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -42,19 +48,45 @@ function parseArgs(argv) {
 
 // ── frontmatter parser ────────────────────────────────────────────────────────
 
-function parseFrontmatter(content) {
-  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!m) return null;
-  const fm = {};
-  for (const line of m[1].split('\n')) {
+// ── W9: narrow invalid-YAML detector ───────────────────────────────────────────
+// NOT a full YAML parser (zero-dep policy). Catches only specific classes the
+// lenient line-scanner (parseFrontmatter, imported from lib) silently passes but
+// a real YAML parser (js-yaml, what Obsidian uses) rejects. Each class is
+// conservative — it may miss, but must NOT false-positive on valid YAML, so it
+// inspects only top-level (unindented) lines: indented lines may be block-scalar
+// content where ": "/tabs are legal, and reliably telling content from structure
+// needs a real parser. (A leading-tab class was considered and dropped for this
+// reason — it cannot distinguish `relations:\n\t- x` from a tabbed block-scalar
+// body without tracking block context.) Returns an array of reasons.
+function checkYamlInvalid(block) {
+  const reasons = [];
+  const seen = new Set();
+  for (const raw of block.split('\n')) {
+    const line = raw.replace(/\r$/, '');
+    if (!line.trim()) continue;
+    if (/^\s/.test(line) || SEQUENCE_ENTRY_RE.test(line)) continue; // top-level keys only
     const idx = line.indexOf(':');
     if (idx < 0) continue;
-    fm[line.slice(0, idx).trim()] = line
-      .slice(idx + 1)
-      .trim()
-      .replace(/^["']|["']$/g, '');
+    const key = line.slice(0, idx).trim();
+    if (!key) continue;
+    // duplicate top-level key (YAML rejects; line-scanner silently keeps one)
+    if (seen.has(key)) reasons.push(`duplicate key: "${key}"`);
+    else seen.add(key);
+    // colon-space inside an unquoted, non-flow plain scalar. A plain scalar may
+    // not contain ": " — js-yaml hard-errors or silently truncates. Skip quoted
+    // ("/') and flow ([/{) values where ": " is legal, and strip an inline
+    // " #" comment before scanning.
+    let val = line.slice(idx + 1).trim();
+    const c = val[0];
+    if (val && c !== '"' && c !== "'" && c !== '[' && c !== '{') {
+      const hash = val.indexOf(' #');
+      if (hash >= 0) val = val.slice(0, hash);
+      if (/:\s/.test(val)) {
+        reasons.push(`unquoted "${key}" value contains ": " (quote it): "${val.slice(0, 40)}"`);
+      }
+    }
   }
-  return fm;
+  return reasons;
 }
 
 function parseTagsField(rawValue) {
@@ -241,10 +273,15 @@ const issues = [];
 // STRICT_PROMOTE_IDS (OQ-E1, frozen as a code constant): confirmed content
 // defects only.
 //   W1 no-frontmatter / W2 unknown-type / W4 broken-wikilink → promote.
+//   W9 invalid-YAML → promote (frontmatter a real YAML parser rejects).
 //   W3 missing-updated  → excluded (auto-repaired by --fix).
 //   W8 design-history-stale → excluded (hypo-personal-check handles it; would
 //                             double-gate).
-const STRICT_PROMOTE_IDS = new Set(['W1', 'W2', 'W4']);
+// NOTE: no gate currently passes --strict (npm run lint / CI / release.yml /
+// crystallize / the close-gate all run plain lint), so promotion is
+// forward-looking — these surface as warnings today. IMPR-3's deliverable is
+// "stop silently green-passing invalid YAML"; the W9 warning satisfies that.
+const STRICT_PROMOTE_IDS = new Set(['W1', 'W2', 'W4', 'W9']);
 
 function issue(severity, rel, msg, fullPath = null, id = null) {
   issues.push({ severity, file: rel, message: msg, path: fullPath, id });
@@ -267,7 +304,7 @@ function lintSessionStateHeadings(content, rel) {
   }
 }
 
-function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
+function lintPage({ path, rel }, slugMap, tagVocab, pageDirs, validTypes) {
   // Directory whitelist: a content page under pages/<subdir>/ must live in a
   // SCHEMA-defined directory. Catches typo'd dirs (e.g. pages/learning/ vs the
   // canonical pages/learnings/) regardless of frontmatter, since a directory
@@ -301,6 +338,16 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
     return;
   }
 
+  // W9: invalid-YAML frontmatter the lenient line-scanner would otherwise pass
+  // green. Runs on the raw `---` block (the `content.match` above guarantees an
+  // opening fence; an unclosed fence falls through to the W3/parse path below).
+  const fmBlock = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (fmBlock) {
+    for (const reason of checkYamlInvalid(fmBlock[1])) {
+      issue('warn', rel, `Invalid YAML frontmatter: ${reason}`, null, 'W9');
+    }
+  }
+
   const fm = parseFrontmatter(content);
   if (!fm) {
     issue('error', rel, 'Malformed frontmatter (unclosed ---)');
@@ -311,7 +358,7 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs) {
     if (!fm[field]) issue('error', rel, `Missing required frontmatter field: ${field}`);
   }
 
-  if (fm.type && !VALID_TYPES.includes(fm.type)) {
+  if (fm.type && !validTypes.has(fm.type)) {
     issue('warn', rel, `Unknown type: "${fm.type}"`, null, 'W2');
   }
 
@@ -400,8 +447,14 @@ const linkTargets = collectLinkTargets(args.hypoDir, ignorePatterns);
 const slugMap = buildSlugMap(pages, linkTargets);
 const tagVocab = parseSchemaVocab(args.hypoDir);
 const pageDirs = parseSchemaPageDirs(args.hypoDir);
+// Accepted page types = hardcoded core ∪ the vault SCHEMA's taxonomy. Union (not
+// replace) so core types lint specially handles (session-state, source, …) are
+// never lost when a vault's SCHEMA omits or predates them, while a vault-local
+// extension (working-doc / draft / qa-run) is honored without editing lint —
+// mirroring how tags and page dirs are SCHEMA-derived.
+const validTypes = new Set([...VALID_TYPES, ...parseSchemaTypes(args.hypoDir)]);
 
-for (const page of pages) lintPage(page, slugMap, tagVocab, pageDirs);
+for (const page of pages) lintPage(page, slugMap, tagVocab, pageDirs, validTypes);
 
 // W8: design-history.md stale relative to session-log.md. Emitted once per
 // project (not per page) — runs outside the page loop. POSIX-separated path

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -31,6 +31,7 @@ import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync
 import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
 import { buildProjectSuggestionLine, resolveActiveProject } from '../hooks/hypo-shared.mjs';
 import { parseSchemaVocab } from '../scripts/lib/schema-vocab.mjs';
+import { parseFrontmatter as libParseFrontmatter } from '../scripts/lib/frontmatter.mjs';
 import { isHypomnemaPluginEnabled } from '../scripts/lib/plugin-detect.mjs';
 import {
   validateChangelog,
@@ -6743,6 +6744,215 @@ test('feedback missing targets → error', () => {
       e.message.includes('Missing required field for type "feedback": targets'),
     ),
     `missing targets error: ${r.stdout}`,
+  );
+});
+
+// ── lint.mjs frontmatter hardening (IMPR-3) ─────────────────────────────────
+// A: top-level-only field extraction (nested `type:` no longer clobbers).
+// B: W9 invalid-YAML detector (colon-space / tab-indent / dup-key) + strict.
+// C: VALID_TYPES ∪ SCHEMA-derived types (vault-local type extensions).
+
+// Direct unit coverage for the shared helper (used by lint, doctor,
+// feedback-sync, upgrade). The integration tests below exercise it via lint;
+// these pin the contract so the lib function can't silently rot if a consumer
+// re-inlines its own parser (the doctor clobber bug that drove consolidation).
+suite('lib/frontmatter.mjs parseFrontmatter (shared)');
+
+test('nested type: under a relations list does not clobber top-level type', () => {
+  const fm = libParseFrontmatter(
+    '---\ntitle: T\ntype: learning\nrelations:\n  - target: y\n    type: depends_on\n---\nbody\n',
+  );
+  assert.equal(fm.type, 'learning');
+  assert.equal(fm['- target'], undefined, 'list item leaked as a key');
+});
+
+test('first-wins on a duplicate top-level key', () => {
+  const fm = libParseFrontmatter('---\ntype: concept\ntype: reference\n---\nbody\n');
+  assert.equal(fm.type, 'concept');
+});
+
+test('CRLF frontmatter parses top-level fields', () => {
+  const fm = libParseFrontmatter('---\r\ntitle: T\r\ntype: concept\r\n---\r\nbody\r\n');
+  assert.equal(fm.type, 'concept');
+  assert.equal(fm.title, 'T');
+});
+
+test('trailing comment stripped only after whitespace', () => {
+  assert.equal(libParseFrontmatter('---\ntype: concept # note\n---\n').type, 'concept');
+  assert.equal(libParseFrontmatter('---\ntype: concept#bad\n---\n').type, 'concept#bad');
+});
+
+suite('lint.mjs frontmatter hardening (IMPR-3)');
+
+// SCHEMA with a Page Type Taxonomy table — parseSchemaTypes reads the first
+// backticked cell of each row, so `working-doc` becomes an accepted type.
+const TAXONOMY_SCHEMA = `---
+title: SCHEMA
+type: schema
+---
+# Schema
+
+## 1. Page Type Taxonomy
+
+| type | location | mutability |
+|------|----------|------------|
+| \`concept\` | \`pages/\` | mutable |
+| \`working-doc\` | \`projects/*/\` | mutable |
+
+## 4. Tag Vocabulary
+
+\`concept\` \`project\`
+`;
+
+function lintStrict(pageRel, content, schemaContent = VOCAB_SCHEMA) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-strict-'));
+  writeFileSync(join(dir, 'SCHEMA.md'), schemaContent);
+  const fullPath = join(dir, pageRel);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+  const r = run('lint.mjs', [`--hypo-dir=${dir}`, '--json', '--strict']);
+  const out = JSON.parse(r.stdout);
+  rmSync(dir, { recursive: true, force: true });
+  return { r, out };
+}
+
+// A — nested `type:` inside a relations list must not clobber the page type.
+test('A: nested type: under relations does not trigger W2 unknown-type', () => {
+  const { r, out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-06-23\nrelations:\n  - target: y\n    type: depends_on\n---\nbody\n',
+  );
+  assert.ok(
+    !out.warns.some((w) => /Unknown type/.test(w.message)),
+    `nested type clobbered top-level: ${r.stdout}`,
+  );
+});
+
+// B — colon-space in an unquoted top-level value → W9 warn (default), error (--strict).
+test('B: unquoted value with ": " → W9 warn', () => {
+  const { out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: Plan: phase 2\ntype: concept\nupdated: 2026-06-23\n---\nbody\n',
+  );
+  const w9 = out.warns.filter((w) => /Invalid YAML/.test(w.message));
+  assert.equal(w9.length, 1, `expected one W9 warn: ${JSON.stringify(out.warns)}`);
+});
+
+test('B: W9 promoted to error under --strict', () => {
+  const { r, out } = lintStrict(
+    'pages/x.md',
+    '---\ntitle: Plan: phase 2\ntype: concept\nupdated: 2026-06-23\n---\nbody\n',
+  );
+  assert.equal(r.status, 1, `--strict should exit 1: ${r.stdout}`);
+  assert.ok(
+    out.errors.some((e) => e.id === 'W9' && /Invalid YAML/.test(e.message)),
+    `W9 not promoted: ${r.stdout}`,
+  );
+});
+
+// B — quoted / flow / commented values containing ":" are valid YAML → no W9.
+test('B: quoted, flow, and comment values do not false-positive W9', () => {
+  for (const fm of ['title: "a: b"', 'tags: ["a: b"]', 'meta: {a: b}', 'title: foo # note: bar']) {
+    const { out } = lintWithSchema(
+      'pages/x.md',
+      `---\n${fm}\ntype: concept\nupdated: 2026-06-23\n---\nbody\n`,
+    );
+    assert.ok(!out.warns.some((w) => /Invalid YAML/.test(w.message)), `false W9 on "${fm}"`);
+  }
+});
+
+// B — duplicate top-level key → W9.
+test('B: duplicate top-level key → W9 warn', () => {
+  const { out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\ntype: reference\nupdated: 2026-06-23\n---\nbody\n',
+  );
+  assert.ok(
+    out.warns.some((w) => /Invalid YAML.*duplicate key/.test(w.message)),
+    `dup-key W9 missing: ${JSON.stringify(out.warns)}`,
+  );
+});
+
+// C — a vault-local type defined only in SCHEMA's taxonomy is accepted.
+test('C: SCHEMA-defined type (working-doc) is not W2 unknown-type', () => {
+  const { out } = lintWithSchema(
+    'projects/p/scope.md',
+    '---\ntitle: T\ntype: working-doc\nupdated: 2026-06-23\n---\nbody\n',
+    TAXONOMY_SCHEMA,
+  );
+  assert.ok(
+    !out.warns.some((w) => /Unknown type/.test(w.message)),
+    `SCHEMA-defined type flagged: ${JSON.stringify(out.warns)}`,
+  );
+});
+
+// C — core type stays valid even when SCHEMA has no taxonomy table (union floor).
+test('C: core type valid when SCHEMA lacks a taxonomy table', () => {
+  const { out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-06-23\n---\nbody\n',
+  );
+  assert.ok(
+    !out.warns.some((w) => /Unknown type/.test(w.message)),
+    `core type lost: ${JSON.stringify(out.warns)}`,
+  );
+});
+
+// C — a non-core type present only in the (template-like) taxonomy is accepted.
+test('C: SCHEMA taxonomy row (log) admits a non-core type', () => {
+  const schema = TAXONOMY_SCHEMA.replace(
+    '| `working-doc` | `projects/*/` | mutable |',
+    '| `log` | `log.md` | append-only |',
+  );
+  const { out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: log\nupdated: 2026-06-23\n---\nbody\n',
+    schema,
+  );
+  assert.ok(
+    !out.warns.some((w) => /Unknown type/.test(w.message)),
+    `SCHEMA taxonomy type rejected: ${JSON.stringify(out.warns)}`,
+  );
+});
+
+// B — tabs in block-scalar bodies are valid content, never W9. Covers plain,
+// structural-looking (`key:` / `- item`) tabbed lines — W9 inspects only
+// top-level lines, so none of these false-positive (codex stage-2/2b guard).
+test('B: tab in block-scalar body does not false-positive W9', () => {
+  for (const body of ['  \tbar', '  \tkey: value', '  \t- item']) {
+    const { out } = lintWithSchema(
+      'pages/x.md',
+      `---\ntitle: T\ntype: concept\nupdated: 2026-06-23\ndesc: |\n  foo\n${body}\n---\nbody\n`,
+    );
+    assert.ok(
+      !out.warns.some((w) => /Invalid YAML/.test(w.message)),
+      `block-scalar tab false-positived on "${body}": ${JSON.stringify(out.warns)}`,
+    );
+  }
+});
+
+// B — `#` without a leading space is a literal scalar char, not a comment, so an
+// unknown type like `concept#bad` must still trip W2 (not be silently stripped).
+test('B: "#" without leading space is literal (W2 still fires)', () => {
+  const { out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept#bad\nupdated: 2026-06-23\n---\nbody\n',
+  );
+  assert.ok(
+    out.warns.some((w) => /Unknown type: "concept#bad"/.test(w.message)),
+    `comment-strip hid unknown type: ${JSON.stringify(out.warns)}`,
+  );
+});
+
+// A — CRLF frontmatter: nested type: still must not clobber, fields still read.
+test('A: CRLF frontmatter parses and nested type does not clobber', () => {
+  const { out } = lintWithSchema(
+    'pages/x.md',
+    '---\r\ntitle: T\r\ntype: concept\r\nupdated: 2026-06-23\r\nrelations:\r\n  - type: depends_on\r\n---\r\nbody\r\n',
+  );
+  assert.ok(
+    !out.warns.some((w) => /Unknown type/.test(w.message)),
+    `CRLF nested type clobbered: ${JSON.stringify(out.warns)}`,
   );
 });
 
@@ -14688,7 +14898,7 @@ test('w8-lint-omits-id-for-other-warns', () => {
 // ── Track E: lint --strict warning→error promotion ──────────────────────────
 // spec-v1.3.0 Track E. Stable warning IDs (W1 no-frontmatter / W2 unknown-type
 // / W3 missing-updated / W4 broken-wikilink; W8 design-history-stale predates).
-// `--strict` promotes STRICT_PROMOTE_IDS = {W1,W2,W4} to errors (exit 1).
+// `--strict` promotes STRICT_PROMOTE_IDS = {W1,W2,W4,W9} to errors (exit 1).
 // Default mode must stay byte-identical (only W8 exposes `id` in --json).
 
 suite('Track E: lint --strict warning ID promotion');


### PR DESCRIPTION
## What

lint's frontmatter parser was a flat regex line-scan that **silently green-passed YAML a real parser (js-yaml, what Obsidian uses) rejects**, and **mis-read fields** when a nested mapping repeated a top-level key. IMPR-3 hardens it and reconciles the accepted type vocabulary with `SCHEMA.md`.

## Changes

- **Top-level-only extraction (shared helper).** Harden `scripts/lib/frontmatter.mjs` `parseFrontmatter` to read only unindented lines with first-wins, so a nested `type:` inside a `relations:` list no longer clobbers the page type. lint now imports it instead of carrying a divergent copy (IMPR-13 consolidation spirit). Also fixes a real consumer bug: `doctor`'s verify-freshness scan routes by `fm.type` and was silently skipping learning/adr pages carrying a relations block.
- **W9 invalid-YAML detector.** Narrow, conservative classes the line-scanner passed but a YAML parser rejects: colon-space in an unquoted non-flow plain scalar, and duplicate top-level key. Warning by default (no vault goes red); joins `STRICT_PROMOTE_IDS` for opt-in `--strict` gates. A leading-tab and an unclosed-quote class were considered and dropped (block-scalar / multiline false-positive risk; 0 real hits).
- **Comment-strip fix.** Require whitespace before `#` (`/\s+#/`), matching YAML: `concept#bad` stays literal and still trips unknown-type, while `concept # note` loses the trailing comment.
- **Type reconcile.** Accepted types = `VALID_TYPES ∪ parseSchemaTypes(SCHEMA taxonomy)`, mirroring the SCHEMA-derived tag/page-dir vocab. Union floor keeps core types when a vault SCHEMA omits them; vault-local extensions (`working-doc`/`draft`/`qa-run`) stop tripping unknown-type without editing lint.

## Verification

- Live vault (335 md): **0 new errors**, unknown-type warnings **62 → 1** (the remaining 1 is a genuine `type: page`), **2** invalid-YAML files surfaced as W9. Definitive OLD-vs-NEW field diff across all keys: only `type` (the fix) plus correctly-dropped non-fields (`- target` list items, a block-scalar body line) differ — no consumer field regresses.
- **860 tests pass** (new direct `lib/frontmatter` unit tests + lint integration tests for parts A/B/C, CRLF, block-scalar tabs, comment-strip).
- Two codex review rounds (design + commit) addressed: severity phrasing, dropped unclosed-quote/tab classes, comment-strip, block-scalar false-positives.

## Notes / out of scope

- No gate currently runs `--strict`, so W9 (like W1/W2/W4) surfaces as a warning today; the deliverable "stop silently green-passing invalid YAML" is met by the visible warning. Wiring `--strict` into release/close gates is a separate decision (affects W1/W2/W4 too).
- `templates/SCHEMA.md` lacks a `postmortem` row that lint core + the vault SCHEMA have — a separate consistency cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)