### PR TITLE
feat(close): cap the lint warn list in the model-facing apply result

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -838,7 +838,7 @@ function applySessionClose(args) {
       ok: false,
       stage: 'preflight-lint',
       error: 'lint preflight failed — apply aborted (no payload bytes written)',
-      lint: { ...preflightLint, blockingErrors },
+      lint: { ...summarizeLintForOutput(preflightLint), blockingErrors },
     };
     if (args.json) {
       console.log(JSON.stringify(out, null, 2));
@@ -1121,7 +1121,10 @@ function applySessionClose(args) {
     // ADR 0055: surface the marker outcome instead of skipping silently, so the
     // caller can tell "closed" from "applied but not marked".
     ...(args.sessionId ? { markerWritten, markerSkipReason } : {}),
-    lint: { preflight: preflightLint, postApply: postApplyLint },
+    lint: {
+      preflight: summarizeLintForOutput(preflightLint),
+      postApply: summarizeLintForOutput(postApplyLint),
+    },
     // Pre-existing lint debt in files this close did not author: surfaced for
     // visibility, never gated. Empty on a clean vault. Scoped to the close-target
     // project's own dir — debt under projects/<project>/ is this close's
@@ -1203,6 +1206,29 @@ function applySessionClose(args) {
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+// Cap the warn list in MODEL-FACING lint output. `result.lint` is serialized
+// into the --json apply result the documented close path reads, and lint runs
+// twice per close (preflight + post-apply), so an un-capped warn list (e.g.
+// hundreds of broken-wikilink warnings) lands in model context twice on every
+// close. Errors stay full (few, actionable); warns collapse to a count plus a
+// small sample for quick diagnosis. The INTERNAL preflightLint / postApplyLint
+// objects are untouched — the blocking filter and the pending-tag scan still
+// read the full warn list. lint.mjs --json itself also stays full: its
+// programmatic consumers (the pending-tag scan, the PreCompact W8 filter, tests)
+// need every warn.
+function summarizeLintForOutput(l) {
+  const SAMPLE = 10;
+  const warns = l.warns || [];
+  const out = {
+    ok: l.ok,
+    errors: l.errors || [],
+    warnCount: warns.length,
+    warns: warns.slice(0, SAMPLE),
+  };
+  if (warns.length > SAMPLE) out.warnsTruncated = warns.length - SAMPLE;
+  return out;
+}
 
 function parseFrontmatter(content) {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3397,6 +3397,48 @@ test('apply notice scope: debt OUTSIDE the close project folds into otherDebtCou
   );
 });
 
+test('apply lint output caps the warn list (model-context guard): full count + sample + remainder', () => {
+  // result.lint is serialized into the --json apply result the close path reads,
+  // and lint runs twice (preflight + post-apply), so an un-capped warn list would
+  // land in model context twice on every close. The warns must collapse to a
+  // count + small sample; errors stay full. (Internal pending-tag / blocking
+  // logic still sees the full warn list — covered by other tests.)
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'bulk'), { recursive: true });
+      // 12 pages, each with one broken wikilink → 12 W4 warnings, over the sample cap.
+      for (let i = 0; i < 12; i++) {
+        writeFileSync(
+          join(dir, 'pages', 'bulk', `p${i}.md`),
+          `---\ntitle: p${i}\ntype: concept\nupdated: 2026-06-28\n---\n\nsee [[does-not-exist-${i}]]\n`,
+        );
+      }
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 0, `apply should succeed past warn debt: ${r.stdout}`);
+      const out = JSON.parse(r.stdout);
+      for (const phase of ['preflight', 'postApply']) {
+        const l = out.lint[phase];
+        assert.ok(
+          l.warnCount >= 12,
+          `${phase}.warnCount should be the full count: ${JSON.stringify(l)}`,
+        );
+        assert.ok(
+          l.warns.length <= 10,
+          `${phase}.warns should be capped to the sample: ${l.warns.length}`,
+        );
+        assert.equal(
+          l.warnsTruncated,
+          l.warnCount - l.warns.length,
+          `${phase}.warnsTruncated should be the remainder: ${JSON.stringify(l)}`,
+        );
+      }
+    },
+  );
+});
+
 test('preflight (#40 + Bug B): corrupt APPEND target (session-log) STILL blocks — appending cannot repair it', () => {
   // The scoping carve-out preserves the #40 guarantee for append targets: a
   // pre-existing malformed session-log file is in the payload scope and is NOT an


### PR DESCRIPTION
# English

## What changed

Cap the lint **warning** list in the model-facing apply result. A new helper `summarizeLintForOutput()` rewrites each lint result that goes into the `--json` output as `{ ok, errors (full), warnCount (full count), warns (first 10), warnsTruncated (remainder) }`. It is applied to `result.lint` (preflight + post-apply) and to the preflight-abort result. `lint.mjs --json` and the internal lint objects are unchanged.

## Why

The session-close apply path runs lint twice (preflight + post-apply) and serialized the **full** lint result, every warning included, into the `--json` result the close path hands back to the model. On a vault with hundreds of warnings (broken wikilinks chief among them) that dumped the whole list into model context twice on every close, involuntarily. The cost is real today: a local vault already emits ~119 warnings, so ~238 warn entries were serialized per close.

## How

Only the model-facing result JSON is summarized. Errors stay full (few and actionable); warnings collapse to a count plus a 10-item sample. The cut is deliberately at `result.lint`, not at `lint.mjs --json`: the linter's JSON has programmatic consumers (the pending-tag auto-register scan, the PreCompact W8 filter, the test suite) that need every warning, so summarizing there would invert a safe default. The internal `preflightLint`/`postApplyLint` objects the blocking filter and pending-tag scan read are left untouched.

Note: `improvement_detail` option 1 framed this as "summarize lint `--json`, full as opt-in". The cut moved to `result.lint` instead because the linter's `--json` is consumed programmatically and must stay complete; the only involuntary model-facing cost is `result.lint`.

## Manual verification

- `npm test` → 993 passed, 0 failed. New test: 12 broken-wikilink pages produce ≥12 warnings; asserts `warnCount` is the full count, `warns` is capped at the 10-item sample, and `warnsTruncated` is the remainder, for both the preflight and post-apply phases.
- `npm run check:tracker-ids` OK. The change is `scripts/crystallize.mjs` only (no hook); the test spawns the real apply binary, not a mock.

## Migration notes

None. `result.lint.{preflight,postApply}` keeps `ok` and `errors`; `warns` is now a sample and gains sibling `warnCount`/`warnsTruncated` fields. No consumer read the full `result.lint.*.warns` list.

---

# 한국어

## 변경 내용

모델 대면 apply 결과에서 lint **경고** 목록에 상한을 둔다. 헬퍼 `summarizeLintForOutput()`가 `--json` 출력에 실리는 lint 결과를 `{ ok, errors(전체), warnCount(전체 개수), warns(앞 10개), warnsTruncated(나머지) }`로 다시 쓴다. `result.lint`(preflight + post-apply)와 preflight-abort 결과에 적용한다. `lint.mjs --json`과 내부 lint 객체는 그대로다.

## 이유

세션 close apply 경로는 lint를 두 번(preflight + post-apply) 돌리고, **전체** lint 결과를 경고까지 포함해 close가 모델에 돌려주는 `--json` 결과에 직렬화했다. 경고가 수백 개인 볼트(주로 broken wikilink)에서는 매 close마다 그 목록 전체가 모델 context에 두 번 실렸다(비자발적). 실재 비용이다: 로컬 볼트가 이미 ~119개 경고를 내므로 close당 ~238개 항목이 직렬화됐다.

## 방법

모델 대면 결과 JSON만 요약한다. errors는 전체 보존(적고 actionable), 경고는 개수 + 10개 샘플로 접는다. 절단 지점을 `lint.mjs --json`이 아니라 `result.lint`로 잡은 건 의도적이다: linter의 JSON은 programmatic 소비자(pending-tag 자동등록 스캔, PreCompact W8 필터, 테스트)가 전체 경고를 필요로 해서, 거기서 요약하면 안전한 default가 뒤집힌다. blocking 필터·pending-tag 스캔이 읽는 내부 `preflightLint`/`postApplyLint` 객체는 그대로 둔다.

참고: `improvement_detail` 개선안 1번은 "lint `--json`을 요약, 전체는 옵션"으로 적혀 있었다. linter의 `--json`은 programmatic 소비라 전체를 유지해야 하고 비자발적 모델 대면 비용은 `result.lint`뿐이라, 절단을 `result.lint`로 옮겼다.

## 수동 검증

- `npm test` → 993 passed, 0 failed. 신규 테스트: broken-wikilink 페이지 12개가 경고 ≥12개를 내고, preflight·post-apply 양쪽에서 `warnCount`(전체 개수)·`warns`(10개 샘플 상한)·`warnsTruncated`(나머지)를 단언.
- `npm run check:tracker-ids` OK. 변경은 `scripts/crystallize.mjs`뿐(훅 무관), 테스트가 실제 apply 바이너리를 spawn(목 아님).

## 마이그레이션 노트

None. `result.lint.{preflight,postApply}`는 `ok`·`errors`를 유지하고, `warns`는 샘플이 되며 `warnCount`/`warnsTruncated` 형제 필드가 추가된다. `result.lint.*.warns` 전체 목록을 읽는 소비자는 없었다.

---

## Changelog

- EN: Session-close now caps the lint warning list in the apply result it returns to the model (full count plus a sample), instead of serializing hundreds of warnings into context twice per close (#158).
- KO: 세션 close가 모델에 돌려주는 apply 결과의 lint 경고 목록에 상한을 둔다(전체 개수 + 샘플). close마다 수백 개 경고를 context에 두 번 직렬화하던 비용을 없앤다 (#158).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
