### PR TITLE
fix(close): require and validate payload.project on session-close apply

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -32,7 +32,7 @@ These are judgment calls; when uncertain, surface the question rather than skip 
 
 The session-close path is **payload-driven**. Instead of writing the 5 mandatory files one-by-one, you compose a single JSON payload that describes the full session-close state, then hand it to `crystallize.mjs --apply-session-close`, which performs idempotent atomic writes and gates the result with lint.
 
-Payload shape (5 required + 1 conditional, per Spec §5.2.7 / §8.3 + ADR 0029):
+Payload shape (`project` + 5 content fields required, 1 conditional, per Spec §5.2.7 / §8.3 + ADR 0029):
 
 ```json
 {
@@ -51,7 +51,7 @@ Payload shape (5 required + 1 conditional, per Spec §5.2.7 / §8.3 + ADR 0029):
 
 Field rules:
 
-- `project` — optional. Falls back to the active project from root `hot.md` pointer table.
+- `project`: **required**. Slug of the project being closed (matches a `projects/<slug>/` directory). Must be a single path segment, charset `A-Za-z0-9._-`, with at least one alphanumeric and not a dot-only name (`.`, `..`, `...`). Apply never infers the target from recency; a same-date pointer-table tie could otherwise write the close into the wrong project (B-3). A missing, malformed, or non-existent value fails the apply before any write.
 - `date` — optional. Defaults to today (local). Must be `YYYY-MM-DD` if supplied.
 - `openQuestions` — optional. Include only when `pages/open-questions.md` exists and changed this session.
 - All other top-level fields are required.

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -31,7 +31,7 @@
  *
  * Payload schema:
  *   {
- *     "project":      "<slug>",                       // optional — defaults to resolveActiveProject()
+ *     "project":      "<slug>",                       // REQUIRED — single segment [A-Za-z0-9._-]+ (≥1 alnum, not dot-only), projects/<slug>/ dir must exist (B-3: no recency fallback for apply)
  *     "date":         "YYYY-MM-DD",                   // optional — defaults to today (local)
  *     "sessionState": { "content": "<full file>" },   // overwrite (idempotent: identical bytes → skip)
  *     "projectHot":   { "content": "<full file>" },   // overwrite
@@ -60,7 +60,7 @@
  *     hard-fails regardless of scope.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
+import { existsSync, statSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
 import { join, dirname } from 'path';
 import { hostname } from 'os';
 import { spawnSync } from 'child_process';
@@ -68,6 +68,7 @@ import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
 import { collectPagesCrystallize, extractWikilinks } from './lib/wikilink.mjs';
+import { isValidProjectName } from './lib/project-create.mjs';
 import {
   sessionCloseFileStatus,
   sessionCloseGlobalStatus,
@@ -585,20 +586,48 @@ function applySessionClose(args) {
     process.exit(1);
   }
 
-  // Resolve project: explicit payload.project wins; else fall back to active project.
-  // Done via sessionCloseFileStatus to keep one source of truth (and so a
-  // missing pointer table surfaces the same error shape as --check-session-close).
+  // Resolve project: payload.project is REQUIRED (B-3, close-gate-hardening). The
+  // old recency fallback (payload.project || probe.project) could, on a same-date
+  // root-hot.md tie, resolve a DIFFERENT project than the one the payload's files
+  // belong to — apply would then write the close into the wrong project (silent
+  // data loss). Validate fail-fast, BEFORE the probe is consulted:
+  //   - missing      → no target to write; abort rather than infer.
+  //   - invalid name → reject (non-string, wrong charset, or dot-only) BEFORE the
+  //                    existsSync(join(...)) path build, so a `../`-style value
+  //                    never reaches a path builder (traversal guard — order is
+  //                    the guard). isValidProjectName is SHARED with createProject
+  //                    so apply accepts exactly the namespace the repo can
+  //                    scaffold (A-Za-z0-9._-, single segment) — no narrower.
+  //   - non-existent → projects/<slug>/ absent; abort rather than create.
+  // A payload.project that merely DIFFERS from the inferred active project is NOT an
+  // error — it is surfaced as a stderr note below and the close proceeds.
+  if (payload.project === undefined || payload.project === null) {
+    const msg = 'payload.project is required (apply must not infer the close target project)';
+    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+    process.exit(1);
+  }
+  if (!isValidProjectName(payload.project)) {
+    const msg = `payload.project ${JSON.stringify(payload.project)} is not a valid project name (single segment, charset A-Za-z0-9._-, ≥1 alnum, not "."/"..")`;
+    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+    process.exit(1);
+  }
+  // existsSync alone is not enough: a regular FILE at projects/<slug> would pass,
+  // then apply would build child paths under it and fail with an unstructured
+  // filesystem error (codex re-review). Require it to be a directory.
+  const projectDir = join(args.hypoDir, 'projects', payload.project);
+  if (!existsSync(projectDir) || !statSync(projectDir).isDirectory()) {
+    const msg = `payload.project "${payload.project}" does not exist as a directory (no projects/${payload.project}/ directory)`;
+    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+    process.exit(1);
+  }
+  const project = payload.project;
+  // probe (the recency-inferred active project) is now consulted ONLY to surface a
+  // divergence note — never to resolve the target. Computed AFTER validation so a
+  // malformed/missing payload.project fails fast without a pointer-table read.
   // Resolved BEFORE preflight because preflight needs overwrite-target paths
   // (which require the project slug) to filter out errors in files this apply
   // is about to replace — see the filter rationale below.
   const probe = sessionCloseFileStatus(args.hypoDir);
-  const project = payload.project || probe.project;
-  if (!project) {
-    const msg =
-      'no project resolved (payload.project missing and root hot.md has no active-project row)';
-    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
-    process.exit(1);
-  }
   // The freshness verification below (and at the post-apply check) already honors
   // payload.project — `project` wins over the inferred active project, and the
   // post-apply sessionCloseFileStatus call passes it as projectOverride. But when the
@@ -606,7 +635,7 @@ function applySessionClose(args) {
   // (probe.project), that divergence used to be silent, so an operator couldn't tell
   // which project the close actually verified. Surface it on stderr (the stdout JSON
   // contract is untouched) so the verified/closed project is always explicit.
-  if (payload.project && probe.project && probe.project !== payload.project) {
+  if (probe.project && probe.project !== payload.project) {
     process.stderr.write(
       `note: payload.project="${payload.project}" differs from the inferred active ` +
         `project "${probe.project}"; verifying and closing "${payload.project}".\n`,

--- a/scripts/lib/project-create.mjs
+++ b/scripts/lib/project-create.mjs
@@ -90,13 +90,31 @@ export function insertHotRow(content, name, today) {
  * @param {{hypoDir: string, name: string, workingDir: string, started?: string, today?: string}} opts
  * @returns {{created: string[], skipped: string[], warnings: string[], projectDir: string}}
  */
+/**
+ * A project name must be a SINGLE path segment with at least one alnum. The
+ * charset alone is not enough: `.`, `..`, `...` all pass `[A-Za-z0-9._-]+` yet
+ * would resolve `projects/<name>` to the wiki root or `projects/` itself (codex
+ * review 2026-05-22, both workers) — so dot-only names are rejected and ≥1 alnum
+ * required. The leading `typeof` guard lets non-CLI callers (e.g. a JSON payload
+ * where the value could be a number) reuse this without a JS regex coercing a
+ * non-string into a "valid" name. Shared so the apply path (crystallize.mjs B-3)
+ * accepts exactly the namespace createProject can scaffold — no wider, no narrower.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isValidProjectName(name) {
+  return (
+    typeof name === 'string' &&
+    /^[A-Za-z0-9._-]+$/.test(name) &&
+    !/^\.+$/.test(name) &&
+    /[A-Za-z0-9]/.test(name)
+  );
+}
+
 export function createProject(opts) {
   const { name, workingDir } = opts;
-  // Name must be a single path segment with at least one alnum. The charset
-  // alone is not enough: `.`, `..`, `...` all pass `[A-Za-z0-9._-]+` yet would
-  // resolve `projects/<name>` to the wiki root or `projects/` itself (codex
-  // review 2026-05-22, both workers). Reject dot-only names and require alnum.
-  if (!name || !/^[A-Za-z0-9._-]+$/.test(name) || /^\.+$/.test(name) || !/[A-Za-z0-9]/.test(name)) {
+  if (!isValidProjectName(name)) {
     throw new Error(
       `invalid project name: ${JSON.stringify(name)} (need a single segment with ≥1 alnum, charset A-Za-z0-9._-, not "."/"..")`,
     );

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2685,6 +2685,116 @@ test('session-close: post-apply verify follows payload.project on same-date tie 
   );
 });
 
+// B-3 (close-gate-hardening): apply must NOT infer the close target from recency.
+// payload.project is REQUIRED and validated (slug shape + on-disk existence) so a
+// same-date root-hot.md tie can never silently write the close into the wrong
+// project. Each guard fails fast with a distinct, named error.
+test('apply: payload.project missing → exit 1 (B-3 data-loss guard)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    delete payload.project;
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `missing project must hard-fail: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.match(
+      out.error,
+      /payload\.project is required/,
+      `error must name the missing field: ${r.stdout}`,
+    );
+  });
+});
+
+test('apply: payload.project malformed name → exit 1 (B-3 traversal/segment guard)', () => {
+  // Path-traversal, separators, whitespace, dot-only: all rejected BEFORE any
+  // existsSync/path build, so a `../`-style value never reaches a path builder.
+  for (const bad of ['../escape', 'a/b', 'has space', '..', '.']) {
+    withWiki(null, (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      payload.project = bad;
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 1, `malformed name "${bad}" must hard-fail: ${r.stdout}\n${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.match(
+        out.error,
+        /not a valid project name/,
+        `error must flag name validity for "${bad}": ${r.stdout}`,
+      );
+    });
+  }
+});
+
+test('apply: payload.project non-string → exit 1 (B-3 regex-coercion guard)', () => {
+  // A JS regex coerces non-strings (42 → "42"); isValidProjectName's typeof guard rejects first.
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.project = 42;
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `non-string project must hard-fail: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.match(
+      out.error,
+      /not a valid project name/,
+      `error must reject non-string project: ${r.stdout}`,
+    );
+  });
+});
+
+test('apply: wide-charset valid name (A-Z/_/.) not rejected as malformed (B-3 namespace parity)', () => {
+  // createProject accepts the namespace A-Za-z0-9._- (single segment). Apply must
+  // accept exactly that, not a narrower one — else an existing Foo_Bar / foo.bar
+  // project can be scaffolded and resumed but never closed (codex review). A
+  // non-existent such name must fail as "does not exist", NOT "not a valid name".
+  for (const name of ['Foo_Bar', 'foo.bar']) {
+    withWiki(null, (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      payload.project = name;
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 1, `non-existent dir still fails, got ${r.status}: ${r.stdout}`);
+      const out = JSON.parse(r.stdout);
+      assert.match(
+        out.error,
+        /does not exist/,
+        `valid wide-charset name must pass name-validity and fail only on existence: ${r.stdout}`,
+      );
+      assert.doesNotMatch(
+        out.error,
+        /not a valid project name/,
+        `valid wide-charset name must NOT be rejected as malformed: ${r.stdout}`,
+      );
+    });
+  }
+});
+
+test('apply: payload.project does not exist on disk → exit 1 (B-3)', () => {
+  // A well-formed slug with no projects/<slug>/ directory: abort rather than create.
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.project = 'ghost-project';
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `non-existent project must hard-fail: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.match(out.error, /does not exist/, `error must flag the missing dir: ${r.stdout}`);
+  });
+});
+
+test('apply: payload.project is a regular file, not a directory → exit 1 (B-3 dir guard)', () => {
+  // A valid-name slug whose projects/<slug> is a FILE (not a dir) must be rejected
+  // structurally here, not crash later building child paths (codex re-review).
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.project = 'filenode';
+    writeFileSync(join(dir, 'projects', 'filenode'), 'not a dir\n');
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `file-at-path must hard-fail: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.match(
+      out.error,
+      /does not exist as a directory/,
+      `error must flag the non-directory: ${r.stdout}`,
+    );
+  });
+});
+
 test('same-day second close: distinct entries are both appended (W1 regression)', () => {
   // Sub-session within the same day must produce a second log entry, not be
   // silently deduped because today's heading already exists — exact-entry dedup


### PR DESCRIPTION
# English

## What changed

`--apply-session-close` now requires `payload.project` and validates it fail-fast before any path is built from it:

- missing: exit 1
- invalid name: exit 1 (shared `isValidProjectName`: single path segment, charset `A-Za-z0-9._-`, at least one alphanumeric, not a dot-only name; rejects a JSON number and a `../`-style value before any path build)
- not a directory: exit 1 (a regular file at `projects/<slug>` is rejected structurally, not as a later filesystem crash)

`isValidProjectName` is extracted as a shared export in `scripts/lib/project-create.mjs` and reused by `createProject`, so apply accepts exactly the namespace the repo can scaffold (no narrower). The packaged command doc (`commands/crystallize.md`) and the payload schema comment are corrected from optional to required.

## Why

The apply path resolved the close target via `payload.project || probe.project`. On a same-date root `hot.md` recency tie that fallback could resolve a different project than the one the payload's files belong to, so apply would write the session close into the wrong project (silent data loss). Making `payload.project` required and validated removes the inference entirely.

## How

Validation runs in `scripts/crystallize.mjs` before the recency probe is consulted, so a malformed or missing value fails before any pointer-table read or path build. The marker gate and the global compact gate are untouched (this PR is the data-loss guard only; the operator `--project=` override is deferred to a follow-up).

## Manual verification

Covered by the test suite (6 new tests plus the existing `createProject` name test). Gates run locally: `npm test` (933 passed, 0 failed), `check:tracker-ids`, `smoke:plugin`, `smoke-pack`. Two-stage codex cross-review (design plus pre-commit) resolved one design BLOCKER (scope narrowed to the data-loss guard) and two pre-commit findings (namespace parity plus packaged-doc drift, then a directory check), all locked by tests.

## Migration notes

Callers that drive `--apply-session-close` with a JSON payload must include `project` (the live session-close flow already authors it). A payload that previously relied on the recency fallback now fails fast with a clear error.

---

# 한국어

## 변경 내용

`--apply-session-close`가 이제 `payload.project`를 필수로 받고, 그 값으로 경로를 만들기 전에 fail-fast로 검증합니다:

- 누락: exit 1
- 잘못된 이름: exit 1 (공유 `isValidProjectName`: 단일 경로 세그먼트, charset `A-Za-z0-9._-`, 영숫자 최소 1개, dot-only 이름 금지. JSON 숫자나 `../` 류 값을 경로 빌드 전에 거부)
- 디렉터리 아님: exit 1 (`projects/<slug>`가 정규 파일이면 나중에 깨지지 않게 구조적으로 거부)

`isValidProjectName`은 `scripts/lib/project-create.mjs`의 공유 export로 추출해 `createProject`와 같이 쓰므로, apply가 레포가 scaffold할 수 있는 namespace를 그대로 받습니다(더 좁지 않게). 패키징되는 command 문서(`commands/crystallize.md`)와 payload 스키마 주석도 optional에서 required로 바로잡았습니다.

## 이유

apply는 `payload.project || probe.project`로 close 대상을 정했습니다. 같은 날짜 root `hot.md` recency 동점에서 이 폴백이 payload 파일이 속한 프로젝트와 다른 프로젝트를 고를 수 있어, close가 엉뚱한 프로젝트에 기록되는 데이터 유실이 가능했습니다. `payload.project`를 필수·검증으로 만들어 추론을 없앴습니다.

## 방법

검증은 `scripts/crystallize.mjs`에서 recency probe보다 먼저 돌아, 잘못되거나 빠진 값이 포인터 테이블 읽기나 경로 빌드 전에 실패합니다. 마커 게이트와 글로벌 compact 게이트는 건드리지 않았습니다(이 PR은 데이터 유실 차단만, 운영자용 `--project=` override는 후속으로 연기).

## 수동 검증

테스트 스위트로 커버(신규 6건과 기존 `createProject` 이름 테스트). 로컬 게이트: `npm test`(933 passed, 0 failed), `check:tracker-ids`, `smoke:plugin`, `smoke-pack`. 2단계 codex 교차검토(설계와 commit)가 설계 BLOCKER 1건(범위를 데이터 유실 차단으로 축소)과 commit 발견 2건(namespace parity와 패키징 문서 누락, 이어서 디렉터리 검사)을 해결했고 모두 테스트로 잠갔습니다.

## 마이그레이션 노트

JSON payload로 `--apply-session-close`를 호출하는 caller는 `project`를 포함해야 합니다(라이브 session-close 흐름은 이미 작성). 이전에 recency 폴백에 의존하던 payload는 이제 명확한 에러로 즉시 실패합니다.

---

## Changelog

- EN: Session-close apply now requires a valid project and fails fast on a missing, malformed, or non-directory project, so a close can no longer be written to the wrong project on a same-date tie.
- KO: 세션 close apply가 유효한 프로젝트를 요구하고 누락이나 형식 오류, 디렉터리 아님이면 즉시 실패해서, 같은 날짜 동점 상황에서 close가 엉뚱한 프로젝트에 기록되는 일을 막습니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally (no new findings; pre-existing maintainer-vault notices only)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line)
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
