### PR TITLE
fix(close): disk-gate ghost slugs and derive root log.md per-close (B-1)

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -10,6 +10,7 @@ import {
   readFileSync,
   writeFileSync,
   existsSync,
+  statSync,
   appendFileSync,
   mkdirSync,
   rmSync,
@@ -607,7 +608,15 @@ function closeCandidateSlugs(hypoDir, dates) {
     }
     for (const d of dates) {
       const re = new RegExp('^## \\[' + escapeRegExp(d) + '\\] session \\| (\\S+)', 'gm');
-      for (const m of content.matchAll(re)) slugs.add(m[1]);
+      for (const m of content.matchAll(re)) {
+        // B-1: only real projects are close candidates. A malformed log heading
+        // (`## [d] session | hypomnema:`) or a stale slug yields a ghost token
+        // that no longer maps to a `projects/<slug>/` directory — gating on disk
+        // keeps it out of the dangling-close set. Directory (not bare-exists)
+        // mirrors the apply-path project check (crystallize.mjs:193).
+        const dir = join(projectsDir, m[1]);
+        if (existsSync(dir) && statSync(dir).isDirectory()) slugs.add(m[1]);
+      }
     }
   }
   return slugs;
@@ -771,6 +780,21 @@ function deriveLogTitle(tail) {
 }
 
 /**
+ * Build the canonical root log.md entry for ONE session-log heading. Single
+ * source of truth for the derived-entry format, shared by the global Stop-hook
+ * derive (deriveRootLogEntries) and apply's direct per-close write (B-1), so the
+ * two paths never drift on the `→ [[projects/<slug>/hot]]` pointer or spacing.
+ * `headingTail` is the text AFTER `## [date]` in the authored session-log heading.
+ * @returns {{ heading: string, block: string }} heading = the `## [date] session
+ *   | <slug>` line used for exact-line dedup; block = the full two-line entry.
+ */
+export function rootLogEntry(slug, date, headingTail) {
+  const title = deriveLogTitle(headingTail);
+  const heading = `## [${date}] session | ${slug}` + (title ? ` — ${title}` : '');
+  return { heading, block: `${heading}\n→ [[projects/${slug}/hot]]` };
+}
+
+/**
  * Append any missing root log.md `## [date] session | <slug>` entries derived from
  * each today-active project's session-log heading(s). Idempotent: dedups on the
  * exact generated heading line, so re-running (or a same-day apply that already
@@ -833,11 +857,10 @@ export function deriveRootLogEntries(hypoDir) {
       const headingRe = new RegExp('^#{1,6} \\[' + escapeRegExp(date) + '\\]\\s*(.*)$', 'gm');
       let m;
       while ((m = headingRe.exec(slog)) !== null) {
-        const title = deriveLogTitle(m[1]);
-        const heading = `## [${date}] session | ${slug}` + (title ? ` — ${title}` : '');
+        const { heading, block } = rootLogEntry(slug, date, m[1]);
         if (seenHeadings.has(heading)) continue; // exact-line dedup (log.md + queued)
         seenHeadings.add(heading);
-        additions.push(`${heading}\n→ [[projects/${slug}/hot]]`);
+        additions.push(block);
       }
     }
   }

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -42,7 +42,7 @@
  *     "projectHot":   { "content": "<full file>" },   // overwrite
  *     "rootHot":      { "content": "<full file>" },   // overwrite
  *     "sessionLog":   { "entry":   "## [date] ..." }, // append, skip if heading already present
- *     "log":          { "entry":   "## [date] session | <project> ..." }, // append, skip if entry present
+ *     "log":          { "entry":   "## [date] session | <project> ..." }, // OPTIONAL (B-1): omit it and apply derives the root log.md entry from this close's sessionLog heading; supply it only for a deliberately custom log line
  *     "openQuestions":{ "content": "<full file>" }    // optional overwrite
  *   }
  *
@@ -85,6 +85,7 @@ import {
   sessionLogShardPath,
   sessionLogReadCandidates,
   sessionLogScopePath,
+  rootLogEntry,
   resolveTranscriptBySessionId,
   hasUserCloseSignal,
   commitWikiChanges,
@@ -444,18 +445,19 @@ function todayLocal() {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
-// Spec §5.2.7 / §8.3 + ADR 0029: 5 mandatory + 1 conditional. The payload
-// shape MUST mirror that contract — missing a mandatory field is a payload
-// bug, not a no-op. Caller is the LLM session-close flow, which composes the
-// payload deliberately; partial payloads must fail loudly so caller fixes them
-// rather than silently relying on yesterday's freshness state. (Codex review
-// of the apply path — Worker 1 finding 1.)
+// Spec §5.2.7 / §8.3 + ADR 0029: 4 mandatory + 2 optional (`log`, `openQuestions`).
+// The payload shape MUST mirror that contract — missing a mandatory field is a
+// payload bug, not a no-op. Caller is the LLM session-close flow, which composes
+// the payload deliberately; partial payloads must fail loudly so caller fixes
+// them rather than silently relying on yesterday's freshness state. (Codex review
+// of the apply path — Worker 1 finding 1.) `log` left the mandatory set in B-1:
+// the root log.md entry is a DERIVABLE artifact (rootLogEntry over this close's
+// sessionLog heading), so apply auto-fills it when the field is absent.
 const REQUIRED_PAYLOAD_FIELDS = [
   ['sessionState', 'content'],
   ['projectHot', 'content'],
   ['rootHot', 'content'],
   ['sessionLog', 'entry'],
-  ['log', 'entry'],
 ];
 
 function validatePayloadShape(payload) {
@@ -481,6 +483,11 @@ function validatePayloadShape(payload) {
       typeof payload.openQuestions.content !== 'string'
     ) {
       errs.push('payload.openQuestions, when present, must be { content: string }');
+    }
+  }
+  if (payload.log !== undefined) {
+    if (!payload.log || typeof payload.log !== 'object' || typeof payload.log.entry !== 'string') {
+      errs.push('payload.log, when present, must be { entry: string }');
     }
   }
   if (payload.date !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(String(payload.date))) {
@@ -740,6 +747,23 @@ function applySessionClose(args) {
   }
   const date = payload.date || todayLocal();
 
+  // B-1 derive precondition: when `log` is omitted, apply reconstructs the root
+  // log.md entry from THIS close's sessionLog heading. If sessionLog.entry has no
+  // `## [<date>] …` heading there is nothing to derive — and on a same-day SECOND
+  // close the date-level freshness verifier would still pass on the earlier
+  // close's entry, so the no-write would slip through as ok:true. Fail loud here,
+  // before any writes (codex pre-commit review).
+  if (
+    !payload.log &&
+    !new RegExp(`^#{1,6} \\[${date}\\]`, 'm').test(payload.sessionLog.entry || '')
+  ) {
+    const msg =
+      `payload.sessionLog.entry has no "## [${date}] …" heading to derive the log.md ` +
+      `entry from. Give it a dated heading, or supply payload.log explicitly.`;
+    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+    process.exit(1);
+  }
+
   // Preflight: lint the wiki BEFORE writing any payload bytes. If lint
   // has blockers (errors) in files this apply WON'T overwrite, the wiki is in
   // a degraded state and apply would mask the root cause — abort fail-fast.
@@ -902,13 +926,43 @@ function applySessionClose(args) {
     }
   }
 
-  {
+  // log.md: `payload.log` is OPTIONAL (B-1). When the caller supplies it, keep
+  // the explicit appendIfAbsent path (backward-compat: a custom log line, with
+  // the same idempotent dedup). When it is ABSENT, the root log.md entry is a
+  // DERIVABLE artifact: reconstruct the canonical `## [date] session | <project>`
+  // line directly from THIS close's session-log heading (`payload.sessionLog`),
+  // not by re-reading the session-log files. Deriving from the payload is what
+  // makes the per-close entry exact: a same-day second close lands its distinct
+  // heading, and a hybrid daily/monthly session-log split can't hide it (apply
+  // never reads those files for this). The global scan-based deriveRootLogEntries
+  // (the Stop hook) still backfills OTHER projects; calling it here would either
+  // miss the current entry (single-candidate read) or, with a loosened guard,
+  // append onto a deliberately custom payload.log (codex pre-commit review). The
+  // two payload paths are mutually exclusive: deriving on top of a present-but-
+  // malformed payload.log would mask it and weaken the verifier's fail-loud.
+  if (payload.log) {
     const wrote = appendIfAbsent(
       join(args.hypoDir, 'log.md'),
       payload.log.entry,
       entryAlreadyPresent(payload.log.entry),
     );
     (wrote ? applied : skipped).push('log (log.md)');
+  } else {
+    // matchAll (not exec) mirrors deriveRootLogEntries: a payload that carried
+    // more than one dated heading derives one canonical line each, symmetric with
+    // the global path. Exact-line dedup on the heading keeps a second apply (or a
+    // titleless vs titled same-day pair) from duplicating.
+    const logFull = join(args.hypoDir, 'log.md');
+    const headingRe = new RegExp(`^#{1,6} \\[${date}\\]\\s*(.*)$`, 'gm');
+    let wroteAny = false;
+    for (const m of (payload.sessionLog.entry || '').matchAll(headingRe)) {
+      const { heading, block } = rootLogEntry(project, date, m[1]);
+      const wrote = appendIfAbsent(logFull, block, (c) =>
+        (c || '').split(/\r?\n/).includes(heading),
+      );
+      wroteAny = wroteAny || wrote;
+    }
+    (wroteAny ? applied : skipped).push('log (log.md, derived)');
   }
 
   // Same-date-tie fix: verify against the SAME project this apply just wrote

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -61,7 +61,8 @@ When uncertain, surface the question rather than skip it. None of the four block
 3. **hot.md (root)** — update `<wiki-root>/hot.md` active-projects pointer table: set the `Last Session` date for this project to today.
 4. **session-log** — append a session entry to `projects/<name>/session-log/YYYY-MM-DD.md` (daily shard; the apply path creates today's file with seeded frontmatter if it does not exist yet).
 5. **open-questions** — only if `pages/open-questions.md` exists and questions were raised or resolved this session: move resolved ones out; add newly raised ones. Skip if unchanged.
-6. **log.md** — append a `session` entry to `<wiki-root>/log.md`.
+
+> Do **not** hand-write the root `log.md` session entry, and do **not** put a `log` field in the apply payload. The `## [date] session | <project>` entry is a derivable artifact: `--apply-session-close` calls `deriveRootLogEntries` after writing the session-log, reconstructing the canonical line from the session-log heading. (Supply `log` only for a deliberately custom line; it is now an optional payload field.)
 
 After completing the checklist, verify it before reporting:
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -2857,6 +2857,128 @@ test('payload schema: invalid date format → exit 1', () => {
   });
 });
 
+// ── B-1: payload.log optional + apply auto-derives the root log.md entry ──────
+test('B-1: apply without payload.log auto-derives the canonical log.md entry (exit 0)', () => {
+  withWiki(
+    (dir) => {
+      // Pre-apply: log.md carries NO fresh test-project entry, so the absent-log
+      // path must reconstruct it via deriveRootLogEntries (not fail the gate).
+      writeFileSync(join(dir, 'log.md'), `## [2020-01-01] session | old-project\n`);
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      delete payload.log; // optional field omitted (B-1)
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, true, `apply must pass with log derived: ${r.stdout}`);
+      const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+      assert.match(
+        log,
+        new RegExp(`^## \\[${today}\\] session \\| test-project`, 'm'),
+        'apply must auto-derive the canonical log.md entry when payload.log is absent',
+      );
+      assert.ok(
+        out.applied.join(' ').includes('log (log.md, derived)'),
+        `derived log slot must be reported applied: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('B-1: apply WITH payload.log keeps the explicit append path (no double-write)', () => {
+  withWiki(
+    (dir) => {
+      writeFileSync(join(dir, 'log.md'), `## [2020-01-01] session | old-project\n`);
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today); // includes log
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, true);
+      const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+      // The explicit payload.log line is written once; the derive path is gated
+      // behind `!payload.log`, so it must NOT append a second canonical line.
+      const matches = (log.match(new RegExp(`\\[${today}\\] session \\| test-project`, 'g')) || [])
+        .length;
+      assert.equal(matches, 1, `exactly one test-project entry, got ${matches}:\n${log}`);
+      assert.ok(out.applied.join(' ').includes('log (log.md)'), 'explicit log slot applied');
+      assert.ok(
+        !out.applied.join(' ').includes('derived'),
+        'derive must not run alongside an explicit payload.log',
+      );
+    },
+  );
+});
+
+test('B-1: payload.log present but malformed → exit 1 (fail-loud preserved, not silently derived)', () => {
+  withWiki(
+    (dir) => {
+      writeFileSync(join(dir, 'log.md'), `## [2020-01-01] session | old-project\n`);
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      // A non-canonical log line (no `session | <project>` form). The old
+      // behavior hard-fails verification; with derive gated to the absent path,
+      // that fail-loud must survive — derive must not paper over a bad explicit
+      // entry (codex design review).
+      payload.log = { entry: `## [${today}] not a canonical session line\n` };
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 1, `malformed explicit log must fail loud: ${r.stdout}`);
+    },
+  );
+});
+
+test('B-1: absent payload.log + sessionLog with no dated heading → exit 1 (no silent no-write)', () => {
+  withWiki(
+    (dir, today) => {
+      // An earlier same-day close already satisfies date-level freshness, so the
+      // post-apply verifier alone would NOT catch a current close that derives
+      // nothing. The pre-write guard must fail loud instead of skipping silently.
+      writeFileSync(join(dir, 'log.md'), `## [${today}] session | test-project — first\n`);
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      payload.sessionLog = { entry: `no dated heading here\n` };
+      delete payload.log;
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 1, `must fail loud when nothing is derivable: ${r.stdout}`);
+      assert.match(
+        JSON.stringify(JSON.parse(r.stdout)),
+        /heading to derive the log\.md/,
+        `error must name the un-derivable sessionLog heading: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('B-1: same-day second close without payload.log derives the distinct entry', () => {
+  withWiki(
+    (dir, today) => {
+      // A first close already left a today entry for test-project. Now that
+      // callers no longer hand-write log (SKILL/T6), the absent-log path must
+      // still recover the SECOND close's distinct heading — the derive guard is
+      // entry-level, not "log.md is wholly absent".
+      writeFileSync(join(dir, 'log.md'), `## [${today}] session | test-project — first\n`);
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      payload.sessionLog = { entry: `## [${today}] session | test-project — second\n` };
+      delete payload.log;
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+      const log = readFileSync(join(dir, 'log.md'), 'utf-8');
+      assert.match(log, /session \| test-project — first/, 'first close entry retained');
+      assert.match(
+        log,
+        /session \| test-project — second/,
+        'second same-day close must derive its own distinct root entry',
+      );
+    },
+  );
+});
+
 test('hasLogEntry: project "foo" must NOT match "foo-bar" (W2 boundary regression)', () => {
   // Pre-existing bug in sessionCloseFileStatus that the helper extraction
   // inherited. \b after "foo" matches before "-" (non-word char), so the
@@ -10903,6 +11025,83 @@ test('guard: does NOT derive when the authored close is otherwise incomplete', (
     const log = readFileSync(join(dir, 'log.md'), 'utf-8');
     assert.doesNotMatch(log, /session \| beta/, 'no beta entry derived');
     assert.equal(sessionCloseGlobalStatus(dir).ok, false, 'gate still blocks the real gap');
+  });
+});
+
+test('guard: does NOT derive when the session-log heading is the gap (T5 AC)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha is a today close candidate via its log.md entry, but its session-log
+    // carries NO today heading (stale). log.md is therefore not the SOLE gap, and
+    // there is no today heading to derive a line from — derive must return 0.
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today, sessionLog: false }]);
+    assert.equal(
+      deriveRootLogEntries(dir),
+      0,
+      'no derive while the session-log heading is missing (guard unmet)',
+    );
+    assert.equal(
+      sessionCloseGlobalStatus(dir).ok,
+      false,
+      'gate still blocks the stale session-log',
+    );
+  });
+});
+
+// ── B-1: closeCandidateSlugs disk-gates log.md slugs (ghost-slug fix) ──────────
+test('B-1: a log.md slug with no projects/<slug>/ dir is not a close candidate', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha is fully closed today; on its own the gate passes.
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today }]);
+    assert.equal(sessionCloseGlobalStatus(dir).ok, true, 'precondition: alpha alone is complete');
+    // A ghost entry (`hypomnema:` has no projects/ directory). Before the disk
+    // gate, closeCandidateSlugs unioned it in and sessionCloseFileStatus reported
+    // it all-missing → the gate false-blocked a finished session.
+    const logPath = join(dir, 'log.md');
+    writeFileSync(logPath, readFileSync(logPath, 'utf-8') + `## [${today}] session | hypomnema:\n`);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, true, 'ghost slug must not be treated as a dangling close');
+    assert.ok(
+      !s.projects.some((p) => p.project === 'hypomnema:'),
+      'ghost slug must not appear in the close-candidate set',
+    );
+  });
+});
+
+test('B-1: a log.md slug that exists as a FILE (not a directory) is excluded', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [{ slug: 'alpha', date: today }]);
+    // projects/notdir is a regular file, not a project directory.
+    writeFileSync(join(dir, 'projects', 'notdir'), 'x');
+    const logPath = join(dir, 'log.md');
+    writeFileSync(logPath, readFileSync(logPath, 'utf-8') + `## [${today}] session | notdir\n`);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, true, 'a file (not directory) slug must not gate a close');
+    assert.ok(
+      !s.projects.some((p) => p.project === 'notdir'),
+      'file slug excluded from candidates',
+    );
+  });
+});
+
+test('B-1: a real project dir keeps its log.md slug as a close candidate (disk gate keeps reals)', () => {
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    // alpha fully closed; beta has a today log.md entry + real dir but is
+    // INCOMPLETE (no session-state). The disk gate must still include beta so
+    // the gate keeps blocking — the fix excludes ghosts, not real directories.
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today },
+      { slug: 'beta', date: today, sessionState: false },
+    ]);
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, false, 'beta is an incomplete real close → gate blocks');
+    assert.ok(
+      s.projects.some((p) => p.project === 'beta'),
+      'real-dir slug stays a candidate',
+    );
   });
 });
 


### PR DESCRIPTION
# English

## What changed

B-1 of close-gate-hardening: retire the hand-written root `log.md` entry and stop ghost slugs from blocking a finished close.

- T4: `closeCandidateSlugs` disk-gates the slug it pulls from a `## [date] session | <slug>` log.md heading (`existsSync` + `statSync().isDirectory()`). A malformed or stale heading (e.g. `hypomnema:`, or a renamed/removed project) no longer becomes a dangling-close candidate.
- T5: `payload.log` is now optional. When omitted, apply derives this close's `log.md` entry directly from its `sessionLog` heading via a new shared `rootLogEntry()` helper, and fails loud if that heading is missing. When supplied, the explicit append path is unchanged.
- T6: the crystallize SKILL no longer tells the model to hand-write the `log.md` entry; the payload omits `log`.

## Why

Two failure modes the close gate had:

1. A ghost slug in `log.md` (a malformed heading, or a project that was renamed/deleted) was treated as an incomplete same-day close and false-blocked `/compact`, even when the real project was fully closed.
2. The `log.md` entry was the last derivable artifact still hand-written. A close that skipped or mis-wrote it left the gate hard-blocking, and a stale step in a checklist is easy to miss.

## How

Deriving the entry from `payload.sessionLog.entry` (not by re-reading session-log files) is what makes it per-close exact: a same-day second close lands its distinct heading, and a hybrid daily/monthly session-log split cannot hide it. The global `deriveRootLogEntries` (the Stop hook) keeps its strict "log.md is the sole gap" guard, so a project closed with a deliberately custom `payload.log` is never given an extra derived line. `rootLogEntry()` is the single source of truth for the two-line entry format, shared by both paths.

## Manual verification

- `npm test`: 955 passed (+8 B-1 cases). New tests cover: apply without `log` derives the entry; apply with `log` keeps the explicit path with no double-write; a present-but-malformed `log` still fails loud; a same-day second close without `log` derives its distinct entry; an absent-`log` close whose sessionLog has no dated heading fails loud (verified it fails without the new guard); ghost slug and file-not-directory slug excluded; a real-dir slug stays a candidate; the session-log-gap derive guard.
- `deriveRootLogEntries` refactor onto `rootLogEntry()` confirmed byte-identical via the existing derive suite and the `hypo-hot-rebuild` Stop-hook end-to-end test.
- `npm run lint`: clean for every file this PR touches. The 20 pre-existing errors are unrelated maintainer-vault content (unknown tags / missing frontmatter in `pages/` and other `projects/*`), which B-4 addresses; CI lints a clean fixture and is green.

## Migration notes

None for installs. Payload authors may drop the `log` field; existing payloads that still send it keep working.

---

# 한국어

## 변경 내용

close-gate-hardening의 B-1: 루트 `log.md` 엔트리 수기 작성을 폐기하고, 유령 slug가 끝난 close를 막지 못하게 한다.

- T4: `closeCandidateSlugs`가 `## [date] session | <slug>` log.md heading에서 뽑은 slug를 디스크로 게이트한다(`existsSync` + `statSync().isDirectory()`). malformed/stale heading(예: `hypomnema:`, 또는 이름 변경·삭제된 프로젝트)은 더는 dangling-close 후보가 되지 않는다.
- T5: `payload.log`를 선택 필드로 바꿨다. 생략하면 apply가 이 close의 `sessionLog` heading에서 새 공용 헬퍼 `rootLogEntry()`로 `log.md` 엔트리를 직접 파생하고, heading이 없으면 fail-loud한다. 제공하면 기존 append 경로 그대로다.
- T6: crystallize SKILL이 `log.md` 엔트리 수기 작성을 더는 지시하지 않는다. payload에서 `log`를 뺀다.

## 이유

close 게이트의 두 가지 실패 모드:

1. `log.md`의 유령 slug(malformed heading, 또는 이름 변경·삭제된 프로젝트)가 미완료 same-day close로 취급돼, 실제 프로젝트가 완전히 닫혔는데도 `/compact`를 false-block 했다.
2. `log.md` 엔트리는 아직 수기로 쓰는 마지막 파생 산출물이었다. 이걸 건너뛰거나 잘못 쓴 close는 게이트가 계속 막았고, 체크리스트의 stale 단계는 놓치기 쉽다.

## 방법

`payload.sessionLog.entry`에서 파생(세션 로그 파일을 다시 읽지 않음)하는 게 per-close exact의 핵심이다. 같은 날 두 번째 close가 자기 distinct heading을 남기고, daily/monthly hybrid 분할도 이를 숨기지 못한다. 글로벌 `deriveRootLogEntries`(Stop 훅)는 "log.md가 유일한 갭"이라는 엄격한 가드를 유지하므로, 의도적으로 custom `payload.log`로 닫은 프로젝트에 파생 라인이 덧붙지 않는다. `rootLogEntry()`는 2줄 엔트리 포맷의 single source of truth로 두 경로가 공유한다.

## 수동 검증

- `npm test`: 955 passed (B-1 8건 추가). 신규 테스트: `log` 없이 apply가 엔트리 파생; `log` 있을 때 기존 경로 유지·이중 기입 없음; present-but-malformed `log`는 fail-loud; `log` 없는 same-day 두 번째 close가 distinct 엔트리 파생; sessionLog에 dated heading 없는 absent-`log` close는 fail-loud(가드 제거 시 실패 확인); 유령 slug·파일(비디렉터리) slug 제외; 실재 디렉터리 slug는 후보 유지; session-log-gap 파생 가드.
- `deriveRootLogEntries`를 `rootLogEntry()`로 리팩터한 결과가 byte-identical임을 기존 derive 스위트와 `hypo-hot-rebuild` Stop 훅 end-to-end 테스트로 확인.
- `npm run lint`: 이 PR이 건드린 모든 파일은 클린. 기존 20개 error는 무관한 메인테이너 볼트 콘텐츠(`pages/`·기타 `projects/*`의 unknown tag·frontmatter 누락)로 B-4가 다루며, CI는 클린 픽스처를 lint해 green이다.

## 마이그레이션 노트

설치 측 변경 없음. payload 작성자는 `log` 필드를 생략해도 되고, 계속 보내는 기존 payload도 동작한다.

---

## Changelog

- EN: Session close no longer needs a hand-written `log.md` entry (it is derived from the session-log heading), and a malformed or stale `log.md` slug no longer false-blocks a finished close.
- KO: 세션 close가 `log.md` 엔트리를 수기로 쓸 필요가 없어졌고(세션 로그 heading에서 파생), malformed/stale `log.md` slug가 끝난 close를 더는 false-block 하지 않는다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally (for the files this PR touches; pre-existing vault-content errors are unrelated, CI is green)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (SKILL.md)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
