### PR TITLE
refactor(session-close): close-result invariant self-check + deterministic marker-decision tests

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -65,11 +65,19 @@
  *     hard-fails regardless of scope.
  */
 
-import { existsSync, statSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
+import {
+  existsSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  renameSync,
+  realpathSync,
+} from 'fs';
 import { join, dirname } from 'path';
 import { hostname } from 'os';
 import { spawnSync } from 'child_process';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
 import { collectPagesCrystallize, extractWikilinks } from './lib/wikilink.mjs';
@@ -645,6 +653,67 @@ function runMarkSessionClosed(args) {
   process.exit(0);
 }
 
+// The close pipeline's marker decision as a PURE function of pre-resolved
+// signals. The caller (applySessionClose) keeps the IO lazy (commit first, then
+// transcript resolve, then gate, then user-signal scan only once the gate
+// passes) and feeds the resulting booleans here; this function owns only the
+// branch PRIORITY and the reason strings, so a deterministic table test can
+// exercise the state machine without spawning the
+// CLI. Returns { write, skipReason }: `write` true means the caller should
+// attempt writeSessionClosedMarker; `skipReason` (non-null on every non-write
+// branch) is the surfaced reason the marker was withheld.
+//   - !ok / no session id     → not a marker-write path (skipReason null)
+//   - commit failed           → commit-failed: <reason>
+//   - compact gate not ok     → compact-gate-not-ok
+//   - no transcript           → transcript-unresolved
+//   - transcript, no signal   → no-user-close-signal
+//   - all clear               → write:true
+export function planMarkerDecision({
+  ok,
+  hasSessionId,
+  committed,
+  commitReason,
+  gateOk,
+  transcriptResolved,
+  hasUserSignal,
+}) {
+  if (!ok || !hasSessionId) return { write: false, skipReason: null };
+  if (!committed) return { write: false, skipReason: `commit-failed: ${commitReason}` };
+  if (!gateOk) return { write: false, skipReason: 'compact-gate-not-ok' };
+  if (!transcriptResolved || !hasUserSignal) {
+    return {
+      write: false,
+      skipReason: transcriptResolved ? 'no-user-close-signal' : 'transcript-unresolved',
+    };
+  }
+  return { write: true, skipReason: null };
+}
+
+// The runtime close-result invariant self-check. Given
+// the settled marker fields, return a non-null contradiction tag when the result
+// is internally inconsistent, else null. This is a REGRESSION GUARD: every
+// non-write branch of planMarkerDecision already records a reason today, so the
+// contradictions below are unreachable — the seam exists so a future branch that
+// forgets to record a reason (or double-sets a written marker with a skip
+// reason) fails LOUDLY (ok flipped false, exit 1) instead of silently emitting a
+// misleading ok:true that a skill-following model reads as "session closed".
+// A "real reason" is a non-blank STRING — every legitimate skip reason is one.
+// Anything else (null, a blank string, or a non-string like false/0/{}) is not a
+// surfaced reason and must not suppress the check, so a future bad assignment
+// cannot hide a withheld marker behind a bogus value.
+//   A: ok:true but the marker was withheld with no reason recorded.
+//   B: a marker was written AND a skip reason was also set (mutually exclusive).
+export function closeResultContradiction({ ok, markerWritten, markerSkipReason }) {
+  const hasRealReason = typeof markerSkipReason === 'string' && markerSkipReason.trim() !== '';
+  if (ok === true && markerWritten === false && !hasRealReason) {
+    return 'internal-contradiction:marker-withheld-without-reason';
+  }
+  if (markerWritten === true && hasRealReason) {
+    return 'internal-contradiction:marker-written-with-skip-reason';
+  }
+  return null;
+}
+
 function applySessionClose(args) {
   // Option D: early-exit fires only when NO payload was supplied.
   // Rationale: payload presence is explicit close intent and must always run
@@ -1067,7 +1136,9 @@ function applySessionClose(args) {
     ));
   }
   const postLintOk = !postApplyCrashed && postBlocking.length === 0;
-  const ok = verification.ok && postLintOk;
+  // `let` (not const): the close-result invariant self-check below may flip this
+  // to false when the settled close result is internally contradictory.
+  let ok = verification.ok && postLintOk;
 
   // Scope the non-blocking notice to the close-target project: debt under
   // projects/<project>/ stays listed; debt elsewhere folds to a count so the
@@ -1100,47 +1171,77 @@ function applySessionClose(args) {
   let markerWritten = false;
   let markerSkipReason = null;
   if (ok && args.sessionId) {
+    // IO stays lazy so this preserves the exact side-effect order (codex design
+    // review): commit first (the only mutation), then resolve the
+    // transcript, then run the compact gate with that transcript, then scan the
+    // user-close signal ONLY once the gate passes. planMarkerDecision owns the
+    // branch priority + reason strings; the booleans below are computed in that
+    // same short-circuiting order so no read runs earlier than it does today.
     const commitOutcome = commitWikiChanges(args.hypoDir);
-    if (!commitOutcome.committed) {
-      markerSkipReason = `commit-failed: ${commitOutcome.reason}`;
-    } else {
-      const closeTranscript = resolveTranscriptBySessionId(args.sessionId);
-      const markerGate = precompactGateStatus(
+    let closeTranscript = null;
+    let gateOk = false;
+    if (commitOutcome.committed) {
+      closeTranscript = resolveTranscriptBySessionId(args.sessionId);
+      gateOk = precompactGateStatus(
         args.hypoDir,
         closeTranscript ? { transcriptPath: closeTranscript } : {},
-      );
-      if (!markerGate.ok) {
-        // compact gate not ok → skip. Caller's `result.ok` already reflects the
-        // file/lint state; next Stop re-blocks until the remaining blocker
-        // (feedback/W8/hot/lint — git is now committed) is resolved.
-        markerSkipReason = 'compact-gate-not-ok';
-      } else if (!closeTranscript || !hasUserCloseSignal(closeTranscript)) {
-        // User-close hard gate: apply succeeded (payload files written)
-        // but the user never signalled session close, so the marker — which attests
-        // "user closed" — is withheld. The wiki record stands; the session is simply
-        // not marked closed. Surfaced (not silent) so the caller knows.
-        markerSkipReason = closeTranscript ? 'no-user-close-signal' : 'transcript-unresolved';
+      ).ok;
+    }
+    const decision = planMarkerDecision({
+      ok,
+      hasSessionId: true,
+      committed: commitOutcome.committed,
+      commitReason: commitOutcome.reason,
+      gateOk,
+      transcriptResolved: !!closeTranscript,
+      // Scan the signal only when the gate passed AND a transcript resolved —
+      // hasUserCloseSignal never runs earlier than the original nested `else if`.
+      hasUserSignal: gateOk && !!closeTranscript && hasUserCloseSignal(closeTranscript),
+    });
+    markerSkipReason = decision.skipReason;
+    if (decision.write) {
+      writeSessionClosedMarker(args.hypoDir, args.sessionId, { project });
+      // Codex CONCERN: the writer swallows IO errors (best-effort).
+      // Verify the file actually landed — mirroring the standalone path — instead of
+      // asserting markerWritten=true, so a .cache permission/disk problem surfaces
+      // rather than the caller reporting "closed" while the next Stop re-blocks.
+      if (existsSync(sessionClosedMarkerPath(args.hypoDir, args.sessionId))) {
+        markerWritten = true;
       } else {
-        writeSessionClosedMarker(args.hypoDir, args.sessionId, { project });
-        // Codex CONCERN: the writer swallows IO errors (best-effort).
-        // Verify the file actually landed — mirroring the standalone path — instead of
-        // asserting markerWritten=true, so a .cache permission/disk problem surfaces
-        // rather than the caller reporting "closed" while the next Stop re-blocks.
-        if (existsSync(sessionClosedMarkerPath(args.hypoDir, args.sessionId))) {
-          markerWritten = true;
-        } else {
-          markerSkipReason = 'marker-did-not-land';
-        }
+        markerSkipReason = 'marker-did-not-land';
       }
     }
   }
-  const stage = ok
+  let stage = ok
     ? null
     : !verification.ok && !postLintOk
       ? 'post-apply-verification+lint'
       : !verification.ok
         ? 'post-apply-verification'
         : 'post-apply-lint';
+  // Runtime close-result invariant self-check. When a
+  // marker-write path (args.sessionId present) settles into an internally
+  // contradictory shape — ok:true with the marker silently withheld and no
+  // reason, or a written marker that also carries a skip reason — flip ok:false
+  // and stage-tag it so the existing `process.exit(ok ? 0 : 1)` yields exit 1.
+  // That non-zero exit is the discriminator that separates a genuine
+  // contradiction (a code bug) from a legitimate withhold (exit 0, e.g.
+  // no-user-close-signal). apply is idempotent, so a non-zero re-run is safe.
+  // Unreachable today; this is a regression guard for future refactors.
+  if (args.sessionId) {
+    const contradiction = closeResultContradiction({ ok, markerWritten, markerSkipReason });
+    if (contradiction) {
+      ok = false;
+      stage = contradiction;
+      process.stderr.write(
+        `\n🛑 INTERNAL CONTRADICTION in session-close result: ${contradiction}\n` +
+          `    markerWritten=${markerWritten}, markerSkipReason=${JSON.stringify(markerSkipReason)}.\n` +
+          `    This is a close-pipeline bug, not a normal withhold. Exiting non-zero so it\n` +
+          `    cannot masquerade as a successful close. The applied payload files stand;\n` +
+          `    re-running apply is idempotent once the pipeline is fixed.\n`,
+      );
+    }
+  }
   const result = {
     ok,
     stage,
@@ -1189,9 +1290,11 @@ function applySessionClose(args) {
     // When ok:true but the session-close marker was NOT written, the Stop-chain
     // still sees an open session and will re-prompt at the next Stop. Surface this
     // loudly so neither the human nor a skill-following model reads "ok:true" as
-    // "session fully closed". Gate on markerSkipReason (non-null exactly when
-    // args.sessionId is present and the marker was withheld).
-    if (markerSkipReason) {
+    // "session fully closed". Gate on `!markerWritten` too so this "marker NOT
+    // written" line cannot fire on the contradiction-B path (a written marker that
+    // also carried a skip reason) — there the invariant's own 🛑 line already
+    // explains the failure, and this message would contradict markerWritten:true.
+    if (markerSkipReason && !markerWritten) {
       process.stderr.write(
         `\n⚠️  session-close marker NOT written (reason: ${markerSkipReason})\n` +
           `    The 5 mandatory files were applied and verified (ok:true), but the\n` +
@@ -1287,119 +1390,133 @@ function parseTags(fm) {
 
 // ── main ─────────────────────────────────────────────────────────────────────
 
-const args = parseArgs(process.argv);
-
-if (args.markSessionClosed) {
-  runMarkSessionClosed(args); // exits
+// Guard the CLI dispatch behind an entry check: the module now exports
+// pure functions (planMarkerDecision / closeResultContradiction) that the test
+// runner imports, and importing must NOT execute the CLI (its process.exit would
+// kill the runner). Mirror feedback-sync.mjs's realpath + pathToFileURL guard so
+// `node crystallize.mjs …` still runs main() while `import` does not.
+function isMain() {
+  if (!process.argv[1]) return false;
+  return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
 }
 
-if (args.applySessionClose) {
-  applySessionClose(args); // exits
-}
+function main() {
+  const args = parseArgs(process.argv);
 
-if (args.checkSessionClose) {
-  runSessionCloseCheck(args); // exits
-}
-
-const ignorePatterns = loadHypoIgnore(args.hypoDir);
-const pagesDir = join(args.hypoDir, 'pages');
-const pages = collectPagesCrystallize(pagesDir, args.hypoDir, ignorePatterns);
-
-const tagGroups = {}; // tag → [{ slug, title }]
-const unlinked = []; // pages with no outbound wikilinks
-const drafts = []; // pages tagged draft
-
-for (const { path, rel } of pages) {
-  let content;
-  try {
-    content = readFileSync(path, 'utf-8');
-  } catch {
-    continue;
-  }
-  const fm = parseFrontmatter(content);
-  if (!fm) continue;
-
-  const slug = rel.replace(/\.md$/, '');
-  const title = fm.title || slug;
-  const tags = parseTags(fm);
-
-  // tag groups
-  for (const tag of tags) {
-    if (!tagGroups[tag]) tagGroups[tag] = [];
-    tagGroups[tag].push({ slug, title });
+  if (args.markSessionClosed) {
+    runMarkSessionClosed(args); // exits
   }
 
-  // draft detection
-  if (tags.includes('draft') || fm.confidence === 'speculative') {
-    drafts.push({ slug, title, confidence: fm.confidence });
+  if (args.applySessionClose) {
+    applySessionClose(args); // exits
   }
 
-  // unlinked (no outbound wikilinks in body)
-  const body = content.replace(/^---[\s\S]*?---/, '');
-  const links = extractWikilinks(body);
-  if (links.length === 0) unlinked.push({ slug, title });
-}
-
-// filter tag groups by min-group
-const synthesisGroups = Object.entries(tagGroups)
-  .filter(([, pages]) => pages.length >= args.minGroup)
-  .sort((a, b) => b[1].length - a[1].length)
-  .map(([tag, pages]) => ({ tag, pages }));
-
-// Lookup-cold candidates (B): pages with inbound wikilinks that lookup has not
-// injected within the recency window. Advisory only, never gates, never mutates.
-const coldCandidates = aggregateColdCandidates(args.hypoDir, { ignorePatterns });
-
-if (args.json) {
-  console.log(JSON.stringify({ synthesisGroups, unlinked, drafts, coldCandidates }, null, 2));
-  process.exit(0);
-}
-
-let found = false;
-
-if (synthesisGroups.length > 0) {
-  found = true;
-  console.log(`Synthesis candidates by tag (${synthesisGroups.length} group(s)):\n`);
-  for (const { tag, pages: grp } of synthesisGroups) {
-    console.log(`  [${tag}] (${grp.length} pages):`);
-    for (const p of grp) console.log(`    [[${p.slug}]] — ${p.title}`);
+  if (args.checkSessionClose) {
+    runSessionCloseCheck(args); // exits
   }
-  console.log('');
+
+  const ignorePatterns = loadHypoIgnore(args.hypoDir);
+  const pagesDir = join(args.hypoDir, 'pages');
+  const pages = collectPagesCrystallize(pagesDir, args.hypoDir, ignorePatterns);
+
+  const tagGroups = {}; // tag → [{ slug, title }]
+  const unlinked = []; // pages with no outbound wikilinks
+  const drafts = []; // pages tagged draft
+
+  for (const { path, rel } of pages) {
+    let content;
+    try {
+      content = readFileSync(path, 'utf-8');
+    } catch {
+      continue;
+    }
+    const fm = parseFrontmatter(content);
+    if (!fm) continue;
+
+    const slug = rel.replace(/\.md$/, '');
+    const title = fm.title || slug;
+    const tags = parseTags(fm);
+
+    // tag groups
+    for (const tag of tags) {
+      if (!tagGroups[tag]) tagGroups[tag] = [];
+      tagGroups[tag].push({ slug, title });
+    }
+
+    // draft detection
+    if (tags.includes('draft') || fm.confidence === 'speculative') {
+      drafts.push({ slug, title, confidence: fm.confidence });
+    }
+
+    // unlinked (no outbound wikilinks in body)
+    const body = content.replace(/^---[\s\S]*?---/, '');
+    const links = extractWikilinks(body);
+    if (links.length === 0) unlinked.push({ slug, title });
+  }
+
+  // filter tag groups by min-group
+  const synthesisGroups = Object.entries(tagGroups)
+    .filter(([, pages]) => pages.length >= args.minGroup)
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([tag, pages]) => ({ tag, pages }));
+
+  // Lookup-cold candidates (B): pages with inbound wikilinks that lookup has not
+  // injected within the recency window. Advisory only, never gates, never mutates.
+  const coldCandidates = aggregateColdCandidates(args.hypoDir, { ignorePatterns });
+
+  if (args.json) {
+    console.log(JSON.stringify({ synthesisGroups, unlinked, drafts, coldCandidates }, null, 2));
+    process.exit(0);
+  }
+
+  let found = false;
+
+  if (synthesisGroups.length > 0) {
+    found = true;
+    console.log(`Synthesis candidates by tag (${synthesisGroups.length} group(s)):\n`);
+    for (const { tag, pages: grp } of synthesisGroups) {
+      console.log(`  [${tag}] (${grp.length} pages):`);
+      for (const p of grp) console.log(`    [[${p.slug}]] — ${p.title}`);
+    }
+    console.log('');
+  }
+
+  if (unlinked.length > 0) {
+    found = true;
+    console.log(`Unlinked pages (no outbound [[wikilinks]]) — ${unlinked.length}:`);
+    for (const p of unlinked) console.log(`  [[${p.slug}]] — ${p.title}`);
+    console.log('');
+  }
+
+  if (drafts.length > 0) {
+    found = true;
+    console.log(`Draft/speculative pages ready to crystallize — ${drafts.length}:`);
+    for (const p of drafts) console.log(`  [[${p.slug}]] — ${p.title}`);
+    console.log('');
+  }
+
+  // Advisory (non-gating): pages the graph treats as live but lookup has not
+  // injected recently. Held until enough page-usage history accrues.
+  if (coldCandidates.status === 'ok' && coldCandidates.candidates.length > 0) {
+    found = true;
+    console.log(
+      `Lookup-cold pages (${coldCandidates.candidates.length}), inbound links but not injected recently:`,
+    );
+    for (const p of coldCandidates.candidates) console.log(`  [[${p.slug}]] (${p.title})`);
+    console.log('');
+  } else if (
+    coldCandidates.status === 'insufficient-data' &&
+    coldCandidates.reason === 'span-too-short'
+  ) {
+    // Only surface the "held" notice once a log is actually accruing (span under
+    // the cold-start window). A vault with no log at all stays silent so this
+    // advisory never becomes permanent noise on every crystallize run.
+    console.log('Lookup-cold scan held: not enough page-usage history yet (advisory).\n');
+  }
+
+  if (!found) {
+    console.log('✓ No crystallization candidates found — Hypomnema looks well-connected.');
+  }
 }
 
-if (unlinked.length > 0) {
-  found = true;
-  console.log(`Unlinked pages (no outbound [[wikilinks]]) — ${unlinked.length}:`);
-  for (const p of unlinked) console.log(`  [[${p.slug}]] — ${p.title}`);
-  console.log('');
-}
-
-if (drafts.length > 0) {
-  found = true;
-  console.log(`Draft/speculative pages ready to crystallize — ${drafts.length}:`);
-  for (const p of drafts) console.log(`  [[${p.slug}]] — ${p.title}`);
-  console.log('');
-}
-
-// Advisory (non-gating): pages the graph treats as live but lookup has not
-// injected recently. Held until enough page-usage history accrues.
-if (coldCandidates.status === 'ok' && coldCandidates.candidates.length > 0) {
-  found = true;
-  console.log(
-    `Lookup-cold pages (${coldCandidates.candidates.length}), inbound links but not injected recently:`,
-  );
-  for (const p of coldCandidates.candidates) console.log(`  [[${p.slug}]] (${p.title})`);
-  console.log('');
-} else if (
-  coldCandidates.status === 'insufficient-data' &&
-  coldCandidates.reason === 'span-too-short'
-) {
-  // Only surface the "held" notice once a log is actually accruing (span under
-  // the cold-start window). A vault with no log at all stays silent so this
-  // advisory never becomes permanent noise on every crystallize run.
-  console.log('Lookup-cold scan held: not enough page-usage history yet (advisory).\n');
-}
-
-if (!found) {
-  console.log('✓ No crystallization candidates found — Hypomnema looks well-connected.');
-}
+if (isMain()) main();

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -29,6 +29,9 @@ import { fileURLToPath } from 'node:url';
 // static import (no top-level await) — feedback-sync.mjs guards main() behind an
 // entry check, so importing it for unit tests does not run the CLI.
 import { resolveProjectId as fbResolveProjectId } from '../scripts/feedback-sync.mjs';
+// crystallize.mjs guards its CLI dispatch behind isMain(), so importing these
+// pure close-pipeline functions does not run the CLI.
+import { planMarkerDecision, closeResultContradiction } from '../scripts/crystallize.mjs';
 import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
 import { buildProjectSuggestionLine, resolveActiveProject } from '../hooks/hypo-shared.mjs';
 import { parseSchemaVocab, appendPendingTags } from '../scripts/lib/schema-vocab.mjs';
@@ -21771,6 +21774,238 @@ test('prompt surfaces: bundled-script references resolve via CLAUDE_PLUGIN_ROOT/
     missingFallback.length,
     0,
     `surfaces invoking a bundled script but missing the hypo-pkg.json resolution fallback: ${missingFallback.join(', ')}`,
+  );
+});
+
+// ── close-pipeline state machine: planMarkerDecision + closeResultContradiction ─
+// Deterministic table tests for the two pure close-pipeline functions. The close
+// marker decision is deterministic given its input signals; these tables exercise
+// that state machine directly (no CLI spawn). Fixtures are distilled from the
+// real session-close failures that motivated the safety net:
+//   ISSUE-27 (git-dirty self-block)   → commit-failed skip
+//   ISSUE-28 (cross-block bookkeeping) → compact-gate-not-ok skip
+//   ISSUE-33 (wrong --session-id)      → transcript-unresolved / no-user-close-signal
+//   ISSUE-1/7/12 (project resolution)  → upstream of gateOk (which project the gate scores)
+suite('close-pipeline: planMarkerDecision (deterministic state machine)');
+
+// [label, input, expected]
+const MARKER_DECISION_CASES = [
+  [
+    'apply not ok → not a marker path (no reason)',
+    {
+      ok: false,
+      hasSessionId: true,
+      committed: true,
+      gateOk: true,
+      transcriptResolved: true,
+      hasUserSignal: true,
+    },
+    { write: false, skipReason: null },
+  ],
+  [
+    'no session id → not a marker path (no reason)',
+    {
+      ok: true,
+      hasSessionId: false,
+      committed: true,
+      gateOk: true,
+      transcriptResolved: true,
+      hasUserSignal: true,
+    },
+    { write: false, skipReason: null },
+  ],
+  [
+    'ISSUE-27: commit failed → commit-failed skip',
+    {
+      ok: true,
+      hasSessionId: true,
+      committed: false,
+      commitReason: 'uncommitted',
+      gateOk: false,
+      transcriptResolved: false,
+      hasUserSignal: false,
+    },
+    { write: false, skipReason: 'commit-failed: uncommitted' },
+  ],
+  [
+    'ISSUE-28: compact gate not ok → compact-gate-not-ok',
+    {
+      ok: true,
+      hasSessionId: true,
+      committed: true,
+      gateOk: false,
+      transcriptResolved: true,
+      hasUserSignal: true,
+    },
+    { write: false, skipReason: 'compact-gate-not-ok' },
+  ],
+  [
+    'ISSUE-33: transcript unresolved → transcript-unresolved',
+    {
+      ok: true,
+      hasSessionId: true,
+      committed: true,
+      gateOk: true,
+      transcriptResolved: false,
+      hasUserSignal: false,
+    },
+    { write: false, skipReason: 'transcript-unresolved' },
+  ],
+  [
+    'ISSUE-33: transcript resolved but no user signal → no-user-close-signal',
+    {
+      ok: true,
+      hasSessionId: true,
+      committed: true,
+      gateOk: true,
+      transcriptResolved: true,
+      hasUserSignal: false,
+    },
+    { write: false, skipReason: 'no-user-close-signal' },
+  ],
+  [
+    'all clear → write the marker',
+    {
+      ok: true,
+      hasSessionId: true,
+      committed: true,
+      gateOk: true,
+      transcriptResolved: true,
+      hasUserSignal: true,
+    },
+    { write: true, skipReason: null },
+  ],
+];
+
+for (const [label, input, expected] of MARKER_DECISION_CASES) {
+  test(label, () => {
+    assert.deepEqual(planMarkerDecision(input), expected);
+  });
+}
+
+test('branch priority: commit-failed wins over a would-be gate/signal skip', () => {
+  // Even with gateOk:false and no signal, a commit failure is reported FIRST
+  // (the tree was never committed, so the downstream gate never ran).
+  assert.deepEqual(
+    planMarkerDecision({
+      ok: true,
+      hasSessionId: true,
+      committed: false,
+      commitReason: 'not a repo',
+      gateOk: false,
+      transcriptResolved: false,
+      hasUserSignal: false,
+    }),
+    { write: false, skipReason: 'commit-failed: not a repo' },
+  );
+});
+
+suite('close-pipeline: closeResultContradiction (runtime invariant self-check)');
+
+// Every legitimate withhold (marker not written, but a real reason recorded) is
+// a VALID outcome, not a contradiction → null.
+const LEGIT_WITHHOLDS = [
+  'commit-failed: uncommitted',
+  'compact-gate-not-ok',
+  'transcript-unresolved',
+  'no-user-close-signal',
+  'marker-did-not-land',
+];
+for (const reason of LEGIT_WITHHOLDS) {
+  test(`legit withhold (${reason}) → no contradiction`, () => {
+    assert.equal(
+      closeResultContradiction({ ok: true, markerWritten: false, markerSkipReason: reason }),
+      null,
+    );
+  });
+}
+
+test('normal write (marker written, no reason) → no contradiction', () => {
+  assert.equal(
+    closeResultContradiction({ ok: true, markerWritten: true, markerSkipReason: null }),
+    null,
+  );
+});
+
+test('apply failed (ok:false, no marker, no reason) → no contradiction', () => {
+  // ok is already false for a file/lint reason; a withheld marker with no reason
+  // is expected here (the marker block never ran), so this is NOT the invariant's
+  // target — it only fires on ok:true.
+  assert.equal(
+    closeResultContradiction({ ok: false, markerWritten: false, markerSkipReason: null }),
+    null,
+  );
+});
+
+test('contradiction A: ok:true, marker withheld, no reason → flagged', () => {
+  assert.equal(
+    closeResultContradiction({ ok: true, markerWritten: false, markerSkipReason: null }),
+    'internal-contradiction:marker-withheld-without-reason',
+  );
+});
+
+for (const blank of ['', '   ']) {
+  test(`contradiction A: a blank-string reason (${JSON.stringify(blank)}) counts as reasonless`, () => {
+    // The stderr warning path gates on truthiness, so a blank reason would evade
+    // a naive `== null` check while surfacing nothing to the reader.
+    assert.equal(
+      closeResultContradiction({ ok: true, markerWritten: false, markerSkipReason: blank }),
+      'internal-contradiction:marker-withheld-without-reason',
+    );
+  });
+}
+
+for (const bogus of [false, 0, [], {}]) {
+  test(`contradiction A: a non-string reason (${JSON.stringify(bogus)}) does not count as a real reason`, () => {
+    // A real reason is a non-blank string; a future bad assignment must not be
+    // able to hide a withheld marker behind a bogus non-string value.
+    assert.equal(
+      closeResultContradiction({ ok: true, markerWritten: false, markerSkipReason: bogus }),
+      'internal-contradiction:marker-withheld-without-reason',
+    );
+  });
+}
+
+test('contradiction B: marker written AND a skip reason set → flagged', () => {
+  assert.equal(
+    closeResultContradiction({
+      ok: true,
+      markerWritten: true,
+      markerSkipReason: 'no-user-close-signal',
+    }),
+    'internal-contradiction:marker-written-with-skip-reason',
+  );
+});
+
+test('marker written with a blank reason → not contradiction B (blank is no reason)', () => {
+  assert.equal(
+    closeResultContradiction({ ok: true, markerWritten: true, markerSkipReason: '' }),
+    null,
+  );
+});
+
+suite('crystallize.mjs entry guard (import must not run the CLI)');
+
+test('importing crystallize.mjs runs no CLI and exposes exactly the pure exports', () => {
+  // The pure close-pipeline exports are usable only because the CLI dispatch is
+  // guarded behind isMain(). A regressed guard that let the CLI run on import
+  // would either crash (process.exit) or leak crystallize output here — assert
+  // the import is silent and yields exactly the two exported names.
+  const script = join(REPO, 'scripts', 'crystallize.mjs');
+  const r = spawnSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `import(${JSON.stringify(script)}).then((m) => process.stdout.write(Object.keys(m).sort().join(',')))`,
+    ],
+    { encoding: 'utf-8' },
+  );
+  assert.equal(r.status, 0, `import must exit 0, got ${r.status}: ${r.stderr}`);
+  assert.equal(
+    r.stdout,
+    'closeResultContradiction,planMarkerDecision',
+    `import must print only the pure exports (no CLI output): ${JSON.stringify(r.stdout)}`,
   );
 });
 


### PR DESCRIPTION
# English

## What changed

The apply-session-close marker decision is extracted into a pure
`planMarkerDecision()`, and a new pure `closeResultContradiction()` runs a
runtime self-check on the settled close result. The CLI dispatch is guarded
behind `isMain()` so the module is importable, and both pure functions are
covered by deterministic table tests plus an import smoke.

## Why

Session-close bugs almost always surface post-release during real dogfooding
(live hooks, real transcripts, accumulated multi-project vaults), not in the
fresh single-project sandbox that release QA runs in. A pure, deterministic
layer around the close state machine catches the dominant class directly and
gives it a test seam that does not need a live session. This is the safety-net
layer (L1 runtime invariant + L2 deterministic tests) the QA-strategy decision
deferred to a follow-up.

## How

- `planMarkerDecision(signals)` owns only the branch priority and the reason
  strings. The caller keeps the IO lazy: commit first (the only mutation), then
  resolve the transcript, then run the compact gate, then scan the user-close
  signal only once the gate passes. So no read runs earlier than it did before,
  and the extraction is behavior-preserving.
- `closeResultContradiction({ ok, markerWritten, markerSkipReason })` returns a
  contradiction tag when the result is internally inconsistent: `ok:true` with
  the marker withheld and no real reason (a real reason is a non-blank string,
  so a blank or non-string value cannot hide a withheld marker), or a written
  marker that also carries a skip reason. The caller then flips `ok=false` and
  stage-tags it, so the existing `process.exit(ok ? 0 : 1)` yields exit 1. The
  non-zero exit is the discriminator that separates a genuine contradiction (a
  pipeline bug) from a legitimate withhold (exit 0, e.g. no user-close signal).
- The contradiction is unreachable today: every non-write branch already records
  a reason. The seam is a regression guard so a future reason-less branch fails
  loudly instead of silently emitting a misleading `ok:true`.

Not in scope (explicit): the negative-path rows for the release QA matrix. The
deterministic table tests already cover the negative/contradiction paths more
robustly than a brittle real-session matrix row would, so that item is deferred.

## Manual verification

- `npm test` -> 1068 passed, 0 failed.
- `node scripts/check-tracker-ids.mjs --all` -> clean.
- `npx prettier --check` on both changed files -> clean.
- Import smoke: `node --input-type=module -e "import('./scripts/crystallize.mjs')..."`
  prints only `closeResultContradiction,planMarkerDecision` (the CLI does not run
  on import).
- Predicate spot-check: `closeResultContradiction` on `false/0/[]/{}/null/""`
  reasons all return the withheld-without-reason tag; only a non-blank string
  suppresses it.

## Migration notes

None.

---

# 한국어

## 변경 내용

apply-session-close의 마커 결정을 순수 함수 `planMarkerDecision()`으로 추출하고,
새 순수 함수 `closeResultContradiction()`이 확정된 close 결과에 런타임 self-check를
돌린다. CLI dispatch를 `isMain()` 뒤로 가드해 모듈을 import 가능하게 만들었고, 두
순수 함수를 결정론적 테이블 테스트와 import smoke로 덮었다.

## 이유

session-close 버그는 릴리스 QA가 도는 fresh·단일 프로젝트 샌드박스가 아니라, 출시
후 실제 dogfooding(라이브 훅, 실 transcript, 누적된 멀티프로젝트 볼트)에서 거의 다
드러난다. close 상태기계 둘레의 순수·결정론적 레이어는 지배적인 버그 클래스를 직접
잡고, 라이브 세션 없이도 테스트할 수 있는 seam을 준다. QA 전략 결정이 후속으로
미뤄둔 안전망 레이어(L1 런타임 불변식 + L2 결정론 테스트)다.

## 방법

- `planMarkerDecision(signals)`는 분기 우선순위와 reason 문자열만 갖는다. caller는
  IO를 lazy하게 유지한다: commit 먼저(유일한 변경), 그다음 transcript 해소, 그다음
  compact 게이트, 그다음 게이트 통과 후에만 user-close 신호 스캔. 어떤 read도 이전보다
  먼저 실행되지 않으므로 추출은 behavior-preserving이다.
- `closeResultContradiction({ ok, markerWritten, markerSkipReason })`는 결과가 내부적으로
  모순일 때 contradiction 태그를 반환한다: 마커가 보류됐고 real reason이 없는데 `ok:true`
  (real reason은 비어있지 않은 문자열이라, blank나 비문자열 값은 보류된 마커를 숨길 수
  없다), 또는 마커가 기록됐는데 skip reason도 달린 경우. caller는 `ok=false`로 flip하고
  stage 태그를 붙여, 기존 `process.exit(ok ? 0 : 1)`이 exit 1을 낸다. 이 non-zero exit이
  진짜 모순(파이프라인 버그)과 정당한 보류(exit 0, 예: user-close 신호 없음)를 가르는
  판별자다.
- 이 모순은 현재 도달 불가능하다: 모든 non-write 분기가 이미 reason을 남긴다. seam은
  회귀 가드로, 미래에 reason 없는 분기가 추가돼도 오해 소지의 `ok:true`를 조용히 내지
  않고 시끄럽게 실패하게 한다.

범위 밖(명시): 릴리스 QA 매트릭스의 negative-path row. 결정론 테이블 테스트가
negative/contradiction 경로를 브리틀한 실세션 매트릭스 row보다 더 견고하게 이미
덮으므로, 해당 항목은 defer한다.

## 수동 검증

- `npm test` -> 1068 passed, 0 failed.
- `node scripts/check-tracker-ids.mjs --all` -> clean.
- 변경된 두 파일 `npx prettier --check` -> clean.
- Import smoke: import 시 `closeResultContradiction,planMarkerDecision`만 출력(CLI 미실행).
- 술어 점검: `false/0/[]/{}/null/""` reason 모두 withheld-without-reason 태그 반환, 비어있지
  않은 문자열만 억제.

## 마이그레이션 노트

None.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally (CI-verified; local lint scans untracked vault pages)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (no user-facing change)
- [x] Filled the `## Changelog` block above (internal-only: None)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
