### PR TITLE
fix(close): emit runnable node CLI for session-close recovery, not bare crystallize bin

### DIFF
--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -59,21 +59,33 @@ function emitContinue() {
 }
 
 function emitBlock(sessionId, transcriptPath, gate = null) {
-  // One-line, skill-first. /hypo:crystallize is the documented session-close
-  // alias; passing --session-id there writes the per-session marker that clears
-  // this block. CLI fallback + bypass live in commands/crystallize.md, not here
-  // — keep the Stop reason terse so the actionable instruction stands out.
-  // Surface the transcript path so the close can pass --transcript-path=<path>,
-  // which scopes the marker's lint gate to this session's own files (Bug A
-  // coherence: a marker written without lint would only let Stop pass for
-  // /compact to immediately re-block on the same errors).
-  const transcriptHint = transcriptPath ? ` --transcript-path=${transcriptPath}` : '';
-  const markCmd = `crystallize --mark-session-closed --session-id=${sessionId}${transcriptHint}`;
+  // One-line recovery action. The gate-precise branches below name an EXACT
+  // command so "only the marker is missing" stays a one-shot fix — but that
+  // command must be a runnable `node <pkg>/scripts/crystallize.mjs` invocation,
+  // never a bare `crystallize` (a package.json `bin` that is NOT on PATH in a
+  // plugin install → `command not found`). When PKG_ROOT is
+  // unresolved we cannot build that path, so fall back to the /hypo:crystallize
+  // skill, which resolves its own package root (the same alias the generic
+  // branch uses). Passing --session-id writes the per-session marker that clears
+  // this block. Surface the transcript path so the close can pass
+  // --transcript-path=<path>, which scopes the marker's lint gate to this
+  // session's own files (Bug A coherence: a marker written without lint would
+  // only let Stop pass for /compact to immediately re-block on the same errors).
+  // Quote the paths so the printed command stays copy-paste runnable even when
+  // an install/transcript path contains spaces (display text only — never exec'd
+  // here).
+  const transcriptHint = transcriptPath ? ` --transcript-path="${transcriptPath}"` : '';
+  const cliBase = PKG_ROOT ? `node "${join(PKG_ROOT, 'scripts', 'crystallize.mjs')}"` : null;
+  const markCmd = cliBase
+    ? `${cliBase} --mark-session-closed --session-id=${sessionId}${transcriptHint}`
+    : `/hypo:crystallize (session_id=${sessionId}${transcriptHint})`;
   // The log-only escape hatch for a non-project (wiki/tooling-only)
   // session. Offered ONLY as an explicit alternative when a close blocker is
   // present — never as the default recovery, so a real project session is not
   // taught to bypass the ADR 0043 close invariant (codex design Finding 3).
-  const logOnlyCmd = `crystallize --mark-session-closed --log-only --session-id=${sessionId}${transcriptHint}`;
+  const logOnlyCmd = cliBase
+    ? `${cliBase} --mark-session-closed --log-only --session-id=${sessionId}${transcriptHint}`
+    : `/hypo:crystallize --log-only (session_id=${sessionId}${transcriptHint})`;
   // ADR 0047: refine the message with the read-only /compact gate result.
   // - gate green → the close is compact-ready and ONLY the marker is missing
   //   (the hand-edit close case: files Written + committed directly, bypassing

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -92,7 +92,11 @@ import {
   commitWikiChanges,
 } from '../hooks/hypo-shared.mjs';
 
-const LINT_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'lint.mjs');
+// This script's own absolute path. Used to print copy-pasteable recovery
+// commands as `node <SELF_SCRIPT> ...` rather than a bare `crystallize` bin,
+// which is not on PATH in a Claude Code plugin install (only in an npm global).
+const SELF_SCRIPT = fileURLToPath(import.meta.url);
+const LINT_SCRIPT = join(dirname(SELF_SCRIPT), 'lint.mjs');
 
 // Spawn lint.mjs --json against `hypoDir` and return parsed result.
 // We shell out instead of refactoring lint.mjs into a library because lint.mjs
@@ -339,7 +343,7 @@ function runSessionCloseCheck(args) {
     console.log(
       markerPresent
         ? `  ✓ session-closed marker present (session_id: ${args.sessionId}).`
-        : `  · session-closed marker absent (session_id: ${args.sessionId}) — the Stop hook will block until it is written. Run \`crystallize --mark-session-closed --session-id=${args.sessionId}${args.transcriptPath ? ` --transcript-path=${args.transcriptPath}` : ''}\`.`,
+        : `  · session-closed marker absent (session_id: ${args.sessionId}) — the Stop hook will block until it is written. Run \`node "${SELF_SCRIPT}" --mark-session-closed --session-id=${args.sessionId}${args.transcriptPath ? ` --transcript-path="${args.transcriptPath}"` : ''}\`.`,
     );
   }
   console.log('');

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -12570,6 +12570,25 @@ test('--check-session-close --session-id reports marker presence without alterin
   });
 });
 
+test('--check-session-close text output: marker-absent recovery is a runnable node command, not a bare bin', () => {
+  withWiki(null, (dir) => {
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      '--session-id=s-recover',
+    ]);
+    // ISSUE-40: `crystallize` is a package.json bin not on PATH in a plugin
+    // install. The marker-absent recovery line must spell out a runnable
+    // `node <pkg>/scripts/crystallize.mjs --mark-session-closed ...`.
+    assert.ok(
+      /Run `node "\S*crystallize\.mjs" --mark-session-closed --session-id=s-recover`/.test(
+        r.stdout,
+      ),
+      `recovery command must be a runnable, path-quoted node invocation: ${r.stdout}`,
+    );
+  });
+});
+
 // ── ISSUE-10: --log-only first-class non-project close path ───────────────────
 suite('crystallize.mjs --mark-session-closed --log-only (ISSUE-10)');
 
@@ -12810,6 +12829,12 @@ test('Stop hook: close gate green but marker absent → precise "close gate gree
       `a green gate must produce the precise marker-missing message: ${out.reason}`,
     );
     assert.ok(/--mark-session-closed/.test(out.reason), 'message must give the exact mark command');
+    // ISSUE-40: the marker command must be a runnable `node <pkg>/.../crystallize.mjs`
+    // invocation, never a bare `crystallize` bin (not on PATH in a plugin install).
+    assert.ok(
+      /node "\S*crystallize\.mjs" --mark-session-closed/.test(out.reason),
+      `marker command must be a runnable, path-quoted node invocation, not a bare bin (ISSUE-40): ${out.reason}`,
+    );
     assert.ok(out.reason.includes('s-green'), 'message must embed the session_id');
   });
 });


### PR DESCRIPTION
# English

## What changed

Both session-close recovery surfaces now print a runnable `node "<pkg>/scripts/crystallize.mjs" ...` command instead of a bare `crystallize ...`:
- the Stop hook (`hypo-auto-minimal-crystallize.mjs`) gate-green / blocker / log-only branches, and
- the `--check-session-close` marker-absent line in `crystallize.mjs`.

## Why

`crystallize` is a `package.json` `bin`. It is on PATH only in an npm global install, not in a Claude Code plugin install, so following the printed recovery command produced `command not found: crystallize` and left the user unable to finish the close.

## How

The hook derives the command from `PKG_ROOT` (already imported), falling back to the `/hypo:crystallize` skill when `PKG_ROOT` is unresolved (the skill resolves its own root). `crystallize.mjs` derives it from its own `import.meta.url`. Paths are double-quoted so the command stays copy-paste runnable even with spaces (display text only, never exec'd). Two regression assertions lock the runnable form in both surfaces.

## Manual verification

```
node scripts/crystallize.mjs --hypo-dir=<tmp> --check-session-close --session-id=demo
# → ... Run `node "/abs/path/scripts/crystallize.mjs" --mark-session-closed --session-id=demo`.
```
`npm test` 961 passed, `npm run lint` clean on the changed files, `npm run check:tracker-ids` OK.

## Migration notes

None.

---

# 한국어

## 변경 내용

세션 close 복구 안내 두 곳이 이제 bare `crystallize ...` 대신 실행 가능한 `node "<pkg>/scripts/crystallize.mjs" ...` 명령을 출력합니다:
- Stop 훅(`hypo-auto-minimal-crystallize.mjs`)의 gate-green / blocker / log-only 분기,
- `crystallize.mjs`의 `--check-session-close` 마커 부재 라인.

## 이유

`crystallize`는 `package.json`의 `bin`이라 npm 글로벌 설치에서만 PATH에 걸리고 Claude Code 플러그인 설치에선 안 걸립니다. 그래서 안내된 복구 명령을 그대로 실행하면 `command not found: crystallize`가 나고 close를 끝낼 수 없었습니다.

## 방법

훅은 이미 import된 `PKG_ROOT`에서 명령을 만들고, `PKG_ROOT`가 해석 안 되면 `/hypo:crystallize` 스킬로 폴백합니다(스킬이 자기 root를 해결). `crystallize.mjs`는 자신의 `import.meta.url`에서 경로를 얻습니다. 경로에 공백이 있어도 copy-paste되도록 큰따옴표로 감쌌습니다(표시 텍스트일 뿐 실행되지 않음). 두 곳의 runnable 형태를 회귀 단언으로 고정했습니다.

## 수동 검증

```
node scripts/crystallize.mjs --hypo-dir=<tmp> --check-session-close --session-id=demo
# → ... Run `node "/abs/path/scripts/crystallize.mjs" --mark-session-closed --session-id=demo`.
```
`npm test` 961 통과, 변경 파일 `npm run lint` clean, `npm run check:tracker-ids` OK.

## 마이그레이션 노트

None.

---

## Changelog

- EN: Fix session-close recovery commands to be runnable in plugin installs (`node ".../crystallize.mjs"` instead of a bare `crystallize` bin not on PATH) (#153)
- KO: 플러그인 설치에서 세션 close 복구 명령이 실행되도록 수정 (PATH에 없는 bare `crystallize` 대신 `node ".../crystallize.mjs"`) (#153)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
