### PR TITLE
feat(release): semi-automatic changelog collector + exclude maintainer scripts from npm (T8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   },
   "files": [
     "scripts/",
+    "!scripts/collect-changelog.mjs",
+    "!scripts/lib/collect-changelog.mjs",
+    "!scripts/bump-version.mjs",
+    "!scripts/smoke-pack.mjs",
+    "!scripts/smoke-plugin.mjs",
     "commands/",
     "hooks/",
     "skills/",

--- a/scripts/collect-changelog.mjs
+++ b/scripts/collect-changelog.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+// collect-changelog.mjs: semi-automatic changelog collector.
+//
+// Walks a git range, classifies each merged PR into a CHANGELOG section
+// (offline, from commit messages, reusing scripts/lib/changelog-classify.mjs),
+// and pulls each PR's `## Changelog` block body + author @handle from the GitHub
+// API (`gh`). It PRINTS a draft section to stdout; it never edits CHANGELOG.md.
+// The maintainer pastes the draft, writes Highlights, and finalizes the wording
+// (the semi-automatic / hybrid flow in docs/CONTRIBUTING.md).
+//
+// Responsibility split (plan.md §1): classification is OFFLINE and authoritative
+// (deterministic, no network). Exact @handle and the `## Changelog` body come
+// from `gh`. Nothing is silently skipped: a missing block, a malformed block, a
+// gh failure, or a commit with no PR is surfaced (warn) or fails the run
+// (--strict).
+//
+// Usage:
+//   node scripts/collect-changelog.mjs [--range <git-range>] [--strict]
+//                                      [--no-api] [--json] [--help]
+//   --range   git range to collect, default `<last-tag>..HEAD`
+//             (last tag via `git describe --tags --abbrev=0`).
+//   --strict  hard-fail (exit 1) on any defect: a commit with no PR, a gh API
+//             failure, a missing/malformed `## Changelog` block, or a fallback
+//             classification. For release automation.
+//   --no-api  offline only: classify + commit author, no `gh`. @handle and block
+//             bodies are left as manual TODOs. `--strict --no-api` is rejected
+//             (strict cannot prove handles/bodies without the API).
+//   --json    emit the structured result instead of markdown.
+//   --help    this text.
+//
+// Exit codes: 0 ok (warn mode tolerates defects) · 1 strict-mode defect ·
+//   2 usage error / empty range / no tags.
+//
+// Edge cases:
+// - gh rate limit (60/hr unauthenticated) and an unauthenticated/absent gh are
+//   reported as API failures (fail-loud), not silently dropped.
+// - fork PRs: `author.login` still resolves via the API.
+// - co-author trailers are ignored for Contributors (PR author only, format §7).
+// - squash-merge subject `(#N)` vs merge-commit `Merge pull request #N`: both are
+//   handled; `git log --first-parent` keeps a merge PR as one entry rather than
+//   exposing its inner commits as PR-less.
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { classifyChange, SECTION_TITLE } from './lib/changelog-classify.mjs';
+import {
+  parsePrNumber,
+  isMergeBoilerplate,
+  parseChangelogBlock,
+  assembleSections,
+  renderDraft,
+} from './lib/collect-changelog.mjs';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const FS = '\x1f'; // field separator
+const RS = '\x1e'; // record separator
+
+function parseArgs(argv) {
+  const args = { range: null, strict: false, noApi: false, json: false, help: false, repo: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--strict') args.strict = true;
+    else if (a === '--no-api') args.noApi = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--range') args.range = argv[++i];
+    else if (a.startsWith('--range=')) args.range = a.slice('--range='.length);
+    else if (a === '--repo') args.repo = argv[++i];
+    else if (a.startsWith('--repo=')) args.repo = a.slice('--repo='.length);
+    else {
+      process.stderr.write(`[collect-changelog] unknown argument: ${a}\n`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+const USAGE = `collect-changelog: draft a CHANGELOG section from merged PRs in a git range.
+
+Usage:
+  node scripts/collect-changelog.mjs [--range <git-range>] [--strict] [--no-api] [--json] [--help]
+
+  --range   git range, default <last-tag>..HEAD
+  --strict  exit 1 on any defect (no PR, gh failure, missing/malformed block, fallback class)
+  --no-api  offline only (no gh); @handle + block bodies become manual TODOs. --strict --no-api is rejected.
+  --json    structured output instead of markdown
+  --repo    git repo dir to read (default: this package); used by tests
+  --help    this text
+
+Prints a draft to stdout; never edits CHANGELOG.md.`;
+
+function git(args, cwd = REPO_ROOT) {
+  return spawnSync('git', args, { cwd, encoding: 'utf-8' });
+}
+
+// Fetch a PR's author login + body via gh. Returns { ok, handle, body } or
+// { ok: false, reason }.
+function ghPrView(pr, cwd = REPO_ROOT) {
+  const res = spawnSync('gh', ['pr', 'view', String(pr), '--json', 'author,body'], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  if (res.error) {
+    return {
+      ok: false,
+      reason: res.error.code === 'ENOENT' ? 'gh not installed' : String(res.error.message),
+    };
+  }
+  if (res.status !== 0) {
+    const err = (res.stderr || '').trim().split('\n')[0] || `gh exited ${res.status}`;
+    return { ok: false, reason: err };
+  }
+  try {
+    const data = JSON.parse(res.stdout || '{}');
+    return {
+      ok: true,
+      handle: data.author && data.author.login ? data.author.login : null,
+      body: data.body || '',
+    };
+  } catch (e) {
+    return { ok: false, reason: `unparseable gh JSON: ${e.message}` };
+  }
+}
+
+function resolveRange(args, cwd) {
+  if (args.range) return args.range;
+  const tag = git(['describe', '--tags', '--abbrev=0'], cwd);
+  if (tag.status !== 0 || !tag.stdout.trim()) {
+    process.stderr.write('[collect-changelog] no tags found; pass --range explicitly.\n');
+    process.exit(2);
+  }
+  return `${tag.stdout.trim()}..HEAD`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(USAGE + '\n');
+    return 0;
+  }
+  if (args.strict && args.noApi) {
+    process.stderr.write(
+      '[collect-changelog] --strict --no-api is rejected: strict cannot verify @handle or block bodies without the API.\n',
+    );
+    return 2;
+  }
+
+  const repo = args.repo || REPO_ROOT;
+  const range = resolveRange(args, repo);
+  // --first-parent collapses each merge PR to one entry instead of exposing its
+  // inner commits as PR-less.
+  const log = git(['log', '--first-parent', `--format=%H${FS}%s${FS}%an${FS}%b${RS}`, range], repo);
+  if (log.status !== 0) {
+    process.stderr.write(
+      `[collect-changelog] git log failed for range "${range}": ${(log.stderr || '').trim()}\n`,
+    );
+    return 2;
+  }
+  const records = log.stdout
+    .split(RS)
+    .map((r) => r.replace(/^\n/, ''))
+    .filter((r) => r.trim());
+  if (records.length === 0) {
+    process.stderr.write(`[collect-changelog] empty range "${range}": no commits to collect.\n`);
+    return 2;
+  }
+
+  const defects = {
+    directPush: [],
+    apiErrors: [],
+    missingBlocks: [],
+    malformedBlocks: [],
+    fallback: [],
+  };
+  const entries = [];
+
+  for (const rec of records) {
+    const [hash, subject, author, ...rest] = rec.split(FS);
+    const bodyText = rest.join(FS) || '';
+    const pr = parsePrNumber(subject);
+
+    // Classification: offline + authoritative. For a merge-commit boilerplate
+    // subject, classify from the PR title carried in the body's first line.
+    const classifySource = isMergeBoilerplate(subject)
+      ? bodyText.split('\n').find((l) => l.trim()) || subject
+      : subject;
+    const { section, basis } = classifyChange(classifySource);
+    if (basis === 'fallback') defects.fallback.push({ hash, subject });
+
+    if (pr == null) {
+      defects.directPush.push({ hash, subject, author });
+    }
+
+    let handle = null;
+    let block = null;
+    if (!args.noApi && pr != null) {
+      const view = ghPrView(pr, repo);
+      if (!view.ok) {
+        defects.apiErrors.push({ pr, reason: view.reason });
+      } else {
+        handle = view.handle;
+        block = parseChangelogBlock(view.body);
+        if (block == null) defects.missingBlocks.push({ pr });
+        else if (block && typeof block === 'object' && block.malformed) {
+          defects.malformedBlocks.push({ pr, reason: block.reason });
+          block = null;
+        }
+      }
+    }
+
+    // titleSource feeds the ### Changelog index title: the same source used for
+    // classification, so a merge commit is indexed by its PR title (from the
+    // body), never by its `Merge pull request #N from ...` boilerplate subject.
+    entries.push({
+      pr,
+      subject,
+      titleSource: classifySource,
+      section,
+      basis,
+      author,
+      handle,
+      block,
+    });
+  }
+
+  const assembled = assembleSections(entries);
+
+  // Warnings (always emitted to stderr; never silent).
+  const warn = (msg) => process.stderr.write(`[collect-changelog] ${msg}\n`);
+  if (args.noApi)
+    warn('--no-api: @handle and block bodies are manual; fill them in the draft before release.');
+  for (const d of defects.directPush)
+    warn(`commit with no PR: ${d.hash.slice(0, 9)} "${d.subject}" by ${d.author}`);
+  for (const d of defects.apiErrors) warn(`gh API failed for #${d.pr}: ${d.reason}`);
+  for (const d of defects.missingBlocks)
+    warn(`PR #${d.pr} has no ## Changelog block (fill it manually).`);
+  for (const d of defects.malformedBlocks)
+    warn(`PR #${d.pr} ## Changelog block malformed: ${d.reason}`);
+  for (const d of defects.fallback)
+    warn(`classification fell back to Chores (no type/id/heading hint): "${d.subject}"`);
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify({ range, entries, assembled, defects }, null, 2) + '\n');
+  } else {
+    // A manual TODO header so a draft with unresolved gaps is never mistaken for
+    // complete. Direct-push commits get an explicit TODO comment, not a fake #N.
+    const todos = [];
+    for (const d of defects.directPush)
+      todos.push(
+        `<!-- TODO: direct push ${d.hash.slice(0, 9)} "${d.subject}" by ${d.author}, no PR -->`,
+      );
+    for (const d of defects.missingBlocks)
+      todos.push(`<!-- TODO: PR #${d.pr} needs a ## Changelog block -->`);
+    for (const d of defects.malformedBlocks)
+      todos.push(`<!-- TODO: PR #${d.pr} ## Changelog block malformed (${d.reason}) -->`);
+    const draft = renderDraft(assembled);
+    process.stdout.write((todos.length ? todos.join('\n') + '\n\n' : '') + draft);
+  }
+
+  const hasDefect =
+    defects.directPush.length ||
+    defects.apiErrors.length ||
+    defects.missingBlocks.length ||
+    defects.malformedBlocks.length ||
+    defects.fallback.length;
+  if (args.strict && hasDefect) {
+    warn('strict mode: defects above must be resolved before release.');
+    return 1;
+  }
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/lib/collect-changelog.mjs
+++ b/scripts/lib/collect-changelog.mjs
@@ -1,0 +1,206 @@
+// collect-changelog.mjs (lib): pure helpers for the semi-automatic changelog
+// collector. The CLI (scripts/collect-changelog.mjs) does the git/gh I/O; this
+// module is side-effect free so the parsing and assembly logic is unit-tested
+// offline. Classification is delegated to changelog-classify.mjs (the single
+// source shared with the linter, sanitizer, and the migration fixture).
+//
+// Format target (docs/CONTRIBUTING.md "CHANGELOG conventions"):
+// - gated sections New Features / Bug Fixes / Chores, each `#### English` then
+//   `#### 한국어`, fed from each PR's `## Changelog` block (one EN, one KO line).
+// - a language-neutral `### Changelog` index: bare `- #N <short title>` lines
+//   plus one de-duplicated `Contributors:` line. No per-line @handle, no tracker
+//   ids on the surface.
+
+import {
+  classifyChange,
+  sanitizeTrackerIds,
+  SECTION,
+  SECTION_TITLE,
+} from './changelog-classify.mjs';
+
+// A GitHub merge-commit subject (`Merge pull request #N from owner/branch`) is
+// boilerplate, so classifying it by subject would always fall through to Chores.
+// Detect it so the caller classifies from the commit BODY (which carries the PR
+// title) instead. Squash-merge subjects are normal Conventional-Commit titles
+// and are NOT boilerplate.
+export function isMergeBoilerplate(subject) {
+  return /^Merge pull request #\d+\b/.test(String(subject ?? ''));
+}
+
+// Parse a PR number from a commit subject. Squash-merge: a TRAILING `(#123)`
+// only. A `(#12)` mid-sentence (e.g. prose about a placeholder) is not a PR
+// reference and must not promote a direct-push commit to a fake PR.
+// Merge-commit: `Merge pull request #123 from ...`. Returns an integer or null.
+export function parsePrNumber(subject) {
+  const s = String(subject ?? '');
+  const merge = /^Merge pull request #(\d+)\b/.exec(s);
+  if (merge) return Number(merge[1]);
+  const trailing = /\(#(\d+)\)\s*$/.exec(s);
+  if (trailing) return Number(trailing[1]);
+  return null;
+}
+
+// Build the `### Changelog` index title from a commit subject: drop a single
+// trailing `(#N)` (the index already prints `#N`, so repeating it duplicates),
+// then sanitize tracker ids off the public surface. Returns the cleaned title.
+export function normalizeIndexTitle(subject) {
+  const stripped = String(subject ?? '')
+    .trim()
+    .replace(/\s*\(#\d+\)\s*$/, '');
+  return sanitizeTrackerIds(stripped).trim();
+}
+
+// Parse a PR body's `## Changelog` block. Returns one of:
+//   { en, ko }              both present and non-empty
+//   'none'                  literal `None` (no gated body entry; still indexed)
+//   null                    the `## Changelog` heading is absent
+//   { malformed, reason }   present but invalid (missing EN/KO, empty value,
+//                           duplicate line, or None mixed with EN/KO)
+// HTML comments (the template's instructions) are stripped before parsing.
+export function parseChangelogBlock(body) {
+  const text = String(body ?? '').replace(/\r\n/g, '\n');
+  const lines = text.split('\n');
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^##\s+Changelog\s*$/i.test(lines[i])) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start === -1) return null; // heading absent
+
+  // Collect the section body until the next `## ` heading or EOF, with HTML
+  // comments removed (they may span multiple lines).
+  const body_lines = [];
+  for (let i = start; i < lines.length; i++) {
+    if (/^##\s+\S/.test(lines[i])) break;
+    body_lines.push(lines[i]);
+  }
+  const cleaned = body_lines.join('\n').replace(/<!--[\s\S]*?-->/g, '');
+
+  const enLines = [];
+  const koLines = [];
+  let noneSeen = false;
+  for (const raw of cleaned.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const en = /^-?\s*EN\s*:\s*(.*)$/i.exec(line);
+    const ko = /^-?\s*KO\s*:\s*(.*)$/i.exec(line);
+    if (en) {
+      enLines.push(en[1].trim());
+    } else if (ko) {
+      koLines.push(ko[1].trim());
+    } else if (/^-?\s*None\s*$/i.test(line)) {
+      noneSeen = true;
+    }
+    // other prose lines are tolerated and ignored
+  }
+
+  if (noneSeen && (enLines.length || koLines.length)) {
+    return { malformed: true, reason: 'None mixed with EN/KO lines' };
+  }
+  if (noneSeen) return 'none';
+  if (enLines.length > 1 || koLines.length > 1) {
+    return { malformed: true, reason: 'duplicate EN or KO line' };
+  }
+  if (enLines.length === 0 && koLines.length === 0) {
+    return { malformed: true, reason: 'empty Changelog block (no EN/KO/None)' };
+  }
+  if (enLines.length === 0 || !enLines[0]) {
+    return { malformed: true, reason: 'missing or empty EN line' };
+  }
+  if (koLines.length === 0 || !koLines[0]) {
+    return { malformed: true, reason: 'missing or empty KO line' };
+  }
+  return { en: enLines[0], ko: koLines[0] };
+}
+
+// Assemble classified, API-enriched entries into a structured draft. Pure: takes
+// the already-collected entry list, returns sections + index + contributors +
+// unresolved. An entry shape:
+//   { pr, subject, titleSource, section, basis, author, handle, block }
+// where block is { en, ko } | 'none' | null | { malformed }. Only an entry with
+// a usable { en, ko } block contributes a gated body line; every entry with a PR
+// number still appears in the index. `titleSource` is what the index title is
+// built from (the merge-commit body line, or the squash subject) so a merge
+// commit is never indexed as its `Merge pull request #N from ...` boilerplate.
+//
+// Contributors hold ONLY verified GitHub handles (from the API). A commit author
+// name is NOT a GitHub handle, so an entry with a PR but no resolved handle goes
+// to `unresolved` (the caller emits a manual-fill TODO) rather than being
+// rendered as a fake `@name`.
+export function assembleSections(entries) {
+  const sections = {
+    [SECTION.NEW_FEATURES]: { en: [], ko: [] },
+    [SECTION.BUG_FIXES]: { en: [], ko: [] },
+    [SECTION.CHORES]: { en: [], ko: [] },
+  };
+  const index = [];
+  const contributors = [];
+  const unresolved = [];
+  const seenHandles = new Set();
+  const seenUnresolved = new Set();
+
+  for (const e of entries) {
+    const block = e.block;
+    if (block && typeof block === 'object' && block.en && block.ko) {
+      const bucket = sections[e.section] || sections[SECTION.CHORES];
+      const pr = e.pr != null ? ` (#${e.pr})` : '';
+      bucket.en.push(`- ${sanitizeTrackerIds(block.en)}${pr}`);
+      bucket.ko.push(`- ${sanitizeTrackerIds(block.ko)}${pr}`);
+    }
+    if (e.pr != null) {
+      index.push({ pr: e.pr, title: normalizeIndexTitle(e.titleSource ?? e.subject) });
+      if (e.handle) {
+        if (!seenHandles.has(e.handle)) {
+          seenHandles.add(e.handle);
+          contributors.push(e.handle);
+        }
+      } else if (e.author && !seenUnresolved.has(e.author)) {
+        seenUnresolved.add(e.author);
+        unresolved.push(e.author);
+      }
+    }
+  }
+  return { sections, index, contributors, unresolved };
+}
+
+// Render an assembled draft to CHANGELOG markdown (the maintainer pastes it,
+// adds Highlights, and edits wording). Empty gated sections are omitted; the
+// index is always present when there is at least one PR. Contributors lists
+// verified @handles; authors without a resolved handle become a manual-fill TODO
+// rather than a fabricated `@name`.
+export function renderDraft(assembled, { headingLevel = '###' } = {}) {
+  const out = [];
+  const order = [SECTION.NEW_FEATURES, SECTION.BUG_FIXES, SECTION.CHORES];
+  for (const key of order) {
+    const sec = assembled.sections[key];
+    if (!sec || (sec.en.length === 0 && sec.ko.length === 0)) continue;
+    out.push(`${headingLevel} ${SECTION_TITLE[key]}`);
+    out.push('#### English');
+    out.push(...sec.en);
+    out.push('#### 한국어');
+    out.push(...sec.ko);
+    out.push('');
+  }
+  if (assembled.index.length) {
+    out.push(`${headingLevel} Changelog`);
+    for (const it of assembled.index) {
+      out.push(`- #${it.pr} ${it.title}`.trimEnd());
+    }
+    if (assembled.contributors.length) {
+      out.push(
+        `Contributors: ${assembled.contributors.map((h) => (h.startsWith('@') ? h : `@${h}`)).join(', ')}`,
+      );
+    }
+    if (assembled.unresolved && assembled.unresolved.length) {
+      out.push(`<!-- TODO: add @handle for: ${assembled.unresolved.join(', ')} -->`);
+    }
+  }
+  return (
+    out
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trimEnd() + '\n'
+  );
+}

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -19273,53 +19273,9 @@ test('empty range exits 2 with a message', () => {
   assert.equal(r.status, 2);
   assert.match(r.stderr, /empty range/);
 });
-test('--no-api offline: warns and still drafts an index', () => {
-  const r = runCollect(['--range', 'HEAD~1..HEAD', '--no-api']);
-  assert.equal(r.status, 0);
-  assert.match(r.stderr, /--no-api/);
-});
-
-// A fixed-SHA range (the #143 squash merge) so the CLI always sees one commit
-// carrying a PR number, independent of any later commits on the branch.
-const PR143_RANGE = 'f6a7144~1..f6a7144';
-
-test('fake gh success: CLI fills block bodies + @handle from the API', () => {
-  withTmpDir((dir) => {
-    const stub = join(dir, 'gh');
-    // node stub → JSON.stringify handles \n escaping (a bash printf would inject
-    // raw newlines and produce invalid JSON).
-    writeFileSync(
-      stub,
-      '#!/usr/bin/env node\n' +
-        "process.stdout.write(JSON.stringify({author:{login:'tester'},body:'## Changelog\\n- EN: stubbed entry\\n- KO: 스텁 항목\\n'}));\n",
-      { mode: 0o755 },
-    );
-    const r = runCollect(['--range', PR143_RANGE], { PATH: `${dir}:${process.env.PATH}` });
-    assert.equal(r.status, 0);
-    assert.match(r.stdout, /stubbed entry/);
-    assert.match(r.stdout, /스텁 항목/);
-    assert.match(r.stdout, /Contributors: @tester/);
-  });
-});
-
-test('fake gh failure: flagged as apiError (warn exits 0, strict exits 1), never silent', () => {
-  withTmpDir((dir) => {
-    const stub = join(dir, 'gh');
-    writeFileSync(
-      stub,
-      '#!/usr/bin/env node\nprocess.stderr.write("gh: rate limit exceeded\\n");process.exit(1);\n',
-      { mode: 0o755 },
-    );
-    const env = { PATH: `${dir}:${process.env.PATH}` };
-    const warn = runCollect(['--range', PR143_RANGE], env);
-    assert.equal(warn.status, 0, 'warn mode tolerates an API failure');
-    assert.match(warn.stderr, /gh API failed/);
-    const strict = runCollect(['--range', PR143_RANGE, '--strict'], env);
-    assert.equal(strict.status, 1, 'strict fails on an API error');
-  });
-});
-
-// Hermetic git repos via --repo so the defect paths are deterministic.
+// Hermetic git repos via --repo so the CLI tests do not depend on the real
+// repo's history (CI uses a shallow clone, so a fixed SHA or HEAD~1 may be
+// absent). Each test builds its own repo and points the collector at it.
 function withGitRepo(setup, fn) {
   withTmpDir((dir) => {
     const g = (args) =>
@@ -19340,6 +19296,71 @@ function withGitRepo(setup, fn) {
     fn(dir, g);
   });
 }
+
+test('--no-api offline: warns and still drafts an index', () => {
+  withGitRepo(
+    (g) => {
+      g(['tag', 'v0.0.1']);
+      g(['commit', '--allow-empty', '-qm', 'feat: a thing (#7)']);
+    },
+    (dir) => {
+      const r = runCollect(['--repo', dir, '--range', 'v0.0.1..HEAD', '--no-api']);
+      assert.equal(r.status, 0);
+      assert.match(r.stderr, /--no-api/);
+      assert.match(r.stdout, /- #7 feat: a thing/);
+    },
+  );
+});
+
+test('fake gh success: CLI fills block bodies + @handle from the API', () => {
+  withGitRepo(
+    (g) => {
+      g(['tag', 'v0.0.1']);
+      g(['commit', '--allow-empty', '-qm', 'feat: a thing (#42)']);
+    },
+    (dir) => {
+      const stub = join(dir, 'gh');
+      // node stub → JSON.stringify handles \n escaping (a bash printf would
+      // inject raw newlines and produce invalid JSON).
+      writeFileSync(
+        stub,
+        '#!/usr/bin/env node\n' +
+          "process.stdout.write(JSON.stringify({author:{login:'tester'},body:'## Changelog\\n- EN: stubbed entry\\n- KO: 스텁 항목\\n'}));\n",
+        { mode: 0o755 },
+      );
+      const r = runCollect(['--repo', dir, '--range', 'v0.0.1..HEAD'], {
+        PATH: `${dir}:${process.env.PATH}`,
+      });
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /stubbed entry/);
+      assert.match(r.stdout, /스텁 항목/);
+      assert.match(r.stdout, /Contributors: @tester/);
+    },
+  );
+});
+
+test('fake gh failure: flagged as apiError (warn exits 0, strict exits 1), never silent', () => {
+  withGitRepo(
+    (g) => {
+      g(['tag', 'v0.0.1']);
+      g(['commit', '--allow-empty', '-qm', 'feat: a thing (#42)']);
+    },
+    (dir) => {
+      const stub = join(dir, 'gh');
+      writeFileSync(
+        stub,
+        '#!/usr/bin/env node\nprocess.stderr.write("gh: rate limit exceeded\\n");process.exit(1);\n',
+        { mode: 0o755 },
+      );
+      const env = { PATH: `${dir}:${process.env.PATH}` };
+      const warn = runCollect(['--repo', dir, '--range', 'v0.0.1..HEAD'], env);
+      assert.equal(warn.status, 0, 'warn mode tolerates an API failure');
+      assert.match(warn.stderr, /gh API failed/);
+      const strict = runCollect(['--repo', dir, '--range', 'v0.0.1..HEAD', '--strict'], env);
+      assert.equal(strict.status, 1, 'strict fails on an API error');
+    },
+  );
+});
 
 test('CLI: merge commit indexed by body PR title; direct-push → TODO not a fake #N', () => {
   withGitRepo(

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -66,6 +66,14 @@ import {
   detectInternalLabels,
   SECTION,
 } from '../scripts/lib/changelog-classify.mjs';
+import {
+  parsePrNumber,
+  isMergeBoilerplate,
+  parseChangelogBlock,
+  normalizeIndexTitle,
+  assembleSections,
+  renderDraft,
+} from '../scripts/lib/collect-changelog.mjs';
 
 const HOME = homedir();
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -17430,7 +17438,11 @@ test('scanText with USER_FACING_PATTERNS flags ADR / decisions pointers', () => 
 test('TAG_BODY_PATTERNS gates all four tracker prefixes; file gate keeps FEAT/IMPR/PRAC (changelog-pr-guide T4)', () => {
   // The tag body is the public release surface — every prefix is a leak.
   for (const id of ['ISSUE-7', 'fix #7', 'FEAT-1', 'IMPR-3', 'PRAC-17']) {
-    assert.equal(scanText(`leak ${id} here`, TAG_BODY_PATTERNS).length, 1, `tag body must flag ${id}`);
+    assert.equal(
+      scanText(`leak ${id} here`, TAG_BODY_PATTERNS).length,
+      1,
+      `tag body must flag ${id}`,
+    );
   }
   // GitHub refs and ADR anchors stay legitimate even on the tag surface.
   assert.equal(scanText('PR #50 (#9) ADR 0040', TAG_BODY_PATTERNS).length, 0);
@@ -17439,10 +17451,11 @@ test('TAG_BODY_PATTERNS gates all four tracker prefixes; file gate keeps FEAT/IM
   assert.equal(scanText('// FEAT-17 hardening, see PRAC-18 and IMPR-13').length, 0);
   assert.equal(scanText('// ISSUE-7 leak in a comment').length, 1);
   // SURFACE_TRACKER_PATTERNS is exactly the three extra prefixes.
-  assert.deepEqual(
-    SURFACE_TRACKER_PATTERNS.map((p) => p.name).sort(),
-    ['FEAT-N', 'IMPR-N', 'PRAC-N'],
-  );
+  assert.deepEqual(SURFACE_TRACKER_PATTERNS.map((p) => p.name).sort(), [
+    'FEAT-N',
+    'IMPR-N',
+    'PRAC-N',
+  ]);
 });
 
 test('CHANGELOG.md is tracker-ID-0 across all four prefixes (surface ID 0 regression, §5)', () => {
@@ -18841,24 +18854,24 @@ test('collectPages presets emit the historical output shape', () => {
 
 test('classifyChange: tracker ID beats Conventional-Commit type', () => {
   // feat(...) typed, but IMPR-/PRAC- tracker → Chores (the real 1.4.0 cases).
-  assert.deepEqual(
-    classifyChange('feat(release): version floor gate (IMPR-14) (#138)'),
-    { section: SECTION.CHORES, basis: 'tracker' },
-  );
-  assert.deepEqual(
-    classifyChange('feat(audit): stamp session_id/device (PRAC-17) (#136)'),
-    { section: SECTION.CHORES, basis: 'tracker' },
-  );
+  assert.deepEqual(classifyChange('feat(release): version floor gate (IMPR-14) (#138)'), {
+    section: SECTION.CHORES,
+    basis: 'tracker',
+  });
+  assert.deepEqual(classifyChange('feat(audit): stamp session_id/device (PRAC-17) (#136)'), {
+    section: SECTION.CHORES,
+    basis: 'tracker',
+  });
   // FEAT- tracker → New Features.
-  assert.deepEqual(
-    classifyChange('feat(feedback): add failure_type (FEAT-1) (#141)'),
-    { section: SECTION.NEW_FEATURES, basis: 'tracker' },
-  );
+  assert.deepEqual(classifyChange('feat(feedback): add failure_type (FEAT-1) (#141)'), {
+    section: SECTION.NEW_FEATURES,
+    basis: 'tracker',
+  });
   // docs(...) typed, but ISSUE- tracker → Bug Fixes (real 1.3.1 case).
-  assert.deepEqual(
-    classifyChange('docs(resume): correct comment (ISSUE-2) (#93)'),
-    { section: SECTION.BUG_FIXES, basis: 'tracker' },
-  );
+  assert.deepEqual(classifyChange('docs(resume): correct comment (ISSUE-2) (#93)'), {
+    section: SECTION.BUG_FIXES,
+    basis: 'tracker',
+  });
 });
 
 test('classifyChange: type when no tracker, Chores fallback otherwise', () => {
@@ -18895,10 +18908,13 @@ test('classifyChange: type when no tracker, Chores fallback otherwise', () => {
 test('classifyChange: legacy heading hint for ID-less, type-less prose (format.md §3 step 3)', () => {
   // a pre-convention `### Added` item with no tracker and no `feat:` prefix
   // maps by its heading, not the Chores default.
-  assert.deepEqual(classifyChange('add resolveWikiRoot() and OSS utilities', { legacyHeading: '### Added' }), {
-    section: SECTION.NEW_FEATURES,
-    basis: 'heading',
-  });
+  assert.deepEqual(
+    classifyChange('add resolveWikiRoot() and OSS utilities', { legacyHeading: '### Added' }),
+    {
+      section: SECTION.NEW_FEATURES,
+      basis: 'heading',
+    },
+  );
   assert.deepEqual(classifyChange('lint no longer false-flags links', { legacyHeading: 'Fixed' }), {
     section: SECTION.BUG_FIXES,
     basis: 'heading',
@@ -18929,7 +18945,10 @@ test('classifyChange: legacy heading hint for ID-less, type-less prose (format.m
 });
 
 test('detectInternalLabels: finds Track A / OQ-NN, ignores tracker IDs and PR numbers', () => {
-  assert.deepEqual(detectInternalLabels('feat (Track A-sot) (OQ-34) (#82)'), ['Track A-sot', 'OQ-34']);
+  assert.deepEqual(detectInternalLabels('feat (Track A-sot) (OQ-34) (#82)'), [
+    'Track A-sot',
+    'OQ-34',
+  ]);
   assert.deepEqual(detectInternalLabels('Track E gate'), ['Track E']);
   assert.deepEqual(detectInternalLabels('nothing here (FEAT-1) (#141)'), []);
   assert.deepEqual(detectInternalLabels(''), []);
@@ -18978,7 +18997,19 @@ test('changelog-classify snapshot: 11 versions lock to expected section/basis', 
 
   // every release is represented (regression: a dropped version goes unnoticed).
   const versions = new Set(entries.map((e) => e.version));
-  for (const v of ['1.0.0', '1.0.1', '1.1.0', '1.2.0', '1.2.1', '1.3.0', '1.3.1', '1.3.2', '1.3.3', '1.3.4', '1.4.0']) {
+  for (const v of [
+    '1.0.0',
+    '1.0.1',
+    '1.1.0',
+    '1.2.0',
+    '1.2.1',
+    '1.3.0',
+    '1.3.1',
+    '1.3.2',
+    '1.3.3',
+    '1.3.4',
+    '1.4.0',
+  ]) {
     assert.ok(versions.has(v), `fixture missing version ${v}`);
   }
 
@@ -18996,9 +19027,14 @@ test('changelog-classify snapshot: 11 versions lock to expected section/basis', 
     );
     // surface ID 0: after sanitize, no tracker ID survives but the PR number does.
     const clean = sanitizeTrackerIds(e.title);
-    assert.equal(hasTrackerId(clean), false, `[${e.version}] tracker ID survived sanitize: "${clean}"`);
+    assert.equal(
+      hasTrackerId(clean),
+      false,
+      `[${e.version}] tracker ID survived sanitize: "${clean}"`,
+    );
     const pr = e.title.match(/\(#\d+\)/);
-    if (pr) assert.ok(clean.includes(pr[0]), `[${e.version}] PR number dropped by sanitize: "${clean}"`);
+    if (pr)
+      assert.ok(clean.includes(pr[0]), `[${e.version}] PR number dropped by sanitize: "${clean}"`);
   }
 
   // The fixture claims to hold REAL commit subjects — verify each title exists
@@ -19024,6 +19060,352 @@ test('changelog-classify snapshot: 11 versions lock to expected section/basis', 
   } else {
     console.log('    (note: git history unavailable — skipped verbatim-subject check)');
   }
+});
+
+// ── collect-changelog (T8) ───────────────────────────────────────────────────
+
+suite('collect-changelog: parsePrNumber()');
+
+test('squash subject: trailing (#N)', () => {
+  assert.equal(parsePrNumber('docs: thing (#143)'), 143);
+});
+test('squash subject: last (#N) wins when prose mentions an earlier PR', () => {
+  assert.equal(parsePrNumber('fix: follow-up to #41, done (#142)'), 142);
+});
+test('merge-commit subject', () => {
+  assert.equal(parsePrNumber('Merge pull request #99 from sk-lim19f/feat/x'), 99);
+});
+test('no PR number → null', () => {
+  assert.equal(parsePrNumber('chore: local tweak'), null);
+});
+test('mid-sentence (#N) is NOT a PR ref → null (a direct push is not faked as a PR)', () => {
+  assert.equal(parsePrNumber('docs: explain the (#12) placeholder syntax'), null);
+});
+
+suite('collect-changelog: isMergeBoilerplate()');
+
+test('merge-commit subject is boilerplate', () => {
+  assert.equal(isMergeBoilerplate('Merge pull request #99 from a/b'), true);
+});
+test('squash Conventional subject is NOT boilerplate', () => {
+  assert.equal(isMergeBoilerplate('feat: add x (#99)'), false);
+});
+
+suite('collect-changelog: parseChangelogBlock()');
+
+test('both EN + KO present', () => {
+  const body =
+    '## What\nstuff\n\n## Changelog\n\n- EN: did a thing\n- KO: 무언가 했습니다\n\n## Migration notes\nNone';
+  assert.deepEqual(parseChangelogBlock(body), { en: 'did a thing', ko: '무언가 했습니다' });
+});
+test('literal None → "none"', () => {
+  assert.equal(parseChangelogBlock('## Changelog\n\nNone\n'), 'none');
+});
+test('heading absent → null', () => {
+  assert.equal(parseChangelogBlock('## What\nno changelog section here'), null);
+});
+test('HTML comment instructions are stripped', () => {
+  const body = '## Changelog\n<!-- one EN line + one KO line -->\n- EN: x\n- KO: 엑스\n';
+  assert.deepEqual(parseChangelogBlock(body), { en: 'x', ko: '엑스' });
+});
+test('missing KO → malformed', () => {
+  const r = parseChangelogBlock('## Changelog\n- EN: only english\n');
+  assert.ok(r && r.malformed, 'should be malformed');
+});
+test('empty EN value → malformed (unfilled template)', () => {
+  const r = parseChangelogBlock('## Changelog\n- EN:\n- KO:\n');
+  assert.ok(r && r.malformed, 'should be malformed');
+});
+test('duplicate EN line → malformed', () => {
+  const r = parseChangelogBlock('## Changelog\n- EN: a\n- EN: b\n- KO: 가\n');
+  assert.ok(r && r.malformed, 'should be malformed');
+});
+test('None mixed with EN/KO → malformed', () => {
+  const r = parseChangelogBlock('## Changelog\nNone\n- EN: a\n- KO: 가\n');
+  assert.ok(r && r.malformed, 'should be malformed');
+});
+
+suite('collect-changelog: normalizeIndexTitle()');
+
+test('strips a single trailing (#N)', () => {
+  assert.equal(normalizeIndexTitle('docs: thing (#143)'), 'docs: thing');
+});
+test('strips tracker IDs off the surface', () => {
+  assert.equal(hasTrackerId(normalizeIndexTitle('feat: x FEAT-1 (#5)')), false);
+});
+
+suite('collect-changelog: assembleSections()');
+
+test('groups by section; none/null skip the body but still index + credit', () => {
+  const entries = [
+    {
+      pr: 1,
+      subject: 'feat: a (#1)',
+      section: SECTION.NEW_FEATURES,
+      basis: 'type',
+      author: 'A',
+      handle: 'gh-a',
+      block: { en: 'added a', ko: 'a 추가' },
+    },
+    {
+      pr: 2,
+      subject: 'fix: b (#2)',
+      section: SECTION.BUG_FIXES,
+      basis: 'type',
+      author: 'B',
+      handle: 'gh-b',
+      block: { en: 'fixed b', ko: 'b 수정' },
+    },
+    {
+      pr: 3,
+      subject: 'chore: c (#3)',
+      section: SECTION.CHORES,
+      basis: 'type',
+      author: 'A',
+      handle: 'gh-a',
+      block: 'none',
+    },
+  ];
+  const a = assembleSections(entries);
+  assert.equal(a.sections[SECTION.NEW_FEATURES].en.length, 1);
+  assert.equal(a.sections[SECTION.BUG_FIXES].ko.length, 1);
+  assert.equal(a.sections[SECTION.CHORES].en.length, 0, 'none-block contributes no body line');
+  assert.equal(a.index.length, 3, 'every PR is indexed, incl. the none-block one');
+  assert.deepEqual(a.contributors, ['gh-a', 'gh-b'], 'de-duped, first-seen order');
+});
+test('sanitizes tracker IDs out of body lines', () => {
+  const entries = [
+    {
+      pr: 5,
+      subject: 'feat: x (#5)',
+      section: SECTION.NEW_FEATURES,
+      basis: 'type',
+      author: 'A',
+      handle: 'a',
+      block: { en: 'x FEAT-1', ko: 'x IMPR-2' },
+    },
+  ];
+  const a = assembleSections(entries);
+  assert.equal(hasTrackerId(a.sections[SECTION.NEW_FEATURES].en[0]), false);
+  assert.equal(hasTrackerId(a.sections[SECTION.NEW_FEATURES].ko[0]), false);
+});
+test('merge entry is indexed by titleSource, never its boilerplate subject', () => {
+  const a = assembleSections([
+    {
+      pr: 99,
+      subject: 'Merge pull request #99 from a/x',
+      titleSource: 'feat: shiny thing',
+      section: SECTION.NEW_FEATURES,
+      basis: 'type',
+      author: 'A',
+      handle: 'gh-a',
+      block: null,
+    },
+  ]);
+  assert.equal(a.index[0].title, 'feat: shiny thing');
+});
+test('no verified handle → unresolved (TODO), never a fabricated @author', () => {
+  const a = assembleSections([
+    {
+      pr: 7,
+      subject: 'fix: x (#7)',
+      titleSource: 'fix: x (#7)',
+      section: SECTION.BUG_FIXES,
+      basis: 'type',
+      author: '임상규',
+      handle: null,
+      block: null,
+    },
+  ]);
+  assert.equal(a.contributors.length, 0);
+  assert.deepEqual(a.unresolved, ['임상규']);
+  const md = renderDraft(a);
+  assert.doesNotMatch(md, /@임상규/);
+  assert.match(md, /TODO: add @handle for: 임상규/);
+});
+
+suite('collect-changelog: renderDraft()');
+
+test('emits section model + bare index + Contributors, omits empty sections', () => {
+  const entries = [
+    {
+      pr: 1,
+      subject: 'feat: a (#1)',
+      section: SECTION.NEW_FEATURES,
+      basis: 'type',
+      author: 'A',
+      handle: 'gh-a',
+      block: { en: 'added a', ko: 'a 추가' },
+    },
+  ];
+  const md = renderDraft(assembleSections(entries));
+  assert.match(md, /### New Features/);
+  assert.match(md, /#### English\n- added a \(#1\)/);
+  assert.match(md, /#### 한국어\n- a 추가 \(#1\)/);
+  assert.match(md, /### Changelog\n- #1 feat: a/);
+  assert.match(md, /Contributors: @gh-a/);
+  assert.doesNotMatch(md, /### Bug Fixes/, 'empty section omitted');
+});
+
+suite('collect-changelog CLI');
+
+const COLLECT = join(SCRIPTS, 'collect-changelog.mjs');
+function runCollect(args, extraEnv = {}) {
+  return spawnSync(process.execPath, [COLLECT, ...args], {
+    cwd: REPO,
+    encoding: 'utf-8',
+    env: { ...process.env, ...extraEnv },
+  });
+}
+
+test('--help exits 0 with usage', () => {
+  const r = runCollect(['--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /collect-changelog/);
+});
+test('--strict --no-api is a usage error (exit 2)', () => {
+  const r = runCollect(['--strict', '--no-api']);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /rejected/);
+});
+test('empty range exits 2 with a message', () => {
+  const r = runCollect(['--range', 'HEAD..HEAD']);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /empty range/);
+});
+test('--no-api offline: warns and still drafts an index', () => {
+  const r = runCollect(['--range', 'HEAD~1..HEAD', '--no-api']);
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, /--no-api/);
+});
+
+// A fixed-SHA range (the #143 squash merge) so the CLI always sees one commit
+// carrying a PR number, independent of any later commits on the branch.
+const PR143_RANGE = 'f6a7144~1..f6a7144';
+
+test('fake gh success: CLI fills block bodies + @handle from the API', () => {
+  withTmpDir((dir) => {
+    const stub = join(dir, 'gh');
+    // node stub → JSON.stringify handles \n escaping (a bash printf would inject
+    // raw newlines and produce invalid JSON).
+    writeFileSync(
+      stub,
+      '#!/usr/bin/env node\n' +
+        "process.stdout.write(JSON.stringify({author:{login:'tester'},body:'## Changelog\\n- EN: stubbed entry\\n- KO: 스텁 항목\\n'}));\n",
+      { mode: 0o755 },
+    );
+    const r = runCollect(['--range', PR143_RANGE], { PATH: `${dir}:${process.env.PATH}` });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /stubbed entry/);
+    assert.match(r.stdout, /스텁 항목/);
+    assert.match(r.stdout, /Contributors: @tester/);
+  });
+});
+
+test('fake gh failure: flagged as apiError (warn exits 0, strict exits 1), never silent', () => {
+  withTmpDir((dir) => {
+    const stub = join(dir, 'gh');
+    writeFileSync(
+      stub,
+      '#!/usr/bin/env node\nprocess.stderr.write("gh: rate limit exceeded\\n");process.exit(1);\n',
+      { mode: 0o755 },
+    );
+    const env = { PATH: `${dir}:${process.env.PATH}` };
+    const warn = runCollect(['--range', PR143_RANGE], env);
+    assert.equal(warn.status, 0, 'warn mode tolerates an API failure');
+    assert.match(warn.stderr, /gh API failed/);
+    const strict = runCollect(['--range', PR143_RANGE, '--strict'], env);
+    assert.equal(strict.status, 1, 'strict fails on an API error');
+  });
+});
+
+// Hermetic git repos via --repo so the defect paths are deterministic.
+function withGitRepo(setup, fn) {
+  withTmpDir((dir) => {
+    const g = (args) =>
+      spawnSync('git', args, {
+        cwd: dir,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: 'T',
+          GIT_AUTHOR_EMAIL: 't@e',
+          GIT_COMMITTER_NAME: 'T',
+          GIT_COMMITTER_EMAIL: 't@e',
+        },
+      });
+    g(['init', '-q']);
+    g(['commit', '--allow-empty', '-qm', 'base']);
+    setup(g, dir);
+    fn(dir, g);
+  });
+}
+
+test('CLI: merge commit indexed by body PR title; direct-push → TODO not a fake #N', () => {
+  withGitRepo(
+    (g) => {
+      g(['tag', 'v0.0.1']);
+      g(['commit', '--allow-empty', '-qm', 'Merge pull request #99 from a/x\n\nfeat: shiny thing']);
+      g(['commit', '--allow-empty', '-qm', 'chore: a direct push']);
+    },
+    (dir) => {
+      const r = runCollect(['--repo', dir, '--range', 'v0.0.1..HEAD', '--no-api']);
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /- #99 feat: shiny thing/);
+      assert.doesNotMatch(r.stdout, /Merge pull request/);
+      assert.match(r.stdout, /TODO: direct push/);
+    },
+  );
+});
+
+test('CLI --strict: a direct-push commit (no PR) exits 1', () => {
+  withGitRepo(
+    (g) => {
+      g(['tag', 'v0.0.1']);
+      g(['commit', '--allow-empty', '-qm', 'chore: a direct push, no PR']);
+    },
+    (dir) => {
+      // no PR-bearing commit in range → no gh call → strict fails on directPush.
+      const r = runCollect(['--repo', dir, '--range', 'v0.0.1..HEAD', '--strict']);
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /commit with no PR/);
+    },
+  );
+});
+
+test('CLI: no tags and no --range → exit 2 with "no tags found"', () => {
+  withGitRepo(
+    () => {
+      /* leave the repo tagless */
+    },
+    (dir) => {
+      const r = runCollect(['--repo', dir]);
+      assert.equal(r.status, 2);
+      assert.match(r.stderr, /no tags found/);
+    },
+  );
+});
+
+test('CLI --strict: a PR missing its ## Changelog block exits 1', () => {
+  withGitRepo(
+    (g) => {
+      g(['tag', 'v0.0.1']);
+      g(['commit', '--allow-empty', '-qm', 'feat: a thing (#42)']);
+    },
+    (dir) => {
+      const stub = join(dir, 'gh');
+      writeFileSync(
+        stub,
+        '#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({author:{login:"t"},body:"no changelog block here"}));\n',
+        { mode: 0o755 },
+      );
+      const r = runCollect(['--repo', dir, '--range', 'v0.0.1..HEAD', '--strict'], {
+        PATH: `${dir}:${process.env.PATH}`,
+      });
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /no ## Changelog block/);
+    },
+  );
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary / 개요

**EN.** T8 of the changelog-pr-guide: a semi-automatic collector that drafts a CHANGELOG section from merged PRs, plus npm packaging hygiene so maintainer-only release scripts no longer ship to users. Follow-up to #143 / #144.

**KO.** changelog-pr-guide T8: 머지된 PR로부터 CHANGELOG 섹션 초안을 만드는 반자동 수집기. 더해서 메인테이너 전용 릴리스 스크립트가 사용자에게 출하되지 않도록 npm 패키징 정리. #143 / #144 후속.

## What changed / 변경 내용

### `scripts/collect-changelog.mjs` (+ `scripts/lib/collect-changelog.mjs`)
- Walks a git range, classifies each merged PR offline (reusing `changelog-classify.mjs`), pulls the `## Changelog` block body + author `@handle` from `gh`, and prints a section-model draft. It never edits `CHANGELOG.md` (the maintainer owns Highlights and final wording).
- fail-loud, no silent-skip: empty range / no-tags / commit-with-no-PR / gh failure / missing or malformed `## Changelog` block are warned (default) or fail the run (`--strict`). `--strict --no-api` is rejected.
- `--first-parent`; a merge-commit boilerplate subject classifies AND indexes from the PR title in the body, not the boilerplate.

### Packaging
- `package.json` `files` negates the maintainer-only release scripts (collect-changelog + its lib, bump-version, smoke-pack, smoke-plugin) so they are not published to npm. They run from the dev checkout, never from an installed package.
- The user-facing version-upgrade surface is unchanged: `/hypo:upgrade` (`scripts/upgrade.mjs`) and the update-available notifier (`hooks/version-check*.mjs`) still ship; no shipped file imports an excluded script.

## Gates / 게이트
- `npm test` 927 pass (unit + CLI + fake-gh + hermetic-repo cases) · new-file em-dash 0 · `check:tracker-ids` OK · `check:versions` OK · `smoke:plugin` OK · `smoke-pack` OK · tarball excludes the 5 maintainer scripts, ships upgrade.mjs + version-check hooks.

## Review / 검토
- `/teams codex` 2-stage cross-review. Design-stage **BLOCKER** (merge-commit support via `--first-parent` + body classification, malformed-block matrix, `--strict --no-api` rejection, no-tags exit, index normalization) and commit-stage **BLOCKER** (index built from the same source as classification, trailing-only `(#N)`, no fabricated `@handle` from a git author name, em-dash-free headers) — every finding applied and locked by a test. The final 2nd-round codex pass over the whole changelog-pr-guide change lands in T9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)