### PR TITLE
docs(contributing): add version-spec lifecycle steps to the release checklist

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -331,6 +331,17 @@ from being dropped.
 Prerequisite: the changelog collector in step 2 reads merged-PR data through the GitHub CLI, so have `gh` installed and authenticated (`gh auth status`) before you start. It is a maintainer-only release script and is not shipped to npm.
 
 ```bash
+# 0. (minor+ releases only) Ensure the wiki vault carries this release's version
+#    spec. Convention (version-plan lifecycle: born-at-stable-path, flip-in-place,
+#    recorded in the vault's decisions log): a minor-or-higher release has
+#    projects/hypomnema/specs/spec-v<version>.md with status: active and
+#    version: <version>. If it is missing, create it from the vault's minimal spec
+#    shape (omit patch-only fields for a minor/major). If you created or changed
+#    it, run the wiki lint and commit + push the vault before bumping, so the
+#    active pre-ship state is recorded remotely. Patch releases are exempt: the
+#    CHANGELOG section and PR body cover them, no spec doc required.
+$EDITOR ~/hypomnema/projects/hypomnema/specs/spec-v<version>.md
+
 # 1. Bump the version across package.json, plugin.json, marketplace.json,
 #    and templates/hypo-config.md. Takes a concrete semver (not patch/minor/major).
 node scripts/bump-version.mjs <new-semver>   # e.g. 1.2.2 or 1.3.0-rc.1
@@ -397,6 +408,13 @@ npm publish --dry-run --access public   # packs + prepublishOnly, NO registry PU
 # 8. Push the SPECIFIC tag alone — NOT --tags (that would push stale local tags
 #    and could trigger releases for versions you did not intend).
 git push origin v<version>
+
+# 9. (minor+ releases only) After the release workflow succeeds, close the spec
+#    lifecycle IN PLACE (no path move): set status: archived and
+#    archived_date: <release date> in the same spec, run the wiki lint, then
+#    commit and push the vault. Do this only after the release is green, never at
+#    tag time: a failed release must not leave an archived spec behind.
+$EDITOR ~/hypomnema/projects/hypomnema/specs/spec-v<version>.md
 ```
 
 The `release.yml` workflow then:


### PR DESCRIPTION
# English

Bakes the version-spec lifecycle convention (born-at-stable-path, flip-in-place, minor+ scope) into the authoritative in-repo release checklist in `docs/CONTRIBUTING.md`, so future releases follow it without re-deriving it. Motivated by v1.4.x/v1.5.x shipping without a version spec even though the convention already existed: the checklist never surfaced it.

- **Step 0 (pre-ship)**: a minor+ release must carry an active `projects/hypomnema/specs/spec-v<version>.md`; create + lint + commit/push the vault if missing, so the active pre-ship state is recorded remotely.
- **Step 9 (post-success)**: flip that same spec to `archived` + `archived_date` in place after the release workflow is green, never at tag time (a failed release must not leave an archived spec behind).

Patch releases are exempt (CHANGELOG + PR body cover them). Wording avoids the private-tracker decision token so `check-tracker-ids` stays green.

# 한국어

버전 spec 라이프사이클 컨벤션(born-at-stable-path, flip-in-place, minor+ 범위)을 `docs/CONTRIBUTING.md`의 릴리스 체크리스트(정본)에 넣어, 앞으로의 릴리스가 이를 매번 재유도하지 않고 따르게 합니다. v1.4.x/v1.5.x가 컨벤션이 있는데도 spec 없이 나간 게 계기입니다(체크리스트가 표면화하지 못함).

- **Step 0 (pre-ship)**: minor 이상 릴리스는 active 상태의 `projects/hypomnema/specs/spec-v<version>.md`를 갖춰야 하며, 없으면 생성 + lint + 볼트 commit/push로 pre-ship active 상태를 원격에 남깁니다.
- **Step 9 (post-success)**: release workflow가 green이 된 뒤 같은 spec을 제자리에서 `archived` + `archived_date`로 flip. tag 시점 금지(실패한 릴리스가 archived spec을 남기지 않도록).

patch 릴리스는 면제(CHANGELOG + PR 본문으로 갈음). private-tracker 결정 토큰을 피해 `check-tracker-ids`가 green을 유지합니다.

## Changelog

- EN: (internal, no user-facing change) Documented the version-spec lifecycle in the maintainer release checklist.
- KO: (내부 변경, 사용자 영향 없음) 메인테이너 릴리스 체크리스트에 버전 spec 라이프사이클을 문서화했습니다.

## Checklist
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)