### PR TITLE
docs: correct false citation-counting claims across skills and docs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -156,7 +156,7 @@ Hypomnema         ───►  합성 · 마크다운 · git · 훅 · 로컬
 | `hot.md` | 프로젝트별 캐시. "방금 무엇을 했는지"(직전 세션의 핵심) |
 | `session-state.md` | 프로젝트별 캐시. "다음에 무엇을 할지"(다음 세션 시작 때 주입되는 이어받기 데이터) |
 | `.hypoignore` | 모든 콘텐츠 주입 훅과 `ingest`에서 제외할 경로(글롭 패턴) |
-| 관측성 점수(observability score) | 세션별 측정값(ingest·query·session-close·citation 비율). 위키가 실제로 쓰였는지 보여줍니다 |
+| 관측성 점수(observability score) | 세션별 측정값(search·ingest·feedback 활동). 위키가 실제로 쓰였는지 보여줍니다 |
 | manifest | 설치 스크립트가 쓰는 작은 JSON. 어떤 파일을 어떤 SHA로 설치했는지 기록 |
 | `additionalContext` | Claude Code 훅이 프롬프트에 컨텍스트를 끼워 넣는 필드. 콘텐츠 주입 훅의 출력 위치 |
 | 바이트 동일(byte-equal) | `--apply` 전후가 비트 단위로 같은 파일. "건드리지 않았다"의 가장 강한 보장 |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ These are the recurring terms used in the rest of the README. Keep this table op
 | `hot.md` | Per-project cache: "what just happened" (most recent session highlights) |
 | `session-state.md` | Per-project cache: "what's next" (the resume payload for the next session) |
 | `.hypoignore` | Glob patterns that exclude paths from every content-injection hook and from `ingest` |
-| observability score | A per-session metric (ingest / query / session-close / citation rates) that measures whether the wiki is actually being used |
+| observability score | A per-session metric (search / ingest / feedback activity) that measures whether the wiki is actually being used |
 | manifest | A small JSON the install scripts write to track exactly which files were installed and at what SHA |
 | `additionalContext` | The Claude Code hook field that injects extra context into the prompt: where content-injection hooks emit |
 | byte-equal | A file that comes out of `--apply` bit-for-bit identical to before: the strongest "we did not touch this" guarantee |

--- a/commands/audit.md
+++ b/commands/audit.md
@@ -2,7 +2,7 @@
 description: Audit recent sessions for observability gaps and optionally write the weekly report. Use when the user asks to review session quality, find tracking gaps, or generate the weekly summary.
 ---
 
-You are running `/hypo:audit`. Inspect recent Claude Code sessions to see how much of the wiki's value motion is actually happening (search, ingest, citation, feedback), then either show the result inline or write a weekly observability page.
+You are running `/hypo:audit`. Inspect recent Claude Code sessions to see how much of the wiki's value motion is actually happening (search, ingest, feedback), then either show the result inline or write a weekly observability page.
 
 ## What this shows
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -379,7 +379,7 @@ If `git status` shows no `.md` changes, the diff step is skipped — Stop hook f
 
 ### Citation convention
 
-The six writer-side skills (`crystallize`, `query`, `ingest`, `verify`, `graph`, `lint`) carry an identical footer instructing Claude to cite wiki pages inline as `[[page-slug]]`. The audit script counts these citations as a "wiki was actually consulted" signal in future iterations.
+The six writer-side skills (`crystallize`, `query`, `ingest`, `verify`, `graph`, `lint`) carry an identical footer instructing Claude to cite wiki pages inline as `[[page-slug]]`, which keeps them connected in the graph. The observability audit does not scan for these inline citations: it scores sessions on tool and command usage recorded by `hypo-session-record` (search / ingest / feedback counts). Counting citations as a signal is a possible future iteration, not current behavior.
 
 ---
 

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -141,4 +141,4 @@ evidence_strength: inferred
 
 ---
 
-> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]`. The observability audit counts citations toward the autonomy score — see [[pages/observability/_index]] (run `/hypo:audit` to inspect).
+> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]` so it stays connected in the graph. The observability audit scores sessions on search / ingest / feedback activity (recorded by `hypo-session-record`), not on these inline citations; run `/hypo:audit` to inspect and see [[pages/observability/_index]].

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -55,4 +55,4 @@ If the graph has 0 edges, note that no `[[wikilinks]]` were found between pages.
 
 ---
 
-> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]`. The observability audit counts citations toward the autonomy score — see [[pages/observability/_index]] (run `/hypo:audit` to inspect).
+> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]` so it stays connected in the graph. The observability audit scores sessions on search / ingest / feedback activity (recorded by `hypo-session-record`), not on these inline citations; run `/hypo:audit` to inspect and see [[pages/observability/_index]].

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -104,4 +104,4 @@ Append an ingest entry to `<wiki-root>/log.md`:
 
 ---
 
-> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]`. The observability audit counts citations toward the autonomy score — see [[pages/observability/_index]] (run `/hypo:audit` to inspect).
+> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]` so it stays connected in the graph. The observability audit scores sessions on search / ingest / feedback activity (recorded by `hypo-session-record`), not on these inline citations; run `/hypo:audit` to inspect and see [[pages/observability/_index]].

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -56,4 +56,4 @@ For **missing required fields** (`title`, `type`): open the affected files and h
 
 ---
 
-> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]`. The observability audit counts citations toward the autonomy score — see [[pages/observability/_index]] (run `/hypo:audit` to inspect).
+> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]` so it stays connected in the graph. The observability audit scores sessions on search / ingest / feedback activity (recorded by `hypo-session-record`), not on these inline citations; run `/hypo:audit` to inspect and see [[pages/observability/_index]].

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -59,4 +59,4 @@ If zero results are returned, say so and offer to broaden the search or suggest 
 
 ---
 
-> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]`. The observability audit counts citations toward the autonomy score — see [[pages/observability/_index]] (run `/hypo:audit` to inspect).
+> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]` so it stays connected in the graph. The observability audit scores sessions on search / ingest / feedback activity (recorded by `hypo-session-record`), not on these inline citations; run `/hypo:audit` to inspect and see [[pages/observability/_index]].

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -93,4 +93,4 @@ updated: <today YYYY-MM-DD>
 
 ---
 
-> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]`. The observability audit counts citations toward the autonomy score — see [[pages/observability/_index]] (run `/hypo:audit` to inspect).
+> **Citation convention.** When you reference a wiki page in your response, link it as `[[page-slug]]` so it stays connected in the graph. The observability audit scores sessions on search / ingest / feedback activity (recorded by `hypo-session-record`), not on these inline citations; run `/hypo:audit` to inspect and see [[pages/observability/_index]].

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -225,7 +225,7 @@ ADRs are immutable once accepted. Mark deprecated/superseded but never edit cont
 
 Hypomnema v1.1.0 ships an **autonomy score** so you can see whether the wiki is actually being used per session, rather than just trusting that it is.
 
-- **Citation:** when a response uses a wiki page, link it inline as `[[page-slug]]`. The audit script counts citations as one signal of "the wiki was actually consulted".
+- **Citation:** when a response uses a wiki page, link it inline as `[[page-slug]]` to keep it connected in the graph. (The audit score is based on the tool and command usage below, not on these inline citations.)
 - **Tools that count:** `Grep`, `WebSearch`, `WebFetch`, and any `/hypo:query` / `/hypo:ingest` / `/hypo:feedback` invocation in the transcript.
 - **Classification (heuristic v0):**
   - `normal` — at least one search, no missed URL ingests


### PR DESCRIPTION
# English

## What changed

Corrects the documentation across six skill footers, `hypo-guide`, `ARCHITECTURE`, both READMEs, and the audit command, all of which claimed the observability audit counts inline `[[wikilink]]` citations toward the autonomy score.

## Why

That claim is false. `autonomyScore` in `scripts/weekly-report.mjs` is computed from search / ingest / feedback activity recorded by `hypo-session-record`; there is no citation scan anywhere in the audit path. The stale claim misled anyone reading the footers, README, or ARCHITECTURE about how the score works.

## How

- Kept the `[[page-slug]]` link convention (it genuinely keeps pages connected in the graph) but removed the false aggregation claim and pointed to the real signal.
- Unified the six writer-side skill footers to one identical corrected string (drift-free).
- Fixed `templates/hypo-guide.md`, `docs/ARCHITECTURE.md`, `README.md`, `README.ko.md`, and `commands/audit.md` to match.
- `CHANGELOG.md` is left untouched (historical record).

## Manual verification

- Confirmed the false basis: `autonomyScore` uses `search_count / ingest_count / feedback_count / urls`, no citations (`scripts/weekly-report.mjs`); grep found no citation scan in `session-audit.mjs` or `weekly-report.mjs`.
- Regression grep (excluding CHANGELOG, specs, qa-runs): no sentence states that citations are counted as a signal.
- Every remaining "citation" mention is either the link convention or an explicit negation.
- `npm run check:readme`, `npm run check:versions`, `npm test` (1037) green.

## Migration notes

None. Documentation only.

---

# 한국어

## 변경 내용

관측성 audit이 인라인 `[[wikilink]]` citation을 autonomy score에 집계한다고 서술하던 6개 skill footer, `hypo-guide`, `ARCHITECTURE`, README 2종, audit 커맨드를 정정한다.

## 이유

그 서술은 거짓이다. `scripts/weekly-report.mjs`의 `autonomyScore`는 `hypo-session-record`가 기록한 search / ingest / feedback 활동으로 계산되며, audit 경로 어디에도 citation 스캔이 없다. 이 낡은 주장이 footer·README·ARCHITECTURE를 읽는 사람에게 점수 계산 방식을 오도했다.

## 방법

- `[[page-slug]]` link 관례는 유지하되(그래프 연결 유지에 실제로 유효) 거짓 집계 주장을 제거하고 실제 신호를 가리키게 했다.
- 6개 writer-side skill footer를 동일한 정정 문구 하나로 통일(드리프트 제거).
- `templates/hypo-guide.md`, `docs/ARCHITECTURE.md`, `README.md`, `README.ko.md`, `commands/audit.md`를 정합.
- `CHANGELOG.md`는 이력 보존을 위해 건드리지 않는다.

## 수동 검증

- 거짓 근거 확인: `autonomyScore`는 `search_count / ingest_count / feedback_count / urls`만 쓰고 citation은 없음(`scripts/weekly-report.mjs`). `session-audit.mjs`·`weekly-report.mjs`에 citation 스캔 없음(grep).
- 회귀 grep(CHANGELOG·specs·qa-runs 제외): citation이 신호로 집계된다고 서술하는 문장 0건.
- 남은 "citation" 언급은 전부 link 관례거나 명시적 부정 서술.
- `npm run check:readme`, `npm run check:versions`, `npm test`(1037) green.

## 마이그레이션 노트

없음. 문서 전용.

---

## Changelog

- EN: Corrected docs (skill footers, README, ARCHITECTURE, audit) that wrongly claimed the observability audit counts inline citations toward the autonomy score; the score is based on search / ingest / feedback activity (#165).
- KO: 관측성 audit이 인라인 citation을 autonomy score에 집계한다는 잘못된 문서(skill footer, README, ARCHITECTURE, audit)를 정정. 점수는 search / ingest / feedback 활동 기반이다 (#165).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally (repo scope; pre-existing vault-content warnings are unrelated)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
