### PR TITLE
feat(freshness): STALE injection markers + page-usage logging

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ Hooks run automatically at Claude Code lifecycle events. They are deployed to `~
 |---|---|
 | `hypo-session-start` | Inject `index.md`, root `hot.md`, project `hot.md`/`session-state.md`. Run `git pull --ff-only` (silent fail on missing remote) |
 | `hypo-first-prompt` | Marker-based one-shot `hot.md` injection on first user prompt (10-min TTL) — for sessions that bypass `SessionStart` |
-| `hypo-lookup` | BM25 search over the wiki on every prompt. **HIT** → inject top-3 page snippets (≤2000 chars each, with verify-by-date warnings). **MISS** → emit closest-slug signal that prompts Claude to research + `/hypo:ingest` |
+| `hypo-lookup` | BM25 search over the wiki on every prompt. **HIT** → inject top-3 page snippets (≤2000 chars each; a page whose `verify_by_date` is overdue gets a `[STALE verify_by_date=…]` marker prepended). **MISS** → emit closest-slug signal that prompts Claude to research + `/hypo:ingest` |
 | `hypo-compact-guard` | Detect `/compact` invocations → enforce session-close checklist before allowing compact |
 | `hypo-personal-check` | PreCompact validation: lint blockers, uncommitted changes, missing session-log entries → block compact |
 | `hypo-auto-stage` | After Write/Edit on a wiki path, run `git add` (skips paths matching `.hypoignore`) |

--- a/hooks/hypo-lookup.mjs
+++ b/hooks/hypo-lookup.mjs
@@ -11,7 +11,15 @@
 
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, basename } from 'path';
-import { HYPO_DIR, buildOutput, loadHypoIgnore, isIgnored } from './hypo-shared.mjs';
+import {
+  HYPO_DIR,
+  buildOutput,
+  loadHypoIgnore,
+  isIgnored,
+  staleMarkerFor,
+  pageUsageLoggingAllowed,
+  recordLookupUsage,
+} from './hypo-shared.mjs';
 
 const INDEX_PATH = join(HYPO_DIR, 'index.md');
 const MAX_HITS = 3;
@@ -178,6 +186,8 @@ process.stdin.on('end', () => {
   try {
     const data = JSON.parse(input);
     const prompt = (data.prompt || '').trim();
+    // Runtime sends a session UUID; older payloads may omit it (parse defensively).
+    const sessionId = data.session_id || null;
 
     if (!prompt || !existsSync(INDEX_PATH)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -235,14 +245,32 @@ process.stdin.on('end', () => {
       ),
     };
 
+    // UTC to match doctor.mjs' overdue set (D1/D2). STALE is advisory, so a
+    // one-day UTC/local skew never misleads.
+    const TODAY = new Date().toISOString().slice(0, 10);
+
     const injected = [];
+    const injectedSlugs = [];
     for (const { slug } of matched.slice(0, MAX_HITS)) {
       const path =
         pageMap[slug] ??
         pageMap[slug.replace(/^(pages|projects)\//, '')] ??
         pageMap[basename(slug)];
       if (path && existsSync(path)) {
-        injected.push(`=== [[${slug}]] ===\n${readFileSync(path, 'utf-8').slice(0, MAX_CHARS)}`);
+        const raw = readFileSync(path, 'utf-8');
+        // Compute the marker on raw (pre-slice) so a long body can't truncate
+        // frontmatter out of reach. fail-open: a marker failure drops the marker,
+        // never the page.
+        let marker = '';
+        try {
+          marker = staleMarkerFor(raw, TODAY);
+        } catch {
+          marker = '';
+        }
+        injected.push(
+          `=== [[${slug}]] ===\n${marker ? marker + '\n' : ''}${raw.slice(0, MAX_CHARS)}`,
+        );
+        injectedSlugs.push(slug);
       }
     }
 
@@ -260,6 +288,13 @@ process.stdin.on('end', () => {
         ),
       );
       return;
+    }
+
+    // Page-usage logging (B): observability only, gated fail-closed on commit
+    // coverage, and fail-open so it never disturbs the injection above. Only the
+    // real HIT branch reaches here (miss / index-hit-but-missing returned early).
+    if (pageUsageLoggingAllowed(HYPO_DIR, sessionId)) {
+      recordLookupUsage(HYPO_DIR, { sessionId, slugs: injectedSlugs });
     }
 
     const overflow =

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -31,6 +31,7 @@ import {
   pickProjectByCwd,
   collectProjectWorkingDirs,
   buildVaultOrientation,
+  staleMarkerFor,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -54,6 +55,21 @@ function readIfNotIgnored(path, maxChars, patterns) {
   if (!path) return null;
   if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return null;
   return readFileSync(path, 'utf-8').slice(0, maxChars);
+}
+
+// Compute the STALE marker for a hot/state file from its RAW content (readIfNotIgnored
+// already slices, which could truncate frontmatter). Honors the same .hypoignore
+// privacy guard, and returns '' for any miss (no path, ignored, absent, no
+// verify_by_date, or error) so derived summaries pass through unchanged.
+function staleMarkerForPath(path, patterns, today) {
+  try {
+    if (!path) return '';
+    if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return '';
+    if (!existsSync(path)) return '';
+    return staleMarkerFor(readFileSync(path, 'utf-8'), today);
+  } catch {
+    return '';
+  }
 }
 
 // Directory of the running hook, and the install root one level up
@@ -372,8 +388,18 @@ process.stdin.on('end', () => {
     const hitPrefix = vaultOrientation ? `${vaultOrientation}\n\n` : '';
 
     if (hit) {
-      const hotContent = readIfNotIgnored(hit.hotPath, HOT_CHARS, ignorePatterns);
-      const stateContent = readIfNotIgnored(hit.statePath, STATE_CHARS, ignorePatterns);
+      // project hot/state only. root/global hot (below) is a derived pointer
+      // table with no per-page frontmatter, so it is never a STALE target and
+      // gets no marker logic. TODAY is UTC to match doctor.mjs (D1/D2). The
+      // marker is computed on raw content (staleMarkerForPath), then prepended
+      // onto the sliced display content; a no-op when there is no verify_by_date.
+      const TODAY = new Date().toISOString().slice(0, 10);
+      let hotContent = readIfNotIgnored(hit.hotPath, HOT_CHARS, ignorePatterns);
+      let stateContent = readIfNotIgnored(hit.statePath, STATE_CHARS, ignorePatterns);
+      const hotMarker = staleMarkerForPath(hit.hotPath, ignorePatterns, TODAY);
+      const stateMarker = staleMarkerForPath(hit.statePath, ignorePatterns, TODAY);
+      if (hotContent && hotMarker) hotContent = `${hotMarker}\n${hotContent}`;
+      if (stateContent && stateMarker) stateContent = `${stateMarker}\n${stateContent}`;
 
       if (hotContent || stateContent) {
         printTerminalSummary(hit.proj, hotContent, stateContent);

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -352,6 +352,139 @@ function parseFrontmatterField(content, key) {
     .replace(/^['"]|['"]$/g, '');
 }
 
+// ── freshness: overdue verify_by_date predicate + STALE injection marker ─────
+// Authority is doctor.mjs:487-491 (D1). Same characters, same meaning: only a
+// well-formed ISO date strictly before `today` is overdue. verify_by (the
+// natural-language question) is never a date and is never consulted here.
+// today is caller-supplied and must use the UTC convention (new Date()
+// .toISOString().slice(0,10)) so this set matches doctor's.
+export function isOverdueDate(dateStr, today) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(dateStr) && dateStr < today;
+}
+
+// Compute the injection marker for a page's raw content. Returns
+// `[STALE verify_by_date=YYYY-MM-DD]` when overdue, otherwise an empty string
+// (so non-targets pass through unchanged). Callers prepend the non-empty result
+// at injection time.
+//
+// The value read here must be normalized exactly as scripts/lib/frontmatter.mjs
+// does (doctor's parser), so the overdue set stays char-identical to doctor.mjs.
+// In particular it strips a trailing YAML inline comment (`2020-01-01 # note`):
+// the plain parseFrontmatterField does not, which would silently miss dates
+// doctor flags overdue. Top-level line only (skip indented / list entries),
+// first-wins, strip comment, then strip surrounding quotes.
+export function staleMarkerFor(rawContent, today) {
+  const m = rawContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return '';
+  let value = null;
+  for (const line of m[1].split(/\r?\n/)) {
+    if (/^\s/.test(line) || /^-(\s|$)/.test(line)) continue; // nested / list item
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    if (line.slice(0, idx).trim() !== 'verify_by_date') continue; // key match (idx: tolerates `key : v`)
+    value = line
+      .slice(idx + 1)
+      .trim()
+      .replace(/\s+#.*$/, '')
+      .replace(/^["']|["']$/g, '');
+    break; // first-wins
+  }
+  return value && isOverdueDate(value, today) ? `[STALE verify_by_date=${value}]` : '';
+}
+
+// ── page-usage logging: commit-coverage guard + append (B, D6) ───────────────
+// Logging which pages lookup injects is observability, never an injection path.
+// The log lives at .cache/page-usage.jsonl and must never be committed. Before
+// any append, prove that file cannot be staged/committed: it must be covered by
+// BOTH git's ignore rules (check-ignore) AND .hypoignore (which is what gates
+// hypo-auto-stage and commitWikiChanges). Missing either signal, or any error
+// (no git, timeout, non-repo), returns false so nothing is written (fail-closed
+// logging). Injection stays fail-open and is unaffected. The verdict is cached
+// per session (keyed by session_id plus a vault-path hash so two vaults in one
+// session can't cross-contaminate) so git runs at most once per session.
+export const PAGE_USAGE_REL = '.cache/page-usage.jsonl';
+
+export function pageUsageGuardCachePath(sessionId, hypoDir) {
+  const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9._-]/g, '_') || 'default';
+  // djb2 over the vault path so the cache key is per-(session, vault).
+  let h = 5381;
+  const s = String(hypoDir || '');
+  for (let i = 0; i < s.length; i++) h = ((h * 33) ^ s.charCodeAt(i)) >>> 0;
+  return join(tmpdir(), `hypo-pageusage-guard-${safe}-${h.toString(36)}.json`);
+}
+
+export function pageUsageLoggingAllowed(hypoDir, sessionId) {
+  // The load-bearing commit gate is .hypoignore: it is what hypo-auto-stage and
+  // commitWikiChanges actually filter on. Re-check it FRESH on every call (it is
+  // cheap, no subprocess) so that if coverage is removed mid-session the guard
+  // flips closed immediately and can never leave logging armed against a
+  // now-committable file. Only the expensive git check-ignore probe is cached
+  // per session. Any error on either signal fails closed.
+  let hypoIgnored = false;
+  try {
+    const target = join(hypoDir, PAGE_USAGE_REL);
+    const patterns = loadHypoIgnore(hypoDir);
+    hypoIgnored = patterns.length > 0 && isIgnored(target, hypoDir, patterns);
+  } catch {
+    hypoIgnored = false;
+  }
+  if (!hypoIgnored) return false;
+
+  return gitIgnoresPageUsageCached(hypoDir, sessionId);
+}
+
+// git check-ignore is the belt signal (defends a manual `git add`); it spawns a
+// subprocess, so cache its result per session. The verdict cached here is only
+// the git signal, never the composite allow decision, so the fresh .hypoignore
+// re-check above always still runs.
+function gitIgnoresPageUsageCached(hypoDir, sessionId) {
+  const cachePath = pageUsageGuardCachePath(sessionId, hypoDir);
+  try {
+    if (existsSync(cachePath)) {
+      const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      if (typeof cached.gitIgnored === 'boolean') return cached.gitIgnored;
+    }
+  } catch {
+    // corrupt cache → recompute below
+  }
+
+  let gitIgnored = false;
+  try {
+    gitIgnored =
+      spawnSync('git', ['-C', hypoDir, 'check-ignore', '-q', '--', PAGE_USAGE_REL], {
+        timeout: 2000,
+      }).status === 0;
+  } catch {
+    gitIgnored = false;
+  }
+
+  try {
+    writeFileSync(cachePath, JSON.stringify({ gitIgnored }));
+  } catch {
+    // cache write failure is non-fatal; the git probe just reruns next prompt
+  }
+  return gitIgnored;
+}
+
+// Append one JSONL record per injected slug to .cache/page-usage.jsonl. Callers
+// MUST gate this behind pageUsageLoggingAllowed first. Fully fail-open: any error
+// (mkdir, disk, serialization) is swallowed so a logging failure never disturbs
+// the lookup injection that already happened (mirrors hypo-session-record).
+export function recordLookupUsage(hypoDir, { sessionId = null, slugs = [] } = {}) {
+  try {
+    if (!Array.isArray(slugs) || slugs.length === 0) return;
+    const target = join(hypoDir, PAGE_USAGE_REL);
+    mkdirSync(join(hypoDir, '.cache'), { recursive: true });
+    const ts = new Date().toISOString();
+    const lines = slugs
+      .map((slug) => JSON.stringify({ ts, session_id: sessionId ?? null, slug, source: 'lookup' }))
+      .join('\n');
+    appendFileSync(target, lines + '\n');
+  } catch {
+    // logging is observability; never let it break injection (fail-open)
+  }
+}
+
 // ── cwd ↔ project matcher ────────────────────────────────────────────────────
 // Hand-synced with scripts/lib/wd-match.mjs: hooks deploy to ~/.claude/hooks/
 // without scripts/, so this cannot import the lib and must mirror it. Keep the

--- a/qa-runs/2026-07-04.md
+++ b/qa-runs/2026-07-04.md
@@ -1,0 +1,41 @@
+# QA run 2026-07-04: wiki-freshness-usage-signals (A+B)
+
+Real hook binaries (repo copies) exercised end-to-end against real git vaults with real .gitignore/.hypoignore. Verifies the codex/advisor fixes: F1 (doctor-parity YAML-comment strip), F2 (fresh .hypoignore recheck / mid-session privacy), F3 (null-record robustness), and the held-advisory gate.
+
+## QA1: freshness (overdue+inline-comment gets STALE, future none) + page-usage logged
+
+- HIT: true
+- cal overdue(inline-comment) STALE: true
+- exactly one STALE (fut excluded): true
+- page-usage.jsonl:
+  {"ts":"2026-07-04T11:07:38.448Z","session_id":"qa1","slug":"cal","source":"lookup"}
+  {"ts":"2026-07-04T11:07:38.448Z","session_id":"qa1","slug":"fut","source":"lookup"}
+
+## QA2: fail-closed logging (no .gitignore coverage) + injection still works
+
+- injection HIT still works: true
+- no page-usage.jsonl written (fail-closed OK)
+
+## QA3: session-start applies STALE to project hot with overdue verify_by_date
+
+- project hot injected: true
+- STALE on overdue project hot: true
+
+## QA4: crystallize advisory gate (no-log vault silent; accruing vault shows held)
+
+- no-log vault: silent (OK)
+- accruing vault (span<14d): held shown (OK)
+
+## QA5: upgrade adds .cache/ to a legacy vault .gitignore, git then ignores the log
+
+- .cache/ appended to .gitignore (OK)
+- git now ignores .cache/page-usage.jsonl (OK)
+
+## QA6: F2 mid-session privacy (removing .hypoignore denies further logging live)
+
+- log lines before removal: 1, after removal: 1 (must be equal = no new logging)
+- mid-session removal fails closed (OK)
+
+## Result
+
+All QA1..QA6 pass. Hooks behave as specified end-to-end; the codex/advisor fixes (F1/F2/F3, held gate) are confirmed against real vaults.

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -73,6 +73,7 @@ import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
 import { collectPagesCrystallize, extractWikilinks } from './lib/wikilink.mjs';
+import { aggregateColdCandidates } from './lib/page-usage.mjs';
 import { isValidProjectName } from './lib/project-create.mjs';
 import { appendPendingTags, checkForbidden } from './lib/schema-vocab.mjs';
 import {
@@ -1315,8 +1316,12 @@ const synthesisGroups = Object.entries(tagGroups)
   .sort((a, b) => b[1].length - a[1].length)
   .map(([tag, pages]) => ({ tag, pages }));
 
+// Lookup-cold candidates (B): pages with inbound wikilinks that lookup has not
+// injected within the recency window. Advisory only, never gates, never mutates.
+const coldCandidates = aggregateColdCandidates(args.hypoDir, { ignorePatterns });
+
 if (args.json) {
-  console.log(JSON.stringify({ synthesisGroups, unlinked, drafts }, null, 2));
+  console.log(JSON.stringify({ synthesisGroups, unlinked, drafts, coldCandidates }, null, 2));
   process.exit(0);
 }
 
@@ -1344,6 +1349,25 @@ if (drafts.length > 0) {
   console.log(`Draft/speculative pages ready to crystallize — ${drafts.length}:`);
   for (const p of drafts) console.log(`  [[${p.slug}]] — ${p.title}`);
   console.log('');
+}
+
+// Advisory (non-gating): pages the graph treats as live but lookup has not
+// injected recently. Held until enough page-usage history accrues.
+if (coldCandidates.status === 'ok' && coldCandidates.candidates.length > 0) {
+  found = true;
+  console.log(
+    `Lookup-cold pages (${coldCandidates.candidates.length}), inbound links but not injected recently:`,
+  );
+  for (const p of coldCandidates.candidates) console.log(`  [[${p.slug}]] (${p.title})`);
+  console.log('');
+} else if (
+  coldCandidates.status === 'insufficient-data' &&
+  coldCandidates.reason === 'span-too-short'
+) {
+  // Only surface the "held" notice once a log is actually accruing (span under
+  // the cold-start window). A vault with no log at all stays silent so this
+  // advisory never becomes permanent noise on every crystallize run.
+  console.log('Lookup-cold scan held: not enough page-usage history yet (advisory).\n');
 }
 
 if (!found) {

--- a/scripts/lib/page-usage.mjs
+++ b/scripts/lib/page-usage.mjs
@@ -1,0 +1,141 @@
+// page-usage.mjs: read-only aggregation over .cache/page-usage.jsonl (B3)
+//
+// The lookup hook appends one JSONL record per injected page slug (see
+// hooks/hypo-shared.mjs recordLookupUsage). This lib reads that log and derives
+// "lookup-cold candidates": pages that have inbound wikilinks (so the graph
+// treats them as live) but have not been injected by lookup within a recency
+// window. It writes nothing and is only invoked from scripts (crystallize), so
+// it never touches the per-prompt hook hot path.
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { collectPagesCrystallize, extractWikilinks, slugForms } from './wikilink.mjs';
+import { parseFrontmatter } from './frontmatter.mjs';
+
+const PAGE_USAGE_REL = '.cache/page-usage.jsonl';
+const DAY_MS = 86400000;
+
+// The distinct link forms a slug may appear as in a [[wikilink]] or in the log:
+// its full path, its basename, and (when nested) the path minus its first
+// segment. Matching by form-set intersection bridges the gap between the log's
+// index-matched slug form and the reverse index's [[wikilink]] form.
+function formSet(slug) {
+  const f = slugForms(slug);
+  const s = new Set([f.full, f.bare]);
+  if (f.dirRel) s.add(f.dirRel);
+  return s;
+}
+
+function intersects(a, b) {
+  for (const x of a) if (b.has(x)) return true;
+  return false;
+}
+
+// Read every record from the usage log, skipping malformed lines. Returns [] if
+// the log is absent or unreadable (fail-soft: aggregation is advisory).
+export function readPageUsage(hypoDir) {
+  const path = join(hypoDir, PAGE_USAGE_REL);
+  if (!existsSync(path)) return [];
+  let text;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return [];
+  }
+  const records = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      // Only keep plain objects. A bare `null`, number, string, or array is
+      // valid JSON but not a record; keeping it would crash the field access in
+      // aggregateColdCandidates (and crystallize calls that outside a try).
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        records.push(parsed);
+      }
+    } catch {
+      // malformed line → skip (log is append-only and may be partially written)
+    }
+  }
+  return records;
+}
+
+// Derive lookup-cold candidates. Guards against cold-start: if there are no
+// records, or the observed log span is shorter than minLogSpanDays, returns
+// { status: 'insufficient-data' } so a fresh log doesn't flag the whole vault.
+// Otherwise returns { status: 'ok', candidates: [{ slug, title }] } for pages
+// that have >= 1 inbound wikilink from another page yet have not been logged
+// within the last thresholdDays.
+export function aggregateColdCandidates(
+  hypoDir,
+  { thresholdDays = 90, minLogSpanDays = 14, now = Date.now(), ignorePatterns = [] } = {},
+) {
+  const records = readPageUsage(hypoDir);
+  if (records.length === 0) return { status: 'insufficient-data', reason: 'no-records' };
+
+  const times = records.map((r) => Date.parse(r.ts)).filter((t) => Number.isFinite(t));
+  if (times.length === 0) return { status: 'insufficient-data', reason: 'no-timestamps' };
+  const span = Math.max(...times) - Math.min(...times);
+  if (span < minLogSpanDays * DAY_MS) {
+    return { status: 'insufficient-data', reason: 'span-too-short' };
+  }
+
+  // Forms of every slug logged within the recency window.
+  const recentCutoff = now - thresholdDays * DAY_MS;
+  const recentForms = new Set();
+  for (const r of records) {
+    const t = Date.parse(r.ts);
+    if (!Number.isFinite(t) || t < recentCutoff) continue;
+    if (typeof r.slug !== 'string' || !r.slug) continue;
+    for (const form of formSet(r.slug)) recentForms.add(form);
+  }
+
+  // Build the page list with slug, title, forms, and outbound links.
+  const pagesDir = join(hypoDir, 'pages');
+  const pageList = [];
+  for (const { path, rel } of collectPagesCrystallize(pagesDir, hypoDir, ignorePatterns)) {
+    let content;
+    try {
+      content = readFileSync(path, 'utf-8');
+    } catch {
+      continue;
+    }
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+    const slug = rel.replace(/\.md$/, '');
+    const body = content.replace(/^---[\s\S]*?---/, '');
+    pageList.push({
+      slug,
+      title: fm.title || slug,
+      forms: formSet(slug),
+      links: extractWikilinks(body),
+    });
+  }
+
+  // Reverse index: which page slugs receive >= 1 inbound link from another page.
+  const formOwners = new Map(); // form → Set<page slug>
+  for (const p of pageList) {
+    for (const form of p.forms) {
+      if (!formOwners.has(form)) formOwners.set(form, new Set());
+      formOwners.get(form).add(p.slug);
+    }
+  }
+  const hasInbound = new Set();
+  for (const p of pageList) {
+    for (const link of p.links) {
+      const targets = new Set();
+      for (const form of formSet(link)) {
+        const owners = formOwners.get(form);
+        if (owners) for (const o of owners) targets.add(o);
+      }
+      for (const t of targets) if (t !== p.slug) hasInbound.add(t);
+    }
+  }
+
+  const candidates = pageList
+    .filter((p) => hasInbound.has(p.slug) && !intersects(p.forms, recentForms))
+    .map((p) => ({ slug: p.slug, title: p.title }));
+
+  return { status: 'ok', candidates };
+}

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -465,6 +465,49 @@ function applyHypoignoreMigration(result) {
   return appended;
 }
 
+// ── .gitignore migration: mirror .cache/ into .gitignore (page-usage privacy) ─
+//
+// Legacy vaults may have a .gitignore that predates .cache/ (init now scaffolds
+// it, but old vaults were migrated only in .hypoignore). Without .cache/ in
+// .gitignore, the page-usage log could be committed. This mirrors the hypoignore
+// migration: idempotent append of the missing entry, no-op when already present
+// or when there is no .gitignore (the runtime logging guard fails closed for the
+// no-file case, so nothing leaks in the meantime).
+
+const GITIGNORE_REQUIRED_ENTRIES = [
+  {
+    pattern: '.cache/',
+    comment: '# Hypomnema runtime cache (page-usage log, session growth metrics)',
+  },
+];
+
+function checkGitignore(hypoDir) {
+  const path = join(hypoDir, '.gitignore');
+  if (!existsSync(path)) return { status: 'no-file', missing: [], path };
+  const content = readFileSync(path, 'utf-8');
+  const entries = new Set(
+    content
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#')),
+  );
+  const missing = GITIGNORE_REQUIRED_ENTRIES.filter((e) => !entries.has(e.pattern));
+  return { status: missing.length === 0 ? 'up-to-date' : 'needs-migration', missing, path };
+}
+
+function applyGitignoreMigration(result) {
+  if (result.status !== 'needs-migration') return [];
+  let content = readFileSync(result.path, 'utf-8');
+  if (!content.endsWith('\n')) content += '\n';
+  const appended = [];
+  for (const entry of result.missing) {
+    content += `\n${entry.comment}\n${entry.pattern}\n`;
+    appended.push(entry.pattern);
+  }
+  writeFileSync(result.path, content);
+  return appended;
+}
+
 function writeMigrationReport(hypoDir, fromVersion, toVersion, { pluginMode = false } = {}) {
   const today = new Date().toISOString().slice(0, 10);
   const filename = `MIGRATION-v${toVersion}.md`;
@@ -849,6 +892,7 @@ const pkgJson = checkPkgJson();
 const commands = checkCommands();
 const oldHookRefs = checkOldHookNames(claudeSettingsPath);
 const hypoignore = checkHypoignore(args.hypoDir);
+const gitignore = checkGitignore(args.hypoDir);
 
 // when --codex is set, mirror the same core-hook checks against ~/.codex/
 // so `hypomnema upgrade --codex` reports drift symmetrically and `--apply --codex`
@@ -930,6 +974,7 @@ let appliedSettingsCodex = [];
 let appliedHookNameRenamesCodex = [];
 let appliedCommands = [];
 let appliedHypoignore = [];
+let appliedGitignore = [];
 let appliedExtensions = null;
 let appliedExtensionsCodex = null;
 
@@ -1014,6 +1059,7 @@ if (args.apply) {
     }
   }
   appliedHypoignore = applyHypoignoreMigration(hypoignore);
+  appliedGitignore = applyGitignoreMigration(gitignore);
   // codex core hooks + settings + wiki-*→hypo-* rename mirror. Same order
   // as the claude side (rename first so subsequent hook copy can find renamed targets).
   if (args.codex) {
@@ -1089,6 +1135,7 @@ const hasDrift =
   pkgJsonDrift ||
   schemaDrift ||
   hypoignore.status === 'needs-migration' ||
+  gitignore.status === 'needs-migration' ||
   extDrift ||
   codexCoreDrift;
 
@@ -1109,6 +1156,7 @@ if (args.json) {
         commands,
         oldHookRefs,
         hypoignore,
+        gitignore,
         extensions: extCheck,
         extensionsCodex: extCheckCodex,
         // codex core mirror (null when --codex absent).
@@ -1122,6 +1170,7 @@ if (args.json) {
           hookNameRenames: appliedHookNameRenames,
           commands: appliedCommands,
           hypoignore: appliedHypoignore,
+          gitignore: appliedGitignore,
           extensions: appliedExtensions,
           extensionsCodex: appliedExtensionsCodex,
           hooksCodex: appliedHooksCodex,
@@ -1369,6 +1418,18 @@ if (hypoignore.status === 'no-file') {
   for (const e of hypoignore.missing) lines.push(`    + ${e.pattern}`);
 }
 
+// .gitignore migration (page-usage privacy: mirror .cache/ into .gitignore)
+if (gitignore.status === 'no-file') {
+  lines.push(`⚠ .gitignore        not found at ${gitignore.path} (init.mjs scaffolds this)`);
+} else if (gitignore.status === 'up-to-date') {
+  lines.push(`✓ .gitignore        required entries present`);
+} else {
+  lines.push(
+    `⚠ .gitignore        ${gitignore.missing.length} missing entry(s), run --apply to append:`,
+  );
+  for (const e of gitignore.missing) lines.push(`    + ${e.pattern}`);
+}
+
 // Extensions companion (conflict/drift gating E3, #31). Shared by the
 // claude target and, under --codex, the codex target (E4, #32) — the label keeps
 // the two blocks distinguishable in the report.
@@ -1424,6 +1485,7 @@ if (
   appliedHookNameRenames.length > 0 ||
   appliedCommands.length > 0 ||
   appliedHypoignore.length > 0 ||
+  appliedGitignore.length > 0 ||
   appliedHooksCodex.length > 0 ||
   appliedSettingsCodex.length > 0 ||
   appliedHookNameRenamesCodex.length > 0
@@ -1451,6 +1513,10 @@ if (
   if (appliedHypoignore.length > 0) {
     lines.push(`✓ Appended .hypoignore entries (${appliedHypoignore.length}):`);
     for (const e of appliedHypoignore) lines.push(`    → ${e}`);
+  }
+  if (appliedGitignore.length > 0) {
+    lines.push(`✓ Appended .gitignore entries (${appliedGitignore.length}):`);
+    for (const e of appliedGitignore) lines.push(`    → ${e}`);
   }
   // codex-target applied actions (mirrors claude blocks above).
   if (appliedHookNameRenamesCodex.length > 0) {
@@ -1507,6 +1573,7 @@ const totalDrift =
   (pkgJsonDrift ? 1 : 0) +
   (schemaDrift ? 1 : 0) +
   (hypoignore.status === 'needs-migration' ? hypoignore.missing.length : 0) +
+  (gitignore.status === 'needs-migration' ? gitignore.missing.length : 0) +
   extCheck.actions.filter(
     (a) => a.action === 'create' || a.action === 'update' || a.action === 'force-update',
   ).length +
@@ -1544,6 +1611,7 @@ if (totalDrift === 0) {
     (appliedPkgJson ? 1 : 0) +
     appliedHookNameRenames.length +
     appliedHypoignore.length +
+    appliedGitignore.length +
     appliedExtCount +
     appliedHooksCodex.length +
     appliedSettingsCodex.length +

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -33,6 +33,7 @@ import { buildProjectSuggestionLine, resolveActiveProject } from '../hooks/hypo-
 import { parseSchemaVocab, appendPendingTags } from '../scripts/lib/schema-vocab.mjs';
 import { parseFrontmatter as libParseFrontmatter } from '../scripts/lib/frontmatter.mjs';
 import { isHypomnemaPluginEnabled } from '../scripts/lib/plugin-detect.mjs';
+import { readPageUsage, aggregateColdCandidates } from '../scripts/lib/page-usage.mjs';
 import {
   validateChangelog,
   validateTagBody,
@@ -1053,6 +1054,12 @@ const {
   precompactGateStatus,
   commitWikiChanges,
   syncRemote,
+  isOverdueDate,
+  staleMarkerFor,
+  pageUsageLoggingAllowed,
+  pageUsageGuardCachePath,
+  recordLookupUsage,
+  PAGE_USAGE_REL,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
@@ -1642,6 +1649,142 @@ test('merges extra fields alongside additionalContext', () => {
   const out = buildOutput('ctx', { continue: true });
   assert.equal(out.continue, true);
   assert.equal(out.additionalContext, 'ctx');
+});
+
+// ── A1: overdue verify_by_date predicate + STALE marker (freshness) ──────────
+suite('hypo-shared.mjs — overdue predicate + STALE marker (A1)');
+
+test('isOverdueDate: past ISO date is overdue', () => {
+  assert.equal(isOverdueDate('2020-01-01', '2026-07-02'), true);
+});
+
+test('isOverdueDate: future and today are not overdue', () => {
+  assert.equal(isOverdueDate('2030-01-01', '2026-07-02'), false);
+  assert.equal(isOverdueDate('2026-07-02', '2026-07-02'), false);
+});
+
+test('isOverdueDate: malformed date is not overdue', () => {
+  assert.equal(isOverdueDate('2020-1-1', '2026-07-02'), false);
+  assert.equal(isOverdueDate('not-a-date', '2026-07-02'), false);
+  assert.equal(isOverdueDate('', '2026-07-02'), false);
+  assert.equal(isOverdueDate(null, '2026-07-02'), false);
+});
+
+test('staleMarkerFor: overdue verify_by_date yields marker', () => {
+  const raw = '---\ntype: page\nverify_by_date: 2020-01-01\n---\n# body';
+  assert.equal(staleMarkerFor(raw, '2026-07-02'), '[STALE verify_by_date=2020-01-01]');
+});
+
+test('staleMarkerFor: future/absent/malformed verify_by_date yields empty', () => {
+  assert.equal(staleMarkerFor('---\nverify_by_date: 2030-01-01\n---\nx', '2026-07-02'), '');
+  assert.equal(staleMarkerFor('---\ntype: page\n---\nx', '2026-07-02'), '');
+  assert.equal(staleMarkerFor('---\nverify_by_date: 2020-1-1\n---\nx', '2026-07-02'), '');
+  assert.equal(staleMarkerFor('no frontmatter at all', '2026-07-02'), '');
+});
+
+test('staleMarkerFor: legacy date in verify_by (not verify_by_date) yields empty', () => {
+  // verify_by holds the question, never a date. A date parked there must not
+  // trigger STALE (D1: only verify_by_date is a deadline).
+  const raw = '---\ntype: page\nverify_by: 2020-01-01\n---\n# body';
+  assert.equal(staleMarkerFor(raw, '2026-07-02'), '');
+});
+
+test('staleMarkerFor: strips a trailing YAML comment (doctor parity)', () => {
+  // doctor parses via frontmatter.mjs, which strips `\s+#.*`. staleMarkerFor must
+  // match, or an overdue page with an inline comment silently loses its marker.
+  const raw = '---\ntype: page\nverify_by_date: 2020-01-01 # yearly recheck\n---\n# body';
+  assert.equal(staleMarkerFor(raw, '2026-07-02'), '[STALE verify_by_date=2020-01-01]');
+  const quoted = '---\nverify_by_date: "2020-01-01" # note\n---\nx';
+  assert.equal(staleMarkerFor(quoted, '2026-07-02'), '[STALE verify_by_date=2020-01-01]');
+  // doctor's parser splits on the first colon, so `key : value` is tolerated.
+  const spaced = '---\nverify_by_date : 2020-01-01\n---\nx';
+  assert.equal(staleMarkerFor(spaced, '2026-07-02'), '[STALE verify_by_date=2020-01-01]');
+});
+
+test('verify.mjs stays independent of the shared predicate (A1 invariant)', () => {
+  // The shared predicate must not be silently unified into verify.mjs, whose
+  // missing-short-circuit (verify_by absent → missing) is a distinct contract.
+  const verifySrc = readFileSync(join(REPO, 'scripts', 'verify.mjs'), 'utf-8');
+  assert.ok(
+    !/hypo-shared/.test(verifySrc),
+    'verify.mjs must not import hypo-shared (overdue set stays distinct)',
+  );
+});
+
+// ── B1: page-usage logging coverage guard (fail-closed) ──────────────────────
+suite('hypo-shared.mjs — page-usage logging guard (B1)');
+
+function gitRepo(dir) {
+  const opts = { cwd: dir, encoding: 'utf-8' };
+  spawnSync('git', ['init', '-q'], opts);
+  spawnSync('git', ['config', 'user.email', 't@t.test'], opts);
+  spawnSync('git', ['config', 'user.name', 'test'], opts);
+}
+
+test('guard true when both .gitignore and .hypoignore cover .cache/', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+    writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-both'), true);
+  });
+});
+
+test('guard false when only .gitignore covers .cache/ (both signals required)', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-git-only'), false);
+  });
+});
+
+test('guard false when only .hypoignore covers .cache/', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-hypo-only'), false);
+  });
+});
+
+test('guard false in a non-git vault (fail-closed)', () => {
+  withTmpDir((dir) => {
+    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+    writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-nogit'), false);
+  });
+});
+
+test('git probe is cached per session (no recompute of the git signal)', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+    writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-cache'), true);
+    const cachePath = pageUsageGuardCachePath('b1-cache', dir);
+    assert.ok(existsSync(cachePath), 'guard must write a session cache file');
+    // Remove .gitignore coverage. A fresh git probe would now say "not ignored",
+    // but the git signal is cached, so with .hypoignore still present the verdict
+    // stays true, proving the 2nd call skipped the git subprocess.
+    rmSync(join(dir, '.gitignore'));
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-cache'), true, 'git signal must be cached');
+  });
+});
+
+test('privacy: removing .hypoignore mid-session flips the guard closed', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+    writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-privacy'), true);
+    // .hypoignore is the load-bearing commit gate and is re-checked fresh every
+    // call: dropping it must immediately deny logging even within the session.
+    rmSync(join(dir, '.hypoignore'));
+    assert.equal(
+      pageUsageLoggingAllowed(dir, 'b1-privacy'),
+      false,
+      'a mid-session .hypoignore removal must fail closed',
+    );
+  });
 });
 
 suite('hypo-shared.mjs — session-scoped lint (Bug A/B)');
@@ -3665,6 +3808,90 @@ test('--apply .hypoignore migration appends .cache/ and is idempotent', () => {
         afterFirst,
         '.hypoignore content drifted across idempotent --apply',
       );
+    });
+  });
+});
+
+// ── B5: .gitignore migration mirrors .cache/ (page-usage privacy) ────────────
+test('--apply .gitignore migration appends .cache/, git-ignores the log, idempotent', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      // Simulate a legacy vault: a .gitignore that predates the .cache/ entry.
+      const gitignorePath = join(hypoDir, '.gitignore');
+      const original = (existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : '')
+        .split('\n')
+        .filter((line) => line.trim() !== '.cache/')
+        .join('\n');
+      writeFileSync(gitignorePath, original || '# legacy\nnode_modules/\n');
+      // Make it a git repo so we can prove the log ends up ignored.
+      const gopts = { cwd: hypoDir, encoding: 'utf-8' };
+      spawnSync('git', ['init', '-q'], gopts);
+      spawnSync('git', ['config', 'user.email', 't@t.test'], gopts);
+      spawnSync('git', ['config', 'user.name', 'test'], gopts);
+
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r1.status, 0, `first --apply failed: ${r1.stderr}`);
+      const out1 = JSON.parse(r1.stdout);
+      assert.deepEqual(
+        out1.applied.gitignore,
+        ['.cache/'],
+        'expected .cache/ appended to .gitignore',
+      );
+      const afterFirst = readFileSync(gitignorePath, 'utf-8');
+      assert.equal(
+        (afterFirst.match(/^\.cache\/$/gm) || []).length,
+        1,
+        '.cache/ should appear exactly once in .gitignore',
+      );
+      // Privacy: the page-usage log is now git-ignored.
+      const ci = spawnSync(
+        'git',
+        ['-C', hypoDir, 'check-ignore', '-q', '--', '.cache/page-usage.jsonl'],
+        { encoding: 'utf-8' },
+      );
+      assert.equal(ci.status, 0, 'page-usage.jsonl must be git-ignored after migration');
+
+      // Idempotent second run.
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r2.status, 0, `second --apply failed: ${r2.stderr}`);
+      const out2 = JSON.parse(r2.stdout);
+      assert.deepEqual(out2.applied.gitignore, [], 'second --apply must not re-append');
+      assert.equal(out2.gitignore.status, 'up-to-date', 'gitignore status should be up-to-date');
+      assert.equal(
+        readFileSync(gitignorePath, 'utf-8'),
+        afterFirst,
+        '.gitignore drifted across idempotent --apply',
+      );
+    });
+  });
+});
+
+test('--apply text report lists the appended .gitignore entry and counts it', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const gitignorePath = join(hypoDir, '.gitignore');
+      const stripped = (existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : '')
+        .split('\n')
+        .filter((line) => line.trim() !== '.cache/')
+        .join('\n');
+      writeFileSync(gitignorePath, stripped || '# legacy\n');
+      // Text mode (no --json): the applied-actions block and the count must
+      // include the gitignore migration, not silently omit it.
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(r.status, 0, `text --apply failed: ${r.stderr}`);
+      assert.ok(
+        /Appended \.gitignore entries/.test(r.stdout),
+        `report must list gitignore: ${r.stdout}`,
+      );
+      const m = r.stdout.match(/Result: (\d+) update\(s\) applied/);
+      assert.ok(m && Number(m[1]) >= 1, `applied count must include gitignore: ${r.stdout}`);
     });
   });
 });
@@ -8445,6 +8672,74 @@ test('session-start still injects non-ignored project hot/state', () => {
   });
 });
 
+// ── A3: STALE marker on project hot/state (session-start) ────────────────────
+suite('hypo-session-start.mjs — STALE marker on project hot/state (A3)');
+
+function withDatedProject(hotBody, fn) {
+  withGrowthWiki((dir) => {
+    const work = mkdtempSync(join(tmpdir(), 'hypo-dated-work-'));
+    const projDir = join(dir, 'projects', 'dated');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'index.md'),
+      `---\ntitle: dated\ntype: project-index\nupdated: 2026-07-04\nworking_dir: "${work}"\n---\n# Dated\n`,
+    );
+    writeFileSync(join(projDir, 'hot.md'), hotBody);
+    writeFileSync(join(projDir, 'session-state.md'), '# state\n## 다음 작업\nDATED_STATE_VALUE\n');
+    try {
+      fn(dir, work);
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+}
+
+test('project hot with overdue verify_by_date gets STALE marker', () => {
+  const hot = '---\ntype: page\nverify_by_date: 2020-01-01\n---\n# hot\nDATED_HOT_VALUE\n';
+  withDatedProject(hot, (dir, work) => {
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+      input: JSON.stringify({ cwd: work, session_id: 'test-a3-stale' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(/DATED_HOT_VALUE/.test(r.stdout), `expected hot injection: ${r.stdout}`);
+    assert.ok(
+      r.stdout.includes('[STALE verify_by_date=2020-01-01]'),
+      `expected STALE marker on overdue project hot: ${r.stdout}`,
+    );
+  });
+});
+
+test('derived project hot without verify_by_date gets no STALE marker', () => {
+  // The realistic case: hot/state are derived summaries with no frontmatter.
+  const hot = '# hot\nDATED_HOT_VALUE\n';
+  withDatedProject(hot, (dir, work) => {
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+      input: JSON.stringify({ cwd: work, session_id: 'test-a3-nostale' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(/DATED_HOT_VALUE/.test(r.stdout), `expected hot injection: ${r.stdout}`);
+    assert.ok(!/\[STALE/.test(r.stdout), `derived hot must not be STALE: ${r.stdout}`);
+  });
+});
+
+test('root/global hot injection path carries no STALE marker logic', () => {
+  // Global hot is a derived pointer table (hypo-hot-rebuild) with no per-page
+  // frontmatter, so A3 deliberately leaves its injection path untouched. Pin
+  // that scope: staleMarkerForPath is only wired to the project hot/state block.
+  const src = readFileSync(join(HOOKS, 'hypo-session-start.mjs'), 'utf-8');
+  const markerCount = (src.match(/staleMarkerForPath\(/g) || []).length;
+  // one definition + two call sites (hotPath, statePath); nothing on global hot.
+  assert.equal(
+    markerCount,
+    3,
+    `staleMarkerForPath must be scoped to project hot/state, found ${markerCount} refs`,
+  );
+});
+
 // ── vault orientation (IMPR-19) ─────────────────────────────────────
 // When cwd is a project working_dir distinct from the vault, the hooks surface
 // a one-line "[WIKI VAULT: <path>]" orientation so the AI does not re-discover
@@ -10312,6 +10607,360 @@ test('ADR entry ranked above plain entry with same keyword', () => {
     const plainPos = ctx.indexOf('bm25-notes');
     assert.ok(adrPos !== -1, 'ADR entry should appear in context');
     assert.ok(adrPos < plainPos || plainPos === -1, 'ADR should rank before plain entry');
+  });
+});
+
+// ── A2: STALE marker at lookup injection ─────────────────────────────────────
+suite('hypo-lookup.mjs — STALE marker at injection (A2)');
+
+function stalePageVault(dir, verifyByDateLine) {
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  const fm = ['---', 'type: page', 'title: Overdue Notes', verifyByDateLine, '---']
+    .filter(Boolean)
+    .join('\n');
+  writeFileSync(
+    join(dir, 'pages', 'freshness-notes.md'),
+    `${fm}\n# body about widget calibration\n`,
+  );
+  writeFileSync(
+    join(dir, 'index.md'),
+    ['# Index', '- [[freshness-notes]] — widget calibration freshness notes'].join('\n'),
+  );
+}
+
+test('overdue verify_by_date page gets STALE marker injected', () => {
+  withTmpDir((dir) => {
+    stalePageVault(dir, 'verify_by_date: 2020-01-01');
+    const r = runHook('hypo-lookup.mjs', { prompt: 'widget calibration' }, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    assert.ok(ctx.includes('freshness-notes'), `page should be a HIT: ${ctx}`);
+    assert.ok(
+      ctx.includes('[STALE verify_by_date=2020-01-01]'),
+      `expected STALE marker in injection: ${ctx}`,
+    );
+  });
+});
+
+test('future verify_by_date page gets no STALE marker', () => {
+  withTmpDir((dir) => {
+    stalePageVault(dir, 'verify_by_date: 2099-01-01');
+    const r = runHook('hypo-lookup.mjs', { prompt: 'widget calibration' }, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    assert.ok(ctx.includes('freshness-notes'), `page should be a HIT: ${ctx}`);
+    assert.ok(!/\[STALE/.test(ctx), `future date must not be STALE: ${ctx}`);
+  });
+});
+
+test('legacy date in verify_by (not verify_by_date) gets no STALE marker', () => {
+  withTmpDir((dir) => {
+    // verify_by holds the question, never a date (D1). A date parked there must
+    // not trigger STALE at injection.
+    stalePageVault(dir, 'verify_by: 2020-01-01');
+    const r = runHook('hypo-lookup.mjs', { prompt: 'widget calibration' }, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    assert.ok(ctx.includes('freshness-notes'), `page should be a HIT: ${ctx}`);
+    assert.ok(!/\[STALE/.test(ctx), `verify_by date must not be STALE: ${ctx}`);
+  });
+});
+
+// ── B2: page-usage logging at lookup injection ───────────────────────────────
+suite('hypo-lookup.mjs — page-usage logging at injection (B2)');
+
+function usageVault(dir, { git = true, gitignore = true, hypoignore = true } = {}) {
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  writeFileSync(
+    join(dir, 'pages', 'freshness-notes.md'),
+    '---\ntype: page\ntitle: Notes\n---\n# body about widget calibration\n',
+  );
+  writeFileSync(
+    join(dir, 'index.md'),
+    ['# Index', '- [[freshness-notes]] — widget calibration freshness notes'].join('\n'),
+  );
+  if (git) {
+    const opts = { cwd: dir, encoding: 'utf-8' };
+    spawnSync('git', ['init', '-q'], opts);
+    spawnSync('git', ['config', 'user.email', 't@t.test'], opts);
+    spawnSync('git', ['config', 'user.name', 'test'], opts);
+  }
+  if (gitignore) writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+  if (hypoignore) writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+}
+
+test('HIT in a guard-passing vault appends a well-formed page-usage record', () => {
+  withTmpDir((dir) => {
+    usageVault(dir);
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'widget calibration', session_id: 'b2-hit' },
+      { HYPO_DIR: dir },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.ok((out.additionalContext ?? '').includes('freshness-notes'), 'expected HIT');
+    const logPath = join(dir, '.cache', 'page-usage.jsonl');
+    assert.ok(existsSync(logPath), 'page-usage.jsonl must be written on guarded HIT');
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
+    const rec = JSON.parse(lines[lines.length - 1]);
+    assert.equal(rec.slug, 'freshness-notes');
+    assert.equal(rec.source, 'lookup');
+    assert.equal(rec.session_id, 'b2-hit');
+    assert.ok(/^\d{4}-\d{2}-\d{2}T/.test(rec.ts), `ts must be ISO: ${rec.ts}`);
+  });
+});
+
+test('fail-closed logging: no coverage → no log, injection still succeeds', () => {
+  withTmpDir((dir) => {
+    // git repo but .gitignore does NOT cover .cache/ → guard denies logging.
+    usageVault(dir, { gitignore: false });
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'widget calibration', session_id: 'b2-closed' },
+      { HYPO_DIR: dir },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(r.status, 0);
+    assert.ok(
+      (out.additionalContext ?? '').includes('freshness-notes'),
+      'injection must still work',
+    );
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'page-usage.jsonl')),
+      'no log may be written without commit coverage',
+    );
+  });
+});
+
+test('fail-open injection: append failure does not break the HIT', () => {
+  withTmpDir((dir) => {
+    usageVault(dir);
+    // Make the append target a directory so appendFileSync throws (EISDIR).
+    mkdirSync(join(dir, '.cache', 'page-usage.jsonl'), { recursive: true });
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'widget calibration', session_id: 'b2-open' },
+      { HYPO_DIR: dir },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(r.status, 0);
+    assert.ok(
+      (out.additionalContext ?? '').includes('freshness-notes'),
+      'injection must survive a logging failure',
+    );
+  });
+});
+
+// ── B3: read-only page-usage aggregation (cold-start guard) ──────────────────
+suite('page-usage.mjs — cold-candidate aggregation (B3)');
+
+const B3_NOW = Date.parse('2026-07-04T00:00:00Z');
+const B3_DAY = 86400000;
+
+function coldVault(dir, logLines) {
+  mkdirSync(join(dir, 'pages', 'learnings'), { recursive: true });
+  // hub links out to a nested page (bare/prefix mismatch) and a flat page.
+  writeFileSync(
+    join(dir, 'pages', 'hub.md'),
+    '---\ntype: page\ntitle: Hub\n---\n# Hub\n[[cold-page]] and [[learnings/warm-page]]\n',
+  );
+  writeFileSync(join(dir, 'pages', 'cold-page.md'), '---\ntype: page\ntitle: Cold\n---\n# Cold\n');
+  writeFileSync(
+    join(dir, 'pages', 'learnings', 'warm-page.md'),
+    '---\ntype: page\ntitle: Warm\n---\n# Warm\n',
+  );
+  mkdirSync(join(dir, '.cache'), { recursive: true });
+  writeFileSync(join(dir, '.cache', 'page-usage.jsonl'), logLines.join('\n') + '\n');
+}
+
+test('readPageUsage skips malformed lines, keeps valid records', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'page-usage.jsonl'),
+      [
+        '{"ts":"2026-07-01T00:00:00Z","slug":"a","source":"lookup"}',
+        'not json',
+        '',
+        '{"slug":"b"}',
+      ].join('\n') + '\n',
+    );
+    const recs = readPageUsage(dir);
+    assert.equal(recs.length, 2);
+    assert.equal(recs[0].slug, 'a');
+  });
+});
+
+test('readPageUsage drops non-object JSON values (null/number/array)', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'page-usage.jsonl'),
+      ['null', '42', '["x"]', '{"slug":"ok","ts":"2026-07-01T00:00:00Z"}'].join('\n') + '\n',
+    );
+    const recs = readPageUsage(dir);
+    assert.equal(recs.length, 1, 'only the object record survives');
+    assert.equal(recs[0].slug, 'ok');
+  });
+});
+
+test('aggregateColdCandidates does not crash on a poisoned null record', () => {
+  withTmpDir((dir) => {
+    coldVault(dir, [
+      'null',
+      JSON.stringify({
+        ts: new Date(B3_NOW - 20 * B3_DAY).toISOString(),
+        slug: 'hub',
+        source: 'lookup',
+      }),
+      JSON.stringify({
+        ts: new Date(B3_NOW - 1 * B3_DAY).toISOString(),
+        slug: 'warm-page',
+        source: 'lookup',
+      }),
+    ]);
+    const out = aggregateColdCandidates(dir, { now: B3_NOW });
+    assert.equal(out.status, 'ok', 'a null line must be skipped, not crash aggregation');
+  });
+});
+
+test('insufficient-data when the observed log span is under minLogSpanDays', () => {
+  withTmpDir((dir) => {
+    coldVault(dir, [
+      JSON.stringify({
+        ts: new Date(B3_NOW - 2 * B3_DAY).toISOString(),
+        slug: 'hub',
+        source: 'lookup',
+      }),
+      JSON.stringify({
+        ts: new Date(B3_NOW - 1 * B3_DAY).toISOString(),
+        slug: 'warm-page',
+        source: 'lookup',
+      }),
+    ]);
+    const out = aggregateColdCandidates(dir, { now: B3_NOW });
+    assert.equal(out.status, 'insufficient-data');
+  });
+});
+
+test('ok: inbound-but-unlogged page is a candidate, recently-logged is not', () => {
+  withTmpDir((dir) => {
+    coldVault(dir, [
+      // 20-day span clears the 14-day cold-start guard.
+      JSON.stringify({
+        ts: new Date(B3_NOW - 20 * B3_DAY).toISOString(),
+        slug: 'hub',
+        source: 'lookup',
+      }),
+      // Logged as the BARE form 'warm-page' though the page is pages/learnings/warm-page:
+      // slugForms normalization must still treat it as logged (excluded).
+      JSON.stringify({
+        ts: new Date(B3_NOW - 1 * B3_DAY).toISOString(),
+        slug: 'warm-page',
+        source: 'lookup',
+      }),
+    ]);
+    const out = aggregateColdCandidates(dir, { now: B3_NOW });
+    assert.equal(out.status, 'ok');
+    const slugs = out.candidates.map((c) => c.slug);
+    // slug is the hypoDir-relative path (pages/...), matching crystallize's convention.
+    assert.ok(slugs.includes('pages/cold-page'), `cold-page must be a candidate: ${slugs}`);
+    assert.ok(
+      !slugs.some((s) => s.endsWith('warm-page')),
+      `recently-logged warm-page must be excluded (slugForms normalization): ${slugs}`,
+    );
+    assert.ok(
+      !slugs.some((s) => s.endsWith('hub')),
+      `hub has no inbound link, must be excluded: ${slugs}`,
+    );
+  });
+});
+
+// ── B4: crystallize surfaces cold candidates (advisory, non-gating) ──────────
+suite('crystallize.mjs — lookup-cold advisory (B4)');
+
+test('scan surfaces cold candidates and exits 0', () => {
+  withTmpDir((dir) => {
+    const now = Date.now();
+    coldVault(dir, [
+      JSON.stringify({
+        ts: new Date(now - 20 * B3_DAY).toISOString(),
+        slug: 'hub',
+        source: 'lookup',
+      }),
+      JSON.stringify({
+        ts: new Date(now - 1 * B3_DAY).toISOString(),
+        slug: 'warm-page',
+        source: 'lookup',
+      }),
+    ]);
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`]);
+    assert.equal(r.status, 0, `scan must stay non-blocking: ${r.stderr}`);
+    assert.ok(/Lookup-cold pages/.test(r.stdout), `expected advisory section: ${r.stdout}`);
+    assert.ok(/cold-page/.test(r.stdout), `expected cold-page candidate: ${r.stdout}`);
+  });
+});
+
+test('--json carries coldCandidates status=ok with the candidate', () => {
+  withTmpDir((dir) => {
+    const now = Date.now();
+    coldVault(dir, [
+      JSON.stringify({
+        ts: new Date(now - 20 * B3_DAY).toISOString(),
+        slug: 'hub',
+        source: 'lookup',
+      }),
+      JSON.stringify({
+        ts: new Date(now - 1 * B3_DAY).toISOString(),
+        slug: 'warm-page',
+        source: 'lookup',
+      }),
+    ]);
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']);
+    assert.equal(r.status, 0);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.coldCandidates.status, 'ok');
+    assert.ok(
+      out.coldCandidates.candidates.some((c) => c.slug === 'pages/cold-page'),
+      `expected cold-page in json: ${r.stdout}`,
+    );
+  });
+});
+
+test('cold-start vault shows held advisory, still exits 0', () => {
+  withTmpDir((dir) => {
+    const now = Date.now();
+    coldVault(dir, [
+      JSON.stringify({
+        ts: new Date(now - 2 * B3_DAY).toISOString(),
+        slug: 'hub',
+        source: 'lookup',
+      }),
+      JSON.stringify({
+        ts: new Date(now - 1 * B3_DAY).toISOString(),
+        slug: 'warm-page',
+        source: 'lookup',
+      }),
+    ]);
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`]);
+    assert.equal(r.status, 0);
+    assert.ok(/held/.test(r.stdout), `expected held advisory: ${r.stdout}`);
+    const rj = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']);
+    assert.equal(JSON.parse(rj.stdout).coldCandidates.status, 'insufficient-data');
+  });
+});
+
+test('vault with no page-usage log stays silent (no held noise)', () => {
+  withTmpDir((dir) => {
+    // No .cache/page-usage.jsonl at all (every current vault). The held advisory
+    // must NOT print, or it becomes permanent noise on every crystallize run.
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'p.md'), '---\ntype: page\ntitle: P\n---\n# P\n');
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`]);
+    assert.equal(r.status, 0);
+    assert.ok(!/Lookup-cold scan held/.test(r.stdout), `no-log vault must be silent: ${r.stdout}`);
+    const rj = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']);
+    assert.equal(JSON.parse(rj.stdout).coldCandidates.status, 'insufficient-data');
   });
 });
 


### PR DESCRIPTION
# English

## What changed

Implements spec `wiki-freshness-usage-signals`, bundles A and B.

- A (injection-time freshness): `hypo-lookup` and `hypo-session-start` prepend a `[STALE verify_by_date=YYYY-MM-DD]` marker to any injected page whose `verify_by_date` is overdue. The overdue predicate lives in `hypo-shared` and is char-identical to `doctor.mjs` (D1). `docs/ARCHITECTURE.md` is updated to describe the real behavior.
- B (page-usage logging + cold-candidate surfacing): `hypo-lookup` logs the slugs it injects to a local-only `.cache/page-usage.jsonl`, behind a fail-closed coverage guard. A read-only aggregator (`scripts/lib/page-usage.mjs`) derives "lookup-cold" pages (inbound links but not injected recently), which `crystallize` surfaces as a non-gating advisory. `upgrade` mirrors `.cache/` into legacy vaults' `.gitignore`.

## Why

`docs/ARCHITECTURE.md` promised "verify-by-date warnings" at lookup injection that did not exist, so overdue knowledge was injected with no staleness signal. Separately, the graph could not tell "linked" from "actually used by lookup", so stale-but-linked pages were invisible. A surfaces the freshness signal at the point of use; B distinguishes graph-liveness from lookup-usage without any new gating.

## How

- The overdue predicate is shared (not duplicated across hooks) and normalizes `verify_by_date` exactly as `doctor.mjs` does, including trailing YAML comments and `key : value`. `verify_by` (the question field) is never treated as a date.
- The marker is computed on raw page content before the 2000-char slice, so a long body cannot truncate frontmatter out of reach. Marker computation is fail-open: a failure drops the marker, never the page.
- Logging is fail-closed: `.cache/page-usage.jsonl` is written only when covered by BOTH `.hypoignore` (re-checked fresh every call, since it is the commit gate) AND git check-ignore (cached per session). Injection itself stays fail-open. Only real HITs log.
- Aggregation guards cold-start (holds until enough log span) and normalizes slug forms so a page logged under its bare form is not a false cold candidate. It skips non-object JSONL records so a poisoned log line cannot crash `crystallize`.
- The crystallize "held" notice appears only while a log is actively accruing, so a vault with no log stays silent.

## Manual verification

Changed hooks (`hypo-lookup`, `hypo-session-start`, `hypo-shared`), so I ran the deployed hook binaries end-to-end against real git vaults with real `.gitignore`/`.hypoignore`. Full run in `qa-runs/2026-07-04.md`. Summary:

- QA1: an overdue page (with an inline YAML comment) gets `[STALE verify_by_date=2020-01-01]` at lookup injection; a future-dated page does not; injected slugs are logged with the `{ts,session_id,slug,source}` schema.
- QA2: a vault without git coverage writes no log (fail-closed) while injection still works.
- QA3: `session-start` applies the marker to overdue project hot/state.
- QA4: `crystallize` is silent on a no-log vault and shows the held notice only while a log is accruing.
- QA5: `upgrade --apply` appends `.cache/` to a legacy `.gitignore`, and git then ignores the log.
- QA6: removing `.hypoignore` mid-session immediately stops further logging (no leak).

`npm test` (1037 passing) and the local CI gate set (lint, check:versions, check:readme, check:tracker-ids, smoke:plugin, init/upgrade smoke) are green.

## Migration notes

Legacy vaults get `.cache/` added to `.gitignore` on the next `/hypo:upgrade --apply` (idempotent). Until then, the runtime logging guard fails closed, so nothing leaks. No data migration: `page-usage.jsonl` is a new local-only file.

---

# 한국어

## 변경 내용

`wiki-freshness-usage-signals` spec의 A, B 묶음을 구현한다.

- A (주입 시점 신선도): `hypo-lookup`과 `hypo-session-start`가 `verify_by_date`가 만료된 주입 페이지 앞에 `[STALE verify_by_date=YYYY-MM-DD]` 마커를 붙인다. 만료 판정은 `hypo-shared`에 두고 `doctor.mjs`와 문자까지 일치시킨다(D1). `docs/ARCHITECTURE.md`도 실제 동작에 맞춰 정정한다.
- B (사용 로깅 + cold 후보 표면화): `hypo-lookup`이 주입한 slug를 로컬 전용 `.cache/page-usage.jsonl`에 fail-closed 커버리지 가드 뒤에서 기록한다. 읽기 전용 집계기(`scripts/lib/page-usage.mjs`)가 "lookup-cold"(inbound 링크는 있으나 최근 주입 안 됨) 페이지를 뽑고, `crystallize`가 비차단 advisory로 표면화한다. `upgrade`는 구버전 볼트 `.gitignore`에 `.cache/`를 보강한다.

## 이유

`docs/ARCHITECTURE.md`가 lookup 주입의 "verify-by-date 경고"를 약속했지만 코드에 없어, 만료된 지식이 신선도 신호 없이 주입됐다. 또한 그래프는 "링크됨"과 "실제 lookup으로 쓰임"을 구분하지 못해, 오래됐지만 링크된 페이지가 보이지 않았다. A는 사용 지점에서 신선도 신호를 붙이고, B는 새로운 게이팅 없이 그래프-생존과 lookup-사용을 분리한다.

## 방법

- 만료 술어는 공유(훅마다 복제 안 함)하고 `verify_by_date`를 `doctor.mjs`와 똑같이 정규화한다(트레일링 YAML 주석, `key : value` 포함). 질문 필드 `verify_by`는 날짜로 취급하지 않는다.
- 마커는 2000자 slice 이전 raw 콘텐츠에서 계산해, 긴 본문이 frontmatter를 잘라내지 못하게 한다. 마커 계산은 fail-open이라 실패해도 페이지가 아니라 마커만 빠진다.
- 로깅은 fail-closed다. `.cache/page-usage.jsonl`은 `.hypoignore`(커밋 게이트라 매 호출 프레시 재검증)와 git check-ignore(세션 1회 캐시) 둘 다 커버할 때만 기록한다. 주입 자체는 fail-open을 유지하고, 실제 HIT만 로깅한다.
- 집계는 cold-start를 가드하고(로그 span이 충분해질 때까지 보류) slug 형태를 정규화해 bare 형태로 기록된 페이지가 거짓 cold 후보가 되지 않게 한다. 객체가 아닌 JSONL 레코드는 건너뛰어 오염된 로그 라인이 `crystallize`를 죽이지 못한다.
- crystallize "held" 안내는 로그가 실제로 쌓이는 중에만 뜨므로, 로그 없는 볼트는 조용하다.

## 수동 검증

훅(`hypo-lookup`, `hypo-session-start`, `hypo-shared`)을 바꿔서, 배포된 훅 바이너리를 실 `.gitignore`/`.hypoignore`를 갖춘 실 git 볼트에 대고 end-to-end로 돌렸다. 전체는 `qa-runs/2026-07-04.md`. 요약:

- QA1: 만료 페이지(인라인 YAML 주석 포함)가 lookup 주입에서 `[STALE verify_by_date=2020-01-01]`를 받고, 미래 날짜 페이지는 안 받는다. 주입 slug는 `{ts,session_id,slug,source}` 스키마로 기록된다.
- QA2: git 커버리지 없는 볼트는 로그를 안 쓰지만(fail-closed) 주입은 정상.
- QA3: `session-start`가 만료된 project hot/state에 마커를 붙인다.
- QA4: `crystallize`는 로그 없는 볼트에서 조용하고, 로그가 쌓이는 중에만 held 안내를 낸다.
- QA5: `upgrade --apply`가 구버전 `.gitignore`에 `.cache/`를 붙이고, git이 로그를 무시하게 된다.
- QA6: 세션 중 `.hypoignore`를 제거하면 즉시 추가 로깅이 멈춘다(누출 없음).

`npm test`(1037 통과)와 로컬 CI 게이트(lint, check:versions, check:readme, check:tracker-ids, smoke:plugin, init/upgrade 스모크)가 green이다.

## 마이그레이션 노트

구버전 볼트는 다음 `/hypo:upgrade --apply` 때 `.gitignore`에 `.cache/`가 추가된다(멱등). 그 전까지는 런타임 로깅 가드가 fail-closed라 누출이 없다. 데이터 마이그레이션 없음: `page-usage.jsonl`은 새 로컬 전용 파일이다.

---

## Changelog

- EN: Lookup and session-start now flag injected pages whose verify_by_date is overdue with a `[STALE ...]` marker, and lookup usage is tracked (locally, fail-closed) to surface linked-but-unused pages in crystallize (#164).
- KO: lookup과 session-start가 verify_by_date가 만료된 주입 페이지에 `[STALE ...]` 마커를 붙이고, lookup 사용을 (로컬, fail-closed로) 추적해 링크됐지만 안 쓰인 페이지를 crystallize에서 표면화한다 (#164).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally (repo scope; pre-existing vault-content warnings are unrelated)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
