### PR TITLE
feat(close): add --project=<slug> override for session-close check/mark

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -234,3 +234,5 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs --check-session-close [--hypo
 ```
 
 It reports any file as `missing` or `stale`. For an actual close, prefer `--apply-session-close --payload=<path>` (Step 3) — it bundles freshness + lint into one gate and is the documented dogfood path. (`parseArgs` only accepts the `--payload=<path>` spelling; a space-separated `--payload <path>` is silently ignored and triggers "payload is required".)
+
+Add `--project=<slug>` to scope the check to one project (close status + lint scope) when recency picks the wrong one. This is a project-scoped diagnostic only: a green scoped result (JSON `scope: "project"`) attests that slug is close-complete, **not** that `/compact` is unblocked globally. The marker writer (`--mark-session-closed --project=<slug>`) keeps a **global** gate; there `--project` only sets the marker's attribution slug.

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -675,7 +675,29 @@ function hasTodayCloseActivity(hypoDir, project, dates) {
  *            dates: string[], fallback: boolean, primary: string|null,
  *            project: string|null, stale: string[], missing: string[]}}
  */
-export function sessionCloseGlobalStatus(hypoDir) {
+export function sessionCloseGlobalStatus(hypoDir, opts = {}) {
+  // projectOverride (check-only): the caller (`crystallize --check-session-close
+  // --project=<slug>`) wants THIS project's close status, not the recency pick —
+  // bypass discovery and report the single project, preserving the global return
+  // shape. NEVER threaded from a marker-writing path (--mark / apply auto-marker /
+  // PreCompact): those stay global so the marker == compact-ready invariant holds
+  // (ADR 0047, codex design review). A green status here is a project-scoped
+  // diagnostic, not the global compact-readiness verdict.
+  if (opts.projectOverride) {
+    const s = sessionCloseFileStatus(hypoDir, { projectOverride: opts.projectOverride });
+    return {
+      ok: s.ok,
+      projects: s.project
+        ? [{ project: s.project, ok: s.ok, stale: s.stale, missing: s.missing }]
+        : [],
+      dates: freshDates(),
+      fallback: false,
+      primary: s.project,
+      project: s.project,
+      stale: s.stale,
+      missing: s.missing,
+    };
+  }
   const dates = freshDates();
   const recency = resolveActiveProject(hypoDir); // no cwd — close never picks by cwd
   const todayActive = [...closeCandidateSlugs(hypoDir, dates)].filter((p) =>
@@ -1560,23 +1582,40 @@ export function closeFileTargets(hypoDir) {
  * evidence file for EVERY freshDate (not just dates[0]) so the lint scope matches
  * what sessionCloseFileStatus actually checks across a local/UTC date boundary.
  */
+// The lint-scope target set for ONE project's close: the shared root files
+// (hot.md / log.md) plus that project's mandatory close files — session-state,
+// project hot, and each fresh date's session-log evidence file. Used both by
+// `--check-session-close --project=<slug>` (a project-scoped diagnostic — see
+// precompactGateStatus opts.projectOverride) and as the per-project building
+// block of closeFileTargetsGlobal, so the two scopes stay identical per project.
+export function closeFileTargetsForProject(hypoDir, slug) {
+  const dates = freshDates();
+  const out = new Set(['hot.md', 'log.md']);
+  out.add(`projects/${slug}/session-state.md`);
+  out.add(`projects/${slug}/hot.md`);
+  // Scope to the file each date's freshness is PROVEN by (daily shard or, via
+  // fallback, the legacy monthly), so a corrupt evidence file can't pass the
+  // gate while its lint error is demoted to an out-of-scope notice.
+  for (const d of dates) out.add(sessionLogScopePath(hypoDir, slug, d));
+  return out;
+}
+
 export function closeFileTargetsGlobal(hypoDir) {
   const dates = freshDates();
   const out = new Set(['hot.md', 'log.md']);
   let active = [...closeCandidateSlugs(hypoDir, dates)].filter((p) =>
     hasTodayCloseActivity(hypoDir, p, dates),
   );
+  // No project closed today → fall back to the recency project (mirrors
+  // sessionCloseGlobalStatus's own fallback at the top of this file), so the lint
+  // scope never narrows below the close-status scope. Dropping this (root-only
+  // when active=[]) would re-open the very gap closeFileTargetsForProject closes.
   if (active.length === 0) {
     const recency = resolveActiveProject(hypoDir);
     if (recency) active = [recency];
   }
   for (const p of active) {
-    out.add(`projects/${p}/session-state.md`);
-    out.add(`projects/${p}/hot.md`);
-    // Scope to the file each date's freshness is PROVEN by (daily shard or, via
-    // fallback, the legacy monthly), so a corrupt evidence file can't pass the
-    // gate while its lint error is demoted to an out-of-scope notice.
-    for (const d of dates) out.add(sessionLogScopePath(hypoDir, p, d));
+    for (const f of closeFileTargetsForProject(hypoDir, p)) out.add(f);
   }
   return out;
 }
@@ -1629,8 +1668,18 @@ export function partitionLintScope(findings, scope) {
  * opts.transcriptPath to widen it to the session's edited files exactly as the
  * hook does.
  *
+ * opts.projectOverride (CHECK-ONLY) narrows BOTH the close status and the lint
+ * scope to a single project, for `--check-session-close --project=<slug>`. A
+ * green result is then a project-scoped diagnostic, NOT the global compact-ready
+ * verdict (ADR 0046) — the caller must surface the scope. It is NEVER passed from
+ * a marker-writing path (--mark / apply auto-marker / PreCompact); those stay
+ * global so a marker can't attest compact-ready while PreCompact re-checks red
+ * (the marker == compact-ready invariant, ADR 0047 / codex design review). When a
+ * log-only marker governs the session, log-only mode wins and projectOverride is
+ * ignored.
+ *
  * @param {string} hypoDir
- * @param {{lintScope?: Iterable<string>, transcriptPath?: string|null, claudeHome?: string}} [opts]
+ * @param {{lintScope?: Iterable<string>, transcriptPath?: string|null, claudeHome?: string, projectOverride?: string|null}} [opts]
  * @returns {{ok: boolean, close: object, blockers: {type:string,reason:string}[], notices: {type:string,reason:string}[], driftTargets: string[], skipped: {lint:boolean, feedback:boolean}}}
  */
 export function precompactGateStatus(hypoDir, opts = {}) {
@@ -1693,7 +1742,9 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       });
     }
   } else {
-    close = sessionCloseGlobalStatus(hypoDir);
+    // projectOverride narrows the close status to one project (check-only); a
+    // marker-writing caller never sets it, so the marker path stays global.
+    close = sessionCloseGlobalStatus(hypoDir, { projectOverride: opts.projectOverride });
     if (!close.ok) {
       blockers.push({
         type: 'close',
@@ -1744,8 +1795,16 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       // mandatory files in and re-introduce the cross-project attribution. The
       // session's own transcript-touched files are still added below (a log-only
       // session is accountable for the wiki files it actually edited).
+      // Lint scope: explicit opts.lintScope wins; else log-only uses the shared
+      // root files only; else projectOverride narrows to that one project's close
+      // files (matching the narrowed close status above); else the global set.
       const scope = new Set(
-        opts.lintScope || (logOnly ? ['hot.md', 'log.md'] : closeFileTargetsGlobal(hypoDir)),
+        opts.lintScope ||
+          (logOnly
+            ? ['hot.md', 'log.md']
+            : opts.projectOverride
+              ? closeFileTargetsForProject(hypoDir, opts.projectOverride)
+              : closeFileTargetsGlobal(hypoDir)),
       );
       if (opts.transcriptPath && existsSync(opts.transcriptPath)) {
         for (const f of extractTouchedWikiFiles(opts.transcriptPath, hypoDir)) scope.add(f);

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -13,6 +13,11 @@
  *   --hypo-dir=<path>        Hypomnema root (default: resolved via HYPO_DIR / hypo-config.md / ~/hypomnema)
  *   --min-group=<n>          Min pages per tag group to report (default: 2)
  *   --check-session-close    Verify the strict session-close memory files — 5 mandatory + open-questions conditional
+ *   --project=<slug>         Override the recency-inferred project on --check / --mark (single segment
+ *                            [A-Za-z0-9._-]+, projects/<slug>/ must exist). On --check it NARROWS the
+ *                            gate to that one project — a project-scoped diagnostic, NOT a global
+ *                            compact-ready verdict. On --mark it is ATTRIBUTION only; the gate stays
+ *                            global (the marker == compact-ready invariant). Ignored on --apply.
  *   --apply-session-close    Apply a JSON payload that updates the 5 mandatory memory files
  *                            (+ optional open-questions). Idempotent — re-running with the same
  *                            payload is a no-op. Always finishes with the strict gate check.
@@ -134,6 +139,7 @@ function parseArgs(argv) {
     payload: null,
     force: false,
     transcriptPath: null,
+    project: null,
   };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
@@ -145,10 +151,23 @@ function parseArgs(argv) {
     else if (arg.startsWith('--session-id=')) args.sessionId = arg.slice(13);
     else if (arg.startsWith('--payload=')) args.payload = arg.slice(10);
     else if (arg.startsWith('--transcript-path=')) args.transcriptPath = expandHome(arg.slice(18));
+    else if (arg.startsWith('--project=')) args.project = arg.slice(10);
     else if (arg === '--force') args.force = true;
     else if (arg === '--json') args.json = true;
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
+  // --project=<slug> override (check/mark only). Validate the SYNTAX here so a
+  // traversal/charset attack (`--project=../x`) is rejected before any path is
+  // built from it — sessionCloseFileStatus(projectOverride) joins it directly.
+  // isValidProjectName is the SHARED validator (project-create.mjs), so the
+  // override accepts exactly the namespace createProject can scaffold. Existence
+  // (a real projects/<slug>/ directory) is checked in the run functions, where
+  // hypoDir is resolved and only the check/mark paths consume --project.
+  if (args.project != null && !isValidProjectName(args.project)) {
+    const msg = `--project "${args.project}" is not a valid project name (need a single segment with ≥1 alnum, charset A-Za-z0-9._-, not "."/"..")`;
+    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+    process.exit(1);
+  }
   return args;
 }
 
@@ -163,6 +182,20 @@ function parseArgs(argv) {
 // model drops a second `<id>.jsonl` elsewhere the glob returns >1 and fails
 // closed.) `--transcript-path` survives ONLY for `--check-session-close`'s lint
 // scope, which writes no marker and so cannot cause an over-close.
+
+// Validate that an explicit --project=<slug> override names a real project
+// DIRECTORY. Syntax was already checked in parseArgs; this is the existence half,
+// mirroring apply's payload.project check — a regular file or an absent dir at
+// projects/<slug> is a hard error so the override never silently resolves to an
+// all-missing status (which a reader would misread as "exists but incomplete").
+function requireProjectDir(args, slug) {
+  const projectDir = join(args.hypoDir, 'projects', slug);
+  if (!existsSync(projectDir) || !statSync(projectDir).isDirectory()) {
+    const msg = `--project "${slug}" does not exist as a directory (no projects/${slug}/ directory)`;
+    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+    process.exit(1);
+  }
+}
 
 // ── session-close check (spec §5.2.7 / §8.3) ────────────────────────
 // Mirrors the hard gate in hypo-personal-check.mjs so the /hypo:crystallize
@@ -180,8 +213,21 @@ function runSessionCloseCheck(args) {
   // (marker_present:true) while `ok` still reflected the stale active project —
   // the completion-signal trio (PreCompact / --check / marker) would diverge
   // (codex design Finding 2).
+  //
+  // --project=<slug> narrows BOTH the close status and the lint scope to that one
+  // project: a project-scoped DIAGNOSTIC, NOT the global compact-ready verdict
+  // (ADR 0046 caveat below). It is check-only — the marker writers stay global so
+  // the marker == compact-ready invariant holds (ADR 0047). When narrowed, the
+  // transcript widening is suppressed: a transcript touch in some OTHER project
+  // would re-add that project's files to the lint scope and re-block the scoped
+  // check, defeating the point. The global (no --project) check keeps widening.
+  if (args.project) requireProjectDir(args, args.project);
   const status = precompactGateStatus(args.hypoDir, {
-    ...(args.transcriptPath ? { transcriptPath: args.transcriptPath } : {}),
+    ...(args.project
+      ? { projectOverride: args.project }
+      : args.transcriptPath
+        ? { transcriptPath: args.transcriptPath }
+        : {}),
     ...(args.sessionId ? { sessionId: args.sessionId } : {}),
   });
   const close = status.close;
@@ -199,9 +245,18 @@ function runSessionCloseCheck(args) {
   // while /compact's Stop still blocks — the exact incoherence this ADR closes
   // (codex pre-commit CONCERN). readSessionClosedMarker unlinks an invalid
   // marker as it reads, matching the hook's behavior on the next Stop.
-  const markerPresent = args.sessionId
-    ? readSessionClosedMarker(args.hypoDir, args.sessionId) !== null
-    : null;
+  const markerObj = args.sessionId ? readSessionClosedMarker(args.hypoDir, args.sessionId) : null;
+  const markerPresent = args.sessionId ? markerObj !== null : null;
+
+  // Scope of this check (codex design review finding 2 — the scope must be
+  // explicit in JSON + prose, not implied). `global` = the full PreCompact mirror
+  // (green ⇒ compact-ready). `project` = narrowed to --project=<slug> (green ⇒
+  // only THAT project is close-complete, NOT global compact-readiness). When a
+  // log-only marker governs the session, the gate runs in log-only mode and the
+  // --project override is IGNORED — surface that rather than implying X was
+  // checked (it was not).
+  const logOnlyWon = args.project != null && markerObj?.scope === 'log-only';
+  const scope = args.project ? (logOnlyWon ? 'log-only' : 'project') : 'global';
 
   if (args.json) {
     console.log(
@@ -216,6 +271,14 @@ function runSessionCloseCheck(args) {
           blockers: status.blockers,
           notices: status.notices,
           skipped: status.skipped,
+          // scope is additive; `global` keeps prior semantics for existing readers
+          scope,
+          ...(args.project
+            ? {
+                scoped_project: args.project,
+                ...(logOnlyWon ? { project_override_ignored: true } : {}),
+              }
+            : {}),
           ...(args.sessionId ? { session_id: args.sessionId, marker_present: markerPresent } : {}),
         },
         null,
@@ -225,8 +288,20 @@ function runSessionCloseCheck(args) {
     process.exit(status.ok ? 0 : 1);
   }
 
+  if (logOnlyWon) {
+    console.log(
+      `Note: a log-only session-closed marker governs session ${args.sessionId}, so the gate ran in log-only mode and --project=${args.project} was IGNORED (no project was checked).\n`,
+    );
+  } else if (scope === 'project') {
+    console.log(
+      `Note: --project=${args.project} — this is a PROJECT-SCOPED diagnostic, not the global /compact gate. A green result means only ${args.project} is close-complete; another project can still block /compact.\n`,
+    );
+  }
+
   const proj = close.project || '(unresolved)';
-  console.log(`Compact-ready check (project: ${proj}, date: ${close.dates.join(' / ')}):\n`);
+  console.log(
+    `Compact-ready check (${scope === 'global' ? `project: ${proj}` : `scope: ${scope}, project: ${proj}`}, date: ${close.dates.join(' / ')}):\n`,
+  );
 
   const required = close.project
     ? [
@@ -266,11 +341,21 @@ function runSessionCloseCheck(args) {
     );
   }
   console.log('');
-  console.log(
-    status.ok
-      ? '✓ Compact-ready — no PreCompact gate blocker needs a human fix. (open-questions.md: conditional, not checked. The live /compact can still differ on a context-≥70% prompt, HYPO_SKIP_GATE, or a transcript-scoped lint error this check did not see — pass --transcript-path to include the latter.)'
-      : '✗ Not compact-ready — resolve the ✗ items above, then retry. /compact would block on these.',
-  );
+  if (scope === 'project') {
+    // Project-scoped diagnostic: green means ONLY this project is close-complete.
+    // Do NOT claim global compact-readiness (the whole point of the narrow).
+    console.log(
+      status.ok
+        ? `✓ ${args.project} is close-complete (project-scoped). This is NOT a global /compact guarantee — run \`--check-session-close\` without --project for that.`
+        : `✗ ${args.project} is not close-complete — resolve the ✗ items above.`,
+    );
+  } else {
+    console.log(
+      status.ok
+        ? '✓ Compact-ready — no PreCompact gate blocker needs a human fix. (open-questions.md: conditional, not checked. The live /compact can still differ on a context-≥70% prompt, HYPO_SKIP_GATE, or a transcript-scoped lint error this check did not see — pass --transcript-path to include the latter.)'
+        : '✗ Not compact-ready — resolve the ✗ items above, then retry. /compact would block on these.',
+    );
+  }
   process.exit(status.ok ? 0 : 1);
 }
 
@@ -420,6 +505,14 @@ function runMarkSessionClosed(args) {
     console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
     process.exit(1);
   }
+  // --project=<slug> on --mark is ATTRIBUTION ONLY (the marker's `project` field).
+  // The gate stays GLOBAL — never narrowed — because a marker that narrowed its
+  // gate could attest compact-ready while PreCompact re-checks all of today's
+  // projects and stays red (the marker == compact-ready invariant, ADR 0047 /
+  // codex design finding 1/2). Validate the attribution slug exists as a
+  // directory, exactly as --check does, but only when it is actually used (a
+  // --log-only mark attributes to no project, so --project is moot there).
+  if (args.project && !args.logOnly) requireProjectDir(args, args.project);
   // ADR 0047: the per-session marker is the THIRD session-close completion
   // signal (after the PreCompact gate and `--check-session-close`). It must use
   // the SAME gate that governs /compact — precompactGateStatus — so the marker
@@ -485,8 +578,12 @@ function runMarkSessionClosed(args) {
     console.log(args.json ? JSON.stringify(result, null, 2) : `✗ ${reason}`);
     process.exit(1);
   }
+  // --project attributes the marker to that slug (gate stayed global); falls back
+  // to the gate's resolved primary. log-only marks attribute to no project. Used
+  // for the marker, the JSON result, and the success message so all three agree.
+  const markerProject = !args.logOnly && args.project ? args.project : status.project;
   writeSessionClosedMarker(args.hypoDir, args.sessionId, {
-    project: status.project,
+    project: markerProject,
     ...(args.logOnly ? { scope: 'log-only' } : {}),
   });
   // Marker writer swallows IO errors (best-effort, see hypo-shared.mjs). Verify
@@ -505,7 +602,7 @@ function runMarkSessionClosed(args) {
   const result = {
     ok: true,
     session_id: args.sessionId,
-    project: status.project,
+    project: markerProject,
     scope: args.logOnly ? 'log-only' : 'project',
     date: status.dates[0],
     notices: gate.notices,
@@ -521,7 +618,7 @@ function runMarkSessionClosed(args) {
     console.log(
       args.logOnly
         ? `✓ session-closed marker written (session_id: ${args.sessionId}, scope: log-only — no project attribution).`
-        : `✓ session-closed marker written (session_id: ${args.sessionId}, project: ${status.project}).`,
+        : `✓ session-closed marker written (session_id: ${args.sessionId}, project: ${markerProject}).`,
     );
     if (gate.driftTargets.length > 0) {
       console.log(

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -76,6 +76,13 @@ reports and re-run until it prints **"Compact-ready"** — that is the signal th
 session is closed. A close-files-only pass is not enough; the real `/compact`
 also blocks on those other checks.
 
+Optional `--project=<slug>` narrows the check to ONE project (close status plus
+lint scope). It is a project-scoped **diagnostic**, not the compact-ready
+signal. A green `--project` result (JSON `scope: "project"`) means only that
+project is close-complete; another today-active project can still block
+`/compact`. Use the plain `--check-session-close` (no `--project`) for the
+go/no-go close signal.
+
 **When using `--apply-session-close --session-id=<id>`** (the payload-driven
 path), the `--session-id` must be the main conversation's session id. Do NOT
 extract it from a background task or Agent output path (e.g., a UUID from

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -95,7 +95,10 @@ Ask: *"이 작업이 마무리되었나요? 세션을 정리(crystallize)할까�
    guarantee: the live gate can still differ on a context-≥70% prompt,
    `HYPO_SKIP_GATE`, or a transcript-scoped lint error — pass `--transcript-path`
    to include the last.) Pass `--session-id=<id>` to also see `marker_present`
-   (step 7).
+   (step 7). `--project=<slug>` narrows the check to one project (a scoped
+   diagnostic, JSON `scope: "project"`): green there means only that slug is
+   close-complete, **not** that `/compact` is globally unblocked. Use the plain
+   check for the go/no-go signal.
 7. Record the session-closed marker (ADR 0047). The Stop hook blocks until this
    session's per-session marker exists, and a hand-edit close (writing the files
    directly + committing) never writes it; the marker is written only by the

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -875,6 +875,7 @@ const {
   extractTouchedWikiFiles,
   closeFileTargets,
   closeFileTargetsGlobal,
+  closeFileTargetsForProject,
   sessionCloseGlobalStatus,
   deriveRootLogEntries,
   partitionLintScope,
@@ -10611,6 +10612,211 @@ test('regression (ADR 0050): once a daily shard carries today, IT (not the month
       !scope.has(`projects/alpha/session-log/${ym}.md`),
       'the monthly file is no longer the evidence, so it is out of scope (its stale debt does not block)',
     );
+  });
+});
+
+// ── B-3 T2: --project=<slug> override (close-gate-hardening) ──────────────────
+suite('--project=<slug> override (B-3 T2: scoped check + global-gate mark attribution)');
+
+// projectOverride narrows the close status to ONE project, bypassing recency /
+// today-active discovery. Key invariant: a scoped-green status must NOT imply
+// global compact-readiness (the contract caveat behind the redesign).
+test('sessionCloseGlobalStatus(projectOverride): scoped-green while global is red', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha fully closed today; beta today-active but with a dangling session-state.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      { slug: 'beta', date: today, sessionState: '2020-01-01' },
+    ]);
+    assert.equal(sessionCloseGlobalStatus(dir).ok, false, 'global blocks on beta');
+    const a = sessionCloseGlobalStatus(dir, { projectOverride: 'alpha' });
+    assert.equal(a.ok, true, 'scoped to alpha → green even though beta is dangling');
+    assert.deepEqual(
+      a.projects.map((p) => p.project),
+      ['alpha'],
+      'only alpha reported',
+    );
+    assert.equal(a.project, 'alpha');
+    assert.equal(a.fallback, false);
+    assert.equal(
+      sessionCloseGlobalStatus(dir, { projectOverride: 'beta' }).ok,
+      false,
+      'scoped to beta → red (its own files are stale)',
+    );
+  });
+});
+
+test('sessionCloseGlobalStatus(projectOverride): overrides the recency pick, not just the top hot row', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha is the recency/top row but stale + no today activity; beta is closed.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: '2020-01-01' },
+      { slug: 'beta', date: today },
+    ]);
+    const s = sessionCloseGlobalStatus(dir, { projectOverride: 'alpha' });
+    assert.equal(s.project, 'alpha', 'override picks alpha regardless of activity');
+    assert.equal(s.ok, false, 'alpha is stale → red');
+  });
+});
+
+test('closeFileTargetsForProject: root baseline + that project only', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      { slug: 'beta', date: today },
+    ]);
+    const t = closeFileTargetsForProject(dir, 'alpha');
+    assert.ok(t.has('hot.md') && t.has('log.md'), 'root files in scope');
+    assert.ok(
+      t.has('projects/alpha/session-state.md') && t.has('projects/alpha/hot.md'),
+      'alpha files in scope',
+    );
+    assert.ok(
+      [...t].some((f) => /^projects\/alpha\/session-log\//.test(f)),
+      'alpha session-log in scope',
+    );
+    assert.ok(![...t].some((f) => f.includes('projects/beta/')), 'beta files NOT in scope');
+  });
+});
+
+// codex design finding 1 regression: the closeFileTargetsGlobal refactor MUST keep
+// the recency fallback when no project closed today. Dropping it to a root-only
+// scope would make lint narrower than the close status — a false-pass reopener.
+test('closeFileTargetsGlobal: no today-active project → recency-fallback files still in scope (not root-only)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // nobody closed today (all old dates); alpha is the recency project.
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: '2020-01-01', hotRow: '2020-01-01' }]);
+    const scope = closeFileTargetsGlobal(dir);
+    assert.ok(scope.has('hot.md') && scope.has('log.md'), 'root baseline present');
+    assert.ok(
+      scope.has('projects/alpha/session-state.md') && scope.has('projects/alpha/hot.md'),
+      `recency fallback must keep alpha's files in scope, got ${JSON.stringify([...scope])}`,
+    );
+  });
+});
+
+suite('crystallize.mjs --project= override (B-3 T2 CLI)');
+
+test('--check-session-close --project=<traversal> → exit 1 (syntax rejected in parseArgs)', () => {
+  withTmpDir((dir) => {
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--project=../etc',
+      '--json',
+    ]);
+    assert.equal(r.status, 1, r.stdout);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.match(out.error, /not a valid project name/);
+  });
+});
+
+test('--check-session-close --project=<absent> → exit 1 (does not exist as a directory)', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'projects'), { recursive: true }); // valid syntax, no ghost dir
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--project=ghost',
+      '--json',
+    ]);
+    assert.equal(r.status, 1, r.stdout);
+    assert.match(JSON.parse(r.stdout).error, /does not exist as a directory/);
+  });
+});
+
+test('--check-session-close --project=<real>: JSON carries scope:project + scoped_project', () => {
+  withCleanWiki((dir) => {
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--project=test-project',
+      '--json',
+    ]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.scope, 'project', `scope must be project: ${r.stdout}`);
+    assert.equal(out.scoped_project, 'test-project');
+    assert.equal(out.ok, true, 'test-project is fully closed → scoped green');
+  });
+});
+
+test('--check-session-close (no --project): JSON scope is global, no scoped_project', () => {
+  withCleanWiki((dir) => {
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.scope, 'global');
+    assert.ok(!('scoped_project' in out), 'no scoped_project on the global path');
+  });
+});
+
+test('--mark-session-closed --project=<absent> → exit 1 before the gate (existence check)', () => {
+  withCleanWiki((dir) => {
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--mark-session-closed',
+      '--session-id=s-ghost',
+      '--project=ghost',
+      '--json',
+    ]);
+    assert.equal(r.status, 1, r.stdout);
+    assert.match(JSON.parse(r.stdout).error, /does not exist as a directory/);
+  });
+});
+
+test('--mark-session-closed --project=<real>: global gate passes + marker attributed to the slug', () => {
+  withCleanWiki((dir) => {
+    const cleanup = seedCloseTranscript('s-attr');
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--mark-session-closed',
+      '--session-id=s-attr',
+      '--project=test-project',
+      '--json',
+    ]);
+    cleanup();
+    assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.equal(out.project, 'test-project', 'result attributed to --project slug');
+    const marker = JSON.parse(
+      readFileSync(join(dir, '.cache', 'session-closed-s-attr.marker'), 'utf-8'),
+    );
+    assert.equal(marker.project, 'test-project', 'marker carries the attribution slug');
+  });
+});
+
+// log-only marker governs the session → log-only mode wins and --project is
+// IGNORED (no project is checked). The JSON must say so, not imply X was checked.
+test('--check-session-close --project=<X> with a log-only marker → scope:log-only, override ignored', () => {
+  withCleanWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'session-closed-s-logonly.marker'),
+      JSON.stringify({
+        session_id: 's-logonly',
+        project: null,
+        scope: 'log-only',
+        transcript_path: null,
+        closed_at: new Date().toISOString(),
+        verification: 'log-only-close:ok',
+      }) + '\n',
+    );
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--project=test-project',
+      '--session-id=s-logonly',
+      '--json',
+    ]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.scope, 'log-only', `log-only marker must win: ${r.stdout}`);
+    assert.equal(out.scoped_project, 'test-project');
+    assert.equal(out.project_override_ignored, true);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

Adds a `--project=<slug>` override to `crystallize --check-session-close` and `--mark-session-closed`.

- `--check-session-close --project=<slug>` narrows the gate to one project (both the close status and the lint scope). It is a project-scoped diagnostic. A green result (JSON `scope: "project"`) means only that project is close-complete, not that `/compact` is globally unblocked.
- `--mark-session-closed --project=<slug>` keeps a global gate; `--project` only sets the marker's attribution slug.
- The slug is validated with the shared `isValidProjectName` (rejects traversal) and must resolve to a real `projects/<slug>/` directory.
- A log-only marker still wins: the check reports `scope: "log-only"` with `project_override_ignored: true` rather than implying the project was checked.

## Why

Session-close picks the target project by recency. When you close a secondary project (not the most recently active one), recency resolves the wrong project, so `--check`/`--mark` report against a project you are not closing. T1 (#148) already removed the same-date-tie data-loss path in apply; this adds the explicit override for the check/mark diagnostic paths so you can ask "is project X close-complete?" directly.

## How

`projectOverride` is threaded as a check-only option. `sessionCloseGlobalStatus(hypoDir, {projectOverride})` bypasses recency discovery and reports a single project in the global return shape. The lint scope reuses a new `closeFileTargetsForProject(hypoDir, slug)`, and `closeFileTargetsGlobal` is refactored on top of it while keeping its recency fallback (so the lint scope never narrows below the close status). `precompactGateStatus` threads `projectOverride` into both, and W8 design-history narrows automatically because it derives from `close.projects`.

The load-bearing invariant (marker == compact-ready, ADR 0047) is preserved: `projectOverride` is passed only by `runSessionCloseCheck` (which writes no marker). The marker writers (`--mark`, the apply auto-marker), the PreCompact hook, and the auto-minimal hook all keep a global gate.

## Manual verification

`hooks/hypo-shared.mjs` changed, so beyond the suite I exercised the new paths through the real CLI in the test harness:

```
npm test            # 946 passed, 0 failed (includes new scoped-check / mark-attribution / log-only / recency-fallback cases)
npm run check:versions check:bilingual check:readme smoke:plugin smoke-pack check:tracker-ids   # all pass
```

`npm run lint` reports only pre-existing errors in the maintainer's local vault (`pages/`, `journal/`), unrelated to this diff; CI lint runs against the repo fixtures and is clean.

Stage-1 (design) and stage-2 (diff) codex cross-review both run: design returned CONCERN (3 items, all folded in: recency-fallback preservation, JSON/docs scope surfacing, directory existence check), diff returned CLEAR.

## Migration notes

None. `--project` is opt-in; without it every path behaves exactly as before.

---

# 한국어

## 변경 내용

`crystallize --check-session-close`와 `--mark-session-closed`에 `--project=<slug>` 오버라이드를 추가합니다.

- `--check-session-close --project=<slug>`는 게이트를 한 프로젝트로 좁힙니다(close 상태 + lint scope 둘 다). 프로젝트 범위 진단입니다. green 결과(JSON `scope: "project"`)는 그 프로젝트만 close 완료라는 뜻이지, `/compact`가 전역으로 풀렸다는 보장이 아닙니다.
- `--mark-session-closed --project=<slug>`는 게이트를 전역으로 유지합니다. `--project`은 마커의 attribution slug만 정합니다.
- slug는 공유 `isValidProjectName`으로 검증하고(traversal 차단), 실제 `projects/<slug>/` 디렉터리가 있어야 합니다.
- log-only 마커는 여전히 우선합니다. 체크는 프로젝트를 검사한 것처럼 굴지 않고 `scope: "log-only"` + `project_override_ignored: true`로 보고합니다.

## 이유

세션 close는 대상 프로젝트를 recency로 고릅니다. 가장 최근 활동 프로젝트가 아닌 보조 프로젝트를 닫을 때 recency가 엉뚱한 프로젝트를 잡아서, `--check`/`--mark`가 닫으려는 프로젝트가 아닌 곳을 기준으로 보고합니다. T1(#148)이 apply의 same-date 동점 데이터 유실은 이미 막았고, 이 PR은 check/mark 진단 경로에 명시적 오버라이드를 더해 "프로젝트 X가 close 완료인가?"를 직접 물을 수 있게 합니다.

## 방법

`projectOverride`를 check 전용 옵션으로 배선합니다. `sessionCloseGlobalStatus(hypoDir, {projectOverride})`는 recency 탐색을 우회해 전역 반환 shape 그대로 단일 프로젝트를 보고합니다. lint scope는 새 `closeFileTargetsForProject(hypoDir, slug)`를 쓰고, `closeFileTargetsGlobal`은 그 위로 리팩터하되 recency 폴백을 유지합니다(그래서 lint scope가 close 상태보다 좁아지지 않음). `precompactGateStatus`가 둘 다에 `projectOverride`를 전달하고, W8 design-history는 `close.projects`에서 파생되므로 자동으로 좁혀집니다.

load-bearing 불변식(marker == compact-ready, ADR 0047)은 유지됩니다. `projectOverride`는 마커를 쓰지 않는 `runSessionCloseCheck`에서만 전달됩니다. 마커 라이터(`--mark`, apply 자동 마커), PreCompact 훅, auto-minimal 훅은 모두 전역 게이트를 유지합니다.

## 수동 검증

`hooks/hypo-shared.mjs`를 바꿨으므로 테스트 스위트 외에 실제 CLI로 새 경로를 돌렸습니다.

```
npm test            # 946 passed, 0 failed (scoped-check / mark-attribution / log-only / recency-fallback 신규 케이스 포함)
npm run check:versions check:bilingual check:readme smoke:plugin smoke-pack check:tracker-ids   # 전부 통과
```

`npm run lint`은 메인테이너 로컬 볼트(`pages/`, `journal/`)의 기존 에러만 보고하며 이 diff와 무관합니다. CI lint는 레포 fixture 기준이라 clean입니다.

codex 2단계 교차검토를 모두 수행했습니다. 설계 단계 CONCERN(3건: recency 폴백 유지, JSON/docs scope 노출, 디렉터리 존재 검사) 전부 반영, diff 단계 CLEAR.

## 마이그레이션 노트

None. `--project`은 opt-in이고, 없으면 모든 경로가 이전과 동일하게 동작합니다.

---

## Changelog

- EN: `crystallize --check-session-close --project=<slug>` scopes the close check to one project, and `--mark-session-closed --project=<slug>` sets the marker attribution (#150).
- KO: `crystallize --check-session-close --project=<slug>`로 close 체크를 한 프로젝트로 좁히고, `--mark-session-closed --project=<slug>`로 마커 attribution을 지정합니다 (#150).

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally (only pre-existing maintainer-vault errors; CI clean)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
