### PR TITLE
feat(extensions): reverse capture for commands + agents

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -33,6 +33,7 @@ Andrej Karpathy의 "LLM 네이티브 위키" 스케치에서 출발했습니다.
 
 - 피드백 한 곳만 고치면 나머지는 따라옵니다. `pages/feedback/`에 한 번 적으면 위키가 `MEMORY.md`와 `~/.claude/CLAUDE.md`의 `<learned_behaviors>` 블록을 자동으로 갱신합니다(단방향 projection).
 - 확장 파일도 함께 동기화. 위키 안 `~/hypomnema/extensions/{agents,commands,hooks,skills}/`에 둔 파일을 `~/.claude/`에 자동 반영합니다. `--codex`를 붙이면 `hooks`·`commands`는 `~/.codex/`에도 반영하지만, `agents`와 `skills`는 Claude 전용이라 건너뜁니다.
+- 역방향 capture는 반대로 갑니다. `hypomnema capture`(또는 `/hypo:capture`)는 `~/.claude/{commands,agents}/`에 보통 방식으로 만든 command·agent를 위키로 끌어와, 이후 다른 머신에 원래 이름 그대로 동기화되게 합니다. capture는 명시적이며 내용이 다른 위키 파일은 덮어쓰지 않습니다. hook과 skill은 아직 capture 대상이 아닙니다.
 - 프로젝트 자동 생성. 프로젝트 표식(`package.json`·`Cargo.toml` 등)이 있는 git 저장소로 `cd` 했는데 대응하는 위키 프로젝트가 없으면 만들지 물어봅니다.
 - 세션 종료 자동 정리와 `/clear` 복구. 의미 있는 세션이 끝나면 "마무리 메모를 짧게 남길까요?"가 자동으로 뜹니다. 마무리하지 않은 채 `/clear`를 입력해도 다음 세션 시작 때 이어서 정리할 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The lanes that already run on their own: v1.1.0 shipped the observability score 
 
 - Edit feedback in one place and the rest follows. `pages/feedback/` is the single source of truth for behavior corrections, and Hypomnema derives `MEMORY.md` and the `<learned_behaviors>` block inside `~/.claude/CLAUDE.md` from it automatically.
 - Extensions sync alongside. Anything under `~/hypomnema/extensions/{agents,commands,hooks,skills}/` is mirrored into `~/.claude/` automatically. The `--codex` flag also mirrors `hooks` and `commands` into `~/.codex/`; `agents` and `skills` are Claude-only and skipped on purpose.
+- Reverse capture goes the other way. `hypomnema capture` (or `/hypo:capture`) pulls a command or agent you made the normal way under `~/.claude/{commands,agents}/` into the wiki, so it then syncs to your other machines under its original name. Capture is explicit and never overwrites a differing wiki file. Hooks and skills are not captured yet.
 - Auto-project creation. When you `cd` into a git repo with a project marker (`package.json`, `Cargo.toml`, etc.) and no matching wiki project exists, Hypomnema offers to scaffold one.
 - Session-close cleanup and `/clear` recovery. After a non-trivial session, a "save a minimal session-close note?" prompt appears automatically; a `/clear` after a forgotten close is detected and recovered at the next session start.
 

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -1,0 +1,40 @@
+---
+description: Pull extensions you made the normal way under ~/.claude/{commands,agents} into the wiki so they sync to your other machines. Use when the user wants to capture, adopt, or back up a locally-authored slash command or agent into Hypomnema.
+---
+
+You are running `/hypo:capture`. Bring a command or agent that the user created the normal way (directly under `~/.claude/commands/` or `~/.claude/agents/`) into the wiki `extensions/` tree so the existing forward-sync propagates it to their other machines.
+
+Scope: commands and agents only. Hooks and skills are not captured yet.
+
+## Step 1: Resolve the package root
+
+Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema capture` or reinstall instead of guessing the cache layout.
+
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag.
+
+## Step 2: List what can be captured
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/capture.mjs [--hypo-dir="<path>"]
+```
+
+With no names and no `--all`, the script lists capturable candidates and stops. It excludes anything already managed by the wiki, the reserved `hypo-*` namespace, symlinks, and non-`.md` files.
+
+Show the list. Note that these are every unowned regular `.md` under the top-level directories, not a provenance check: explicit selection is the trust boundary. A third-party tool's file could appear here, so let the user pick deliberately.
+
+## Step 3: Capture the user's selection
+
+Ask which ones to capture, then run with the chosen names (space-separated), or `--all` if the user wants everything listed:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/capture.mjs [--hypo-dir="<path>"] <name> [<name> ...]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/capture.mjs [--hypo-dir="<path>"] --all
+```
+
+A name is the filename (`mycmd.md`), its stem (`mycmd`), or the `type/file` form (`commands/mycmd.md`). Add `--dry-run` to preview without writing.
+
+Each capture stores the file in the wiki as `extensions/<type>/hypo-ext-<name>.md` with a sidecar `hypo-ext-<name>.manifest.json` that records the original install name, then adopts it so the currently-installed copy is left in place and tracked. A wiki file that already exists with different content (or a mismatched manifest) is refused, not overwritten.
+
+## Step 4: Commit the wiki, then sync elsewhere
+
+Show the script output verbatim. When something was captured, remind the user to commit and push the wiki, then run `hypomnema upgrade --apply` on their other machine to install the captured extension under its original name.

--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+/**
+ * scripts/capture.mjs — Reverse extension capture (MVP capture design).
+ *
+ * Pulls extensions authored the "normal way" under `~/.claude/{commands,agents}/`
+ * into the wiki `~/hypomnema/extensions/{commands,agents}/` so they propagate to
+ * other machines via the existing forward-sync ("register on A → sync on B").
+ *
+ * MVP scope: commands + agents only (pure file copy, no settings.json). hooks
+ * (manifest reverse-generation is lossy) and skills (directory support) are
+ * deferred to separate PRs.
+ *
+ * Naming (capture design §3): the wiki STORAGE name is `hypo-ext-<name>.md` (keeps the
+ * discovery whitelist), and a sidecar `hypo-ext-<name>.manifest.json` records
+ * `{ type, installName }` so forward-sync installs the file back under the user's
+ * ORIGINAL name (`~/.claude/commands/<name>.md`), not the wiki storage name.
+ *
+ * Adopt (capture design §4): capture copies the source verbatim into the wiki, then
+ * runs forward-sync. The install target already holds byte-identical content, so
+ * `copyOne` hits its `up-to-date` branch and records the SHA — ownership is
+ * acquired through the normal sync path, never by injecting a SHA directly.
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+  renameSync,
+  realpathSync,
+} from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { pathToFileURL } from 'url';
+import { sha256, isRegularFile, readFileIfRegular } from './lib/pkg-json.mjs';
+import { resolveHypoRoot } from './lib/hypo-root.mjs';
+import {
+  syncExtensions,
+  readExtensionPkgStateNoMutate,
+  isValidInstallStem,
+  EXT_PREFIX,
+} from './lib/extensions.mjs';
+
+const HOME = homedir();
+
+// MVP-captured types and their singular manifest `type` value. Both install as
+// top-level `.md` files, so a single extension covers them.
+const CAPTURE_TYPES = ['commands', 'agents'];
+const TYPE_SINGULAR = { commands: 'command', agents: 'agent' };
+const MD = '.md';
+
+function pkgJsonPath() {
+  return join(HOME, '.claude', 'hypo-pkg.json');
+}
+
+// ── pure helpers (exported for tests) ────────────────────────────────────────
+
+/**
+ * Decide whether a top-level `~/.claude/<type>/<file>` is a capture candidate.
+ * Excludes (capture design §6): the reserved `hypo` namespace (case-insensitive — core
+ * hooks/commands + already-synced hypo-ext-* copies), anything already owned
+ * (a recorded SHA for its install path means the wiki already manages it), and
+ * non-.md files. Symlink/non-regular is checked by the caller (needs an fs stat).
+ */
+export function isCaptureCandidate(type, file, recorded) {
+  if (!file.endsWith(MD)) return { ok: false, reason: 'not a .md file' };
+  const lower = file.toLowerCase();
+  if (lower === 'hypo' || lower.startsWith('hypo-')) {
+    return { ok: false, reason: 'reserved hypo namespace' };
+  }
+  if (recorded[`${type}/${file}`]) {
+    return { ok: false, reason: 'already managed by the wiki' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Plan the capture of one candidate against the current wiki state. Returns a
+ * status the caller acts on. Pure w.r.t. decisions; the caller supplies the
+ * already-read source + wiki contents so this stays testable.
+ *
+ * status:
+ *   'invalid'  — the derived installName stem is unsafe/reserved (skip).
+ *   'conflict' — a wiki .md or sidecar manifest already exists and disagrees
+ *                (refuse; never silently overwrite, capture design §7).
+ *   'already'  — wiki .md + manifest already match this capture (no-op).
+ *   'ready'    — safe to write.
+ */
+export function planCapture({ type, stem, srcSha, existingMdSha, existingManifestRaw }) {
+  if (!isValidInstallStem(stem)) {
+    return { status: 'invalid', reason: `invalid installName "${stem}"` };
+  }
+  const wantManifest = { type: TYPE_SINGULAR[type], installName: stem };
+
+  if (existingMdSha !== null && existingMdSha !== undefined) {
+    if (existingMdSha !== srcSha) {
+      return { status: 'conflict', reason: 'wiki storage file exists with different content' };
+    }
+    // .md matches — the manifest must also match, else install semantics differ.
+    if (existingManifestRaw == null) {
+      return { status: 'conflict', reason: 'wiki file exists without its installName manifest' };
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(existingManifestRaw);
+    } catch {
+      return { status: 'conflict', reason: 'wiki manifest is not valid JSON' };
+    }
+    if (parsed.type !== wantManifest.type || parsed.installName !== wantManifest.installName) {
+      return { status: 'conflict', reason: 'wiki manifest declares a different installName/type' };
+    }
+    return { status: 'already', manifest: wantManifest };
+  }
+  // No wiki .md yet. A stray manifest with a different mapping is still a conflict.
+  if (existingManifestRaw != null) {
+    let parsed;
+    try {
+      parsed = JSON.parse(existingManifestRaw);
+    } catch {
+      return { status: 'conflict', reason: 'stray wiki manifest is not valid JSON' };
+    }
+    if (parsed.type !== wantManifest.type || parsed.installName !== wantManifest.installName) {
+      return { status: 'conflict', reason: 'stray wiki manifest declares a different mapping' };
+    }
+  }
+  return { status: 'ready', manifest: wantManifest };
+}
+
+// ── filesystem orchestration ─────────────────────────────────────────────────
+
+function scanCandidates(claudeHome, recorded, types) {
+  const out = [];
+  for (const type of types) {
+    const dir = join(claudeHome, type);
+    if (!existsSync(dir)) continue;
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const file of entries) {
+      const verdict = isCaptureCandidate(type, file, recorded);
+      if (!verdict.ok) continue;
+      const srcPath = join(dir, file);
+      if (!isRegularFile(srcPath)) continue; // never follow symlinks/sockets
+      out.push({ type, file, stem: file.slice(0, -MD.length), srcPath });
+    }
+  }
+  return out;
+}
+
+function parseArgs(argv) {
+  const args = { names: [], all: false, types: CAPTURE_TYPES.slice(), dryRun: false, help: false };
+  let hypoDir = null;
+  for (const a of argv.slice(2)) {
+    if (a === '--all') args.all = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else if (a.startsWith('--type=')) {
+      args.types = a
+        .slice(7)
+        .split(',')
+        .map((s) => s.trim())
+        .filter((t) => CAPTURE_TYPES.includes(t));
+    } else if (a.startsWith('--hypo-dir=')) hypoDir = a.slice(11);
+    else if (!a.startsWith('-')) args.names.push(a);
+  }
+  args.hypoDir = hypoDir || resolveHypoRoot();
+  if (args.types.length === 0) args.types = CAPTURE_TYPES.slice();
+  return args;
+}
+
+function log(msg) {
+  process.stdout.write(`${msg}\n`);
+}
+
+// Write via a sibling temp + rename so the final replace is atomic and, crucially,
+// never follows a symlink already sitting at `dest` (rename swaps the link itself).
+function writeAtomic(dest, buf) {
+  const tmp = `${dest}.tmp.${process.pid}`;
+  writeFileSync(tmp, buf);
+  try {
+    renameSync(tmp, dest);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {}
+    throw err;
+  }
+}
+
+// Undo one capture's wiki writes: drop the .md, and either restore the manifest
+// bytes we overwrote (a pre-existing same-mapping sidecar) or remove the manifest
+// we created. Used on a failed/aborted adopt so a capture never half-lands.
+function rollbackRec(rec) {
+  try {
+    unlinkSync(rec.mdPath);
+  } catch {}
+  if (rec.manifestExisted && rec.manifestPrevBuf != null) {
+    try {
+      writeFileSync(rec.manifestPath, rec.manifestPrevBuf);
+    } catch {}
+  } else {
+    try {
+      unlinkSync(rec.manifestPath);
+    } catch {}
+  }
+}
+
+function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
+  const extDir = join(args.hypoDir, 'extensions');
+  const recorded = readExtensionPkgStateNoMutate(pkgJsonPath(), 'claude');
+  const candidates = scanCandidates(claudeHome, recorded, args.types);
+
+  // No explicit selection → list candidates and stop (capture design §6).
+  if (!args.all && args.names.length === 0) {
+    if (candidates.length === 0) {
+      log('No capturable extensions found under ~/.claude/{' + args.types.join(',') + '}.');
+      return { selected: [], captured: [], skipped: [], failed: [], listedOnly: true };
+    }
+    log('Capturable extensions (pass names to capture, or --all):');
+    for (const c of candidates) log(`  ${c.type}/${c.file}`);
+    log('');
+    log('Note: --all captures every unowned regular .md here — not a provenance check.');
+    log('Explicit selection is the trust boundary.');
+    return { selected: candidates, captured: [], skipped: [], failed: [], listedOnly: true };
+  }
+
+  // Resolve the selection.
+  let selected;
+  if (args.all) {
+    selected = candidates;
+  } else {
+    const byName = new Map();
+    for (const c of candidates) {
+      byName.set(c.file, c);
+      byName.set(c.stem, c);
+      byName.set(`${c.type}/${c.file}`, c);
+    }
+    selected = [];
+    for (const name of args.names) {
+      const c = byName.get(name);
+      if (c) selected.push(c);
+      else log(`⊘ ${name}: no capturable candidate by that name — skipped`);
+    }
+  }
+
+  const captured = [];
+  const skipped = [];
+  const failed = [];
+  const created = []; // files written THIS run, for rollback on adopt failure
+
+  for (const c of selected) {
+    const wikiStem = `${EXT_PREFIX}${c.stem}`;
+    const typeDir = join(extDir, c.type);
+    const mdPath = join(typeDir, `${wikiStem}${MD}`);
+    const manifestPath = join(typeDir, `${wikiStem}.manifest.json`);
+
+    // A pre-existing NON-regular wiki target (symlink / dir / socket) is a hard
+    // conflict: readFileIfRegular reports it as absent, so without this guard a
+    // naive write would follow a symlink out of the wiki (codex pre-commit
+    // BLOCKER). Refuse before reading or planning.
+    if (
+      (existsSync(mdPath) && !isRegularFile(mdPath)) ||
+      (existsSync(manifestPath) && !isRegularFile(manifestPath))
+    ) {
+      const reason = 'wiki target exists but is not a regular file';
+      log(`⊘ ${c.type}/${c.file}: ${reason} — skipped`);
+      skipped.push({ ...c, reason, status: 'conflict' });
+      continue;
+    }
+
+    const srcBuf = readFileSync(c.srcPath); // verbatim bytes (capture design §4)
+    const srcSha = sha256(srcBuf);
+    const existingMdBuf = readFileIfRegular(mdPath);
+    const existingMdSha = existingMdBuf ? sha256(existingMdBuf) : null;
+    const existingManifestBuf = readFileIfRegular(manifestPath);
+    const existingManifestRaw = existingManifestBuf ? existingManifestBuf.toString('utf-8') : null;
+
+    const plan = planCapture({
+      type: c.type,
+      stem: c.stem,
+      srcSha,
+      existingMdSha,
+      existingManifestRaw,
+    });
+
+    if (plan.status === 'invalid' || plan.status === 'conflict') {
+      log(`⊘ ${c.type}/${c.file}: ${plan.reason} — skipped`);
+      skipped.push({ ...c, reason: plan.reason, status: plan.status });
+      continue;
+    }
+    if (plan.status === 'already') {
+      log(`= ${c.type}/${c.file}: already captured`);
+      captured.push({ ...c, installFile: `${c.stem}${MD}`, status: 'already' });
+      continue;
+    }
+
+    // status === 'ready'. Write the manifest FIRST, then the .md (capture design §4):
+    // a crash between the two leaves only a manifest (no sibling → discovery
+    // skips it), never a lone .md that forward-sync would install under the wiki
+    // storage name. Both writes are atomic (temp + rename) so a symlink at the
+    // target is replaced, not followed.
+    if (!args.dryRun) {
+      mkdirSync(typeDir, { recursive: true });
+      const rec = {
+        type: c.type,
+        stem: c.stem,
+        mdPath,
+        manifestPath,
+        manifestExisted: existingManifestBuf != null,
+        manifestPrevBuf: existingManifestBuf,
+      };
+      writeAtomic(manifestPath, JSON.stringify(plan.manifest, null, 2) + '\n');
+      writeAtomic(mdPath, srcBuf);
+      created.push(rec);
+    }
+    captured.push({ ...c, installFile: `${c.stem}${MD}`, status: 'ready' });
+  }
+
+  const toAdopt = captured.filter((c) => c.status === 'ready');
+  if (toAdopt.length === 0 || args.dryRun) {
+    report(captured, skipped, failed, args.dryRun);
+    return { selected, captured, skipped, failed };
+  }
+
+  // Adopt: run forward-sync so the install targets (byte-identical) hit the
+  // up-to-date branch and record ownership. If sync THROWS, roll back every file
+  // written this run so a hard failure never leaves a half-captured extension
+  // behind (codex pre-commit CONCERN).
+  let sync;
+  try {
+    sync = syncExtensions({
+      extDir,
+      hypoDir: args.hypoDir,
+      target: 'claude',
+      settingsPath: join(claudeHome, 'settings.json'),
+      pkgPath: pkgJsonPath(),
+      apply: true,
+      force: false,
+    });
+  } catch (err) {
+    for (const rec of created) rollbackRec(rec);
+    log(`capture aborted: forward-sync failed (${err.message}); wiki files rolled back.`);
+    for (const c of toAdopt) {
+      c.status = 'failed';
+      failed.push(c);
+    }
+    report([], skipped, failed, false);
+    return { selected, captured, skipped, failed, sync: null };
+  }
+  const newSHAs = sync.newSHAs || {};
+
+  // VERIFY each expected key is owned; roll back any capture whose adoption did
+  // not take (e.g. the install target changed between copy and sync → skip-conflict
+  // with a null SHA) so the wiki does not keep an un-adopted file.
+  for (const c of toAdopt) {
+    const key = `${c.type}/${c.installFile}`;
+    if (newSHAs[key]) {
+      c.status = 'captured';
+    } else {
+      c.status = 'failed';
+      failed.push(c);
+      const rec = created.find((r) => r.type === c.type && r.stem === c.stem);
+      if (rec) rollbackRec(rec);
+    }
+  }
+  const okCaptured = captured.filter((c) => c.status === 'captured' || c.status === 'already');
+  for (const w of sync.warnings || []) log(`  sync: ${w}`);
+  report(okCaptured, skipped, failed, args.dryRun);
+  return { selected, captured, skipped, failed, sync };
+}
+
+function report(captured, skipped, failed, dryRun) {
+  log('');
+  if (captured.length > 0) {
+    log(`${dryRun ? 'Would capture' : 'Captured'} ${captured.length} extension(s):`);
+    for (const c of captured)
+      log(`  ${c.type}/${c.file} → extensions/${c.type}/${EXT_PREFIX}${c.stem}${MD}`);
+  }
+  if (skipped.length > 0) log(`Skipped ${skipped.length} (conflict/invalid — see above).`);
+  if (failed.length > 0)
+    log(`Failed to adopt ${failed.length} (see sync warnings; wiki files rolled back).`);
+  if (!dryRun && captured.some((c) => c.status === 'captured')) {
+    log('');
+    log('Next: commit + push the wiki, then run `hypomnema upgrade --apply` on another machine.');
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    log('Usage: hypomnema capture [names…] [--all] [--type=commands,agents] [--dry-run]');
+    log('  Pull ~/.claude/{commands,agents} extensions into the wiki for cross-machine sync.');
+    return 0;
+  }
+  const res = run(args);
+  return res.failed.length > 0 ? 1 : 0;
+}
+
+function isMain() {
+  try {
+    if (!process.argv[1]) return false;
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
+  } catch {
+    return false;
+  }
+}
+
+if (isMain()) {
+  process.exit(main());
+}
+
+export { parseArgs, scanCandidates, run };

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -85,7 +85,14 @@ function sha256(buf) {
 // keeps running init for backwards compatibility — that's the documented
 // Path-B onboarding command. An explicit `hypomnema init` is accepted too,
 // and is stripped before flag parsing so the rest of this file is unchanged.
-const KNOWN_SUBCOMMANDS = new Set(['init', 'upgrade', 'doctor', 'uninstall', 'feedback-sync']);
+const KNOWN_SUBCOMMANDS = new Set([
+  'init',
+  'upgrade',
+  'doctor',
+  'uninstall',
+  'feedback-sync',
+  'capture',
+]);
 const _verb = process.argv[2];
 if (_verb && KNOWN_SUBCOMMANDS.has(_verb) && _verb !== 'init') {
   const _target = join(SCRIPT_DIR, `${_verb}.mjs`);

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -49,6 +49,138 @@ export const CODEX_TYPES = ['hooks', 'commands'];
 // Per-type expected file extension. Hooks are executable .mjs; the rest are .md.
 const TYPE_FILE_EXT = { hooks: '.mjs', commands: '.md', skills: '.md', agents: '.md' };
 
+// Singular manifest `type` value per directory (capture design §3). A captured
+// extension's sidecar manifest must declare a `type` matching its parent dir
+// before its `installName` is honored (guards against a mislabelled manifest
+// retargeting an install path).
+const TYPE_SINGULAR = { hooks: 'hook', commands: 'command', skills: 'skill', agents: 'agent' };
+
+// installName carrier (capture design §3): reverse-captured commands/agents install
+// under the user's ORIGINAL name, not the wiki `hypo-ext-*` storage name. Only
+// commands/agents opt in — hooks keep the wiki name (their settings.json command
+// string is prefix-derived) and skills are not captured in the MVP.
+const INSTALLNAME_TYPES = new Set(['commands', 'agents']);
+
+// A valid installName stem: same conservative charset as SAFE_EXT_STEM but
+// WITHOUT the required hypo-ext- prefix (the whole point of C is to restore the
+// user's own name). Rejects path separators, traversal (leading dot blocks `..`
+// and `.`), and anything outside the charset.
+const SAFE_INSTALL_STEM = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+// Windows reserved device names (capture design §5 — the extensions-companion design chose hard-copy partly
+// for Windows compatibility, so an installName must never resolve to one).
+const WINDOWS_RESERVED = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+]);
+
+/**
+ * True iff `stem` is a syntactically valid, non-reserved installName (the reverse-capture design
+ * §5). Case-insensitive on the reservations so `Hypo-x` cannot slip past on a
+ * case-insensitive filesystem. Does NOT append an extension — callers add
+ * TYPE_FILE_EXT in code so a manifest can never inject the extension.
+ */
+export function isValidInstallStem(stem) {
+  if (typeof stem !== 'string' || !SAFE_INSTALL_STEM.test(stem)) return false;
+  // Reject `..` anywhere, not just a leading dot: an internal `a..b` passes the
+  // charset but parseExtKey (uninstall) rejects it, which would strand a captured
+  // file it can never remove. Keep the two validators in agreement.
+  if (stem.includes('..')) return false;
+  const lower = stem.toLowerCase();
+  if (lower === 'hypo' || lower.startsWith('hypo-')) return false; // reserved namespace
+  // Windows treats a device name reserved even WITH an extension (`con.v1`), so
+  // test the segment before the first dot, not just the whole stem.
+  const base = lower.split('.')[0];
+  if (WINDOWS_RESERVED.has(base)) return false;
+  return true;
+}
+
+/**
+ * Resolve the install filename for a discovered extension (capture design §3).
+ * Returns `{ installFile }` — the basename under `~/.claude/<type>/`. Defaults
+ * to `ext.file` (the wiki storage name) so existing hypo-ext-* extensions are
+ * untouched (backward compatible). Only commands/agents with a sidecar manifest
+ * whose `type` matches the directory AND whose `installName` is valid install
+ * under the user's original name. A present-but-invalid installName yields
+ * `{ skip, warn }` — the extension is dropped rather than silently installed
+ * under a surprising name.
+ */
+export function resolveInstallFile(ext) {
+  if (!INSTALLNAME_TYPES.has(ext.type) || !ext.manifestPath) {
+    return { installFile: ext.file };
+  }
+  const parsed = parseManifest(ext.manifestPath);
+  // Non-hook manifests are always ok:true (parseManifest only fails hook ones),
+  // so a malformed non-hook manifest is not reachable here; be defensive anyway.
+  if (!parsed.ok) return { installFile: ext.file };
+  const m = parsed.manifest;
+  if (!m || m.type !== TYPE_SINGULAR[ext.type] || m.installName === undefined) {
+    return { installFile: ext.file };
+  }
+  if (!isValidInstallStem(m.installName)) {
+    return {
+      skip: true,
+      warn: `${ext.type}/${ext.file}: invalid installName "${m.installName}" — extension skipped`,
+    };
+  }
+  return { installFile: m.installName + TYPE_FILE_EXT[ext.type] };
+}
+
+/**
+ * Parse + validate a recorded pkg-json extension key `${type}/${installFile}`
+ * for destructive use (capture design §8 — uninstall traverses recorded keys, which
+ * come from an on-disk JSON we do not fully control). Returns
+ * `{ type, installFile }` only when the key is exactly one covered type, a
+ * single path segment for the filename (no separators / traversal), and the
+ * expected extension. Returns null otherwise so the caller skips it — never
+ * `join`s an untrusted key that could escape the extension directory.
+ */
+export function parseExtKey(key, coveredTypes) {
+  if (typeof key !== 'string') return null;
+  const slash = key.indexOf('/');
+  if (slash === -1) return null;
+  const type = key.slice(0, slash);
+  const installFile = key.slice(slash + 1);
+  if (!coveredTypes.includes(type)) return null;
+  // The filename portion must be a single safe segment: no further separators,
+  // no traversal, and it must end in the type's expected extension. Only HOOKS
+  // additionally track a `.manifest.json` sidecar copy in the SHA map, so the
+  // manifest suffix is accepted for hooks alone — accepting it for every type
+  // would let a forged `commands/x.manifest.json` key name a removable file that
+  // sync never owns (codex pre-commit CONCERN).
+  if (installFile.includes('/') || installFile.includes('\\')) return null;
+  if (installFile.includes('..') || installFile.startsWith('.')) return null;
+  const MANIFEST_SUFFIX = '.manifest.json';
+  const suffix =
+    type === 'hooks' && installFile.endsWith(MANIFEST_SUFFIX)
+      ? MANIFEST_SUFFIX
+      : TYPE_FILE_EXT[type];
+  if (!installFile.endsWith(suffix)) return null;
+  const stem = installFile.slice(0, -suffix.length);
+  if (stem.length === 0) return null;
+  return { type, installFile };
+}
+
 // Claude Code hook events (D3 allowlist). A manifest with an event outside this
 // set is malformed → the whole extension is skipped (no copy, no registration).
 export const HOOK_EVENT_ALLOWLIST = new Set([
@@ -387,9 +519,57 @@ export function syncExtensions({
 
   const expectedHookExts = [];
 
+  // capture design §3/§3a: resolve each extension's install filename (installName
+  // decoupling) and detect duplicate install targets BEFORE any hard-copy. A
+  // case-folded collision on `${type}/${installFile}` (two wiki files mapping to
+  // the same install path, or a case-only clash on macOS/Windows) skips the
+  // WHOLE group — otherwise file traversal order would decide ownership and
+  // overwrite/skip unpredictably. Keyed by ext object identity.
+  const installFileByExt = new Map();
+  const dupSkip = new Set();
+  for (const type of types) {
+    const seen = new Map(); // case-folded `${type}/${installFile}` → first ext
+    for (const ext of discovered[type]) {
+      const res = resolveInstallFile(ext);
+      if (res.skip) {
+        dupSkip.add(ext);
+        result.warnings.push(res.warn);
+        continue;
+      }
+      installFileByExt.set(ext, res.installFile);
+      const norm = `${type}/${res.installFile.toLowerCase()}`;
+      const first = seen.get(norm);
+      if (first !== undefined) {
+        dupSkip.add(ext);
+        dupSkip.add(first);
+        result.warnings.push(
+          `${type}/${res.installFile} install target claimed by multiple extensions — all skipped (rename installName)`,
+        );
+      } else {
+        seen.set(norm, ext);
+      }
+    }
+  }
+
+  // Preserve the ownership record of an already-installed file whose extension we
+  // now skip on a duplicate-target collision. Without this, the newSHAs map (which
+  // replaces the target map wholesale) would drop the recorded SHA and orphan the
+  // previously-owned installed copy — it would linger on disk, untracked by doctor
+  // and unreachable by uninstall (codex pre-commit BLOCKER).
+  for (const ext of dupSkip) {
+    const inst = installFileByExt.get(ext);
+    if (!inst) continue; // invalid-installName skip: never owned
+    const key = `${ext.type}/${inst}`;
+    if (recorded[key] !== undefined && newSHAs[key] === undefined) newSHAs[key] = recorded[key];
+  }
+
   for (const type of types) {
     const typeDir = join(targetRoot, type);
     for (const ext of discovered[type]) {
+      if (dupSkip.has(ext)) continue;
+      // Install under the manifest-declared installName (capture design §3) or, by
+      // default, the wiki storage name (backward compatible).
+      const installFile = installFileByExt.get(ext) ?? ext.file;
       // D3: validate the manifest before touching the filesystem.
       let manifestParsed = null;
       if (type === 'hooks') {
@@ -408,11 +588,12 @@ export function syncExtensions({
 
       if (apply) mkdirSync(typeDir, { recursive: true });
 
-      // (2) hard-copy the main file.
-      const fileKey = `${type}/${ext.file}`;
+      // (2) hard-copy the main file. Key + destPath use installFile so the
+      // recorded SHA map, doctor, and uninstall all agree on the install path.
+      const fileKey = `${type}/${installFile}`;
       const fileRes = copyOne({
         srcPath: ext.srcPath,
-        destPath: join(typeDir, ext.file),
+        destPath: join(typeDir, installFile),
         key: fileKey,
         recordedSHA: recorded[fileKey],
         apply,

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -38,6 +38,7 @@ import {
   EXT_TYPES,
   CODEX_TYPES,
   readExtensionPkgStateNoMutate,
+  parseExtKey,
 } from './lib/extensions.mjs';
 
 const HOME = homedir();
@@ -138,13 +139,23 @@ function stripExtensionsFromPkg(pkgPath, target, removedKeys, apply) {
   return changed;
 }
 
-// Remove hypo-ext-* hard-copies for one target (claude | codex). Mirrors
-// removeCommands' 3-way model: filesystem scan + per-target recorded SHA from
-// hypo-pkg.json#extensions[target] decides ownership. A file we never installed
-// (no recorded SHA) is left alone — that may be a foreign hypo-ext-* file the
-// user created by hand, never ours to delete. A user-modified file is preserved
-// unless --force-extensions; a symlink/non-regular target is always preserved
-// (force does not follow them, matching install/upgrade E3's guard).
+// Remove Hypomnema-installed extension hard-copies for one target (claude |
+// codex). Ownership is decided by the per-target recorded SHA map in
+// hypo-pkg.json#extensions[target]: we iterate the RECORDED KEYS (not a
+// filesystem+prefix scan) because the reverse-capture design decoupled the install filename from
+// the wiki `hypo-ext-*` storage name — a reverse-captured command installs as
+// `commands/mycmd.md`, which a prefix scan would never reach. The SHA map key
+// IS the install path relative to the target root, so it names every file we
+// own regardless of its filename.
+//
+// Safety (capture design §8): a recorded key comes from an on-disk JSON we do not
+// fully control, so each key is validated by `parseExtKey` to a single covered
+// `<type>/<safe-basename>` segment (no separators / traversal) before any
+// join/rm — a corrupt or malicious key can never delete outside the extension
+// directory. "Never delete unowned" holds via SHA MATCHING, not the prefix: a
+// file whose on-disk SHA differs from the recorded one is user-modified and
+// preserved unless --force-extensions; a symlink/non-regular target is always
+// preserved (force does not follow them, matching install/upgrade E3's guard).
 function removeExtensions(target, apply, force) {
   const targetRoot = target === 'codex' ? join(HOME, '.codex') : join(HOME, '.claude');
   const types = target === 'codex' ? CODEX_TYPES : EXT_TYPES;
@@ -158,37 +169,27 @@ function removeExtensions(target, apply, force) {
   const skippedUserModified = [];
   const skippedNonRegular = [];
 
-  for (const type of types) {
-    const typeDir = join(targetRoot, type);
-    if (!existsSync(typeDir)) continue;
-    let entries;
-    try {
-      entries = readdirSync(typeDir);
-    } catch {
+  for (const [key, recordedSHA] of Object.entries(recorded)) {
+    if (!recordedSHA) continue; // no ownership baseline → nothing to remove
+    const parsed = parseExtKey(key, types);
+    if (!parsed) continue; // untrusted / cross-target key → never join+rm
+    const fullPath = join(targetRoot, parsed.type, parsed.installFile);
+    if (!existsSync(fullPath)) continue; // already gone
+
+    if (!isRegularFile(fullPath)) {
+      // Refuse to follow symlinks/sockets even under --force-extensions.
+      skippedNonRegular.push(fullPath);
       continue;
     }
-    for (const fname of entries) {
-      if (!fname.startsWith(EXT_PREFIX)) continue;
-      const key = `${type}/${fname}`;
-      const recordedSHA = recorded[key];
-      if (!recordedSHA) continue; // not tracked by us → leave alone
-      const fullPath = join(typeDir, fname);
+    const buf = readFileIfRegular(fullPath);
+    const sha = buf ? sha256(buf) : null;
 
-      if (!isRegularFile(fullPath)) {
-        // Refuse to follow symlinks/sockets even under --force-extensions.
-        skippedNonRegular.push(fullPath);
-        continue;
-      }
-      const buf = readFileIfRegular(fullPath);
-      const sha = buf ? sha256(buf) : null;
-
-      if (sha === recordedSHA || force) {
-        if (apply) rmSync(fullPath);
-        removed.push(fullPath);
-        removedKeys.push(key);
-      } else {
-        skippedUserModified.push(fullPath);
-      }
+    if (sha === recordedSHA || force) {
+      if (apply) rmSync(fullPath);
+      removed.push(fullPath);
+      removedKeys.push(key);
+    } else {
+      skippedUserModified.push(fullPath);
     }
   }
   return { target, removed, removedKeys, skippedUserModified, skippedNonRegular };

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -22009,6 +22009,406 @@ test('importing crystallize.mjs runs no CLI and exposes exactly the pure exports
   );
 });
 
+// ── reverse extension capture (ADR 0061) ────────────────────────
+
+const { isValidInstallStem, resolveInstallFile, parseExtKey } = await import(
+  `${SCRIPTS}/lib/extensions.mjs`
+);
+const { planCapture, isCaptureCandidate } = await import(`${SCRIPTS}/capture.mjs`);
+
+suite('capture: isValidInstallStem (ADR 0061 §5)');
+
+test('accepts a plain user name', () => {
+  assert.ok(isValidInstallStem('mycmd'));
+  assert.ok(isValidInstallStem('my-cmd.v2'));
+});
+test('rejects the reserved hypo namespace case-insensitively', () => {
+  assert.ok(!isValidInstallStem('hypo'));
+  assert.ok(!isValidInstallStem('hypo-foo'));
+  assert.ok(!isValidInstallStem('Hypo-foo'));
+  assert.ok(!isValidInstallStem('HYPO-foo'));
+});
+test('rejects Windows reserved device stems, including dot-suffixed, case-insensitively', () => {
+  assert.ok(!isValidInstallStem('con'));
+  assert.ok(!isValidInstallStem('CON'));
+  assert.ok(!isValidInstallStem('com1'));
+  assert.ok(!isValidInstallStem('LPT9'));
+  assert.ok(!isValidInstallStem('con.v1')); // reserved even with an extension
+  assert.ok(!isValidInstallStem('AUX.backup'));
+  assert.ok(isValidInstallStem('com0')); // not a real device
+  assert.ok(isValidInstallStem('console')); // not a device name
+});
+test('rejects path separators, traversal (leading and internal), leading dot, empty', () => {
+  assert.ok(!isValidInstallStem('a/b'));
+  assert.ok(!isValidInstallStem('a\\b'));
+  assert.ok(!isValidInstallStem('..'));
+  assert.ok(!isValidInstallStem('a..b')); // internal traversal must match parseExtKey
+  assert.ok(!isValidInstallStem('.hidden'));
+  assert.ok(!isValidInstallStem(''));
+  assert.ok(!isValidInstallStem(42));
+});
+
+suite('capture: resolveInstallFile (ADR 0061 §3 installName decoupling)');
+
+// Build a discovered-ext shape with a real on-disk manifest for parseManifest.
+function extWithManifest(dir, type, file, manifest) {
+  const stem = file.replace(/\.[^.]+$/, '');
+  const manifestName = `${stem}.manifest.json`;
+  let manifestPath = null;
+  if (manifest !== undefined) {
+    manifestPath = join(dir, manifestName);
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+  }
+  return { type, name: stem, file, srcPath: join(dir, file), manifestName, manifestPath };
+}
+
+test('defaults to the wiki filename when no manifest (backward compatible)', () => {
+  withTmpDir((dir) => {
+    const ext = extWithManifest(dir, 'commands', 'hypo-ext-legacy.md', undefined);
+    assert.deepEqual(resolveInstallFile(ext), { installFile: 'hypo-ext-legacy.md' });
+  });
+});
+test('honors installName when manifest.type matches the directory', () => {
+  withTmpDir((dir) => {
+    const ext = extWithManifest(dir, 'commands', 'hypo-ext-new.md', {
+      type: 'command',
+      installName: 'newcmd',
+    });
+    assert.deepEqual(resolveInstallFile(ext), { installFile: 'newcmd.md' });
+  });
+});
+test('ignores installName when manifest.type mismatches the directory', () => {
+  withTmpDir((dir) => {
+    const ext = extWithManifest(dir, 'commands', 'hypo-ext-x.md', {
+      type: 'agent',
+      installName: 'x',
+    });
+    assert.deepEqual(resolveInstallFile(ext), { installFile: 'hypo-ext-x.md' });
+  });
+});
+test('skips (not installs under wiki name) an invalid installName', () => {
+  withTmpDir((dir) => {
+    const ext = extWithManifest(dir, 'commands', 'hypo-ext-bad.md', {
+      type: 'command',
+      installName: '../evil',
+    });
+    const res = resolveInstallFile(ext);
+    assert.equal(res.skip, true);
+    assert.ok(/invalid installName/.test(res.warn));
+  });
+});
+test('hooks keep the wiki name even with a hook manifest (installName is commands/agents only)', () => {
+  withTmpDir((dir) => {
+    const ext = extWithManifest(dir, 'hooks', 'hypo-ext-h.mjs', {
+      type: 'hook',
+      event: 'Stop',
+    });
+    assert.deepEqual(resolveInstallFile(ext), { installFile: 'hypo-ext-h.mjs' });
+  });
+});
+
+suite('capture: parseExtKey (ADR 0061 §8 uninstall key safety)');
+
+const COVERED = ['hooks', 'commands', 'skills', 'agents'];
+test('accepts a well-formed key', () => {
+  assert.deepEqual(parseExtKey('commands/mycmd.md', COVERED), {
+    type: 'commands',
+    installFile: 'mycmd.md',
+  });
+});
+test('rejects traversal / separators / wrong extension / unknown type', () => {
+  assert.equal(parseExtKey('commands/../evil.md', COVERED), null);
+  assert.equal(parseExtKey('commands/a/b.md', COVERED), null);
+  assert.equal(parseExtKey('commands/a..b.md', COVERED), null);
+  assert.equal(parseExtKey('commands/mycmd.txt', COVERED), null);
+  assert.equal(parseExtKey('hooks/x.md', COVERED), null); // hooks want .mjs
+  assert.equal(parseExtKey('unknown/x.md', COVERED), null);
+  assert.equal(parseExtKey('commands/.hidden.md', COVERED), null);
+  assert.equal(parseExtKey('nokey', COVERED), null);
+  assert.equal(parseExtKey('commands/', COVERED), null);
+});
+test('accepts the hook manifest sidecar but only for hooks', () => {
+  assert.deepEqual(parseExtKey('hooks/hypo-ext-x.manifest.json', COVERED), {
+    type: 'hooks',
+    installFile: 'hypo-ext-x.manifest.json',
+  });
+  // Only hooks record a manifest copy — a non-hook manifest key must not name a
+  // removable file (widened destructive surface).
+  assert.equal(parseExtKey('commands/x.manifest.json', COVERED), null);
+  assert.equal(parseExtKey('agents/x.manifest.json', COVERED), null);
+});
+test('respects the covered-types scope (codex excludes skills/agents)', () => {
+  assert.equal(parseExtKey('agents/x.md', ['hooks', 'commands']), null);
+  assert.deepEqual(parseExtKey('commands/x.md', ['hooks', 'commands']), {
+    type: 'commands',
+    installFile: 'x.md',
+  });
+});
+
+suite('capture: isCaptureCandidate + planCapture (ADR 0061 §6/§7)');
+
+test('candidate filter excludes hypo-*, non-.md, and already-owned', () => {
+  assert.ok(isCaptureCandidate('commands', 'mycmd.md', {}).ok);
+  assert.ok(!isCaptureCandidate('commands', 'hypo-core.md', {}).ok);
+  assert.ok(!isCaptureCandidate('commands', 'Hypo-core.md', {}).ok);
+  assert.ok(!isCaptureCandidate('commands', 'readme.txt', {}).ok);
+  assert.ok(!isCaptureCandidate('commands', 'owned.md', { 'commands/owned.md': 'sha' }).ok);
+});
+test('planCapture: ready when no wiki file exists', () => {
+  const p = planCapture({
+    type: 'commands',
+    stem: 'x',
+    srcSha: 'A',
+    existingMdSha: null,
+    existingManifestRaw: null,
+  });
+  assert.equal(p.status, 'ready');
+  assert.deepEqual(p.manifest, { type: 'command', installName: 'x' });
+});
+test('planCapture: invalid stem', () => {
+  const p = planCapture({
+    type: 'commands',
+    stem: 'hypo-x',
+    srcSha: 'A',
+    existingMdSha: null,
+    existingManifestRaw: null,
+  });
+  assert.equal(p.status, 'invalid');
+});
+test('planCapture: conflict when wiki .md differs', () => {
+  const p = planCapture({
+    type: 'commands',
+    stem: 'x',
+    srcSha: 'A',
+    existingMdSha: 'B',
+    existingManifestRaw: null,
+  });
+  assert.equal(p.status, 'conflict');
+});
+test('planCapture: conflict when .md matches but manifest missing', () => {
+  const p = planCapture({
+    type: 'commands',
+    stem: 'x',
+    srcSha: 'A',
+    existingMdSha: 'A',
+    existingManifestRaw: null,
+  });
+  assert.equal(p.status, 'conflict');
+});
+test('planCapture: conflict when manifest declares a different installName', () => {
+  const raw = JSON.stringify({ type: 'command', installName: 'other' });
+  const p = planCapture({
+    type: 'commands',
+    stem: 'x',
+    srcSha: 'A',
+    existingMdSha: 'A',
+    existingManifestRaw: raw,
+  });
+  assert.equal(p.status, 'conflict');
+});
+test('planCapture: already when .md + manifest both match', () => {
+  const raw = JSON.stringify({ type: 'command', installName: 'x' });
+  const p = planCapture({
+    type: 'commands',
+    stem: 'x',
+    srcSha: 'A',
+    existingMdSha: 'A',
+    existingManifestRaw: raw,
+  });
+  assert.equal(p.status, 'already');
+});
+test('planCapture: conflict on a stray manifest with a different mapping', () => {
+  const raw = JSON.stringify({ type: 'command', installName: 'other' });
+  const p = planCapture({
+    type: 'commands',
+    stem: 'x',
+    srcSha: 'A',
+    existingMdSha: null,
+    existingManifestRaw: raw,
+  });
+  assert.equal(p.status, 'conflict');
+});
+
+suite('capture: forward-sync installFile integration (backward compat + adopt)');
+
+test('installName-less command installs under the wiki name (no regression)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      writeExt(hypoDir, 'commands', 'hypo-ext-legacy.md', '# legacy\n');
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(existsSync(join(home, '.claude', 'commands', 'hypo-ext-legacy.md')));
+    });
+  });
+});
+test('installName manifest installs under the original name', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      writeExt(hypoDir, 'commands', 'hypo-ext-new.md', '# new\n', {
+        type: 'command',
+        installName: 'newcmd',
+      });
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(
+        existsSync(join(home, '.claude', 'commands', 'newcmd.md')),
+        'installed under installName',
+      );
+      assert.ok(
+        !existsSync(join(home, '.claude', 'commands', 'hypo-ext-new.md')),
+        'wiki storage name NOT installed',
+      );
+    });
+  });
+});
+test('duplicate installName skips the whole group (no partial install)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      writeExt(hypoDir, 'commands', 'hypo-ext-a.md', '# a\n', {
+        type: 'command',
+        installName: 'dup',
+      });
+      writeExt(hypoDir, 'commands', 'hypo-ext-b.md', '# b\n', {
+        type: 'command',
+        installName: 'dup',
+      });
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(
+        !existsSync(join(home, '.claude', 'commands', 'dup.md')),
+        'no file installed on collision',
+      );
+    });
+  });
+});
+test('a later duplicate does not orphan an already-owned installed file', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      // A owns commands/dup.md after the first sync.
+      writeExt(hypoDir, 'commands', 'hypo-ext-a.md', '# a\n', {
+        type: 'command',
+        installName: 'dup',
+      });
+      assert.equal(
+        runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home).status,
+        0,
+      );
+      let pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(pkg.extensions.claude['commands/dup.md'], 'A owns dup.md after first sync');
+      // Now a colliding B appears; the group is skipped but A's ownership record
+      // must survive so the installed file is not orphaned.
+      writeExt(hypoDir, 'commands', 'hypo-ext-b.md', '# b\n', {
+        type: 'command',
+        installName: 'dup',
+      });
+      assert.equal(
+        runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home).status,
+        0,
+      );
+      pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(
+        pkg.extensions.claude['commands/dup.md'],
+        'ownership of the already-installed file is preserved on a later collision',
+      );
+    });
+  });
+});
+test('capture refuses a wiki target that is a symlink (no follow, no overwrite)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      mkdirSync(join(home, '.claude', 'commands'), { recursive: true });
+      writeFileSync(join(home, '.claude', 'commands', 'mycmd.md'), '# mine\n');
+      // Plant a symlink at the wiki storage path pointing outside the wiki.
+      const outside = join(dir, 'secret.txt');
+      writeFileSync(outside, 'ORIGINAL SECRET\n');
+      const wikiCmds = join(hypoDir, 'extensions', 'commands');
+      mkdirSync(wikiCmds, { recursive: true });
+      symlinkSync(outside, join(wikiCmds, 'hypo-ext-mycmd.md'));
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home);
+      // Refused as a conflict: the symlink is never followed or overwritten, and
+      // nothing is adopted (no ownership recorded for the install path).
+      assert.match(r.stdout, /not a regular file/);
+      assert.equal(readFileSync(outside, 'utf-8'), 'ORIGINAL SECRET\n', 'symlink target untouched');
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      const owned = existsSync(pkgPath)
+        ? (JSON.parse(readFileSync(pkgPath, 'utf-8')).extensions?.claude ?? {})
+        : {};
+      assert.ok(!owned['commands/mycmd.md'], 'nothing adopted on conflict');
+    });
+  });
+});
+
+suite('capture: end-to-end adopt + uninstall by key');
+
+test('capture --all adopts into wiki and records ownership under the install path', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      mkdirSync(join(home, '.claude', 'commands'), { recursive: true });
+      writeFileSync(join(home, '.claude', 'commands', 'mycmd.md'), '# My Command\n');
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(existsSync(join(hypoDir, 'extensions', 'commands', 'hypo-ext-mycmd.md')));
+      assert.ok(
+        existsSync(join(hypoDir, 'extensions', 'commands', 'hypo-ext-mycmd.manifest.json')),
+      );
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(
+        pkg.extensions.claude['commands/mycmd.md'],
+        'ownership recorded under install path',
+      );
+    });
+  });
+});
+test('uninstall --apply removes the captured install-path file and preserves unowned', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      mkdirSync(join(home, '.claude', 'commands'), { recursive: true });
+      writeFileSync(join(home, '.claude', 'commands', 'mycmd.md'), '# owned\n');
+      assert.equal(runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home).status, 0);
+      writeFileSync(join(home, '.claude', 'commands', 'foreign.md'), '# foreign\n');
+      const r = runWithHome('uninstall.mjs', ['--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(!existsSync(join(home, '.claude', 'commands', 'mycmd.md')), 'owned removed');
+      assert.ok(existsSync(join(home, '.claude', 'commands', 'foreign.md')), 'unowned preserved');
+    });
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
# English

## What changed

Added reverse extension capture: a new `hypomnema capture` subcommand and `/hypo:capture` slash command that pull a command or agent you created the normal way under `~/.claude/{commands,agents}/` into the wiki `extensions/` tree, so the existing forward-sync propagates it to your other machines under its original name. Scope is commands and agents only; hooks and skills are deferred.

## Why

The extensions companion sync is one-way (wiki to `~/.claude`). An extension you author the normal way on machine A has no path into the wiki, so "register on A, sync on B" only worked if you placed the file in the wiki by hand with the `hypo-ext-*` naming. Capture closes that gap while keeping the install name intact, so a synced command stays `/mycmd` rather than becoming `/hypo-ext-mycmd`.

## How

- Decouple the wiki storage name from the install name. The wiki keeps the `hypo-ext-<name>` discovery whitelist, and a sidecar `hypo-ext-<name>.manifest.json` carries `installName`. Forward-sync installs under `installName`; absent it, it installs under the wiki name, so existing extensions are unaffected (backward compatible).
- Adopt without injecting a SHA: capture copies the source verbatim into the wiki, then runs forward-sync, which sees the install target already byte-identical, hits `copyOne`'s up-to-date branch, and records ownership.
- `uninstall` removes captured files by their recorded SHA-map key (the install path), validated against traversal by `parseExtKey`; "never delete a file we do not own" now holds via SHA match rather than the filename prefix.
- Security: `installName` is charset / traversal / reserved-namespace (`hypo`, case-insensitive) / Windows-device validated, and the extension is appended in code so a manifest cannot control it. Duplicate install targets are skipped as a group without orphaning an already-owned file. Capture refuses a non-regular wiki target and writes atomically (temp + rename), so a planted symlink is replaced, never followed.

## Manual verification

Verified end-to-end in a sandboxed `HOME` (no effect on the real home):

```
# adopt roundtrip
hypomnema capture --all                 # writes wiki hypo-ext-*.md + manifest, records ownership under the install path
# machine B: wipe ownership + installed copy, forward-sync -> installs mycmd.md under the ORIGINAL name
# conflict: source differs from wiki -> refused, not overwritten
# symlink: a wiki hypo-ext-mycmd.md symlink to an outside file -> refused, target untouched
# uninstall --apply -> removes the owned install-path file, preserves an unowned sibling
```

Also `node tests/runner.mjs` (1096 passed), `npm run lint`, `prettier --check`, `check:tracker-ids`, `check:bilingual` all pass.

## Migration notes

None. Existing `hypo-ext-*` extensions with no `installName` install exactly as before.

---

# 한국어

## 변경 내용

역방향 확장 capture를 추가했습니다. `hypomnema capture` 서브커맨드와 `/hypo:capture` 슬래시 커맨드로, `~/.claude/{commands,agents}/`에 보통 방식으로 만든 command·agent를 위키 `extensions/`로 끌어와 기존 forward-sync가 다른 머신에 원래 이름 그대로 전파하게 합니다. 대상은 commands·agents뿐이고 hooks·skills는 연기했습니다.

## 이유

확장 companion sync는 단방향(위키 to `~/.claude`)입니다. 머신 A에서 보통 방식으로 만든 확장은 위키로 들어오는 경로가 없어, "A에서 등록, B에서 동기화"가 `hypo-ext-*` 이름으로 위키에 손수 넣은 경우에만 됐습니다. capture가 그 갭을 메우면서 설치 이름을 보존해, 동기화된 커맨드가 `/hypo-ext-mycmd`가 아니라 `/mycmd`로 유지됩니다.

## 방법

- 위키 저장명과 설치명을 분리합니다. 위키는 `hypo-ext-<name>` discovery 화이트리스트를 유지하고, sidecar `hypo-ext-<name>.manifest.json`이 `installName`을 담습니다. forward-sync는 `installName`으로 설치하고, 없으면 위키명으로 설치해 기존 확장은 무영향입니다(backward compatible).
- SHA 직접 주입 없이 adopt: capture는 원본을 verbatim 복사한 뒤 forward-sync를 돌리고, 설치 대상이 이미 바이트 동일이라 `copyOne`의 up-to-date 분기로 소유권을 기록합니다.
- `uninstall`은 캡처된 파일을 기록된 SHA-map 키(설치 경로)로 제거하며, `parseExtKey`가 traversal을 막습니다. "소유하지 않은 파일은 삭제하지 않음"은 이제 접두어가 아니라 SHA 매칭으로 유지됩니다.
- 보안: `installName`은 charset·traversal·예약 네임스페이스(`hypo`, 대소문자 무시)·Windows device로 검증하고, 확장자는 코드에서 붙여 manifest가 제어하지 못합니다. 중복 설치 대상은 이미 소유된 파일을 고아로 만들지 않고 그룹째 skip합니다. capture는 non-regular 위키 대상을 거부하고 원자적으로(temp + rename) 써, 심어진 심링크를 따라가지 않고 교체합니다.

## 수동 검증

샌드박스 `HOME`에서 왕복 검증했습니다(실제 홈 무영향):

```
# adopt 왕복
hypomnema capture --all                 # 위키 hypo-ext-*.md + manifest 작성, 설치 경로로 소유권 기록
# 머신 B: 소유+설치본 제거 후 forward-sync -> 원래 이름 mycmd.md로 설치
# conflict: 원본이 위키와 다름 -> 덮어쓰지 않고 거부
# symlink: 위키 hypo-ext-mycmd.md가 외부 파일로의 심링크 -> 거부, 대상 무손상
# uninstall --apply -> 소유한 설치 경로 파일 제거, 소유 안 한 형제 보존
```

`node tests/runner.mjs`(1096 passed), `npm run lint`, `prettier --check`, `check:tracker-ids`, `check:bilingual` 모두 통과.

## 마이그레이션 노트

None. `installName`이 없는 기존 `hypo-ext-*` 확장은 전과 똑같이 설치됩니다.

---

## Changelog

- EN: Added reverse extension capture (`hypomnema capture` / `/hypo:capture`) to pull a locally-authored command or agent under `~/.claude/{commands,agents}/` into the wiki so it syncs to your other machines under its original name. ([#170](https://github.com/sk-lim19f/Hypomnema/pull/170))
- KO: 역방향 확장 capture(`hypomnema capture` / `/hypo:capture`)를 추가해, `~/.claude/{commands,agents}/`에 만든 command·agent를 위키로 끌어와 다른 머신에 원래 이름으로 동기화합니다. ([#170](https://github.com/sk-lim19f/Hypomnema/pull/170))

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
