### PR TITLE
feat(feedback): optional failure_type enum for feedback frontmatter (FEAT-1)

### DIFF
--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -26,6 +26,7 @@ If the user did not provide them, ask. The classification fields are required so
 6. **Targets**: "Where should this project?" → `project-memory` (MEMORY.md) and/or `claude-learned` (global CLAUDE.md). Default `project-memory`.
 7. **Priority** (1–5, higher sorts first; default 3).
 8. **Sensitivity**: `public` (default) or `sanitized` (redacted secrets/paths). `private` is not allowed — the wiki is git-pushed.
+9. **Failure type** (optional): if this correction came from a real failure incident, classify it — `hallucination` | `false-completion` | `process-stall` | `over-caution` | `overreach` | `incompleteness` | `instruction-miss` | `convention-violation`. Omit it for a pure preference or a brand-new convention ("always do X"). When several fit, take the most specific (the list is in precedence order; see SCHEMA §3.1).
 
 If **claude-learned** is among the targets, the page must be `scope: global` + `tier: L1`, and you must also collect:
 - **Global summary**: a one-line summary for the CLAUDE.md learned-behaviors entry.
@@ -61,12 +62,15 @@ node <package-root>/scripts/feedback.mjs \
   --memory-summary="<one-line MEMORY.md summary>" \
   --reason="<why this rule exists>" \
   [--global-summary="<one-line CLAUDE.md summary>" --promote-to-global] \
+  [--failure-type="<enum>"] \
   [--source="session:<date>"] \
   [--hypo-dir="<path>"] \
   [--dry-run]
 ```
 
 When `--targets` includes `claude-learned`, `--global-summary` and `--promote-to-global` are required (and `--scope=global --tier=L1`).
+
+`--failure-type` is optional (one of the eight values above). On **append** to an existing topic it is set only if the page has none; if the page already carries a different `failure_type` the command errors (a page holds a single failure_type — use a separate topic for a different one). Without the flag, an append leaves the frontmatter untouched as before.
 
 > **`scope: project:<project-id>` 주의.** `<project-id>`는 `feedback-sync`가 resolve한 project-id와 정확히 일치해야 한다 (default: cwd의 `/`,`.` → `-` 치환; `--project-id=<id>` 로 override). 일치하지 않으면 그 페이지는 해당 project의 MEMORY로 projection되지 **않는다** (silent skip — lint error 아님). v1.3.0부터 scope regex(`^(global|project:[A-Za-z0-9_-]+)$`)가 cwd-derived id 형식(`-Users-...`)을 그대로 허용하므로 lint 통과를 위해 `--project-id=<slug>`를 override할 필요는 없다. 단 cwd에 공백 등 `[A-Za-z0-9_-]` 밖 문자가 있으면 그 id는 여전히 거부되니 그때만 `--project-id=<id>`로 override한다.
 

--- a/scripts/feedback.mjs
+++ b/scripts/feedback.mjs
@@ -48,6 +48,8 @@ import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
+import { FAILURE_TYPE_ENUM } from './lib/failure-type.mjs';
+import { parseFrontmatter } from './lib/frontmatter.mjs';
 
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
 
@@ -69,6 +71,7 @@ function parseArgs(argv) {
     promoteToGlobal: false,
     reason: null,
     source: null,
+    failureType: null,
     behavior: null,
     claudeHome: null,
     projectId: null,
@@ -91,6 +94,7 @@ function parseArgs(argv) {
     else if (arg === '--promote-to-global') args.promoteToGlobal = true;
     else if (arg.startsWith('--reason=')) args.reason = arg.slice(9);
     else if (arg.startsWith('--source=')) args.source = arg.slice(9);
+    else if (arg.startsWith('--failure-type=')) args.failureType = arg.slice(15);
     else if (arg.startsWith('--behavior=')) args.behavior = arg.slice(11);
     else if (arg.startsWith('--claude-home=')) args.claudeHome = expandHome(arg.slice(14));
     else if (arg.startsWith('--project-id=')) args.projectId = arg.slice(13);
@@ -132,6 +136,16 @@ function parseTargets(raw) {
     .filter(Boolean);
 }
 
+// FEAT-1: `failure_type` is OPTIONAL — an unset value is always fine. A set value
+// must be one of the eight enum members (same vocabulary lint enforces). Returns
+// an error string or null. Shared by create (validateClassification) and append.
+function failureTypeError(value) {
+  if (!value) return null;
+  if (!FAILURE_TYPE_ENUM.includes(value))
+    return `--failure-type invalid: "${value}" (allowed: ${FAILURE_TYPE_ENUM.join(', ')})`;
+  return null;
+}
+
 // Validate the create-mode classification. Returns an array of error strings.
 function validateClassification(args, targets) {
   const errs = [];
@@ -151,6 +165,8 @@ function validateClassification(args, targets) {
     errs.push(`--priority must be an integer 1-5 (got "${args.priority}")`);
   if (!args.memorySummary) errs.push('--memory-summary is required');
   if (!args.reason) errs.push('--reason is required');
+  const ftErr = failureTypeError(args.failureType);
+  if (ftErr) errs.push(ftErr);
 
   // CLAUDE.md projection candidates must be global + L1 (ADR 0031 §6 filter), and
   // carry the two conditional fields (lint #8). Enforce here so we never write a
@@ -201,6 +217,7 @@ function renderPage(args, targets, today) {
   }
   lines.push(`reason: ${oneLine(args.reason)}`);
   lines.push(`source: ${oneLine(args.source || `session:${today}`)}`);
+  if (args.failureType) lines.push(`failure_type: ${args.failureType}`);
   lines.push(`corrected_at: ${today}`);
   lines.push(`updated: ${today}`);
   lines.push(`created: ${today}`);
@@ -233,6 +250,24 @@ function bumpUpdated(content, today) {
   return content.replace(m[0], `---\n${bumped}\n---`);
 }
 
+// Set `failure_type: <value>` in the leading frontmatter block. Scoped to the
+// first `---` fence (like bumpUpdated) so a body line starting "failure_type:" is
+// never touched; the `^` anchor keeps it top-level (an indented/nested key starts
+// with whitespace and won't match). CRLF-aware (the shared parser accepts CRLF,
+// so this must too — an LF-only match would silently skip a CRLF page) and it
+// REPLACES an existing empty `failure_type:` line rather than leaving it blank.
+// The caller only invokes this when the page has no real value (absent or empty),
+// so a populated top-level key never reaches here.
+function addFailureType(content, value) {
+  const m = content.match(/^---(\r?\n)([\s\S]*?)\r?\n---/);
+  if (!m) return content; // no frontmatter fence to host the field
+  const nl = m[1];
+  const fm = /^failure_type:\s*.*$/m.test(m[2])
+    ? m[2].replace(/^failure_type:\s*.*$/m, `failure_type: ${value}`)
+    : `${m[2]}${nl}failure_type: ${value}`;
+  return content.replace(m[0], `---${nl}${fm}${nl}---`);
+}
+
 function writeFeedback(args, today) {
   const feedbackDir = join(args.hypoDir, 'pages', 'feedback');
   const filePath = join(feedbackDir, `${args.topic}.md`);
@@ -244,7 +279,39 @@ function writeFeedback(args, today) {
     // Append a dated entry; preserve existing frontmatter classification.
     mode = 'append';
     const existing = readFileSync(filePath, 'utf-8');
-    const appended = existing.trimEnd() + `\n\n## ${today}\n\n${args.entry}\n`;
+    // FEAT-1: failure_type is a per-page classification property. On append,
+    // set it if the page has none, error if it conflicts with an existing value,
+    // no-op if it matches. Without the flag, append is byte-for-byte unchanged.
+    const existingFt = (parseFrontmatter(existing) || {}).failure_type || null;
+    if (args.failureType) {
+      const ftErr = failureTypeError(args.failureType);
+      if (ftErr) {
+        console.error(`Error: ${ftErr}`);
+        process.exit(1);
+      }
+      if (existingFt && existingFt !== args.failureType) {
+        console.error(
+          `Error: failure_type mismatch on append: page has "${existingFt}", ` +
+            `--failure-type=${args.failureType}. A feedback page carries a single ` +
+            `failure_type; use a separate topic for a different failure type.`,
+        );
+        process.exit(1);
+      }
+    }
+    let appended = existing.trimEnd() + `\n\n## ${today}\n\n${args.entry}\n`;
+    if (args.failureType && !existingFt) {
+      appended = addFailureType(appended, args.failureType);
+      // Fail loud rather than silently appending without the field: if the page's
+      // frontmatter is too malformed to host failure_type (no fence at all), the
+      // set-if-absent contract could not be honored.
+      if ((parseFrontmatter(appended) || {}).failure_type !== args.failureType) {
+        console.error(
+          `Error: could not set failure_type on "${args.topic}" — its frontmatter ` +
+            `is malformed (no parseable --- block). Fix the page, then retry.`,
+        );
+        process.exit(1);
+      }
+    }
     content = bumpUpdated(appended, today);
   } else {
     mode = 'create';

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -46,6 +46,7 @@ import {
   readFileIfRegular,
 } from './lib/pkg-json.mjs';
 import { syncExtensions } from './lib/extensions.mjs';
+import { templateSchemaVersion } from './lib/template-schema-version.mjs';
 import { classifyInstall, downgradeGuardMessage } from '../hooks/version-check.mjs';
 
 const HOME = homedir();
@@ -477,7 +478,7 @@ function writePkgJson(dryRun, extraFields = {}) {
     ...existing,
     pkgRoot: PKG_ROOT,
     pkgVersion: PKG_VERSION,
-    schemaVersion: '2.0',
+    schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.1',
     ...extraFields,
   };
   if (!dryRun) {

--- a/scripts/lib/failure-type.mjs
+++ b/scripts/lib/failure-type.mjs
@@ -1,0 +1,33 @@
+// Feedback page `failure_type:` field vocabulary — shared single source of truth.
+//
+// Consumed by:
+//   - scripts/lint.mjs      (lint-time enum validation of feedback frontmatter)
+//   - scripts/feedback.mjs  (create/append-time --failure-type validation)
+// Keep this the ONLY definition; both consumers import it so the two validators
+// never drift (mirrors feedback-scope.mjs / ADR 0034). stats.mjs aggregates by
+// plain string and does not validate, so it is intentionally not a consumer.
+//
+// `failure_type` is an OPTIONAL field: it classifies feedback that came from a
+// real failure incident. Pure preferences / new conventions ("always do X")
+// omit it. Order below is the precedence used when classifying — most specific
+// first (a failure that matches several is labeled by the earliest match):
+//   hallucination       fabricated a fact / API / path
+//   false-completion    declared "done" without running the required gate/test
+//   process-stall       stopped instead of asking / continuing when it should
+//   over-caution        re-asked / re-gated despite standing authority
+//   overreach           acted beyond the requested scope
+//   incompleteness      started correctly but omitted a required step / scope
+//   instruction-miss    ignored an explicit this-session instruction
+//   convention-violation broke a standing documented convention (not restated)
+// The runtime does NOT enforce the precedence tree — it only validates that a
+// supplied value is one of these eight; classification is a human judgement.
+export const FAILURE_TYPE_ENUM = [
+  'hallucination',
+  'false-completion',
+  'process-stall',
+  'over-caution',
+  'overreach',
+  'incompleteness',
+  'instruction-miss',
+  'convention-violation',
+];

--- a/scripts/lib/template-schema-version.mjs
+++ b/scripts/lib/template-schema-version.mjs
@@ -1,0 +1,21 @@
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { parseFrontmatter } from './frontmatter.mjs';
+
+// The SCHEMA version this package ships, read from templates/SCHEMA.md
+// frontmatter. init.mjs / upgrade.mjs stamp it into hypo-pkg.json metadata;
+// deriving it here (rather than hardcoding a literal at each write site) keeps
+// the stamped value from going stale on a schema bump — the failure mode that
+// FEAT-1's 2.0 → 2.1 bump would otherwise have introduced. Returns null only if
+// the template is missing/unreadable (a broken package), in which case callers
+// keep their prior literal default.
+export function templateSchemaVersion(pkgRoot) {
+  const p = join(pkgRoot, 'templates', 'SCHEMA.md');
+  if (!existsSync(p)) return null;
+  try {
+    const v = (parseFrontmatter(readFileSync(p, 'utf-8')) || {}).version;
+    return v ? String(v) : null;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -29,6 +29,7 @@ import {
 } from './lib/schema-vocab.mjs';
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
+import { FAILURE_TYPE_ENUM } from './lib/failure-type.mjs';
 import { collectPagesLint, slugForms } from './lib/wikilink.mjs';
 import { parseFrontmatter, SEQUENCE_ENTRY_RE } from './lib/frontmatter.mjs';
 
@@ -141,6 +142,9 @@ const TYPE_ENUM_FIELDS = {
     status: ['active', 'superseded', 'archived'],
     tier: ['L1', 'L2'],
     sensitivity: ['public', 'sanitized'],
+    // FEAT-1: optional failure taxonomy. The enum loop guards on `if (fm[field])`,
+    // so an omitted failure_type is never validated (optional, migration-safe).
+    failure_type: FAILURE_TYPE_ENUM,
   },
 };
 

--- a/scripts/stats.mjs
+++ b/scripts/stats.mjs
@@ -45,16 +45,25 @@ function collectMdFiles(dir, acc = [], hypoDir = '', ignorePatterns = []) {
   return acc;
 }
 
+// Local top-level-only extractor, behavior-aligned with lib/frontmatter.mjs:
+// skip indented / list lines, first-wins, strip a trailing `# comment`. Without
+// the comment strip a `failure_type: overreach # note` would aggregate under the
+// literal "overreach # note" key (FEAT-1). Kept local (not the shared import) to
+// hold stats' dependency surface flat per the FEAT-1 scope split.
 function parseFrontmatter(content) {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!m) return null;
   const fm = {};
-  for (const line of m[1].split('\n')) {
+  for (const line of m[1].split(/\r?\n/)) {
+    if (/^\s/.test(line) || /^-(\s|$)/.test(line)) continue; // nested / list item
     const idx = line.indexOf(':');
     if (idx < 0) continue;
-    fm[line.slice(0, idx).trim()] = line
+    const key = line.slice(0, idx).trim();
+    if (!key || Object.hasOwn(fm, key)) continue; // first-wins
+    fm[key] = line
       .slice(idx + 1)
       .trim()
+      .replace(/\s+#.*$/, '')
       .replace(/^["']|["']$/g, '');
   }
   return fm;
@@ -92,6 +101,7 @@ const sources = existsSync(join(args.hypoDir, 'sources'))
   : [];
 
 const typeCounts = {};
+const failureTypeCounts = {}; // FEAT-1: feedback pages carrying a failure_type
 let missingFrontmatter = 0;
 
 for (const f of pageFiles) {
@@ -108,6 +118,9 @@ for (const f of pageFiles) {
   }
   const t = fm.type || 'unknown';
   typeCounts[t] = (typeCounts[t] || 0) + 1;
+  if (t === 'feedback' && fm.failure_type) {
+    failureTypeCounts[fm.failure_type] = (failureTypeCounts[fm.failure_type] || 0) + 1;
+  }
 }
 
 let adrCount = 0;
@@ -122,6 +135,9 @@ const lastActivity = getLastActivity(args.hypoDir);
 
 const stats = {
   pages: { total: pageFiles.length, byType: typeCounts, missingFrontmatter },
+  // Omit the key entirely when no feedback page is classified (OQ-4: no empty
+  // section noise) so consumers can branch on presence.
+  ...(Object.keys(failureTypeCounts).length ? { failureTypes: failureTypeCounts } : {}),
   projects: projects.length,
   sources: sources.length,
   adrs: adrCount,
@@ -138,6 +154,10 @@ if (args.json) {
   }
   if (missingFrontmatter) {
     console.log(`  missing frontmatter: ${missingFrontmatter}`);
+  }
+  const ftEntries = Object.entries(failureTypeCounts).sort((a, b) => b[1] - a[1]);
+  if (ftEntries.length) {
+    console.log(`  failure types: ${ftEntries.map(([t, n]) => `${t} (${n})`).join(', ')}`);
   }
   console.log(`Projects: ${projects.length}`);
   console.log(`Sources:  ${sources.length}`);

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -42,6 +42,7 @@ import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
+import { templateSchemaVersion } from './lib/template-schema-version.mjs';
 import {
   readPkgJson as readPkgJsonSafe,
   writePkgJsonAtomic,
@@ -477,7 +478,14 @@ function writeMigrationReport(hypoDir, fromVersion, toVersion, { pluginMode = fa
   // right to keep SCHEMA.md as user-owned (Option C); auto-stub of the 9 new
   // fields is rejected because scope/tier/targets/sensitivity/reason/source
   // are semantic decisions whose wrong defaults would project wrong behavior.
-  const isV1ToV2 = fromVersion === '1.0' && toVersion === '2.0';
+  // Fire for any 1.x → 2.x major crossing, not just 1.0 → 2.0 exactly: the ADR
+  // 0031 feedback-field backfill that this body explains was introduced at 2.0
+  // and still applies to a user landing on any later 2.x (e.g. 2.1's additive
+  // failure_type — FEAT-1). Keying on the exact target string would silently
+  // drop this guidance the moment the template minor moves.
+  const fromV = parseVersion(fromVersion);
+  const toV = parseVersion(toVersion);
+  const isV1ToV2 = fromV?.major === 1 && toV?.major === 2;
   const specificBody = isV1ToV2
     ? `## What changed in SCHEMA 2.0
 
@@ -755,7 +763,7 @@ function applyCommands(commandResults, force) {
     ...existing,
     pkgRoot: PKG_ROOT,
     pkgVersion,
-    schemaVersion: '2.0',
+    schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.1',
     commands: newSHAs,
   });
   return applied;
@@ -781,7 +789,7 @@ function writePluginModeMetadata() {
     ...existing,
     pkgRoot: PKG_ROOT,
     pkgVersion,
-    schemaVersion: '2.0',
+    schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.1',
   });
   return true;
 }

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -2,7 +2,7 @@
 title: Wiki Schema
 type: schema
 updated: YYYY-MM-DD
-version: 2.0
+version: 2.1
 ---
 
 # Wiki Schema
@@ -118,10 +118,34 @@ memory_summary: <one line for the MEMORY.md index>
 reason: <why this rule is needed>
 source: session:YYYY-MM-DD | commit:<hash> | pr:<n> | https://...
 
+# optional (2.1) — failure taxonomy for incident-driven corrections:
+failure_type: <enum>                     # one of the 8 values below; OMIT for pure
+                                         # preferences / new conventions ("always do X")
+
 # conditional — required when `targets` includes `claude-learned`:
 global_summary: <one line for the <learned_behaviors> entry>
 promote_to_global: true                  # explicit opt-in to global projection
 ```
+
+`failure_type` (optional, added 2.1) classifies feedback that came from a real
+failure incident so recurring mistake types become machine-aggregatable
+(surfaced by `hypomnema stats`). Leave it off when the page records a preference
+rather than a failure. The eight values, in classification-precedence order
+(most specific first — a failure matching several takes the earliest):
+
+| value | when |
+|-------|------|
+| `hallucination` | fabricated a fact / API / path |
+| `false-completion` | declared "done" without running the required gate or test |
+| `process-stall` | stopped instead of asking / continuing when it should have |
+| `over-caution` | re-asked or re-gated despite standing authority |
+| `overreach` | acted beyond the requested scope |
+| `incompleteness` | started correctly but omitted a required step or scope |
+| `instruction-miss` | ignored an explicit this-session instruction |
+| `convention-violation` | broke a standing documented convention (not restated) |
+
+`lint` rejects any value outside this set; an omitted `failure_type` is always
+allowed.
 
 Edit the feedback page only — never hand-edit the generated
 `<!-- HYPO:FEEDBACK-SYNC:START … -->` managed blocks (sync detects tampering as a conflict).

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3169,9 +3169,38 @@ test('--apply generates migration report for major SCHEMA bump', () => {
       const content = readFileSync(out.migrationReport, 'utf-8');
       assert.ok(content.includes('0.9'), 'migration report should reference old version');
       assert.ok(
-        content.includes('2.0'),
-        'migration report should reference the new (current) version 2.0',
+        content.includes('2.1'),
+        'migration report should reference the new (current) version 2.1',
       );
+    });
+  });
+});
+
+// FEAT-1 boundary: SCHEMA 2.0 → 2.1 is an additive minor bump (optional
+// failure_type). A minor bump needs no migration report — nothing to backfill.
+test('--apply: SCHEMA 2.0 → 2.1 is a minor bump with no migration report', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      // init stamps the current template (2.1); roll the wiki SCHEMA back one minor.
+      const schemaPath = join(hypoDir, 'SCHEMA.md');
+      writeFileSync(
+        schemaPath,
+        readFileSync(schemaPath, 'utf-8').replace(/^version: .+$/m, 'version: 2.0'),
+      );
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.signal, null, `process killed with signal: ${r.signal}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.schema.bump,
+        'minor',
+        `expected minor bump, got: ${JSON.stringify(out.schema)}`,
+      );
+      assert.ok(!out.migrationReport, 'minor bump must not emit a migration report');
     });
   });
 });
@@ -3188,8 +3217,8 @@ test('--apply migration report v1→v2 includes ADR 0031 feedback fields guidanc
       assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
 
       // Simulate a wiki that's still on SCHEMA 1.0 (a v1.1.0 hypomnema user).
-      // The package template is now 2.0, so --apply produces MIGRATION-v2.0.md
-      // and the specific body path must fire.
+      // The package template is now 2.1, so --apply produces MIGRATION-v2.1.md
+      // and the v1.x→2.x specific body path must still fire (major crossing).
       const schemaPath = join(hypoDir, 'SCHEMA.md');
       writeFileSync(
         schemaPath,
@@ -6719,6 +6748,33 @@ test('feedback invalid tier → error', () => {
     out.errors.some((e) => e.message.includes('Invalid value for tier')),
     `invalid tier must error: ${r.stdout}`,
   );
+});
+
+// ── FEAT-1: optional failure_type enum ──────────────────────────────────────
+test('feedback failure_type valid value → no error', () => {
+  const { r } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('reason: r\n', 'reason: r\nfailure_type: incompleteness\n'),
+  );
+  assert.equal(r.status, 0, `valid failure_type must lint clean: ${r.stdout}`);
+});
+
+test('feedback failure_type invalid value → error', () => {
+  const { r, out } = lintWithSchema(
+    'pages/feedback/x.md',
+    FB_FM_OK.replace('reason: r\n', 'reason: r\nfailure_type: tool-misuse\n'),
+  );
+  assert.equal(r.status, 1);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Invalid value for failure_type')),
+    `invalid failure_type must error: ${r.stdout}`,
+  );
+});
+
+test('feedback failure_type omitted → no error (optional, migration-safe)', () => {
+  // FB_FM_OK carries no failure_type; assert the field is genuinely optional.
+  const { r } = lintWithSchema('pages/feedback/x.md', FB_FM_OK);
+  assert.equal(r.status, 0, `omitted failure_type must be clean: ${r.stdout}`);
 });
 
 test('feedback claude-learned target without promote_to_global → error', () => {
@@ -13467,6 +13523,146 @@ test('feedback.mjs create: invalid scope vocabulary (project:.) → exit 1 (Trac
   });
 });
 
+// ── FEAT-1: --failure-type create + append rules ────────────────────────────
+const FB_BASE_ARGS = (dir, topic) => [
+  `--topic=${topic}`,
+  '--entry=항상 X를 한다.',
+  '--scope=project:hypomnema',
+  '--tier=L2',
+  '--targets=project-memory',
+  '--priority=3',
+  '--memory-summary=X 수행',
+  '--reason=Y 방지',
+  '--no-sync',
+  `--hypo-dir=${dir}`,
+];
+
+test('feedback.mjs create: --failure-type written + lint-clean', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [
+      ...FB_BASE_ARGS(dir, 'ft-rule'),
+      '--failure-type=incompleteness',
+    ]);
+    assert.equal(r.status, 0, `create with failure-type failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'ft-rule.md'), 'utf-8');
+    assert.ok(page.includes('failure_type: incompleteness'), `failure_type not written:\n${page}`);
+    const lint = run('lint.mjs', ['--json', `--hypo-dir=${dir}`]);
+    assert.equal(JSON.parse(lint.stdout).errors.length, 0, `lint errors: ${lint.stdout}`);
+  });
+});
+
+test('feedback.mjs create: invalid --failure-type → exit 1', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', [...FB_BASE_ARGS(dir, 'ft-bad'), '--failure-type=tool-misuse']);
+    assert.equal(r.status, 1, `invalid failure-type must be rejected: ${r.stdout}`);
+    assert.ok(/failure-type invalid/.test(r.stderr), `error message missing: ${r.stderr}`);
+  });
+});
+
+test('feedback.mjs create: --failure-type omitted → no field (optional)', () => {
+  withFeedbackWriterWiki((dir) => {
+    const r = run('feedback.mjs', FB_BASE_ARGS(dir, 'ft-none'));
+    assert.equal(r.status, 0, `create without failure-type failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'ft-none.md'), 'utf-8');
+    assert.ok(!/^failure_type:/m.test(page), `failure_type should be absent:\n${page}`);
+  });
+});
+
+test('feedback.mjs append: set-if-absent adds failure_type to existing page', () => {
+  withFeedbackWriterWiki((dir) => {
+    run('feedback.mjs', FB_BASE_ARGS(dir, 'ft-app')); // create without failure_type
+    const r = run('feedback.mjs', [
+      `--topic=ft-app`,
+      '--entry=두 번째 교정.',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+      '--failure-type=convention-violation',
+    ]);
+    assert.equal(r.status, 0, `append with failure-type failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'ft-app.md'), 'utf-8');
+    assert.ok(
+      page.includes('failure_type: convention-violation'),
+      `append did not add failure_type:\n${page}`,
+    );
+    assert.ok(page.includes('두 번째 교정.'), 'dated entry not appended');
+  });
+});
+
+// codex stage-2 CONCERN: an existing EMPTY `failure_type:` key must be filled by
+// set-if-absent, not left blank (parseFrontmatter reads empty → "absent").
+test('feedback.mjs append: empty failure_type key is filled, not left blank', () => {
+  withFeedbackWriterWiki((dir) => {
+    writeFileSync(
+      join(dir, 'pages', 'feedback', 'ft-empty.md'),
+      '---\ntitle: T\ntype: feedback\nstatus: active\nfailure_type:\nupdated: 2026-06-23\n---\nbody\n',
+    );
+    const r = run('feedback.mjs', [
+      '--topic=ft-empty',
+      '--entry=교정.',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+      '--failure-type=overreach',
+    ]);
+    assert.equal(r.status, 0, `append over empty key failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'ft-empty.md'), 'utf-8');
+    assert.ok(/^failure_type: overreach$/m.test(page), `empty key not filled:\n${page}`);
+  });
+});
+
+// codex stage-2 CONCERN: CRLF frontmatter must be handled (the shared parser is
+// CRLF-aware, so the injector must be too — an LF-only match silently skipped it).
+test('feedback.mjs append: CRLF frontmatter still gets failure_type set', () => {
+  withFeedbackWriterWiki((dir) => {
+    writeFileSync(
+      join(dir, 'pages', 'feedback', 'ft-crlf.md'),
+      '---\r\ntitle: T\r\ntype: feedback\r\nstatus: active\r\nupdated: 2026-06-23\r\n---\r\nbody\r\n',
+    );
+    const r = run('feedback.mjs', [
+      '--topic=ft-crlf',
+      '--entry=교정.',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+      '--failure-type=process-stall',
+    ]);
+    assert.equal(r.status, 0, `append on CRLF page failed: ${r.stderr}`);
+    const page = readFileSync(join(dir, 'pages', 'feedback', 'ft-crlf.md'), 'utf-8');
+    assert.ok(/failure_type: process-stall/.test(page), `CRLF page not set:\n${page}`);
+  });
+});
+
+test('feedback.mjs append: conflicting failure_type → exit 1 (no silent ignore)', () => {
+  withFeedbackWriterWiki((dir) => {
+    run('feedback.mjs', [...FB_BASE_ARGS(dir, 'ft-cnf'), '--failure-type=incompleteness']);
+    const r = run('feedback.mjs', [
+      `--topic=ft-cnf`,
+      '--entry=다른 유형 교정.',
+      '--no-sync',
+      `--hypo-dir=${dir}`,
+      '--failure-type=overreach',
+    ]);
+    assert.equal(r.status, 1, `mismatched failure_type must error: ${r.stdout}`);
+    assert.ok(/failure_type mismatch/.test(r.stderr), `mismatch message missing: ${r.stderr}`);
+  });
+});
+
+test('feedback.mjs append: no --failure-type → frontmatter unchanged (regression)', () => {
+  withFeedbackWriterWiki((dir) => {
+    run('feedback.mjs', FB_BASE_ARGS(dir, 'ft-reg'));
+    const before = readFileSync(join(dir, 'pages', 'feedback', 'ft-reg.md'), 'utf-8');
+    const fmBefore = before.match(/^---\n[\s\S]*?\n---/)[0];
+    run('feedback.mjs', [`--topic=ft-reg`, '--entry=추가 교정.', '--no-sync', `--hypo-dir=${dir}`]);
+    const after = readFileSync(join(dir, 'pages', 'feedback', 'ft-reg.md'), 'utf-8');
+    const fmAfter = after.match(/^---\n[\s\S]*?\n---/)[0];
+    // only `updated:` may change; failure_type must not appear and no other key added
+    assert.ok(!/^failure_type:/m.test(fmAfter), `failure_type leaked into append:\n${fmAfter}`);
+    assert.equal(
+      fmBefore.replace(/^updated:.*$/m, 'updated:X'),
+      fmAfter.replace(/^updated:.*$/m, 'updated:X'),
+      'append mutated frontmatter beyond updated:',
+    );
+  });
+});
+
 test('feedback.mjs create: projection post-step targets --claude-home (no ~/.claude touch)', () => {
   withFeedbackWriterWiki((dir) => {
     // Isolated projection target: --claude-home keeps the post-step out of the
@@ -13500,6 +13696,54 @@ test('feedback.mjs create: projection post-step targets --claude-home (no ~/.cla
         claudeMd.includes('HYPO:FEEDBACK-SYNC:START source=proj-rule'),
         `projection should write a managed block:\n${claudeMd}`,
       );
+    } finally {
+      rmSync(cHome, { recursive: true, force: true });
+    }
+  });
+});
+
+// FEAT-1: the failure_type field must not perturb the default (non-`--no-sync`)
+// projection path. feedback-sync field-selects known keys, so an extra
+// failure_type is ignored — assert the full create→auto-sync flow still projects.
+test('feedback.mjs create: --failure-type page still projects clean (no --no-sync)', () => {
+  withFeedbackWriterWiki((dir) => {
+    const cHome = mkdtempSync(join(tmpdir(), 'hypo-fbw-claude-'));
+    try {
+      mkdirSync(join(cHome, 'projects', 'pid', 'memory'), { recursive: true });
+      writeFileSync(
+        join(cHome, 'CLAUDE.md'),
+        '# Global\n<learned_behaviors>\n</learned_behaviors>\n',
+      );
+      writeFileSync(join(cHome, 'projects', 'pid', 'memory', 'MEMORY.md'), '# Memory Index\n');
+      const r = run('feedback.mjs', [
+        '--topic=ft-proj',
+        '--entry=항상 게이트를 돌린다.',
+        '--scope=global',
+        '--tier=L1',
+        '--targets=project-memory,claude-learned',
+        '--priority=4',
+        '--memory-summary=게이트 수행',
+        '--global-summary=항상 게이트',
+        '--promote-to-global',
+        '--reason=false-completion 방지',
+        '--failure-type=false-completion',
+        `--claude-home=${cHome}`,
+        '--project-id=pid',
+        `--hypo-dir=${dir}`,
+      ]);
+      assert.equal(r.status, 0, `create+sync with failure_type failed: ${r.stderr}`);
+      const page = readFileSync(join(dir, 'pages', 'feedback', 'ft-proj.md'), 'utf-8');
+      assert.ok(
+        page.includes('failure_type: false-completion'),
+        `failure_type not written:\n${page}`,
+      );
+      const claudeMd = readFileSync(join(cHome, 'CLAUDE.md'), 'utf-8');
+      assert.ok(
+        claudeMd.includes('HYPO:FEEDBACK-SYNC:START source=ft-proj'),
+        `projection must still write a managed block:\n${claudeMd}`,
+      );
+      // the projected line carries the summary, not the failure_type key
+      assert.ok(!claudeMd.includes('failure_type'), 'failure_type must not leak into projection');
     } finally {
       rmSync(cHome, { recursive: true, force: true });
     }
@@ -13804,6 +14048,67 @@ test('mergeLatest: refreshes latest but preserves notifiedFor', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// ── FEAT-1: stats.mjs failure_type aggregation ───────────────────────────────
+suite('stats.mjs — failure_type aggregation (FEAT-1)');
+
+function withStatsWiki(pages, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-stats-'));
+  try {
+    mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+    for (const [name, body] of Object.entries(pages)) {
+      writeFileSync(join(dir, 'pages', 'feedback', name), body);
+    }
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const fbWithFt = (ft) =>
+  `---\ntitle: T\ntype: feedback\nstatus: active\nfailure_type: ${ft}\nupdated: 2026-06-23\n---\nbody\n`;
+
+test('stats: counts failure_type across feedback pages', () => {
+  withStatsWiki(
+    {
+      'a.md': fbWithFt('incompleteness'),
+      'b.md': fbWithFt('incompleteness'),
+      'c.md': fbWithFt('overreach'),
+      'd.md': '---\ntitle: T\ntype: feedback\nstatus: active\nupdated: 2026-06-23\n---\nno ft\n',
+    },
+    (dir) => {
+      const r = run('stats.mjs', ['--json', `--hypo-dir=${dir}`]);
+      const out = JSON.parse(r.stdout);
+      assert.deepEqual(out.failureTypes, { incompleteness: 2, overreach: 1 });
+    },
+  );
+});
+
+test('stats: strips trailing comment + ignores nested failure_type line', () => {
+  withStatsWiki(
+    {
+      'a.md': fbWithFt('overreach # noted'),
+      'b.md':
+        '---\ntitle: T\ntype: feedback\nstatus: active\nrelations:\n  - failure_type: bogus\nupdated: 2026-06-23\n---\nnested must not count\n',
+    },
+    (dir) => {
+      const r = run('stats.mjs', ['--json', `--hypo-dir=${dir}`]);
+      const out = JSON.parse(r.stdout);
+      assert.deepEqual(out.failureTypes, { overreach: 1 }, `got: ${r.stdout}`);
+    },
+  );
+});
+
+test('stats: omits failureTypes key when no page is classified (OQ-4)', () => {
+  withStatsWiki(
+    { 'a.md': '---\ntitle: T\ntype: feedback\nstatus: active\nupdated: 2026-06-23\n---\nx\n' },
+    (dir) => {
+      const r = run('stats.mjs', ['--json', `--hypo-dir=${dir}`]);
+      const out = JSON.parse(r.stdout);
+      assert.ok(!('failureTypes' in out), `failureTypes should be absent: ${r.stdout}`);
+    },
+  );
 });
 
 // ── stale-sibling detection (ADR 0038) ────────────────────────────────────────


### PR DESCRIPTION
## What

Adds an **optional** `failure_type` classification (8-value enum) to `feedback` frontmatter so recurring AI-failure types become machine-aggregatable. The enum and its precedence order were validated against the 20-page real feedback corpus before locking (the enum is the only irreversible decision).

The 8 values, in classification-precedence order (most specific first):
`hallucination` · `false-completion` · `process-stall` · `over-caution` · `overreach` · `incompleteness` · `instruction-miss` · `convention-violation`

## Changes

- **SCHEMA 2.0 → 2.1** — additive optional field + precedence table + "omit for pure preferences" guidance (`templates/SCHEMA.md`).
- **lint** — registers `failure_type` in `TYPE_ENUM_FIELDS.feedback`: hard-errors an invalid value, but the existing `if (fm[field])` guard keeps omission valid, so **no existing vault is newly red-flagged**.
- **feedback.mjs** — `--failure-type` flag. On append: set-if-absent / error-on-mismatch / no-op-if-same; without the flag the page is byte-unchanged. The injector is CRLF-aware, fills an empty key, and fails loud on a malformed page rather than silently dropping the field.
- **stats.mjs** — aggregates `failure_type` per feedback page; the local parser is aligned with `lib/frontmatter.mjs` (skip nested/list, first-wins, strip trailing comment) so a `# comment` or nested line never miscounts. The key is omitted entirely when nothing is classified.
- **shared vocabulary** — `scripts/lib/failure-type.mjs` is the single source imported by both lint and the writer, so the two validators cannot drift.
- **upgrade/init** — the stamped `schemaVersion` metadata is now derived from `templates/SCHEMA.md` (via `templateSchemaVersion`) instead of a hardcoded literal; and the v1→v2 backfill guidance fires on any 1.x→2.x crossing (not just exact 2.0) so a 1.0→2.1 user still receives it.

## Migration safety

Optional field; an omitted value never validates, so default lint stays green for any vault that never used the key. A vault that hand-edited a free-text `failure_type` before would newly error (rare) — to be noted in the release CHANGELOG.

## Tests / gates

- 876 tests pass (15 new covering lint enum, create/append paths, the empty-key and CRLF edge cases, projection round-trip, stats aggregation, and the 2.0→2.1 minor-bump boundary).
- All gates green: lint (fresh wiki), check:versions / check:bilingual / check:readme / smoke:plugin / smoke-pack / check:tracker-ids.

## Review

Two-stage codex review via /teams: design-stage (CONCERN → taxonomy reworked to corpus-validated 8-value tree, append semantics + migration note added) and commit-stage (CONCERN → append edge cases for empty-key / CRLF frontmatter fixed + tests). Both resolved.

Version bump / CHANGELOG / README are handled by the separate 1.4.0 release PR, matching the prior feature-PR pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)