### PR TITLE
feat(hooks): surface vault path when cwd is a project working_dir outside the vault

### DIFF
--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -20,6 +20,7 @@ import {
   sanitizeProjForPrompt,
   pickProjectByCwd,
   collectProjectWorkingDirs,
+  buildVaultOrientation,
 } from './hypo-shared.mjs';
 
 const PROJECTS_DIR = join(HYPO_DIR, 'projects');
@@ -108,10 +109,14 @@ process.stdin.on('end', () => {
           );
         }
       }
+      // Same vault orientation as session-start: when the new cwd is a project
+      // working_dir distinct from the vault, surface where wiki files live.
+      const vaultOrientation = buildVaultOrientation(newCwd);
+      const orientPrefix = vaultOrientation ? `${vaultOrientation}\n\n` : '';
       console.log(
         JSON.stringify(
           buildOutput(
-            `[WIKI: cwd changed → project=${sanitizeProjForPrompt(newHit.proj)}]\n\n${content}`,
+            `${orientPrefix}[WIKI: cwd changed → project=${sanitizeProjForPrompt(newHit.proj)}]\n\n${content}`,
             {
               continue: true,
               suppressOutput: true,

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -30,6 +30,7 @@ import {
   sanitizeProjForPrompt,
   pickProjectByCwd,
   collectProjectWorkingDirs,
+  buildVaultOrientation,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -364,6 +365,12 @@ process.stdin.on('end', () => {
 
     const ignorePatterns = loadHypoIgnore(HYPO_DIR);
 
+    // When cwd is a project working_dir that is NOT the vault itself, tell the
+    // AI where the vault lives so it does not re-discover the path or look for
+    // wiki files in the code repo. '' when cwd === vault root.
+    const vaultOrientation = hit ? buildVaultOrientation(cwd) : '';
+    const hitPrefix = vaultOrientation ? `${vaultOrientation}\n\n` : '';
+
     if (hit) {
       const hotContent = readIfNotIgnored(hit.hotPath, HOT_CHARS, ignorePatterns);
       const stateContent = readIfNotIgnored(hit.statePath, STATE_CHARS, ignorePatterns);
@@ -386,7 +393,7 @@ process.stdin.on('end', () => {
         console.log(
           JSON.stringify(
             buildOutput(
-              `${noticePrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}]\n\n${parts.join('\n\n')}`,
+              `${noticePrefix}${hitPrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}]\n\n${parts.join('\n\n')}`,
               outExtra,
             ),
           ),
@@ -402,7 +409,7 @@ process.stdin.on('end', () => {
         console.log(
           JSON.stringify(
             buildOutput(
-              `${noticePrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}, no snapshot yet]`,
+              `${noticePrefix}${hitPrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}, no snapshot yet]`,
               outExtra,
             ),
           ),

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -486,6 +486,58 @@ export function collectProjectWorkingDirs(hypoDir) {
   return out;
 }
 
+/**
+ * When the session cwd is a project working_dir distinct from the vault root,
+ * the wiki/knowledge files live in the VAULT, not in this cwd. SessionStart and
+ * CwdChanged inject hot.md/session-state content but never the vault's absolute
+ * path, so the AI re-discovers it each session and can wrongly conclude a wiki
+ * file is missing after checking only the code repo (a real misjudgment seen in
+ * a dev-repo session, 2026-06-23).
+ *
+ * Returns a one-line "look in the vault, not here" orientation carrying the
+ * absolute vault path, or '' when cwd is anywhere inside the vault tree (the
+ * "wiki files live in the vault, not here" framing would be false there) or
+ * hypoDir is unset. The HIT matcher is prefix-based, so a project whose
+ * working_dir is the vault root can match a vault SUBDIRECTORY; checking only
+ * exact root-equality would wrongly fire for those. Compared via realpath so a
+ * symlinked cwd or vault still matches.
+ *
+ * Containment uses the SAME normalize + case-fold + prefix policy as
+ * pickProjectByCwd so the two never disagree: on a case-insensitive FS the
+ * matcher case-folds, so a cwd differing only in case is still a HIT and must be
+ * suppressed here too (otherwise a false orientation leaks).
+ *
+ * @param {string} cwd  the session cwd (already known to be a project HIT)
+ * @param {string} [hypoDir=HYPO_DIR]
+ * @param {{caseInsensitive?: boolean}} [opts]  override FS case policy (tests)
+ * @returns {string}
+ */
+export function buildVaultOrientation(cwd, hypoDir = HYPO_DIR, opts = {}) {
+  if (!cwd || !hypoDir) return '';
+  const { caseInsensitive = isCaseInsensitiveFs() } = opts;
+  let realCwd = cwd;
+  let realVault = hypoDir;
+  try {
+    realCwd = realpathSync(cwd);
+  } catch {
+    /* keep raw path when cwd is unreadable */
+  }
+  try {
+    realVault = realpathSync(hypoDir);
+  } catch {
+    /* keep raw path when vault is unreadable */
+  }
+  // Suppress when cwd is the vault root OR a descendant of it.
+  const c = _fold(normalizeWorkingDir(realCwd) || '', caseInsensitive);
+  const v = _fold(normalizeWorkingDir(realVault) || '', caseInsensitive);
+  if (!c || !v) return '';
+  if (c === v || c.startsWith(`${v}/`)) return '';
+  return (
+    `[WIKI VAULT: ${hypoDir}] 이 cwd는 작업/코드 레포이고 vault가 아니다. ` +
+    `wiki·knowledge·세션로그 파일은 여기가 아니라 vault(${hypoDir})에서 조회한다.`
+  );
+}
+
 // resume/close entry: match `slugs` against cwd via the two-tier matcher.
 // Uniqueness is judged over EVERY project on disk, not just `slugs`. close
 // callers pass no cwd, so it stays inert for them.

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -8337,6 +8337,89 @@ test('session-start still injects non-ignored project hot/state', () => {
   });
 });
 
+// ── vault orientation (IMPR-19) ─────────────────────────────────────
+// When cwd is a project working_dir distinct from the vault, the hooks surface
+// a one-line "[WIKI VAULT: <path>]" orientation so the AI does not re-discover
+// the vault path or look for wiki files in the code repo.
+suite('hypo-session-start.mjs / hypo-cwd-change.mjs — vault orientation (IMPR-19)');
+
+test('session-start injects vault orientation when cwd is a project HIT ≠ vault', () => {
+  withPrivateProject((dir, work) => {
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+      input: JSON.stringify({ cwd: work, session_id: 'test-impr19-ss' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stdout, /\[WIKI VAULT:/, `expected vault orientation, got: ${r.stdout}`);
+    assert.ok(
+      r.stdout.includes(dir),
+      `vault orientation must carry the absolute vault path: ${r.stdout}`,
+    );
+  });
+});
+
+test('session-start omits vault orientation when cwd IS the vault root', () => {
+  withGrowthWiki((dir) => {
+    const projDir = join(dir, 'projects', 'vaultproj');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'index.md'),
+      `---\ntitle: vaultproj\ntype: project-index\nupdated: 2026-06-28\nworking_dir: "${dir}"\n---\n# vaultproj\n`,
+    );
+    writeFileSync(join(projDir, 'hot.md'), '# hot\nVAULT_ROOT_HOT\n');
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+      input: JSON.stringify({ cwd: dir, session_id: 'test-impr19-ss-vault' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !/\[WIKI VAULT:/.test(r.stdout),
+      `orientation must be suppressed when cwd === vault: ${r.stdout}`,
+    );
+  });
+});
+
+test('session-start omits vault orientation when cwd is a vault SUBDIR (working_dir=vault root)', () => {
+  withGrowthWiki((dir) => {
+    // A project whose working_dir is the vault root. The HIT matcher is
+    // prefix-based, so a session started in a vault subdirectory matches it —
+    // the orientation must still be suppressed (cwd is inside the vault).
+    const projDir = join(dir, 'projects', 'vaultroot');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'index.md'),
+      `---\ntitle: vaultroot\ntype: project-index\nupdated: 2026-06-28\nworking_dir: "${dir}"\n---\n# vaultroot\n`,
+    );
+    writeFileSync(join(projDir, 'hot.md'), '# hot\nVAULT_SUBDIR_HOT\n');
+    const subdir = join(dir, 'pages');
+    mkdirSync(subdir, { recursive: true });
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+      input: JSON.stringify({ cwd: subdir, session_id: 'test-impr19-ss-subdir' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !/\[WIKI VAULT:/.test(r.stdout),
+      `orientation must be suppressed inside the vault tree: ${r.stdout}`,
+    );
+  });
+});
+
+test('cwd-change injects vault orientation when new cwd is a project HIT ≠ vault', () => {
+  withPrivateProject((dir, work) => {
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
+      input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/other', session_id: 'test-impr19-cc' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stdout, /\[WIKI VAULT:/, `expected vault orientation, got: ${r.stdout}`);
+  });
+});
+
 test('cwd-change refuses to inject .hypoignore-matched project hot.md', () => {
   withPrivateProject((dir, work) => {
     writeFileSync(join(dir, '.hypoignore'), 'projects/private/hot.md\n');
@@ -8809,6 +8892,37 @@ test('replay-first-prompt-forces-summary: marker.proj is sanitized before interp
 });
 
 const sharedMod = await import(`${REPO}/hooks/hypo-shared.mjs`);
+
+test('buildVaultOrientation: containment honors FS case policy (IMPR-19, codex review)', () => {
+  const { buildVaultOrientation } = sharedMod;
+  // Fake (nonexistent) paths so realpathSync throws and the raw strings are
+  // compared — keeps the case behavior deterministic across platforms.
+  const VAULT = '/nonexistent-hypo-test/Vault';
+  const SUBDIR = '/nonexistent-hypo-test/Vault/pages';
+  // exact root → always suppressed
+  assert.equal(buildVaultOrientation(VAULT, VAULT, { caseInsensitive: false }), '');
+  // descendant (same case) → suppressed on either policy
+  assert.equal(buildVaultOrientation(SUBDIR, VAULT, { caseInsensitive: false }), '');
+  // case-only difference: suppressed on a case-insensitive FS (matches the
+  // case-folding HIT matcher), NOT suppressed on a case-sensitive FS
+  const CASE_CWD = '/nonexistent-hypo-test/vault/pages';
+  assert.equal(
+    buildVaultOrientation(CASE_CWD, VAULT, { caseInsensitive: true }),
+    '',
+    'case-insensitive FS must suppress a case-only vault subdir',
+  );
+  assert.match(
+    buildVaultOrientation(CASE_CWD, VAULT, { caseInsensitive: false }),
+    /\[WIKI VAULT:/,
+    'case-sensitive FS treats a different-case path as outside the vault',
+  );
+  // genuinely distinct repo → orientation injected, carries the vault path
+  const out = buildVaultOrientation('/nonexistent-hypo-test/code/repo', VAULT, {
+    caseInsensitive: false,
+  });
+  assert.match(out, /\[WIKI VAULT:/);
+  assert.ok(out.includes(VAULT), 'orientation carries the absolute vault path');
+});
 
 test('sanitizeProjForPrompt: strips angle brackets, control chars, and Unicode line separators (codex v2 review)', () => {
   const { sanitizeProjForPrompt } = sharedMod;


### PR DESCRIPTION
# English

## What changed

SessionStart and CwdChanged now prepend a one-line vault orientation when the session cwd is a project working_dir that sits outside the vault tree:

`[WIKI VAULT: <abs path>] this cwd is a code/work repo, not the vault. Look for wiki/knowledge/session-log files in the vault, not here.`

A new shared helper `buildVaultOrientation(cwd, hypoDir)` in `hooks/hypo-shared.mjs` computes it; both hooks call it on their project-HIT path.

## Why

On a cwd HIT the hooks inject the project's hot.md and session-state, but never the vault's absolute path. So a session running in a code repo re-discovers the vault location every time, and can wrongly conclude a wiki file is missing after checking only the code repo. The orientation gives the model the vault path and the "look there, not here" distinction up front.

## How

`buildVaultOrientation` returns the line only when cwd is a project working_dir that is neither the vault root nor a descendant of it. Containment reuses the exact `pickProjectByCwd` policy (normalize, then case-fold on a case-insensitive filesystem, then prefix match), so the two never disagree: a cwd that differs from the vault only in letter case is still a HIT for the matcher and is correctly suppressed here too. Paths are resolved through realpath so a symlinked cwd or vault still matches. The case policy is overridable via an options argument for deterministic tests.

No new imports beyond the deployed `hypo-shared.mjs`, so the hook deployment constraint (no `scripts/` at runtime) holds.

## Manual verification

```
# Real vault, this repo as cwd (a project working_dir outside the vault):
$ echo '{"cwd":"/path/to/Hypomnema","session_id":"smoke"}' | node hooks/hypo-session-start.mjs
[WIKI VAULT: /path/to/vault] 이 cwd는 작업/코드 레포이고 vault가 아니다. ...

$ npm test          # 990 passed, 0 failed
$ node scripts/check-tracker-ids.mjs   # OK: no wiki-internal tracker ids
```

The post-commit hook synced the updated copies to `~/.claude/hooks/`; the deployed `hypo-shared.mjs` produces the same line.

## Migration notes

None. Additive context only; no schema or stored-state change.

---

# 한국어

## 변경 내용

세션 cwd가 vault 트리 밖의 프로젝트 working_dir일 때, SessionStart와 CwdChanged가 한 줄짜리 vault orientation을 앞에 붙입니다:

`[WIKI VAULT: <절대경로>] 이 cwd는 작업/코드 레포이고 vault가 아니다. wiki/knowledge/세션로그 파일은 여기가 아니라 vault에서 조회한다.`

`hooks/hypo-shared.mjs`에 공유 헬퍼 `buildVaultOrientation(cwd, hypoDir)`를 추가하고, 두 훅이 프로젝트 HIT 경로에서 호출합니다.

## 이유

cwd HIT 시 훅은 프로젝트의 hot.md와 session-state는 주입하지만 vault 절대경로는 주지 않습니다. 그래서 코드 레포에서 세션을 시작하면 매번 vault 위치를 새로 탐색하고, 코드 레포만 확인한 뒤 wiki 파일이 "없다"고 잘못 단정할 수 있습니다. orientation이 vault 경로와 "여기 말고 거기를 보라"는 구분을 미리 줍니다.

## 방법

`buildVaultOrientation`은 cwd가 vault 루트도, 그 하위도 아닌 프로젝트 working_dir일 때만 줄을 반환합니다. 포함 판정은 `pickProjectByCwd`와 동일한 정책(normalize, 대소문자 무시 FS에서 case-fold, prefix 매치)을 재사용하므로 둘이 어긋나지 않습니다. 철자만 대소문자가 다른 cwd도 매처에선 HIT이고, 여기서도 동일하게 억제됩니다. 경로는 realpath로 풀어 심링크된 cwd/vault도 매칭됩니다. 대소문자 정책은 결정론적 테스트를 위해 옵션으로 덮어쓸 수 있습니다.

배포되는 `hypo-shared.mjs` 외 새 import가 없어 훅 배포 제약(런타임에 `scripts/` 없음)을 지킵니다.

## 수동 검증

```
$ echo '{"cwd":"/path/to/Hypomnema","session_id":"smoke"}' | node hooks/hypo-session-start.mjs
[WIKI VAULT: /path/to/vault] 이 cwd는 작업/코드 레포이고 vault가 아니다. ...

$ npm test          # 990 passed, 0 failed
$ node scripts/check-tracker-ids.mjs   # OK
```

post-commit 훅이 갱신본을 `~/.claude/hooks/`로 동기화했고, 배포된 `hypo-shared.mjs`도 동일한 줄을 냅니다.

## 마이그레이션 노트

None. 컨텍스트 추가뿐이며 스키마/저장 상태 변경 없음.

---

## Changelog

- EN: SessionStart and cwd-change now surface the vault's absolute path when working in a code repo, so the assistant stops re-discovering it and does not mistake a code repo for the vault (#156)
- KO: 코드 레포에서 작업할 때 SessionStart와 cwd 변경이 vault 절대경로를 알려줘, 매번 재탐색하거나 코드 레포를 vault로 혼동하지 않게 했습니다 (#156)

## Checklist

- [x] `npm test` passes locally (990 passed)
- [x] `npm run lint` passes locally (pre-existing vault-content warnings only, unrelated to this code change; CI clean)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (internal context injection; no doc surface change)
- [x] Filled the `## Changelog` block above (EN + KO line)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
