### PR TITLE
fix(session-close): recognize colon log entries, reject malformed payloads pre-apply

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -32,7 +32,7 @@ These are judgment calls; when uncertain, surface the question rather than skip 
 
 The session-close path is **payload-driven**. Instead of writing the 5 mandatory files one-by-one, you compose a single JSON payload that describes the full session-close state, then hand it to the `--apply-session-close` apply path (the Step 3 command), which performs idempotent atomic writes and gates the result with lint.
 
-Payload shape (`project` + 5 content fields required, 1 conditional, per Spec §5.2.7 / §8.3):
+Payload shape (`project` + 4 content fields required; `log` optional/derived; `openQuestions` conditional, per Spec §5.2.7 / §8.3):
 
 ```json
 {
@@ -54,7 +54,8 @@ Field rules:
 - `project`: **required**. Slug of the project being closed (matches a `projects/<slug>/` directory). Must be a single path segment, charset `A-Za-z0-9._-`, with at least one alphanumeric and not a dot-only name (`.`, `..`, `...`). Apply never infers the target from recency; a same-date pointer-table tie could otherwise write the close into the wrong project (B-3). A missing, malformed, or non-existent value fails the apply before any write.
 - `date` — optional. Defaults to today (local). Must be `YYYY-MM-DD` if supplied.
 - `openQuestions` — optional. Include only when `pages/open-questions.md` exists and changed this session.
-- All other top-level fields are required.
+- `log`: optional. Omit it by default (apply derives the canonical `## [date] session | <project>` line from your `sessionLog` heading). Supply it only for a custom log.md line, which must still be a canonical `session | <project>` heading, or the apply fails at `stage='pre-apply-verification'`.
+- The remaining fields (`sessionState`, `projectHot`, `rootHot`, `sessionLog`) are required.
 
 Notes:
 
@@ -68,7 +69,7 @@ Content guidance for each slot:
 2. **projectHot** — session snapshot under 500 words: what changed and decisions made. Do **not** put next-step tasks here; those belong in `sessionState`.
 3. **rootHot** — active-projects pointer table with this project's `Last Session` date set to today.
 4. **sessionLog** — one session entry to append to `projects/<name>/session-log/YYYY-MM-DD.md` (daily shard).
-5. **log** — one `session` entry to append to `<hypo-root>/log.md`.
+5. **log** (optional): a custom `session` entry for `<hypo-root>/log.md`. Omit it to let apply derive the canonical line from `sessionLog`.
 6. **openQuestions** (conditional) — only if `pages/open-questions.md` exists and questions were raised or resolved this session.
 
 ---
@@ -96,7 +97,9 @@ so it stops re-prompting. Omit it only when running crystallize purely for
 synthesis (no session-close intent) — the marker is then simply not written.
 
 > **Source rule for `--session-id`:** use only the main conversation's session id
-> (the id shown in the `[WIKI_AUTOCLOSE]` block reason, or `$CLAUDE_SESSION_ID`).
+> (the id shown in the `[WIKI_AUTOCLOSE]` block reason, or the injected
+> `$CLAUDE_CODE_SESSION_ID`; accept the legacy spelling via
+> `${CLAUDE_CODE_SESSION_ID:-$CLAUDE_SESSION_ID}`).
 > Do NOT extract it from a background task output path or Agent thread (e.g.,
 > `/tmp/.../<uuid>/tasks/...`). A UUID from such a path is a background task id,
 > not the main conversation id. Passing it causes `markerSkipReason:
@@ -129,7 +132,8 @@ The result JSON includes a `stage` field when `ok: false`. Branch on it:
 
 | `stage` | What broke | How to recover |
 |---|---|---|
-| `preflight-lint` | A payload file (append target — session-log / log.md) has a pre-existing blocking lint error. | Fix the lint error in that file, then re-run. No payload bytes were written. (Debt outside the payload files is a non-blocking notice, not this stage.) |
+| `pre-apply-verification` | A payload heading does not match the freshness contract the close gate enforces: `sessionLog.entry` has no dated `## [YYYY-MM-DD] …` heading, or an explicit `log.entry` is not the canonical `## [date] session | <project>` line. Caught **before** any write. | Fix the heading in the payload (the session-log entry needs a bracketed dated heading; the log line needs `session \| <project>` after the date, colon or space delimiter), then re-run. No payload bytes were written. |
+| `preflight-lint` | A payload file (append target: session-log / log.md) has a pre-existing blocking lint error. | Fix the lint error in that file, then re-run. No payload bytes were written. (Debt outside the payload files is a non-blocking notice, not this stage.) |
 | `post-apply-verification` | A mandatory file's `updated:` frontmatter is stale (≠ today) after apply. | Edit the payload's stale `content` (or supply correct `date`), then re-run. Writes are idempotent — re-applying a corrected payload is safe. |
 | `post-apply-lint` | The payload introduced an error-level lint blocker in a payload file (malformed body / bad frontmatter), or lint crashed. | Fix the offending content in the payload, then re-run. (Broken wikilinks are W4 warnings — not gated.) |
 | `post-apply-verification+lint` | Both above. | Fix both; re-run. |
@@ -142,11 +146,15 @@ Once `ok: true`, report:
 - ✓ open-questions applied (or skipped if unchanged)
 - ✓ log.md entry appended
 - ✓ post-apply lint clean
-- **marker written?** (required check): if `markerWritten: true`, report "session-close marker written"; if `markerWritten: false`, report "session-close marker NOT written (reason: `<markerSkipReason>`)" and do NOT declare the session "closed" or "complete". A missing marker means the Stop-chain is still open. Instruct the user to re-run with the correct main-conversation `--session-id`.
+- **marker written?** (required check): if `markerWritten: true`, report "session-close marker written"; if `markerWritten: false`, report "session-close marker NOT written (reason: `<markerSkipReason>`)" and do NOT declare the session "closed" or "complete". A missing marker means the Stop-chain is still open; recover per the `markerSkipReason` branch below.
 
 If `markerWritten: true` (or `--session-id` was not passed): ask: "Session closed. Would you like to also run knowledge synthesis now, or stop here?"
 
-If `markerWritten: false`: do NOT say "session closed." Say instead: "Files applied and verified (ok: true), but the session-close marker was not written (reason: `<markerSkipReason>`). The Stop-chain is still active. To fully close: re-run with the correct main-conversation `--session-id`."
+If `markerWritten: false`, do NOT say "session closed." Branch on `markerSkipReason`:
+
+- `no-user-close-signal`: the files applied cleanly and the `--session-id` resolved a transcript, but that transcript carries no close phrase the gate recognizes (the user asked to close in wording that fell outside the close-signal set, e.g. "세션 마무리까지 진행해줘" or "세션 마무리 진행"). Re-running with the same id will not help, since the transcript is unchanged. Instead, confirm intent once with `AskUserQuestion`, header "세션", a single option labelled **세션 마무리** (설명: "이 세션을 마무리하고 close 마커를 기록"). If the user picks 세션 마무리, that answer becomes a recognized close signal in the transcript, so re-run the exact same `--apply-session-close … --session-id` command (the writes are idempotent no-ops; the marker now lands). If the user declines, leave the session unmarked: the wiki record stands, but the session is not closed. Do NOT touch the close-signal matcher itself.
+- `transcript-unresolved` (or a background / agent id was passed): say "Files applied and verified (ok: true), but the session-close marker was not written (reason: `<markerSkipReason>`). The Stop-chain is still active. To fully close: re-run with the correct main-conversation `--session-id`."
+- any other reason (`compact-gate-not-ok`, `commit-failed: …`, `marker-did-not-land`): surface the reason verbatim and address it (resolve the compact blocker, fix the git / disk issue) before re-running.
 
 If the user says stop, end here. Otherwise continue to Step 5.
 

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -284,17 +284,22 @@ export function sessionLogScopePath(hypoDir, project, date) {
  * True if `content` carries a today-dated `## [date] session | <project>` entry
  * in log.md.
  *
- * Bounded with an explicit `(?=\s|$)` lookahead, NOT `\b`: a regex word boundary
- * matches between word and non-word chars, so `\b` after "foo" still matches in
- * "foo-bar" (hyphen is non-word). The canonical log format always separates the
- * project slug from anything that follows by whitespace or end-of-line, so the
- * lookahead correctly rejects "session | foo-bar" when looking for "foo".
- * (Was a pre-existing bug in sessionCloseFileStatus that the helper extraction
- * inherited.)
+ * Bounded with an explicit `(?=[\s:]|$)` lookahead, NOT `\b`: a regex word
+ * boundary matches between word and non-word chars, so `\b` after "foo" still
+ * matches in "foo-bar" (hyphen is non-word). The canonical log format separates
+ * the project slug from anything that follows by whitespace, a colon, or
+ * end-of-line, so the lookahead correctly rejects "session | foo-bar" when
+ * looking for "foo". Both delimiters are canonical: the derive path
+ * (rootLogEntry) emits `<project> — <title>` (space), while the dominant
+ * hand-written convention is `<project>: <title>` (colon, since the tone rule
+ * banned the em dash). The colon must be accepted: without it, a close whose
+ * only log.md evidence used the colon form was misread as "stale" and blocked
+ * non-deterministically. (Was a pre-existing boundary bug in
+ * sessionCloseFileStatus that the helper extraction inherited.)
  */
 export function hasLogEntry(content, date, project) {
   return new RegExp(
-    '^## \\[' + escapeRegExp(date) + '\\] session \\| ' + escapeRegExp(project) + '(?=\\s|$)',
+    '^## \\[' + escapeRegExp(date) + '\\] session \\| ' + escapeRegExp(project) + '(?=[\\s:]|$)',
     'm',
   ).test(content || '');
 }
@@ -920,13 +925,20 @@ function closeCandidateSlugs(hypoDir, dates) {
       content = '';
     }
     for (const d of dates) {
-      const re = new RegExp('^## \\[' + escapeRegExp(d) + '\\] session \\| (\\S+)', 'gm');
+      // Capture the slug up to the first whitespace OR colon so both canonical
+      // log delimiters resolve to the same bare slug: `session | beta — t` and
+      // `session | beta: t` both yield `beta`. This parser shares the
+      // colon-delimiter contract with hasLogEntry, so a colon-form entry for a
+      // real project is a close candidate, not a ghost. `[^\s:]+` cannot span
+      // the colon, so a stale/typo heading still yields a token that fails the
+      // on-disk directory gate below.
+      const re = new RegExp('^## \\[' + escapeRegExp(d) + '\\] session \\| ([^\\s:]+)', 'gm');
       for (const m of content.matchAll(re)) {
-        // B-1: only real projects are close candidates. A malformed log heading
-        // (`## [d] session | hypomnema:`) or a stale slug yields a ghost token
-        // that no longer maps to a `projects/<slug>/` directory — gating on disk
-        // keeps it out of the dangling-close set. Directory (not bare-exists)
-        // mirrors the apply-path project check (crystallize.mjs:193).
+        // B-1: only real projects are close candidates. A stale or misspelled
+        // slug yields a token that no longer maps to a `projects/<slug>/`
+        // directory — gating on disk keeps it out of the dangling-close set.
+        // Directory (not bare-exists) mirrors the apply-path project check
+        // (crystallize.mjs:193).
         const dir = join(projectsDir, m[1]);
         if (existsSync(dir) && statSync(dir).isDirectory()) slugs.add(m[1]);
       }

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -89,6 +89,8 @@ import {
   sessionLogReadCandidates,
   sessionLogScopePath,
   rootLogEntry,
+  hasSessionLogHeading,
+  hasLogEntry,
   resolveTranscriptBySessionId,
   hasUserCloseSignal,
   commitWikiChanges,
@@ -754,21 +756,49 @@ function applySessionClose(args) {
   }
   const date = payload.date || todayLocal();
 
-  // B-1 derive precondition: when `log` is omitted, apply reconstructs the root
-  // log.md entry from THIS close's sessionLog heading. If sessionLog.entry has no
-  // `## [<date>] …` heading there is nothing to derive — and on a same-day SECOND
-  // close the date-level freshness verifier would still pass on the earlier
-  // close's entry, so the no-write would slip through as ok:true. Fail loud here,
-  // before any writes (codex pre-commit review).
-  if (
-    !payload.log &&
-    !new RegExp(`^#{1,6} \\[${date}\\]`, 'm').test(payload.sessionLog.entry || '')
-  ) {
-    const msg =
-      `payload.sessionLog.entry has no "## [${date}] …" heading to derive the log.md ` +
-      `entry from. Give it a dated heading, or supply payload.log explicitly.`;
-    console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
+  // Pre-apply freshness-contract gate: the post-apply verification holds
+  // sessionCloseFileStatus's hasSessionLogHeading / hasLogEntry as the
+  // definition of "closed today". Enforce that SAME contract on the payload
+  // BEFORE writing a byte, so a heading the gate won't recognize is rejected
+  // here as a format mismatch — not written and then misdiagnosed downstream as
+  // "stale" (the "not updated" vs "format mismatch" conflation). All checks
+  // exit 1 with stage='pre-apply-verification' and leave the tree untouched.
+  const failPreApply = (msg) => {
+    console.log(
+      args.json
+        ? JSON.stringify({ ok: false, stage: 'pre-apply-verification', error: msg }, null, 2)
+        : `✗ ${msg}`,
+    );
     process.exit(1);
+  };
+  // (a) The session-log entry must carry a dated `## [<date>] …` ATX heading. The
+  // post-apply gate checks the session-log file for exactly this heading, so a
+  // headingless entry would write then false-fail as "stale". This also doubles
+  // as the B-1 derive precondition: when `log` is omitted the root log.md entry
+  // is reconstructed from THIS heading, and on a same-day SECOND close the
+  // date-level verifier would still pass on the earlier entry, so a no-derive
+  // would slip through as ok:true. The `!payload.log` branch keeps the original
+  // derive-specific wording (a test asserts it).
+  if (!hasSessionLogHeading(payload.sessionLog.entry || '', date)) {
+    failPreApply(
+      !payload.log
+        ? `payload.sessionLog.entry has no "## [${date}] …" heading to derive the log.md ` +
+            `entry from. Give it a dated heading, or supply payload.log explicitly.`
+        : `payload.sessionLog.entry has no "## [${date}] …" heading. The close gate ` +
+            `identifies a session-log by its dated ATX heading; give the entry a ` +
+            `"## [${date}] <title>" heading (the brackets are required).`,
+    );
+  }
+  // (b) An explicit payload.log entry must match the canonical
+  // `## [<date>] session | <project>` line the gate looks for (colon or space
+  // delimiter after the slug). Otherwise the write lands but post-apply
+  // verification reports log.md as stale. When `log` is omitted the line is
+  // derived canonically (rootLogEntry) so this cannot mismatch.
+  if (payload.log && !hasLogEntry(payload.log.entry || '', date, project)) {
+    failPreApply(
+      `payload.log.entry has no "## [${date}] session | ${project}" heading that the ` +
+        `close gate recognizes. Fix the entry heading, or omit payload.log to derive it.`,
+    );
   }
 
   // Preflight: lint the wiki BEFORE writing any payload bytes. If lint

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -92,7 +92,9 @@ main conversation id. Passing the wrong id causes `markerWritten: false` with
 `markerSkipReason: "transcript-unresolved"` or `"no-user-close-signal"`: the
 5 mandatory files are written (ok: true) but the Stop-chain marker is withheld,
 so the session is not actually closed and the Stop hook re-prompts. The correct
-id comes from the `[WIKI_AUTOCLOSE]` block reason or `$CLAUDE_SESSION_ID`.
+id comes from the `[WIKI_AUTOCLOSE]` block reason or the injected
+`$CLAUDE_CODE_SESSION_ID` (accept the legacy spelling via
+`${CLAUDE_CODE_SESSION_ID:-$CLAUDE_SESSION_ID}`).
 
 Once it passes, report each item with ✓:
 - ✓ session-state.md
@@ -100,11 +102,15 @@ Once it passes, report each item with ✓:
 - ✓ session-log entry
 - ✓ open-questions (or skipped if unchanged)
 - ✓ log.md entry
-- **marker written?** (required, if `--apply-session-close --session-id` was used): check `markerWritten` in the JSON output. If `true`, report "session-close marker written." If `false`, do NOT declare the session closed or complete. Instead report: "Files applied and verified (ok: true), but the session-close marker was not written (reason: `<markerSkipReason>`). The Stop-chain is still active. Re-run with the correct main-conversation `--session-id`."
+- **marker written?** (required, if `--apply-session-close --session-id` was used): check `markerWritten` in the JSON output. If `true`, report "session-close marker written." If `false`, do NOT declare the session closed or complete; recover per the `markerSkipReason` branch below.
 
 If `markerWritten: true` (or `--session-id` was not passed), ask: "Session closed. Would you like to also run knowledge synthesis now, or stop here?"
 
-If `markerWritten: false`, do NOT say "session closed." Surface the skip reason and instruct a re-run with the correct main-conversation `--session-id` (see the bullet above) before treating the session as closed.
+If `markerWritten: false`, do NOT say "session closed." Branch on `markerSkipReason`:
+
+- `no-user-close-signal`: files applied cleanly and the transcript resolved, but it carries no close phrase the gate recognizes (the user's close wording fell outside the close-signal set, e.g. "세션 마무리까지 진행해줘" / "세션 마무리 진행"). Re-running the same id will not help. Confirm intent once with `AskUserQuestion` (header "세션", one option **세션 마무리**); if the user picks it, that answer is a recognized close signal, so re-run the same `--apply-session-close … --session-id` command (idempotent no-op writes; the marker lands). If the user declines, leave the session unmarked. Do NOT change the close-signal matcher.
+- `transcript-unresolved` (wrong / background id): report "Files applied and verified (ok: true), but the marker was not written (reason: `<markerSkipReason>`). The Stop-chain is still active. Re-run with the correct main-conversation `--session-id`."
+- any other reason (`compact-gate-not-ok`, `commit-failed: …`, `marker-did-not-land`): surface it verbatim and resolve the underlying blocker before re-running.
 
 ---
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -12,6 +12,7 @@ import {
   mkdirSync,
   rmSync,
   writeFileSync,
+  appendFileSync,
   readFileSync,
   readdirSync,
   existsSync,
@@ -1050,6 +1051,7 @@ const {
   sessionLogShardPath,
   sessionLogReadCandidates,
   sessionCloseFileStatus,
+  hasLogEntry,
   hypoIsClean,
   precompactGateStatus,
   commitWikiChanges,
@@ -3368,6 +3370,136 @@ test('hasLogEntry: project "foo" must NOT match "foo-bar" (W2 boundary regressio
       );
     },
   );
+});
+
+// ── ISSUE-42: freshness gate write/verify format contract ────────────────────
+suite('ISSUE-42: colon-delimiter log entries + pre-apply format gate');
+
+test('ISSUE-42a: a colon-delimiter log.md entry ALONE satisfies the close gate (2026-07-01 repro)', () => {
+  // The dominant hand-written log convention is `## [date] session | <project>: title`
+  // (colon, since the tone rule banned the em dash). Before the fix hasLogEntry
+  // required whitespace/eol after the slug, so a close whose ONLY log.md evidence
+  // used the colon form false-failed as "stale". Replace log.md with a single
+  // colon-form entry (no space-form sibling to mask it) and require exit 0.
+  withWiki(
+    (dir, today) => {
+      writeFileSync(
+        join(dir, 'log.md'),
+        `## [${today}] session | test-project: real work this session\n`,
+      );
+    },
+    (dir) => {
+      const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+      assert.equal(
+        r.status,
+        0,
+        `colon-form log entry must satisfy the gate, got status=${r.status}\n${r.stdout}`,
+      );
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        !out.stale.includes('log.md') && !out.missing.includes('log.md'),
+        `log.md must not be flagged stale/missing for a colon entry: ${JSON.stringify(out)}`,
+      );
+    },
+  );
+});
+
+test('ISSUE-42b: colon delimiter must NOT loosen the slug-prefix guard (foo vs foo-bar: title)', () => {
+  const today = '2026-07-04';
+  // Space form (derive path) — accepted.
+  assert.ok(
+    hasLogEntry(`## [${today}] session | foo — title\n`, today, 'foo'),
+    'space/em-dash form must match',
+  );
+  // Colon form — accepted.
+  assert.ok(
+    hasLogEntry(`## [${today}] session | foo: title\n`, today, 'foo'),
+    'colon form must match',
+  );
+  // Bare slug at EOL — accepted.
+  assert.ok(hasLogEntry(`## [${today}] session | foo\n`, today, 'foo'), 'bare slug must match');
+  // Look-alike longer slug must NOT satisfy "foo", with a colon after the tail.
+  assert.ok(
+    !hasLogEntry(`## [${today}] session | foo-bar: title\n`, today, 'foo'),
+    'foo-bar: title must NOT match the "foo" gate (colon did not loosen the prefix guard)',
+  );
+});
+
+test('ISSUE-42c: headingless sessionLog entry is rejected pre-apply, no bytes written', () => {
+  withWiki(null, (dir, today) => {
+    const before = {
+      log: readFileSync(join(dir, 'log.md'), 'utf-8'),
+      state: readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8'),
+    };
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog = { entry: `no dated heading at all\n` };
+    // Keep payload.log present so the payload.log branch message fires (not the
+    // derive-precondition wording).
+    payload.log = { entry: `## [${today}] session | test-project: x\n` };
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `headingless sessionLog must fail pre-apply: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.stage, 'pre-apply-verification', `stage must be pre-apply: ${r.stdout}`);
+    // No bytes written: the append targets are byte-identical to before.
+    assert.equal(
+      readFileSync(join(dir, 'log.md'), 'utf-8'),
+      before.log,
+      'log.md must be untouched',
+    );
+    assert.equal(
+      readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8'),
+      before.state,
+      'session-state.md must be untouched',
+    );
+  });
+});
+
+test('ISSUE-42d: non-canonical explicit payload.log is rejected pre-apply, no bytes written', () => {
+  withWiki(null, (dir, today) => {
+    const beforeLog = readFileSync(join(dir, 'log.md'), 'utf-8');
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog = { entry: `## [${today}] valid dated heading\n` };
+    payload.log = { entry: `## [${today}] not a canonical session line\n` };
+    const r = runApply(dir, payload);
+    assert.equal(r.status, 1, `non-canonical payload.log must fail pre-apply: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.stage, 'pre-apply-verification', `stage must be pre-apply: ${r.stdout}`);
+    assert.equal(readFileSync(join(dir, 'log.md'), 'utf-8'), beforeLog, 'log.md must be untouched');
+  });
+});
+
+test('ISSUE-42 F1: a colon-form log entry is the sole today signal → dangling close still blocks', () => {
+  // closeCandidateSlugs must extract the BARE slug from a colon entry (not `beta:`),
+  // or a project whose only today evidence is a colon-form log line escapes the
+  // dangling-close scan. beta has a real dir but stale own files and is absent from
+  // the hot table, so its ONLY today signal is the colon log.md line.
+  withTmpDir((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, [
+      { slug: 'alpha', date: today }, // fully closed today
+      {
+        slug: 'beta',
+        date: today,
+        sessionState: '2020-01-01', // stale own files → incomplete close
+        projectHot: '2020-01-01',
+        sessionLog: false, // no today session-log heading
+        hotRow: false, // not in today's hot table
+        logEntry: false, // suppress the default space-form line; we write our own
+      },
+    ]);
+    // beta's only today signal: a colon-delimiter log.md entry with a title.
+    writeFileSync(
+      join(dir, 'log.md'),
+      `## [${today}] session | alpha\n## [${today}] session | beta: some real title\n`,
+    );
+    const s = sessionCloseGlobalStatus(dir);
+    assert.equal(s.ok, false, `beta's colon-form dangling close must block: ${JSON.stringify(s)}`);
+    const beta = s.projects.find((p) => p.project === 'beta');
+    assert.ok(
+      beta && !beta.ok,
+      `beta must be a detected today-active candidate: ${JSON.stringify(s.projects)}`,
+    );
+  });
 });
 
 // ── fix #39: probe early-exit (option D) ─────────────────────────────────────
@@ -13140,6 +13272,109 @@ test('--apply-session-close --session-id WITH user-close signal → commits payl
       'marker file must exist after a verified close with a user-close signal',
     );
   });
+});
+
+test('IMPR-15: no-user-close-signal → after an AskUserQuestion 세션 마무리 answer, a re-run lands the marker', () => {
+  // The documented recovery (crystallize.md Step 4): when apply is ok:true but the
+  // marker is withheld as `no-user-close-signal` (the transcript resolves but the
+  // user's close wording evaded the close-signal set), confirming once with
+  // AskUserQuestion [세션 마무리] injects a recognized close answer, so re-running
+  // the SAME idempotent apply lands the marker — no script change, no matcher edit.
+  const sid = 's-impr15-rerun';
+  const projDir = join(SESSION_TMP_HOME, '.claude', 'projects', 'hypo-test-proj');
+  const tpath = join(projDir, `${sid}.jsonl`);
+  mkdirSync(projDir, { recursive: true });
+  try {
+    withWiki(null, (dir, today) => {
+      const payload = {
+        project: 'test-project',
+        date: today,
+        sessionState: {
+          content: readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8'),
+        },
+        projectHot: {
+          content: readFileSync(join(dir, 'projects', 'test-project', 'hot.md'), 'utf-8'),
+        },
+        rootHot: { content: readFileSync(join(dir, 'hot.md'), 'utf-8') },
+        sessionLog: { entry: `## [${today}] impr15 rerun test\n` },
+        log: { entry: `## [${today}] session | test-project: impr15 rerun\n` },
+      };
+      const payloadPath = join(dir, '.payload.json');
+      writeFileSync(payloadPath, JSON.stringify(payload));
+      const args = [
+        `--hypo-dir=${dir}`,
+        '--apply-session-close',
+        `--payload=${payloadPath}`,
+        `--session-id=${sid}`,
+        '--json',
+      ];
+
+      // (1) Transcript resolves but carries NO close signal → marker withheld.
+      writeFileSync(
+        tpath,
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: '코드 리뷰 계속 부탁해' },
+        }) + '\n',
+      );
+      const r1 = run('crystallize.mjs', args);
+      assert.equal(r1.status, 0, `apply must exit 0: ${r1.stdout}\n${r1.stderr}`);
+      const o1 = JSON.parse(r1.stdout);
+      assert.equal(o1.ok, true, `apply ok expected: ${r1.stdout}`);
+      assert.equal(
+        o1.markerSkipReason,
+        'no-user-close-signal',
+        `expected the no-signal skip (not transcript-unresolved): ${JSON.stringify(o1)}`,
+      );
+      assert.equal(o1.markerWritten, false, 'marker must be withheld on the first run');
+
+      // (2) The user picks [세션 마무리] in an AskUserQuestion; that answer value
+      // lands in the transcript as a correlated tool_result. Append it and re-run.
+      const askLines = [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', name: 'AskUserQuestion', id: 'ask-1' }],
+          },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'ask-1',
+                content: 'Your questions have been answered: "세션?"="세션 마무리".',
+              },
+            ],
+          },
+        }),
+      ];
+      appendFileSync(tpath, askLines.join('\n') + '\n');
+      const r2 = run('crystallize.mjs', args);
+      assert.equal(r2.status, 0, `re-run must exit 0: ${r2.stdout}\n${r2.stderr}`);
+      const o2 = JSON.parse(r2.stdout);
+      assert.equal(o2.ok, true, `re-run ok expected: ${r2.stdout}`);
+      assert.equal(
+        o2.markerWritten,
+        true,
+        `marker must land after the close answer: ${JSON.stringify(o2)}`,
+      );
+      assert.equal(
+        o2.markerSkipReason,
+        null,
+        `no skip reason on the re-run: ${o2.markerSkipReason}`,
+      );
+      assert.ok(
+        existsSync(join(dir, '.cache', `session-closed-${sid}.marker`)),
+        'marker file must exist after the AskUserQuestion close answer + re-run',
+      );
+    });
+  } finally {
+    rmSync(tpath, { force: true });
+  }
 });
 
 // ── feedback-sync.mjs (ADR 0031) ─────────────────────────────


### PR DESCRIPTION
# English

## What changed

Three fixes to the session-close path, bundled as a patch:

1. The log.md freshness gate now accepts a colon delimiter (`## [date] session | <project>: title`), not only the space form. The dominant hand-written log convention switched to the colon after the em dash was banned, so a close whose only log.md evidence used the colon form was misread as "stale" and blocked. The dangling-close slug parser is aligned to the same colon contract.
2. Session-close apply gained a pre-apply verification stage: a payload whose session-log or log heading the freshness gate would not recognize is now rejected before any file is written (`stage='pre-apply-verification'`), instead of being written and then misdiagnosed downstream as "stale".
3. Docs: the crystallize session-id guidance points to `$CLAUDE_CODE_SESSION_ID` (the actually-injected variable, with a legacy fallback), the `payload.log` field is documented as optional/derived, and a recovery path is documented for the `no-user-close-signal` marker skip (confirm once via AskUserQuestion, then re-run the idempotent apply so the marker lands).

## Why

A real user-facing bug: `/hypo:crystallize` session-close failed non-deterministically with exit 1, reporting log.md and the session-log as "stale" even though both carried today's entry. The freshness regex required whitespace or end-of-line after the project slug, but the standard log convention writes `project: title` (colon). The mismatch was masked whenever a same-day sibling entry used the older space form; on a day with only a colon entry it surfaced as a hard block the user could not diagnose.

Separately, the marker-skip path left a confusing half-state: files applied cleanly, but the Stop-chain kept re-prompting because the user's close wording fell outside the recognized close-signal set. The new docs give a bounded recovery that does not touch the close-signal matcher.

## How

- `hasLogEntry` boundary `(?=\s|$)` becomes `(?=[\s:]|$)`; the foo vs foo-bar prefix guard is preserved (a hyphen is neither whitespace, colon, nor end-of-line).
- `closeCandidateSlugs` captures the slug with `[^\s:]+` so a colon entry resolves to the bare project directory, keeping a colon-form dangling close visible to the global gate.
- The pre-apply gate reuses the same `hasSessionLogHeading` / `hasLogEntry` helpers the post-apply verification uses, so the write path enforces the exact contract the read path checks.
- The marker-skip recovery is documentation only. The mechanism already exists: `hasUserCloseSignal` recognizes a correlated AskUserQuestion answer, and `commitWikiChanges` treats "nothing to commit" as success, so an idempotent re-run reaches the marker write.

## Manual verification

- `npm test`: 1043 passed, 0 failed (+6 new regression tests, run as subprocesses against the real `scripts/crystallize.mjs` + `hooks/hypo-shared.mjs`, so the deployed copies are exercised end-to-end).
  - colon-only log entry satisfies `--check-session-close` (exit 0); the 2026-07-01 repro.
  - `hasLogEntry` accepts colon / space / eol and still rejects `foo-bar: title` for the `foo` gate.
  - headingless session-log and non-canonical explicit log are rejected at `pre-apply-verification` with zero bytes written (target files snapshot-identical).
  - a colon-form entry as the sole today signal still blocks a dangling close.
  - `no-user-close-signal` skip, then an appended AskUserQuestion close answer, then a re-run lands the marker.
- `npm run lint`, prettier, and the tracker-id check are clean on the changed files.
- A live `/hypo:crystallize` session close (including this session's own close) exercises the colon-format path end-to-end.

## Migration notes

None. No schema change; behavior is strictly more permissive (accepts a delimiter it previously rejected) plus an earlier, clearer rejection of malformed payloads.

---

# 한국어

## 변경 내용

session-close 경로의 세 가지 수정을 patch로 묶었다.

1. log.md 신선도 게이트가 공백 형태뿐 아니라 콜론 구분자(`## [date] session | <project>: title`)도 인식한다. em대시 금지 이후 사람이 쓰는 로그 관례가 콜론으로 옮겨가서, 콜론 형태만 있는 close가 "stale"로 오진돼 막혔다. dangling-close slug 파서도 같은 콜론 계약으로 맞췄다.
2. session-close apply에 write 전 검증 단계를 추가했다. 신선도 게이트가 인식 못 할 헤딩을 가진 payload는 이제 파일을 쓰기 전에 거부한다(`stage='pre-apply-verification'`). 예전처럼 일단 쓴 뒤 downstream에서 "stale"로 오진하지 않는다.
3. 문서: crystallize 세션 id 안내를 실제 주입 변수인 `$CLAUDE_CODE_SESSION_ID`로 정정(legacy fallback 포함), `payload.log`를 optional/derived로 문서화, `no-user-close-signal` 마커 skip의 복구 경로를 문서화(AskUserQuestion으로 1회 확인 후 멱등 재실행하면 마커가 기록됨).

## 이유

실제 사용자 버그였다. `/hypo:crystallize` session-close가 비결정적으로 exit 1로 실패하며 log.md와 session-log를 "stale"로 보고했다. 두 파일 다 오늘 엔트리를 정상 보유했는데도. 신선도 정규식이 project slug 뒤에 공백이나 줄끝을 요구했지만, 표준 로그 관례는 `project: title`(콜론)로 쓴다. 같은 날 공백 형태 형제 엔트리가 있으면 이 불일치가 가려지다가, 콜론 엔트리 하나뿐인 날 사용자가 원인을 못 찾는 hard block으로 드러났다.

별개로, 마커 skip 경로는 혼란스러운 half-state를 남겼다. 파일은 정상 적용됐는데 유저의 close 표현이 인식되는 close-signal 집합을 벗어나 Stop-chain이 계속 재촉했다. 새 문서는 close-signal matcher를 건드리지 않는 bounded 복구를 제시한다.

## 방법

- `hasLogEntry` 경계 `(?=\s|$)`를 `(?=[\s:]|$)`로. foo 대 foo-bar 접두 가드는 보존(하이픈은 공백·콜론·줄끝 어느 것도 아님).
- `closeCandidateSlugs`가 `[^\s:]+`로 slug를 잡아 콜론 엔트리도 bare project 디렉터리로 수렴, 콜론 형태 dangling close가 전역 게이트에 계속 보이게 한다.
- write 전 게이트는 post-apply 검증이 쓰는 `hasSessionLogHeading` / `hasLogEntry`를 그대로 재사용한다. write 경로가 read 경로의 계약을 정확히 강제한다.
- 마커 skip 복구는 문서만 바뀐다. 메커니즘은 이미 존재한다. `hasUserCloseSignal`이 상관된 AskUserQuestion 답을 인식하고, `commitWikiChanges`가 "nothing to commit"을 성공으로 처리하므로 멱등 재실행이 마커 write에 도달한다.

## 수동 검증

- `npm test`: 1043 passed, 0 failed(+회귀 테스트 6건, 실제 `scripts/crystallize.mjs` + `hooks/hypo-shared.mjs`에 서브프로세스로 돌려 배포 사본을 end-to-end로 검증).
  - 콜론-only 로그가 `--check-session-close`를 통과(exit 0). 2026-07-01 재현.
  - `hasLogEntry`가 콜론/공백/줄끝을 받고 `foo-bar: title`은 `foo` 게이트에서 여전히 거부.
  - headingless session-log와 비-canonical 명시 log는 `pre-apply-verification`에서 거부, 0바이트 write(대상 파일 스냅샷 동일).
  - 콜론 형태가 유일 today 신호인 dangling close도 여전히 block.
  - `no-user-close-signal` skip 후 AskUserQuestion close 답을 append하고 재실행하면 마커 landing.
- 변경 파일에 대해 `npm run lint`, prettier, tracker-id 체크 clean.
- 실제 `/hypo:crystallize` 세션 close(이 세션 자체의 close 포함)가 콜론 포맷 경로를 end-to-end로 실행.

## 마이그레이션 노트

None. 스키마 변경 없음. 동작은 엄밀히 더 관대해지고(예전에 거부하던 구분자를 수용), malformed payload를 더 이르고 명확하게 거부한다.

---

## Changelog

- EN: Fix non-deterministic session-close failure that misreported log.md as stale when the log entry used a colon delimiter, and reject malformed close payloads before writing (#166).
- KO: 로그 엔트리가 콜론 구분자를 쓸 때 log.md를 stale로 오진하던 비결정적 session-close 실패를 고치고, malformed close payload를 write 전에 거부 (#166).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
