### PR TITLE
docs(pr): bilingual PR body (EN/KO blocks) and ban tool-attribution footer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,18 @@
 <!--
-Thanks for the PR. The sections below map 1:1 to the PR checklist in
-docs/CONTRIBUTING.md. PR title: Conventional Commits + scope, e.g.
+Thanks for the PR. The sections below map to the PR checklist in
+docs/CONTRIBUTING.md.
+
+PR title: Conventional Commits plus a scope, e.g.
 `feat(feedback): add failure_type enum`. Keep any internal tracker id
-out of the title and body (see the Changelog block note below).
+(FEAT-/IMPR-/ISSUE-/PRAC-) out of the title and body.
+
+Body language: write the full body TWICE, once under `# English` and once
+under `# 한국어` (this repo ships bilingual docs). The `## Changelog` and
+`## Checklist` blocks are language-neutral, so they appear once, after both
+blocks. Do NOT add any "Generated with ..." / tool-attribution footer.
 -->
+
+# English
 
 ## What changed
 
@@ -24,14 +33,49 @@ Anything the test suite cannot cover. Required if you changed:
 - a hook (run /hypo:upgrade and verify the hook fires in a real session)
 - hooks/hypo-shared.mjs (verify the deployed copy works)
 - a template or init flow (run a fresh init and inspect the vault)
-
 Paste the exact commands you ran and what you observed.
 -->
+
+## Migration notes
+
+<!-- If existing installs need special handling on upgrade, describe the path. Otherwise: "None". -->
+
+---
+
+# 한국어
+
+## 변경 내용
+
+<!-- 짧은 요약. 이 PR이 무엇을 하나? -->
+
+## 이유
+
+<!-- 사용자에게 보이는 동기. 어떤 문제를 푸나? -->
+
+## 방법
+
+<!-- 접근에서 diff만으로 드러나지 않는 부분만. -->
+
+## 수동 검증
+
+<!--
+테스트가 못 잡는 부분. 다음을 바꿨으면 필수:
+- 훅 (/hypo:upgrade 후 실제 세션에서 훅이 발화하는지 확인)
+- hooks/hypo-shared.mjs (배포된 사본이 동작하는지 확인)
+- 템플릿이나 init 흐름 (fresh init으로 볼트 구조 확인)
+실행한 명령과 관찰 결과를 그대로 붙여넣으세요.
+-->
+
+## 마이그레이션 노트
+
+<!-- 기존 설치가 업그레이드 시 특별 처리가 필요하면 경로를 기술. 없으면 "None". -->
+
+---
 
 ## Changelog
 
 <!--
-One English line + one Korean line, only if this change is user-visible.
+One English line plus one Korean line, only if the change is user-visible.
 The release collector gathers these into CHANGELOG.md at release time, so
 you do NOT edit CHANGELOG.md directly in this PR. Internal-only change
 (refactor with no user-visible effect, test-only, CI plumbing)? Write
@@ -49,15 +93,13 @@ Rules:
 - EN:
 - KO:
 
-## Migration notes
-
-<!-- If existing installs need special handling on upgrade, describe the path. Otherwise: "None". -->
-
 ## Checklist
 
 - [ ] `npm test` passes locally
 - [ ] `npm run lint` passes locally
 - [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
 - [ ] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
+- [ ] Wrote the body in both `# English` and `# 한국어` blocks
+- [ ] No tool-attribution footer in the body
 - [ ] One logical change per PR (rebase / split if necessary)
 - [ ] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -217,13 +217,20 @@ Before opening:
 4. If you changed a template or `init` flow, a fresh `init` produces the expected vault structure.
 5. README / ARCHITECTURE / docs are updated to match.
 
-Open the PR against `main`. Include:
+Open the PR against `main`. The body is **bilingual**: write the full description twice, once under a `# English` heading and once under a `# 한국어` heading, each carrying the same sections. The `## Changelog` and `## Checklist` blocks are language-neutral, so they appear once, after both language blocks. Do **not** add any tool-attribution footer (no "Generated with ..." line) to the body.
 
-- **What changed** — short summary
-- **Why** — the user-visible motivation
-- **Manual verification steps** — anything the test suite cannot cover
+Each language block includes:
+
+- **What changed** / **변경 내용**: short summary
+- **Why** / **이유**: the user-visible motivation
+- **How** / **방법**: approach notes that aren't obvious from the diff
+- **Manual verification** / **수동 검증**: anything the test suite cannot cover
+- **Migration notes** / **마이그레이션 노트**: if upgrading existing installs needs special handling (else "None")
+
+After both blocks, language-neutral:
+
 - **Changelog**: one English line plus one Korean line if the change is user-visible (see CHANGELOG conventions below)
-- **Migration notes** — if upgrading existing installs needs special handling
+- **Checklist**: the boxes from the PR template
 
 ---
 


### PR DESCRIPTION
# English

## What changed

PR descriptions are now bilingual: a `# English` block then a `# 한국어` block carrying the same sections (What changed, Why, How, Manual verification, Migration notes). The `## Changelog` and `## Checklist` blocks stay language-neutral and appear once, after both language blocks. The PR template and CONTRIBUTING also state that no tool-attribution footer (a "Generated with ..." line) belongs in the PR body.

## Why

Maintainer request: PR bodies should read in both English and Korean (the same bilingual treatment the CHANGELOG already gets), and the auto-generated tool-attribution footer should not appear on the public PR surface.

## How

Rewrote `.github/PULL_REQUEST_TEMPLATE.md` into the two-block structure with the language-neutral Changelog/Checklist after both blocks, plus a comment banning the footer. Updated `docs/CONTRIBUTING.md` "Submitting a PR" to match. The release collector (`parseChangelogBlock`) keys on the `## Changelog` H2 and ignores H1 headings, so the new `# English` / `# 한국어` headings do not affect changelog collection.

## Manual verification

Ran `parseChangelogBlock` against a real bilingual PR body: it extracted the EN and KO changelog lines correctly. `npm test` 927 passed on this branch (off main). codex pre-commit review: CLEAR.

## Migration notes

None. Existing merged PRs are unaffected; this changes the template for new PRs only.

---

# 한국어

## 변경 내용

PR 설명을 이제 이중 언어로 쓴다: `# English` 블록 다음 `# 한국어` 블록이 같은 섹션(변경 내용, 이유, 방법, 수동 검증, 마이그레이션 노트)을 담는다. `## Changelog`와 `## Checklist`는 언어 중립이라 두 블록 뒤에 한 번만 둔다. PR 템플릿과 CONTRIBUTING에 PR 본문 tool-attribution 푸터("Generated with ..." 줄) 금지도 명시했다.

## 이유

메인테이너 요청: PR 본문을 영어와 한국어 둘 다로(CHANGELOG가 이미 받는 이중 언어 처리와 동일), 자동 생성되는 tool-attribution 푸터는 공개 PR 표면에 노출하지 않는다.

## 방법

`.github/PULL_REQUEST_TEMPLATE.md`를 두 블록 구조로 재작성하고 언어 중립 Changelog/Checklist를 뒤에 두며, 푸터 금지 주석을 넣었다. `docs/CONTRIBUTING.md`의 "Submitting a PR"도 맞췄다. 릴리스 수집기(`parseChangelogBlock`)는 `## Changelog` H2를 기준으로 찾고 H1은 무시하므로, 새 `# English`/`# 한국어` 헤딩이 changelog 수집에 영향 없다.

## 수동 검증

`parseChangelogBlock`을 실제 이중 언어 PR 본문에 돌려 EN/KO changelog 줄을 정확히 뽑는 것을 확인했다. 이 브랜치(main 기준)에서 `npm test` 927 passed. codex commit 직전 리뷰: CLEAR.

## 마이그레이션 노트

없음. 기존 머지된 PR은 영향 없고, 새 PR 템플릿만 바뀐다.

---

## Changelog

- EN: The PR template and contributing guide now require a bilingual PR body (English and Korean blocks) and ban a tool-attribution footer in the PR body.
- KO: PR 템플릿과 기여 가이드가 PR 본문을 이중 언어(영어·한국어 블록)로 요구하고 PR 본문의 tool-attribution 푸터를 금지합니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
