### PR TITLE
fix(resume): match cwd to project by unique basename on synced multi-machine vaults

### DIFF
--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -6,8 +6,7 @@
  * project hot.md. Skips if still within the same project subtree.
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
-import { homedir } from 'os';
+import { readFileSync, writeFileSync, existsSync, realpathSync } from 'fs';
 import { join } from 'path';
 import {
   HYPO_DIR,
@@ -19,6 +18,8 @@ import {
   buildProjectSuggestionLine,
   recordSuggestionCooldown,
   sanitizeProjForPrompt,
+  pickProjectByCwd,
+  collectProjectWorkingDirs,
 } from './hypo-shared.mjs';
 
 const PROJECTS_DIR = join(HYPO_DIR, 'projects');
@@ -33,42 +34,26 @@ function readIfNotIgnored(path, patterns) {
   return readFileSync(path, 'utf-8').slice(0, MAX_CHARS);
 }
 
-function parseFrontmatterField(content, key) {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
-  const line = match[1].split('\n').find((l) => l.startsWith(`${key}:`));
-  if (!line) return null;
-  return line
-    .slice(key.length + 1)
-    .trim()
-    .replace(/^['"]|['"]$/g, '');
-}
-
 function findProjectHot(cwd) {
   if (!existsSync(PROJECTS_DIR)) return null;
-  for (const proj of readdirSync(PROJECTS_DIR)) {
-    const projDir = join(PROJECTS_DIR, proj);
-    if (!statSync(projDir).isDirectory()) continue;
-    const indexPath = join(projDir, 'index.md');
-    if (!existsSync(indexPath)) continue;
-    const content = readFileSync(indexPath, 'utf-8');
-    const workingDir = parseFrontmatterField(content, 'working_dir');
-    if (!workingDir) continue;
-    const resolved = workingDir.startsWith('~/')
-      ? join(homedir(), workingDir.slice(2))
-      : workingDir;
-    if (cwd === resolved || cwd.startsWith(resolved + '/')) {
-      const hotPath = join(projDir, 'hot.md');
-      const statePath = join(projDir, 'session-state.md');
-      return {
-        proj,
-        hotPath: existsSync(hotPath) ? hotPath : null,
-        statePath: existsSync(statePath) ? statePath : null,
-        resolved,
-      };
-    }
+  let realpathCwd = null;
+  try {
+    realpathCwd = realpathSync(cwd);
+  } catch {
+    realpathCwd = null;
   }
-  return null;
+  // Two-tier match (absolute prefix, then cross-machine unique basename) so a
+  // vault synced from another machine still resolves the cwd to its project.
+  const proj = pickProjectByCwd(collectProjectWorkingDirs(HYPO_DIR), cwd, { realpathCwd });
+  if (!proj) return null;
+  const projDir = join(PROJECTS_DIR, proj);
+  const hotPath = join(projDir, 'hot.md');
+  const statePath = join(projDir, 'session-state.md');
+  return {
+    proj,
+    hotPath: existsSync(hotPath) ? hotPath : null,
+    statePath: existsSync(statePath) ? statePath : null,
+  };
 }
 
 let raw = '';

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -7,7 +7,7 @@
  *   MISS → inject global hot.md pointer only (no fan-out to all projects)
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, realpathSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -28,6 +28,8 @@ import {
   buildProjectSuggestionLine,
   recordSuggestionCooldown,
   sanitizeProjForPrompt,
+  pickProjectByCwd,
+  collectProjectWorkingDirs,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -256,41 +258,26 @@ const GLOBAL_HOT = join(HYPO_DIR, 'hot.md');
 const HOT_CHARS = 2000;
 const STATE_CHARS = 2000;
 
-function parseFrontmatterField(content, key) {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
-  const line = match[1].split('\n').find((l) => l.startsWith(`${key}:`));
-  if (!line) return null;
-  return line
-    .slice(key.length + 1)
-    .trim()
-    .replace(/^['"]|['"]$/g, '');
-}
-
 function findProjectFiles(cwd) {
   if (!existsSync(PROJECTS_DIR)) return null;
-  for (const proj of readdirSync(PROJECTS_DIR)) {
-    const projDir = join(PROJECTS_DIR, proj);
-    if (!statSync(projDir).isDirectory()) continue;
-    const indexPath = join(projDir, 'index.md');
-    if (!existsSync(indexPath)) continue;
-    const content = readFileSync(indexPath, 'utf-8');
-    const workingDir = parseFrontmatterField(content, 'working_dir');
-    if (!workingDir) continue;
-    const resolved = workingDir.startsWith('~/')
-      ? join(homedir(), workingDir.slice(2))
-      : workingDir;
-    if (cwd === resolved || cwd.startsWith(resolved + '/')) {
-      const hotPath = join(projDir, 'hot.md');
-      const statePath = join(projDir, 'session-state.md');
-      return {
-        proj,
-        hotPath: existsSync(hotPath) ? hotPath : null,
-        statePath: existsSync(statePath) ? statePath : null,
-      };
-    }
+  let realpathCwd = null;
+  try {
+    realpathCwd = realpathSync(cwd);
+  } catch {
+    realpathCwd = null;
   }
-  return null;
+  // Two-tier match (absolute prefix, then cross-machine unique basename) so a
+  // vault synced from another machine still resolves the cwd to its project.
+  const proj = pickProjectByCwd(collectProjectWorkingDirs(HYPO_DIR), cwd, { realpathCwd });
+  if (!proj) return null;
+  const projDir = join(PROJECTS_DIR, proj);
+  const hotPath = join(projDir, 'hot.md');
+  const statePath = join(projDir, 'session-state.md');
+  return {
+    proj,
+    hotPath: existsSync(hotPath) ? hotPath : null,
+    statePath: existsSync(statePath) ? statePath : null,
+  };
 }
 
 function extractSection(content, heading) {

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -352,27 +352,155 @@ function parseFrontmatterField(content, key) {
     .replace(/^['"]|['"]$/g, '');
 }
 
-// Among `slugs`, return the one whose projects/<slug>/index.md `working_dir`
-// is the LONGEST prefix of cwd (so /repo/sub wins over /repo). Returns null
-// when cwd is falsy or matches none. resume gives this authority OVER recency
-// (ADR 0044); close callers never pass cwd, so it stays inert for them.
+// ── cwd ↔ project matcher ────────────────────────────────────────────────────
+// Hand-synced with scripts/lib/wd-match.mjs: hooks deploy to ~/.claude/hooks/
+// without scripts/, so this cannot import the lib and must mirror it. Keep the
+// two in step; the lib carries the unit tests.
+
+// Expand a leading ~/ (or bare ~), strip trailing slashes. null for empty.
+export function normalizeWorkingDir(p) {
+  if (!p) return null;
+  let s = String(p).trim();
+  if (s === '~') s = homedir();
+  else if (s.startsWith('~/')) s = `${homedir()}/${s.slice(2)}`;
+  s = s.replace(/\/+$/, '');
+  return s || null;
+}
+
+// macOS/Windows match paths case-insensitively; Linux does not. Fold only there.
+export function isCaseInsensitiveFs(platform = process.platform) {
+  return platform === 'darwin' || platform === 'win32';
+}
+
+function _fold(s, ci) {
+  return ci ? s.toLowerCase() : s;
+}
+function _lastSeg(p) {
+  const i = p.lastIndexOf('/');
+  return i < 0 ? p : p.slice(i + 1);
+}
+
+// Resolve which project owns cwd. Tier 1: longest absolute working_dir prefix
+// (the original behavior). Tier 2 (cross-machine): when the synced vault holds
+// another machine's absolute path, a cwd ancestor whose directory name is a
+// GLOBALLY unique project basename identifies the project; a shared dirname
+// declines (null) so the caller falls back to recency. `projects` is the whole
+// universe (for the uniqueness gate); `eligible` restricts the answer.
+export function pickProjectByCwd(projects, cwd, opts = {}) {
+  const { eligible = null, realpathCwd = null, caseInsensitive = isCaseInsensitiveFs() } = opts;
+  if (!cwd && !realpathCwd) return null;
+  const eligibleSet = eligible ? new Set(eligible) : null;
+  const isEligible = (slug) => !eligibleSet || eligibleSet.has(slug);
+
+  const entries = [];
+  for (const p of projects) {
+    const path = normalizeWorkingDir(p.workingDir);
+    if (path) entries.push({ slug: p.slug, path });
+  }
+  if (entries.length === 0) return null;
+
+  // raw cwd first, realpath only as a fallback (a raw match must not be
+  // overridden by a longer realpath match).
+  const cwds = [];
+  for (const c of [cwd, realpathCwd]) {
+    const n = normalizeWorkingDir(c);
+    if (n && !cwds.includes(n)) cwds.push(n);
+  }
+
+  // Tier 1: first cwd variant with any longest-prefix match wins.
+  for (const c of cwds) {
+    const cf = _fold(c, caseInsensitive);
+    let bestSlug = null;
+    let bestLen = -1;
+    for (const e of entries) {
+      if (!isEligible(e.slug)) continue;
+      const pf = _fold(e.path, caseInsensitive);
+      if ((cf === pf || cf.startsWith(`${pf}/`)) && e.path.length > bestLen) {
+        bestLen = e.path.length;
+        bestSlug = e.slug;
+      }
+    }
+    if (bestSlug) return bestSlug;
+  }
+
+  // Tier 2: unique-basename ancestor, but only when the chain points at exactly
+  // ONE project (two distinct matches along the path → decline, fail closed).
+  const byBasename = new Map();
+  for (const e of entries) {
+    const b = _fold(_lastSeg(e.path), caseInsensitive);
+    if (!b) continue;
+    const hit = byBasename.get(b);
+    if (hit) hit.count += 1;
+    else byBasename.set(b, { slug: e.slug, count: 1 });
+  }
+
+  for (const c of cwds) {
+    const matched = new Set();
+    let cur = c;
+    while (cur && cur.includes('/')) {
+      const b = _fold(_lastSeg(cur), caseInsensitive);
+      const hit = b && byBasename.get(b);
+      if (hit && hit.count === 1 && isEligible(hit.slug)) matched.add(hit.slug);
+      cur = cur.slice(0, cur.lastIndexOf('/'));
+    }
+    if (matched.size === 1) return [...matched][0];
+  }
+  return null;
+}
+
+// Disk companion: [{slug, workingDir}] for every real project (skips _template
+// and dirs without index.md). The full set is the tier-2 uniqueness universe.
+// working_dir is cleaned exactly like scripts/lib/frontmatter.mjs parseFrontmatter
+// (strip a trailing ` # comment`, then surrounding quotes) so this stays in step
+// with the script-side collector — parseFrontmatterField alone skips the comment.
+export function collectProjectWorkingDirs(hypoDir) {
+  const projectsDir = join(hypoDir, 'projects');
+  if (!existsSync(projectsDir)) return [];
+  const out = [];
+  for (const slug of readdirSync(projectsDir)) {
+    if (slug === '_template') continue;
+    const dir = join(projectsDir, slug);
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const indexPath = join(dir, 'index.md');
+    if (!existsSync(indexPath)) continue;
+    let workingDir = null;
+    try {
+      const fm = readFileSync(indexPath, 'utf-8').match(/^---\r?\n([\s\S]*?)\r?\n---/);
+      const line = fm && fm[1].split(/\r?\n/).find((l) => /^working_dir:/.test(l));
+      if (line) {
+        workingDir = line
+          .slice('working_dir:'.length)
+          .trim()
+          .replace(/\s+#.*$/, '')
+          .replace(/^['"]|['"]$/g, '');
+      }
+    } catch {
+      workingDir = null;
+    }
+    out.push({ slug, workingDir: workingDir || null });
+  }
+  return out;
+}
+
+// resume/close entry: match `slugs` against cwd via the two-tier matcher.
+// Uniqueness is judged over EVERY project on disk, not just `slugs`. close
+// callers pass no cwd, so it stays inert for them.
 function pickByCwd(hypoDir, slugs, cwd) {
   if (!cwd) return null;
-  let best = null;
-  let bestLen = -1;
-  for (const slug of slugs) {
-    const indexPath = join(hypoDir, 'projects', slug, 'index.md');
-    if (!existsSync(indexPath)) continue;
-    const wd = parseFrontmatterField(readFileSync(indexPath, 'utf-8'), 'working_dir');
-    if (!wd) continue;
-    let resolved = wd.startsWith('~/') ? join(homedir(), wd.slice(2)) : wd;
-    resolved = resolved.replace(/\/+$/, ''); // trailing-slash normalize
-    if ((cwd === resolved || cwd.startsWith(resolved + '/')) && resolved.length > bestLen) {
-      bestLen = resolved.length;
-      best = slug;
-    }
+  let realpathCwd = null;
+  try {
+    realpathCwd = realpathSync(cwd);
+  } catch {
+    realpathCwd = null;
   }
-  return best;
+  return pickProjectByCwd(collectProjectWorkingDirs(hypoDir), cwd, {
+    eligible: slugs,
+    realpathCwd,
+  });
 }
 
 /**

--- a/scripts/lib/wd-match.mjs
+++ b/scripts/lib/wd-match.mjs
@@ -1,0 +1,181 @@
+/**
+ * scripts/lib/wd-match.mjs — shared cwd ↔ working_dir project matcher.
+ *
+ * The four readers (resume.mjs, hooks/hypo-shared.mjs, hooks/hypo-session-start.mjs,
+ * hooks/hypo-cwd-change.mjs) each used to inline the same prefix-match. This
+ * module is the single source of truth they delegate the path logic to, so the
+ * cross-machine basename fallback below is implemented (and tested) once.
+ *
+ * The cross-machine problem: a git-synced vault carries one machine's absolute
+ * working_dir to every machine, so on a second machine cwd never prefix-matches
+ * and cwd-first resume silently degrades to recency. The basename tier recovers
+ * the match WITHOUT a synced map or a writer: when the absolute prefix fails, a
+ * cwd ancestor whose directory name is a GLOBALLY unique project working_dir
+ * basename identifies the project. Unique-only, so a shared repo dirname fails
+ * closed back to recency (the original prefix-only behavior).
+ *
+ * The matcher (pickProjectByCwd) is PURE — no fs. collectProjectWorkingDirs is
+ * the disk companion that builds the project universe the matcher reasons over.
+ */
+
+import { homedir } from 'os';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { parseFrontmatter } from './frontmatter.mjs';
+
+// Expand a leading `~`/`~/`, strip trailing slashes. Mirrors the inline
+// expansion the readers did, kept here so every caller normalizes identically.
+// Returns null for empty/falsy input.
+export function normalizeWorkingDir(p) {
+  if (!p) return null;
+  let s = String(p).trim();
+  if (s === '~') s = homedir();
+  else if (s.startsWith('~/')) s = `${homedir()}/${s.slice(2)}`;
+  s = s.replace(/\/+$/, '');
+  return s || null;
+}
+
+// macOS (APFS/HFS+ default) and Windows match paths case-insensitively, so a
+// case-only difference between cwd and a recorded working_dir is the SAME dir
+// there and a genuinely different dir on Linux. Fold only on those platforms:
+// on Linux folding stays off, preserving the exact original comparison.
+export function isCaseInsensitiveFs(platform = process.platform) {
+  return platform === 'darwin' || platform === 'win32';
+}
+
+function casefold(s, ci) {
+  return ci ? s.toLowerCase() : s;
+}
+
+// Trailing path segment (basename) without importing path — paths here are
+// already normalized (no trailing slash). Returns '' for a bare root.
+function lastSegment(p) {
+  const i = p.lastIndexOf('/');
+  return i < 0 ? p : p.slice(i + 1);
+}
+
+/**
+ * Resolve which project a cwd belongs to.
+ *
+ * @param {{slug:string, workingDir:string|null|undefined}[]} projects
+ *   EVERY project with an index.md (the universe). The basename-uniqueness gate
+ *   is computed over all of them, so an unrelated project sharing a dirname
+ *   correctly disqualifies the basename tier (fail closed).
+ * @param {string} cwd  process.cwd()
+ * @param {object} [opts]
+ * @param {string[]|null} [opts.eligible]  restrict the ANSWER to these slugs
+ *   (e.g. resume's hot.md rows); uniqueness is still judged over all `projects`.
+ *   null = any project is an acceptable answer.
+ * @param {string|null} [opts.realpathCwd]  realpathSync(cwd), if the caller
+ *   resolved symlinks. Tried in addition to the raw cwd.
+ * @param {boolean} [opts.caseInsensitive]  override FS case sensitivity (tests).
+ * @returns {string|null} matched slug, or null when nothing matches.
+ */
+export function pickProjectByCwd(projects, cwd, opts = {}) {
+  const { eligible = null, realpathCwd = null, caseInsensitive = isCaseInsensitiveFs() } = opts;
+  if (!cwd && !realpathCwd) return null;
+
+  const eligibleSet = eligible ? new Set(eligible) : null;
+  const isEligible = (slug) => !eligibleSet || eligibleSet.has(slug);
+
+  // Universe of normalized (slug, path) entries with a real working_dir.
+  const entries = [];
+  for (const p of projects) {
+    const path = normalizeWorkingDir(p.workingDir);
+    if (path) entries.push({ slug: p.slug, path });
+  }
+  if (entries.length === 0) return null;
+
+  // cwd variants in PRIORITY order: raw first, realpath (symlink-resolved) only
+  // as a fallback. A raw-cwd match must not be overridden by a realpath match
+  // (preserves the original single-cwd behavior; realpath only rescues misses).
+  const cwds = [];
+  for (const c of [cwd, realpathCwd]) {
+    const n = normalizeWorkingDir(c);
+    if (n && !cwds.includes(n)) cwds.push(n);
+  }
+
+  // ── Tier 1: longest absolute prefix (the original behavior) ────────────────
+  // cwd === path or cwd under path/. Longest path wins so /repo/sub beats /repo.
+  // The FIRST cwd variant that yields any prefix match wins (raw before realpath).
+  for (const c of cwds) {
+    const cf = casefold(c, caseInsensitive);
+    let bestSlug = null;
+    let bestLen = -1;
+    for (const e of entries) {
+      if (!isEligible(e.slug)) continue;
+      const pf = casefold(e.path, caseInsensitive);
+      if ((cf === pf || cf.startsWith(`${pf}/`)) && e.path.length > bestLen) {
+        bestLen = e.path.length;
+        bestSlug = e.slug;
+      }
+    }
+    if (bestSlug) return bestSlug;
+  }
+
+  // ── Tier 2: globally-unique basename of a cwd ancestor (cross-machine) ─────
+  // Count basenames across the WHOLE universe. A basename is usable only when
+  // exactly one project carries it, so a shared dirname falls through to null.
+  const byBasename = new Map(); // folded basename -> { slug, count }
+  for (const e of entries) {
+    const b = casefold(lastSegment(e.path), caseInsensitive);
+    if (!b) continue;
+    const hit = byBasename.get(b);
+    if (hit) hit.count += 1;
+    else byBasename.set(b, { slug: e.slug, count: 1 });
+  }
+
+  // For each cwd variant (raw first), collect every ancestor whose basename is a
+  // globally-unique, eligible project basename. Use it ONLY when the whole chain
+  // points at exactly ONE project: if two different projects match along the
+  // path (e.g. cwd /x/monorepo/api with both `monorepo` and `api` registered),
+  // cwd alone can't disambiguate, so decline and let the caller fall back to
+  // recency (fail closed, no wrong-project guess).
+  for (const c of cwds) {
+    const matched = new Set();
+    let cur = c;
+    while (cur && cur.includes('/')) {
+      const b = casefold(lastSegment(cur), caseInsensitive);
+      const hit = b && byBasename.get(b);
+      if (hit && hit.count === 1 && isEligible(hit.slug)) matched.add(hit.slug);
+      cur = cur.slice(0, cur.lastIndexOf('/'));
+    }
+    if (matched.size === 1) return [...matched][0];
+  }
+  return null;
+}
+
+/**
+ * Scan projects/<slug>/index.md and return [{slug, workingDir}] for every real
+ * project. Skips `_template` and dirs without an index.md. The full set is the
+ * uniqueness universe for tier 2, so callers should pass ALL projects here even
+ * when they later restrict the answer via `opts.eligible`.
+ *
+ * @param {string} hypoDir
+ * @returns {{slug:string, workingDir:string|null}[]}
+ */
+export function collectProjectWorkingDirs(hypoDir) {
+  const projectsDir = join(hypoDir, 'projects');
+  if (!existsSync(projectsDir)) return [];
+  const out = [];
+  for (const slug of readdirSync(projectsDir)) {
+    if (slug === '_template') continue;
+    const dir = join(projectsDir, slug);
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const indexPath = join(dir, 'index.md');
+    if (!existsSync(indexPath)) continue;
+    let workingDir = null;
+    try {
+      const fm = parseFrontmatter(readFileSync(indexPath, 'utf-8'));
+      workingDir = fm?.working_dir ?? null;
+    } catch {
+      workingDir = null;
+    }
+    out.push({ slug, workingDir });
+  }
+  return out;
+}

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -26,10 +26,10 @@
  *   --json                Output as JSON
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, realpathSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+import { pickProjectByCwd, collectProjectWorkingDirs } from './lib/wd-match.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -60,27 +60,25 @@ function parseFrontmatterField(content, key) {
     .replace(/^['"]|['"]$/g, '');
 }
 
-// Among `slugs`, return the one whose projects/<slug>/index.md `working_dir`
-// is the LONGEST prefix of cwd (so /repo/sub wins over /repo). Returns null
-// when cwd is falsy or matches none. resume gives this authority OVER recency
-// (ADR 0044): a cwd↔working_dir match wins regardless of which row is newest.
+// Return the project (among `slugs`) that owns cwd: a longest-prefix
+// working_dir match, or — when no absolute path matches because the vault was
+// synced from another machine — a cwd ancestor whose directory name is a
+// globally-unique project basename. Uniqueness is judged over EVERY project on
+// disk (not just `slugs`), so a shared dirname declines and falls back to
+// recency. resume gives this authority over recency: a cwd↔project match wins
+// regardless of which hot.md row is newest.
 function pickByCwd(hypoDir, slugs, cwd) {
   if (!cwd) return null;
-  let best = null;
-  let bestLen = -1;
-  for (const slug of slugs) {
-    const indexPath = join(hypoDir, 'projects', slug, 'index.md');
-    if (!existsSync(indexPath)) continue;
-    const wd = parseFrontmatterField(readFileSync(indexPath, 'utf-8'), 'working_dir');
-    if (!wd) continue;
-    let resolved = wd.startsWith('~/') ? join(homedir(), wd.slice(2)) : wd;
-    resolved = resolved.replace(/\/+$/, ''); // trailing-slash normalize
-    if ((cwd === resolved || cwd.startsWith(resolved + '/')) && resolved.length > bestLen) {
-      bestLen = resolved.length;
-      best = slug;
-    }
+  let realpathCwd = null;
+  try {
+    realpathCwd = realpathSync(cwd);
+  } catch {
+    realpathCwd = null;
   }
-  return best;
+  return pickProjectByCwd(collectProjectWorkingDirs(hypoDir), cwd, {
+    eligible: slugs,
+    realpathCwd,
+  });
 }
 
 // When cwd is set but no project's working_dir matches it, resume falls back to

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -232,6 +232,172 @@ test('finds wiki by hypo-config.md marker', () => {
   }
 });
 
+// ── lib/wd-match.mjs (cross-machine project matcher) ─────────────────────────
+
+const { pickProjectByCwd, normalizeWorkingDir } = await import(`${SCRIPTS}/lib/wd-match.mjs`);
+
+suite('normalizeWorkingDir()');
+
+test('expands ~ and ~/ and strips trailing slashes', () => {
+  assert.equal(normalizeWorkingDir('~'), HOME);
+  assert.equal(normalizeWorkingDir('~/foo/bar/'), join(HOME, 'foo/bar'));
+  assert.equal(normalizeWorkingDir('/abs/path///'), '/abs/path');
+  assert.equal(normalizeWorkingDir(''), null);
+  assert.equal(normalizeWorkingDir(null), null);
+});
+
+suite('pickProjectByCwd() — tier 1 (absolute prefix, original behavior)');
+
+const PJS = [
+  { slug: 'hypomnema', workingDir: '/Users/sangkyu/Workspace/Hypomnema' },
+  { slug: 'guardia', workingDir: '/Users/sangkyu/Workspace/guardia' },
+];
+
+test('exact cwd match', () => {
+  assert.equal(pickProjectByCwd(PJS, '/Users/sangkyu/Workspace/Hypomnema'), 'hypomnema');
+});
+
+test('subdirectory of working_dir matches', () => {
+  assert.equal(
+    pickProjectByCwd(PJS, '/Users/sangkyu/Workspace/Hypomnema/scripts/lib'),
+    'hypomnema',
+  );
+});
+
+test('longest prefix wins (/repo/sub beats /repo)', () => {
+  const nested = [
+    { slug: 'outer', workingDir: '/Users/x/Workspace' },
+    { slug: 'inner', workingDir: '/Users/x/Workspace/Hypomnema' },
+  ];
+  assert.equal(pickProjectByCwd(nested, '/Users/x/Workspace/Hypomnema/scripts'), 'inner');
+});
+
+test('no false prefix match on sibling (Hypomnema vs Hypomnema-old)', () => {
+  const sib = [{ slug: 'h', workingDir: '/Users/x/Hypomnema' }];
+  assert.equal(pickProjectByCwd(sib, '/Users/x/Hypomnema-old'), null);
+});
+
+test('~ working_dir is expanded before compare', () => {
+  const tilde = [{ slug: 'h', workingDir: '~/Workspace/Hypomnema' }];
+  assert.equal(pickProjectByCwd(tilde, join(HOME, 'Workspace/Hypomnema/x')), 'h');
+});
+
+suite('pickProjectByCwd() — tier 2 (cross-machine unique basename)');
+
+test('different machine path matches by unique basename', () => {
+  // working_dir recorded on machine A; cwd is the same repo on machine B.
+  assert.equal(pickProjectByCwd(PJS, '/Users/SKLIM/Workspace/Sangkyu/Hypomnema'), 'hypomnema');
+});
+
+test('basename match works from a subdirectory on the other machine', () => {
+  assert.equal(
+    pickProjectByCwd(PJS, '/Users/SKLIM/Workspace/Sangkyu/Hypomnema/scripts'),
+    'hypomnema',
+  );
+});
+
+test('shared basename across projects fails closed (no tier-2 match)', () => {
+  const dup = [
+    { slug: 'a', workingDir: '/Users/sangkyu/work/Hypomnema' },
+    { slug: 'b', workingDir: '/Users/sangkyu/other/Hypomnema' },
+  ];
+  assert.equal(pickProjectByCwd(dup, '/Users/SKLIM/elsewhere/Hypomnema'), null);
+});
+
+test('uniqueness is judged over ALL projects, not just eligible ones', () => {
+  // 'b' is not eligible to be the answer, but it shares the basename so the
+  // tier-2 gate must still see it as a collision and decline.
+  const dup = [
+    { slug: 'a', workingDir: '/Users/sangkyu/work/Repo' },
+    { slug: 'b', workingDir: '/Users/sangkyu/other/Repo' },
+  ];
+  assert.equal(pickProjectByCwd(dup, '/Users/SKLIM/x/Repo', { eligible: ['a'] }), null);
+});
+
+test('unique basename mapping to an ineligible slug yields null', () => {
+  assert.equal(pickProjectByCwd(PJS, '/Users/SKLIM/x/Hypomnema', { eligible: ['guardia'] }), null);
+});
+
+test('tier 1 wins over tier 2 when an absolute prefix exists', () => {
+  assert.equal(pickProjectByCwd(PJS, '/Users/sangkyu/Workspace/Hypomnema/sub'), 'hypomnema');
+});
+
+suite('pickProjectByCwd() — case folding + symlinks + edges');
+
+test('case-insensitive FS folds case (macOS/Windows)', () => {
+  assert.equal(
+    pickProjectByCwd(PJS, '/Users/sangkyu/Workspace/hypomnema', { caseInsensitive: true }),
+    'hypomnema',
+  );
+});
+
+test('case-sensitive FS does not fold (Linux): case-only diff is no match', () => {
+  // tier 1 fails (different case), tier 2 basename 'hypomnema' != 'Hypomnema'
+  assert.equal(
+    pickProjectByCwd(PJS, '/Users/sangkyu/Workspace/hypomnema', { caseInsensitive: false }),
+    null,
+  );
+});
+
+test('realpathCwd variant is tried in addition to raw cwd', () => {
+  assert.equal(
+    pickProjectByCwd(PJS, '/tmp/symlink', {
+      realpathCwd: '/Users/sangkyu/Workspace/Hypomnema',
+    }),
+    'hypomnema',
+  );
+});
+
+test('empty universe or no cwd yields null', () => {
+  assert.equal(pickProjectByCwd([], '/Users/x/Hypomnema'), null);
+  assert.equal(pickProjectByCwd(PJS, ''), null);
+  assert.equal(pickProjectByCwd(PJS, null, { realpathCwd: null }), null);
+});
+
+test('projects without working_dir are skipped', () => {
+  const mixed = [
+    { slug: 'nowd', workingDir: null },
+    { slug: 'hypomnema', workingDir: '/Users/sangkyu/Workspace/Hypomnema' },
+  ];
+  assert.equal(pickProjectByCwd(mixed, '/Users/SKLIM/y/Hypomnema'), 'hypomnema');
+});
+
+suite('pickProjectByCwd() — review-hardened edges (raw-first, fail-closed tier 2)');
+
+test('raw cwd match wins over a longer realpath match (fallback, not race)', () => {
+  const pjs = [
+    { slug: 'a', workingDir: '/links/a' },
+    { slug: 'b', workingDir: '/physical/deep/b' },
+  ];
+  // raw cwd is under /links/a; realpath resolves under the longer /physical/deep/b.
+  // A naive global longest-prefix race would pick 'b'; raw-first must keep 'a'.
+  assert.equal(pickProjectByCwd(pjs, '/links/a/x', { realpathCwd: '/physical/deep/b/sub' }), 'a');
+});
+
+test('realpath still rescues a tier-1 match when raw cwd matches nothing', () => {
+  const pjs = [{ slug: 'b', workingDir: '/physical/b' }];
+  assert.equal(pickProjectByCwd(pjs, '/links/b/x', { realpathCwd: '/physical/b/x' }), 'b');
+});
+
+test('tier 2 declines when two projects match along the cwd chain (fail closed)', () => {
+  const pjs = [
+    { slug: 'monorepo', workingDir: '/Users/A/monorepo' },
+    { slug: 'api', workingDir: '/Users/A/services/api' },
+  ];
+  // cross-machine cwd: no absolute prefix; both `monorepo` and `api` are unique
+  // basenames in the chain, so cwd cannot disambiguate → null (not a guess).
+  assert.equal(pickProjectByCwd(pjs, '/Users/B/monorepo/api'), null);
+});
+
+test('tier 2 still matches when only one project sits in the cwd chain', () => {
+  const pjs = [
+    { slug: 'monorepo', workingDir: '/Users/A/monorepo' },
+    { slug: 'other', workingDir: '/Users/A/other' },
+  ];
+  // `api` is not a project basename, only `monorepo` matches → single, so it wins.
+  assert.equal(pickProjectByCwd(pjs, '/Users/B/monorepo/api'), 'monorepo');
+});
+
 // ── init.mjs smoke tests ─────────────────────────────────────────────────────
 
 suite('init.mjs --dry-run');
@@ -10164,6 +10330,50 @@ test('cwd null → legacy stable-sort winner (no behavior change)', () => {
       { slug: 'beta', date: '2026-06-08', workingDir: join(dir, 'code/beta') },
     ]);
     assert.equal(resolveActiveProject(dir), 'alpha');
+  });
+});
+
+test('cross-machine: synced index.md (other-machine path) matches by unique basename', () => {
+  withTmpDir((dir) => {
+    // index.md carries another machine's absolute working_dir (the synced-vault
+    // case): no absolute prefix matches this machine's cwd, but the repo dirname
+    // is a globally-unique project basename, so tier 2 recovers the match.
+    makeTieBreakWiki(dir, [
+      { slug: 'other', date: '2026-06-09' }, // newer recency winner, no working_dir
+      { slug: 'myrepo', date: '2026-06-07', workingDir: '/Users/OTHERMACHINE/ws/myrepo' },
+    ]);
+    assert.equal(resolveActiveProject(dir, join(dir, 'clones/myrepo')), 'myrepo');
+    assert.equal(resolveActiveProject(dir, join(dir, 'clones/myrepo/scripts')), 'myrepo');
+    // sanity: without cwd, recency (newer 'other') still wins.
+    assert.equal(resolveActiveProject(dir), 'other');
+  });
+});
+
+test('cross-machine: shared repo basename fails closed → recency wins (no false match)', () => {
+  withTmpDir((dir) => {
+    makeTieBreakWiki(dir, [
+      { slug: 'newer', date: '2026-06-09', workingDir: '/Users/A/x/myrepo' },
+      { slug: 'older', date: '2026-06-07', workingDir: '/Users/A/y/myrepo' },
+    ]);
+    // 'myrepo' basename is not unique → tier 2 declines → recency picks 'newer'.
+    assert.equal(resolveActiveProject(dir, join(dir, 'z/myrepo')), 'newer');
+  });
+});
+
+test('working_dir with a trailing YAML comment is stripped before matching', () => {
+  withTmpDir((dir) => {
+    // The hook-side collectProjectWorkingDirs must clean `working_dir: /repo # note`
+    // identically to the script-side parser, or same-machine resume would miss.
+    mkdirSync(join(dir, 'projects', 'p'), { recursive: true });
+    writeFileSync(
+      join(dir, 'hot.md'),
+      `---\ntitle: Hot\ntype: reference\nupdated: 2026-06-08\n---\n\n## Active Projects\n\n| Project | Last Session | Hot Cache |\n|---|---|---|\n| p | 2026-06-08 | [[projects/p/hot]] |\n`,
+    );
+    writeFileSync(
+      join(dir, 'projects', 'p', 'index.md'),
+      `---\ntitle: p\ntype: project-index\nupdated: 2026-06-08\nworking_dir: ${join(dir, 'repo')} # synced note\n---\n# p\n`,
+    );
+    assert.equal(resolveActiveProject(dir, join(dir, 'repo')), 'p');
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`/hypo:resume` and the session-start / cwd-change hooks now resolve which project a working directory belongs to with a shared two-tier matcher. When a vault is git-synced across machines, a project whose `working_dir` was recorded on another machine is still matched on the current one.

## Why

A synced vault carries one machine's absolute `working_dir` (e.g. `/Users/sangkyu/Workspace/Hypomnema`) into every project's `index.md`. On a second machine (`/Users/SKLIM/...`), the current directory never prefix-matches that path, so cwd-first resume silently fell back to "most recently active project" and could load an unrelated project. The fallback diagnostic was already there; the match itself was missing.

## How

New `scripts/lib/wd-match.mjs`:
- Tier 1: longest absolute `working_dir` prefix of cwd (the existing behavior, unchanged).
- Tier 2: when no absolute prefix matches, a cwd ancestor whose directory name is a globally unique project basename identifies the project. If that basename is shared by two projects, or two different projects match along the cwd path, it declines and the caller falls back to recency (fail closed, never a wrong-project guess).

The four readers (`resume`, `hypo-session-start`, `hypo-cwd-change`, and the `hypo-shared` resolver) delegate to the matcher. Hooks deploy to `~/.claude/hooks/` without `scripts/`, so `hypo-shared.mjs` carries a hand-synced copy that the two sibling hooks import; the lib holds the unit tests.

Considered and rejected for v1: a synced `working_dirs: {device: path}` map. It needs a writer, but session-close has no trustworthy cwd, so the only writer is `resume --project`, which forces a manual bootstrap on each new machine plus a git-synced `index.md` mutation and a nested-map parser. The read-only basename tier self-bootstraps on every machine with no schema change and no writer, and degrades to the prior behavior on a dirname collision.

## Manual verification

Real-vault check (6 projects) on this machine:

```
node --input-type=module -e '
import { pickProjectByCwd, collectProjectWorkingDirs } from "./scripts/lib/wd-match.mjs";
import { homedir } from "os";
const u = collectProjectWorkingDirs(homedir() + "/hypomnema");
// basename collision audit
const byBase = {};
for (const p of u) { if(!p.workingDir) continue; const b=p.workingDir.split("/").pop().toLowerCase(); (byBase[b] ??= []).push(p.slug); }
console.log("collisions:", Object.entries(byBase).filter(([,v])=>v.length>1));
console.log("second-machine path =>", pickProjectByCwd(u, "/Users/SKLIM/Workspace/Sangkyu/Hypomnema"));
'
```

Observed: `collisions: []`, `second-machine path => hypomnema`. The deployed hook copies were re-synced by the repo post-commit hook and `/hypo:resume` still resolves correctly on this machine (tier 1).

## Migration notes

None. No schema change; existing single `working_dir` vaults behave exactly as before, and the new tier only activates when the absolute prefix fails.

---

# 한국어

## 변경 내용

`/hypo:resume`와 session-start / cwd-change 훅이 작업 디렉터리가 어느 프로젝트에 속하는지 공유 2단계 매처로 해석합니다. 볼트가 여러 머신에 git 동기화될 때, 다른 머신에서 기록된 `working_dir`을 가진 프로젝트도 현재 머신에서 매칭됩니다.

## 이유

동기화 볼트는 한 머신의 절대 `working_dir`(예: `/Users/sangkyu/Workspace/Hypomnema`)을 모든 머신의 `index.md`에 그대로 전파합니다. 다른 머신(`/Users/SKLIM/...`)에선 현재 디렉터리가 그 경로에 prefix-match되지 않아, cwd-first resume이 조용히 "가장 최근 활성 프로젝트"로 폴백하며 무관한 프로젝트를 로드할 수 있었습니다. 폴백 진단은 있었지만 매칭 자체가 빠져 있었습니다.

## 방법

새 `scripts/lib/wd-match.mjs`:
- Tier 1: cwd에 대한 가장 긴 절대 `working_dir` prefix(기존 동작, 변경 없음).
- Tier 2: 절대 prefix가 안 맞으면, cwd 조상 중 디렉터리명이 전역적으로 유일한 프로젝트 basename인 것이 프로젝트를 식별합니다. 그 basename을 두 프로젝트가 공유하거나 cwd 경로상 서로 다른 프로젝트가 둘 이상 매칭되면, 매처는 매칭을 포기하고 호출자가 recency로 폴백합니다(fail closed, 틀린 프로젝트를 추측하지 않음).

4개 리더(`resume`, `hypo-session-start`, `hypo-cwd-change`, `hypo-shared` resolver)가 매처에 위임합니다. 훅은 `scripts/` 없이 `~/.claude/hooks/`로 배포되므로, `hypo-shared.mjs`가 형제 훅 둘이 import하는 hand-sync 사본을 갖고, 단위 테스트는 lib가 보유합니다.

v1에서 검토 후 보류한 대안: 동기화 `working_dirs: {device: path}` 맵. writer가 필요한데 session-close엔 믿을 cwd가 없어 유일한 writer가 `resume --project`라, 머신마다 첫 1회 수동 부트스트랩 + git-synced `index.md` 자동 수정 + 중첩맵 파서가 따라옵니다. 읽기 전용 basename tier는 스키마 변경·writer 없이 모든 머신에서 self-bootstrap하고, 디렉터리명 충돌 시 기존 동작으로 degrade합니다.

## 수동 검증

이 머신 실볼트(6개 프로젝트) 점검: basename 충돌 0건, 다른 머신 경로 `/Users/SKLIM/Workspace/Sangkyu/Hypomnema` → `hypomnema`로 정확히 해석. post-commit 훅이 배포 훅 사본을 재동기화했고, 이 머신의 `/hypo:resume`도 여전히 정상(tier 1).

## 마이그레이션 노트

없음. 스키마 변경 없음. 기존 단일 `working_dir` 볼트는 이전과 완전히 동일하게 동작하고, 새 tier는 절대 prefix가 실패할 때만 켜집니다.

---

## Changelog

- EN: `/hypo:resume` and the session hooks now match the current directory to its project across a git-synced multi-machine vault, instead of falling back to the most-recent project when another machine's absolute path was recorded.
- KO: `/hypo:resume`와 세션 훅이 git 동기화된 멀티머신 볼트에서 현재 디렉터리를 해당 프로젝트로 매칭합니다. 다른 머신의 절대경로가 기록돼 있어도 최근 프로젝트로 폴백하지 않습니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
