### PR TITLE
fix(close): demote unknown-tag to warn (W10) and auto-register pending tags

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -74,6 +74,7 @@ import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
 import { collectPagesCrystallize, extractWikilinks } from './lib/wikilink.mjs';
 import { isValidProjectName } from './lib/project-create.mjs';
+import { appendPendingTags, checkForbidden } from './lib/schema-vocab.mjs';
 import {
   sessionCloseFileStatus,
   sessionCloseGlobalStatus,
@@ -971,6 +972,29 @@ function applySessionClose(args) {
   // on a same-date root-hot.md tie, can pick a different project — false-failing
   // a completed close (the 2026-06-09 security-ops-kb incident).
   const verification = sessionCloseFileStatus(args.hypoDir, { projectOverride: project });
+
+  // B-4 auto-register: lift unknown (non-forbidden) tags surfaced by the PREFLIGHT
+  // lint into SCHEMA.md's `### Pending` section so the post-apply lint sees them as
+  // known and the close never stalls on a vocabulary gap. The W10 id is hidden in
+  // non-strict --json output (lint.mjs toOut), so the unknown-tag warns are matched
+  // and the tag extracted from the message string itself — kept in lockstep with
+  // lint.mjs's W10 emit (a copy-edit there breaks this; the close-path round-trip
+  // test guards it). Forbidden patterns stay hard errors and are filtered out.
+  // SCOPE (eventual consistency, intended): this registers PRE-EXISTING wiki debt
+  // visible at preflight, NOT a novel tag this very close's payload introduces —
+  // that one would surface only at post-apply and lands on the NEXT close. The
+  // contract is "must not stall", which warns (not errors) already satisfy; the
+  // registration just keeps the vocabulary catching up.
+  // The capture is anchored on the FULL message suffix (not `[^"]+`) so a tag that
+  // itself contains a `"` — non-forbidden, so reachable — is captured whole rather
+  // than truncated at its first quote (codex stage-2 CONCERN).
+  const unknownTagRe = /^Unknown tag: "(.+)" \(not in SCHEMA\.md Tag Vocabulary\)/;
+  const pendingTags = [];
+  for (const w of preflightLint.warns || []) {
+    const m = unknownTagRe.exec(w.message || '');
+    if (m && !checkForbidden(m[1])) pendingTags.push(m[1]);
+  }
+  if (pendingTags.length > 0) appendPendingTags(args.hypoDir, pendingTags);
 
   // Post-apply lint: payload may have introduced a malformed body or
   // bad frontmatter. Surface as a distinct `stage` so caller can tell "lint

--- a/scripts/lib/schema-vocab.mjs
+++ b/scripts/lib/schema-vocab.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 const VOCAB_HEADER_RE = /^##\s+(?:\d+\.\s+)?Tag\s+(?:Vocabulary|Taxonomy)\s*$/m;
@@ -64,6 +64,110 @@ export function parseSchemaVocab(hypoDir) {
     for (const token of vocabLineTokens(rawLine)) vocab.add(token);
   }
   return vocab;
+}
+
+// Prose seeded into a freshly-created `### Pending` block. It carries NO
+// backtick tokens, so parseSchemaVocab's vocabLineTokens never mistakes it for a
+// vocabulary line — only the `**Pending**:` data line below it contributes tags.
+const PENDING_HEADING = '### Pending (auto-registered)';
+const PENDING_PROSE =
+  'Tags auto-registered by a crystallize close because they were not yet in the ' +
+  'vocabulary above. Review periodically: promote each into a category and delete ' +
+  'it here, or drop the tag from the page.';
+const PENDING_HEADING_RE = /^###[ \t]+Pending\b.*$/im; // prefix/word match
+const PENDING_DATA_RE = /^\*\*Pending[^*]*\*\*:.*$/im;
+const NEXT_H3_RE = /^###[ \t]+/m;
+const FORBIDDEN_HEADING_RE = /^###[ \t]+Forbidden\b/im;
+
+function backtickList(tags) {
+  return tags.map((t) => `\`${t}\``).join(', ');
+}
+
+// Auto-register unknown (non-forbidden) tags into the vault SCHEMA.md `### Pending`
+// section so a close never stalls on a vocabulary gap and the next lint sees them
+// as known (B-4). Pending lives INSIDE the "## Tag Vocabulary" H2 section because
+// parseSchemaVocab is H2-bounded — placing it elsewhere would not widen the vocab.
+// No-ops (returns []) when SCHEMA.md or the Tag Vocabulary header is absent, when
+// every tag is already in the vocabulary, or when a tag is forbidden — registering
+// a forbidden pattern is pointless (lint errors on it before the vocab check) and
+// would only pollute Pending. Idempotent: re-running with the same tags writes
+// nothing (they are already in the parsed vocabulary on the second call).
+export function appendPendingTags(hypoDir, tags) {
+  const path = join(hypoDir, 'SCHEMA.md');
+  if (!existsSync(path)) return [];
+  const content = readFileSync(path, 'utf-8');
+
+  const headerMatch = VOCAB_HEADER_RE.exec(content);
+  if (!headerMatch) return [];
+
+  const current = parseSchemaVocab(hypoDir);
+  const seen = new Set();
+  const newTags = [];
+  for (const raw of tags || []) {
+    const t = typeof raw === 'string' ? raw.trim() : '';
+    // A literal backtick cannot be serialized inside the backtick-delimited
+    // `**Pending**:` line — it would close the token early and make
+    // parseSchemaVocab mis-tokenize (or blank) the whole line, taking valid
+    // sibling tags down with it (codex stage-2 CONCERN). Skip it: the tag stays a
+    // non-blocking unknown-tag warn the author can rename. (A `"` is safe — it
+    // round-trips between backticks — so only the backtick is rejected.)
+    if (!t || t.includes('`') || seen.has(t) || current.has(t) || checkForbidden(t)) continue;
+    seen.add(t);
+    newTags.push(t);
+  }
+  if (newTags.length === 0) return [];
+
+  const sectionStart = headerMatch.index + headerMatch[0].length;
+  const rest = content.slice(sectionStart);
+  const nextH2 = NEXT_H2_RE.exec(rest);
+  const sectionEnd = nextH2 ? sectionStart + nextH2.index : content.length;
+  const section = content.slice(sectionStart, sectionEnd);
+
+  let newSection;
+  const heading = PENDING_HEADING_RE.exec(section);
+  if (heading) {
+    // Pending subsection exists — bound it (heading → next H3 or section end) and
+    // either extend its `**Pending**:` data line or seed one if the block is empty
+    // (the template ships heading + prose with no tags yet).
+    const subStart = heading.index;
+    const after = section.slice(heading.index + heading[0].length);
+    const nextH3 = NEXT_H3_RE.exec(after);
+    const subEnd = nextH3 ? heading.index + heading[0].length + nextH3.index : section.length;
+    const sub = section.slice(subStart, subEnd);
+
+    const dataMatch = PENDING_DATA_RE.exec(sub);
+    let newSub;
+    if (dataMatch) {
+      const existing = [];
+      for (const m of dataMatch[0].matchAll(BACKTICK_TOKEN_RE)) {
+        const t = m[1].trim();
+        if (t && !t.includes(' ')) existing.push(t);
+      }
+      const merged = [...existing, ...newTags];
+      const dataLine = `**Pending**: ${backtickList(merged)}`;
+      newSub =
+        sub.slice(0, dataMatch.index) + dataLine + sub.slice(dataMatch.index + dataMatch[0].length);
+    } else {
+      const dataLine = `**Pending**: ${backtickList(newTags)}`;
+      newSub = `${sub.replace(/\s*$/, '')}\n\n${dataLine}\n`;
+    }
+    newSection = section.slice(0, subStart) + newSub + section.slice(subEnd);
+  } else {
+    // No Pending block yet — build one and place it before "### Forbidden patterns"
+    // if present (Pending is vocabulary; Forbidden is a separate concern), else at
+    // the end of the Tag Vocabulary section.
+    const block = `${PENDING_HEADING}\n\n${PENDING_PROSE}\n\n**Pending**: ${backtickList(newTags)}\n`;
+    const forbidden = FORBIDDEN_HEADING_RE.exec(section);
+    if (forbidden) {
+      newSection =
+        section.slice(0, forbidden.index) + `${block}\n` + section.slice(forbidden.index);
+    } else {
+      newSection = `${section.replace(/\s*$/, '')}\n\n${block}\n`;
+    }
+  }
+
+  writeFileSync(path, content.slice(0, sectionStart) + newSection + content.slice(sectionEnd));
+  return newTags;
 }
 
 // Derive the set of valid immediate subdirectories under pages/ from the

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -426,7 +426,15 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs, validTypes) {
         continue;
       }
       if (!tagVocab.has(tag)) {
-        issue('error', rel, `Unknown tag: "${tag}" (not in SCHEMA.md Tag Vocabulary)`);
+        // W10 (B-4): an unknown but non-forbidden tag is a WARNING, not a hard
+        // error — a session close must never stall on a vocabulary gap. The
+        // crystallize apply path parses these warns (by this exact message
+        // string — load-bearing, see scripts/crystallize.mjs auto-register block)
+        // and registers them into SCHEMA.md's `### Pending` section, so the next
+        // lint sees them as known. W10 is intentionally NOT in STRICT_PROMOTE_IDS:
+        // an unregistered tag is a vocabulary lag, not a content defect, so even
+        // `--strict` keeps it a warning (it only surfaces the id in --json output).
+        issue('warn', rel, `Unknown tag: "${tag}" (not in SCHEMA.md Tag Vocabulary)`, null, 'W10');
       }
     }
   }

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -154,9 +154,11 @@ Edit the feedback page only — never hand-edit the generated
 
 ## 4. Tag Vocabulary
 
-Use lowercase, hyphenated tags. Vocabulary is locked — `lint` blocks unknown tags
-and forbidden patterns (PascalCase, plurals, whitespace, generic words).
-Extend this list (and `~/hypomnema/SCHEMA.md`) before introducing a new tag.
+Use lowercase, hyphenated tags. `lint` hard-blocks forbidden patterns (PascalCase,
+plurals, whitespace, generic words); an unknown but well-formed tag is a warning,
+and a session close auto-registers it into the `### Pending` section below so the
+next lint accepts it. Promote a pending tag into a category here (and in
+`~/hypomnema/SCHEMA.md`) once it has settled.
 
 **Meta**: `wiki`, `index`, `pages`, `home`, `overview`, `guide`, `operations`, `schema`, `reference`, `hypo`, `commands`, `hot-cache`, `migration`
 **Workflow**: `automation`, `hooks`, `observability`, `autonomy`, `wiki-health`, `weekly`
@@ -164,6 +166,12 @@ Extend this list (and `~/hypomnema/SCHEMA.md`) before introducing a new tag.
 **Domain**: `ai`, `dev`, `ops`, `security`, `data`, `design`, `management`
 **Status**: `active`, `completed`, `archived`, `draft`, `stable`, `deprecated`, `needs-review`, `proposed`, `superseded`
 **Content classification**: `learning`, `tip`, `feedback`, `gotcha`, `concept`, `pattern`
+
+### Pending (auto-registered)
+
+Tags auto-registered by a crystallize close because they were not yet in the
+vocabulary above. Review periodically: promote each into a category and delete it
+here, or drop the tag from the page.
 
 ### Forbidden patterns
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -30,7 +30,7 @@ import { fileURLToPath } from 'node:url';
 import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync.mjs';
 import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
 import { buildProjectSuggestionLine, resolveActiveProject } from '../hooks/hypo-shared.mjs';
-import { parseSchemaVocab } from '../scripts/lib/schema-vocab.mjs';
+import { parseSchemaVocab, appendPendingTags } from '../scripts/lib/schema-vocab.mjs';
 import { parseFrontmatter as libParseFrontmatter } from '../scripts/lib/frontmatter.mjs';
 import { isHypomnemaPluginEnabled } from '../scripts/lib/plugin-detect.mjs';
 import {
@@ -7297,15 +7297,19 @@ test('generic tag (todo) → error', () => {
   assert.ok(out.errors.some((e) => e.message.includes('Forbidden tag pattern (generic)')));
 });
 
-test('unknown tag (not in vocab) → error', () => {
+test('unknown tag (not in vocab) → W10 warn, not error (B-4)', () => {
   const { r, out } = lintWithSchema(
     'pages/x.md',
     '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [zzz-unknown]\n---\nbody\n',
   );
-  assert.equal(r.status, 1);
+  assert.equal(r.status, 0, `unknown tag must be a warning, not an error: ${r.stdout}`);
   assert.ok(
-    out.errors.some((e) => e.message.includes('Unknown tag: "zzz-unknown"')),
-    `expected unknown tag error: ${r.stdout}`,
+    out.warns.some((w) => w.message.includes('Unknown tag: "zzz-unknown"')),
+    `expected unknown tag warn: ${r.stdout}`,
+  );
+  assert.ok(
+    !out.errors.some((e) => e.message.includes('Unknown tag')),
+    `unknown tag must not be a hard error: ${r.stdout}`,
   );
 });
 
@@ -7335,9 +7339,12 @@ test('vocab parser excludes prose backticks and Forbidden table examples', () =>
     '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [lint]\n---\nbody\n',
     schema,
   );
-  assert.equal(r.status, 1, `expected error for prose-only tag, got ${r.status}`);
+  // Post B-4 the prose-only tag is an unknown-tag WARNING (not an error), but the
+  // point stands: the parser must not have admitted the prose `lint` token into
+  // the vocabulary, so `lint` is still flagged as unknown.
+  assert.equal(r.status, 0, `prose-only tag is now a warning, got ${r.status}: ${r.stdout}`);
   assert.ok(
-    out.errors.some((e) => e.message.includes('Unknown tag: "lint"')),
+    out.warns.some((w) => w.message.includes('Unknown tag: "lint"')),
     `parser leaked prose token "lint" into vocab: ${r.stdout}`,
   );
 });
@@ -7353,6 +7360,147 @@ test('vocab check skipped when SCHEMA.md absent (back-compat)', () => {
   const r = run('lint.mjs', [`--hypo-dir=${dir}`, '--json']);
   rmSync(dir, { recursive: true, force: true });
   assert.equal(r.status, 0, `expected green when SCHEMA.md missing, got ${r.status}: ${r.stdout}`);
+});
+
+// ── B-4: unknown-tag warn (W10) + SCHEMA Pending auto-registration ──────────────
+
+suite('B-4 — unknown-tag warn + auto-register');
+
+test('B-4: unknown tag stays a warning under --strict (W10 not promoted), id exposed', () => {
+  const { r, out } = lintStrict(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [zzz-unknown]\n---\nbody\n',
+  );
+  assert.equal(r.status, 0, `W10 must NOT promote to error under --strict: ${r.stdout}`);
+  assert.ok(
+    out.warns.some((w) => w.id === 'W10' && /Unknown tag: "zzz-unknown"/.test(w.message)),
+    `W10 id must surface in --strict --json: ${r.stdout}`,
+  );
+  assert.ok(
+    !out.errors.some((e) => /Unknown tag/.test(e.message)),
+    `W10 wrongly promoted to error: ${r.stdout}`,
+  );
+});
+
+test('B-4: forbidden tag stays a hard error (not demoted to a warn)', () => {
+  const { r, out } = lintWithSchema(
+    'pages/x.md',
+    '---\ntitle: T\ntype: concept\nupdated: 2026-05-18\ntags: [Jenkins]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1, `forbidden tag must still be an error: ${r.stdout}`);
+  assert.ok(out.errors.some((e) => e.message.includes('Forbidden tag pattern (PascalCase)')));
+});
+
+test('B-4: appendPendingTags round-trips into parseSchemaVocab and is idempotent', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-pending-'));
+  try {
+    writeFileSync(join(dir, 'SCHEMA.md'), VOCAB_SCHEMA);
+    assert.ok(!parseSchemaVocab(dir).has('new-tag-a'), 'precondition: tag absent');
+    const added = appendPendingTags(dir, ['new-tag-a', 'new-tag-b']);
+    assert.deepEqual([...added].sort(), ['new-tag-a', 'new-tag-b']);
+    const vocab = parseSchemaVocab(dir);
+    assert.ok(vocab.has('new-tag-a') && vocab.has('new-tag-b'), 'pending tags not in vocab');
+    assert.ok(vocab.has('wiki') && vocab.has('concept'), 'existing vocab clobbered');
+    // idempotent: a second register of the same tags writes nothing new
+    assert.equal(appendPendingTags(dir, ['new-tag-a', 'new-tag-b']).length, 0, 'not idempotent');
+    // forbidden patterns are filtered out (registering them is pointless)
+    assert.equal(appendPendingTags(dir, ['BadTag']).length, 0, 'forbidden tag registered');
+    assert.ok(!parseSchemaVocab(dir).has('BadTag'), 'forbidden tag leaked into vocab');
+    // edge tags (codex stage-2): a `"` is non-forbidden and must round-trip; a
+    // backtick can't be serialized and is skipped WITHOUT corrupting siblings.
+    assert.deepEqual(appendPendingTags(dir, ['has"quote']), ['has"quote']);
+    assert.ok(parseSchemaVocab(dir).has('has"quote'), 'quote tag did not round-trip');
+    assert.equal(appendPendingTags(dir, ['bad`tick']).length, 0, 'backtick tag must be skipped');
+    assert.ok(!parseSchemaVocab(dir).has('bad`tick'), 'backtick tag leaked into vocab');
+    assert.ok(parseSchemaVocab(dir).has('new-tag-a'), 'sibling tag lost after edge-case calls');
+    // no-op when SCHEMA.md has no Tag Vocabulary header
+    const dir2 = mkdtempSync(join(tmpdir(), 'hypo-pending-novocab-'));
+    writeFileSync(
+      join(dir2, 'SCHEMA.md'),
+      '---\ntitle: S\ntype: schema\n---\n# Schema\n\n## 1. Other\n',
+    );
+    assert.equal(appendPendingTags(dir2, ['x']).length, 0, 'must no-op without a vocab header');
+    rmSync(dir2, { recursive: true, force: true });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('B-4: appendPendingTags fills a pre-existing empty Pending block (template shape)', () => {
+  // Mirrors the templates/SCHEMA.md shape: an empty `### Pending` (heading +
+  // prose, no data line) sitting before `### Forbidden patterns`. The helper must
+  // seed the data line inside that block, not create a second one.
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-pending-empty-'));
+  try {
+    writeFileSync(
+      join(dir, 'SCHEMA.md'),
+      '---\ntitle: S\ntype: schema\n---\n# Schema\n\n## 4. Tag Vocabulary\n\n' +
+        '**Meta**: `wiki`\n\n### Pending (auto-registered)\n\nAuto-registered tags land here.\n\n' +
+        '### Forbidden patterns\n\n| Pattern | Reason |\n|---|---|\n| PascalCase (`Jenkins`) | x |\n\n## 5. Next\n',
+    );
+    assert.deepEqual(appendPendingTags(dir, ['fresh-tag']), ['fresh-tag']);
+    const vocab = parseSchemaVocab(dir);
+    assert.ok(vocab.has('fresh-tag'), 'tag not added to empty Pending block');
+    assert.ok(vocab.has('wiki'), 'existing vocab lost');
+    assert.ok(!vocab.has('Jenkins'), 'Forbidden table example token leaked into vocab');
+    // exactly one Pending data line (no duplicate block created)
+    const data = readFileSync(join(dir, 'SCHEMA.md'), 'utf-8').match(/^\*\*Pending\b/gm) || [];
+    assert.equal(data.length, 1, 'expected exactly one **Pending** data line');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('B-4: apply-session-close auto-registers a preflight unknown tag; re-lint clean', () => {
+  withWiki(
+    (dir) => {
+      // A SCHEMA with a vocab section (no Pending block yet) + a page carrying an
+      // unknown but well-formed tag → preflight surfaces a W10 warn for it. The
+      // page is OUTSIDE the close payload, so it models PRE-EXISTING wiki debt:
+      // the apply path registers it (eventual consistency), not this close's own
+      // payload tags. Forbidden patterns would stay errors and never reach here.
+      writeFileSync(
+        join(dir, 'SCHEMA.md'),
+        '---\ntitle: SCHEMA\ntype: schema\n---\n# Schema\n\n## 4. Tag Vocabulary\n\n' +
+          '**Meta**: `wiki`, `concept`\n\n## 5. Next\n',
+      );
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      writeFileSync(
+        join(dir, 'pages', 'note.md'),
+        '---\ntitle: N\ntype: concept\nupdated: 2026-06-27\ntags: [brand-new-tag]\n---\nbody\n',
+      );
+      // A second page whose tag contains a `"` — non-forbidden, so it reaches the
+      // auto-register path. Proves the message parse captures the WHOLE tag rather
+      // than truncating at the embedded quote (codex stage-2 fix), end to end.
+      writeFileSync(
+        join(dir, 'pages', 'note2.md'),
+        "---\ntitle: N2\ntype: concept\nupdated: 2026-06-27\ntags: ['weird\"tag']\n---\nbody\n",
+      );
+    },
+    (dir, today) => {
+      assert.ok(!parseSchemaVocab(dir).has('brand-new-tag'), 'precondition: tag unknown');
+      const r = runApply(dir, payloadForCleanWiki(dir, today));
+      assert.equal(r.status, 0, `apply must not stall on a vocab gap: ${r.stdout}\n${r.stderr}`);
+      const vocab = parseSchemaVocab(dir);
+      assert.ok(
+        vocab.has('brand-new-tag'),
+        'unknown tag was not auto-registered into SCHEMA Pending',
+      );
+      assert.ok(vocab.has('weird"tag'), 'quote-containing tag truncated, not registered whole');
+      // Drive REAL lint (not just the round-trip helper): neither registered tag
+      // warns — proves the message-string parse and the SCHEMA write agree.
+      const lr = run('lint.mjs', [`--hypo-dir=${dir}`, '--json']);
+      const lout = JSON.parse(lr.stdout);
+      assert.ok(
+        !lout.warns.some((w) => /Unknown tag: "brand-new-tag"/.test(w.message)),
+        `re-lint still warns on the registered tag: ${lr.stdout}`,
+      );
+      assert.ok(
+        !lout.warns.some((w) => /Unknown tag: "weird"tag"/.test(w.message)),
+        `re-lint still warns on the quote tag: ${lr.stdout}`,
+      );
+    },
+  );
 });
 
 // ── lint.mjs pages/ directory whitelist (B6 — SCHEMA dir typo guard) ─────────


### PR DESCRIPTION
# English

## What changed

A session close no longer stalls on an unregistered tag. An unknown but well-formed tag is now a lint warning (`W10`) instead of a hard error, and `crystallize --apply-session-close` auto-registers it into the SCHEMA `### Pending` section so the next lint accepts it. Forbidden patterns (PascalCase, plurals, whitespace, generic words) stay hard errors.

## Why

Before this change, a single unknown tag anywhere in the vault made `lint` exit 1, which blocked the close gate and the `npm publish` dry run. A vocabulary lag is not a content defect, so it should not be able to halt a finished session.

## How

- `lint.mjs`: the unknown-tag branch emits `issue('warn', ..., 'W10')`. `W10` is deliberately left out of `STRICT_PROMOTE_IDS`, so even `--strict` keeps it a warning (it only surfaces the id in `--json`).
- `lib/schema-vocab.mjs`: new `appendPendingTags(hypoDir, tags)` writes unknown non-forbidden tags into a `### Pending` block inside the `## Tag Vocabulary` H2 (so `parseSchemaVocab`, which is H2-bounded, picks them up). Idempotent; no-ops when SCHEMA.md or the vocab header is absent.
- `crystallize.mjs`: between the payload writes and the post-apply lint, the preflight `W10` warns are parsed and registered. This is eventual-consistency by design: it registers pre-existing wiki debt visible at preflight, not a tag this close's own payload introduces (that one lands on the next close).
- `templates/SCHEMA.md`: ships an empty `### Pending` block; the stale "vocabulary is locked / lint blocks unknown tags" prose is corrected to match the new behavior.

Two reachable edge tags are handled (caught in cross-review): a tag containing `"` is captured whole by anchoring the message regex on the full suffix, and a tag containing a backtick is skipped (it cannot be serialized inside the backtick-delimited Pending line).

## Manual verification

- `node tests/runner.mjs` → 960 passed, 0 failed (4 new B-4 tests + 1 empty-Pending test; 2 prior unknown-tag-error tests flipped to warn semantics).
- All CI gates green: `check:versions`, `check:bilingual`, `check:readme`, `smoke:plugin`, `smoke-pack`, `check:tracker-ids`.
- Probe: a page with `tags: ['weird"tag']` → apply → SCHEMA Pending holds `weird"tag` whole; re-lint emits no unknown-tag warn.
- Note for local reviewers: `npm run lint` may exit 1 locally because `resolveHypoRoot` points at your real `~/hypomnema` vault; those errors are pre-existing vault content debt (missing frontmatter, invalid `prd` status), unrelated to this diff. CI lints a clean tree (the repo has no `pages/projects/journal`) and is green.

## Migration notes

None. Existing vaults gain a `### Pending` section the first time a close registers a tag; the section is plain SCHEMA prose with no upgrade step.

---

# 한국어

## 변경 내용

세션 close가 미등록 태그에서 더는 멈추지 않습니다. 형식은 맞지만 어휘에 없는 태그는 이제 hard error가 아니라 lint 경고(`W10`)이고, `crystallize --apply-session-close`가 그 태그를 SCHEMA `### Pending` 섹션에 자동 등록해 다음 lint가 받아들입니다. 금지 패턴(PascalCase, 복수형, 공백, 일반어)은 hard error로 남습니다.

## 이유

이전에는 볼트 어딘가의 미등록 태그 하나가 `lint`를 exit 1로 만들어 close 게이트와 `npm publish` dry run을 막았습니다. 어휘가 뒤따라오지 못한 것은 content 결함이 아니므로, 끝난 세션을 멈출 이유가 없습니다.

## 방법

- `lint.mjs`: 미등록 태그 분기가 `issue('warn', ..., 'W10')`을 냅니다. `W10`은 `STRICT_PROMOTE_IDS`에 일부러 넣지 않아 `--strict`에서도 경고로 남습니다(`--json`에 id만 노출).
- `lib/schema-vocab.mjs`: 신규 `appendPendingTags(hypoDir, tags)`가 미등록 비금지 태그를 `## Tag Vocabulary` H2 안의 `### Pending` 블록에 씁니다(H2 범위로 읽는 `parseSchemaVocab`가 인식). 멱등이고, SCHEMA.md나 어휘 헤더가 없으면 no-op입니다.
- `crystallize.mjs`: 페이로드 쓰기와 post-apply lint 사이에서 preflight `W10` 경고를 파싱해 등록합니다. 설계상 eventual consistency입니다. preflight에 보이는 기존 볼트 부채를 등록하지, 이 close의 페이로드가 새로 만든 태그를 등록하지 않습니다(그건 다음 close에서 잡힘).
- `templates/SCHEMA.md`: 빈 `### Pending` 블록을 제공하고, "vocabulary is locked / lint blocks unknown tags"라는 낡은 문구를 새 동작에 맞게 고쳤습니다.

도달 가능한 엣지 태그 두 개를 처리했습니다(교차 검토에서 발견): `"`를 포함한 태그는 메시지 정규식을 전체 suffix에 앵커링해 통째로 잡고, 백틱을 포함한 태그는 건너뜁니다(백틱으로 구분되는 Pending 라인 안에 직렬화할 수 없음).

## 수동 검증

- `node tests/runner.mjs` → 960 passed, 0 failed (신규 B-4 테스트 4 + empty-Pending 1; 기존 unknown-tag-error 테스트 2개를 warn 의미로 전환).
- CI 게이트 전부 green: `check:versions`, `check:bilingual`, `check:readme`, `smoke:plugin`, `smoke-pack`, `check:tracker-ids`.
- Probe: `tags: ['weird"tag']` 페이지 → apply → SCHEMA Pending에 `weird"tag` 통째로 등록, 재lint에서 unknown-tag 경고 없음.
- 로컬 검토자 주의: `npm run lint`가 로컬에서 exit 1일 수 있습니다. `resolveHypoRoot`가 실제 `~/hypomnema` 볼트를 가리키기 때문이고, 그 에러들은 이 diff와 무관한 기존 볼트 content 부채(frontmatter 누락, `prd` status 무효)입니다. CI는 clean 트리(repo에 `pages/projects/journal` 없음)를 lint해 green입니다.

## 마이그레이션 노트

None. 기존 볼트는 close가 처음 태그를 등록할 때 `### Pending` 섹션이 생깁니다. 일반 SCHEMA 산문이라 업그레이드 단계가 없습니다.

---

## Changelog

- EN: Session close no longer stalls on an unregistered tag: an unknown but well-formed tag is a lint warning (W10) and is auto-registered into the SCHEMA Pending section, while forbidden patterns stay hard errors
- KO: 세션 close가 미등록 태그에서 멈추지 않습니다: 형식은 맞지만 어휘에 없는 태그는 lint 경고(W10)이자 SCHEMA Pending에 자동 등록되고, 금지 패턴은 hard error로 남습니다

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally (on a clean tree; see Manual verification for the local real-vault caveat)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (SCHEMA template prose corrected)
- [x] Filled the `## Changelog` block above (EN + KO line)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
