### PR TITLE
fix(session-close): count background and scheduled work as in-flight for close reconfirm

### DIFF
--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -36,8 +36,9 @@
  * gate above was found to be unable to distinguish "close now" from "close
  * once X is done" by regex alone — same sentence shape either way). When the
  * close-intent gate above fires AND the session has a work-incomplete signal
- * (an uncommitted wiki, or an in-flight delegated subagent per
- * hasInFlightSubagent), step 6's block reason is replaced with an
+ * (an uncommitted wiki, or pending background work — a non-terminal
+ * background task or a scheduled cron wake — per hasPendingBackgroundWork),
+ * step 6's block reason is replaced with an
  * AskUserQuestion instruction instead of a crystallize command — the model
  * asks the user "close now?" rather than deciding for them. A correlated
  * "아직"/"나중"/"not yet"/"later" answer (isCloseReconfirmDeclined) suppresses
@@ -65,7 +66,7 @@ import {
   isClosePattern,
   isGateSkipped,
   precompactGateStatus,
-  hasInFlightSubagent,
+  hasPendingBackgroundWork,
   isCloseReconfirmDeclined,
   CLOSE_RECONFIRM_MARK,
 } from './hypo-shared.mjs';
@@ -95,8 +96,8 @@ function emitBlock(sessionId, transcriptPath, gate = null, opts = {}) {
       JSON.stringify({
         decision: 'block',
         reason:
-          `[WIKI_AUTOCLOSE] close 신호가 잡혔지만 아직 커밋되지 않은 변경(또는 진행 중인 ` +
-          `위임 작업)이 있어 지금 닫을지 뒤로 미룰지 모호합니다 (session_id=${sessionId}). ` +
+          `[WIKI_AUTOCLOSE] close 신호가 잡혔지만 아직 커밋되지 않은 변경 또는 진행 중인 ` +
+          `백그라운드·위임 작업이 있어 지금 닫을지 뒤로 미룰지 모호합니다 (session_id=${sessionId}). ` +
           `임의로 닫지 말고 AskUserQuestion으로 사용자에게 지금 세션을 닫을지 물어보세요. ` +
           `선택지는 "${CLOSE_RECONFIRM_MARK}"와 "아직, 계속"으로 제시합니다. 사용자가 ` +
           `"${CLOSE_RECONFIRM_MARK}"를 고른 뒤에만 세션 마무리를 진행하세요. 그전에는 ` +
@@ -250,14 +251,16 @@ process.stdin.on('end', () => {
     // "work-incomplete" together are exactly the case where the transcript's
     // NL close phrase can't tell "close now" from "close once X is done" —
     // regex can't disambiguate this (see spec background). Narrowed to the
-    // two work-incomplete signals only: an uncommitted wiki (`git` blocker;
-    // real unsaved work) OR an in-flight delegated subagent. `hot` / `lint` /
-    // `close` / `design-history` / `feedback` blockers are real close
-    // blockers but not evidence of "later" intent, so they keep the existing
-    // wording (unchanged from before this feature).
+    // work-incomplete signals only: an uncommitted wiki (`git` blocker; real
+    // unsaved work) OR pending background work — a non-terminal background task
+    // (delegated subagent OR shell, e.g. a deferred push/CI wait) or a
+    // scheduled cron wake (hasPendingBackgroundWork). `hot` / `lint` / `close`
+    // / `design-history` / `feedback` blockers are real close blockers but not
+    // evidence of "later" intent, so they keep the existing wording (unchanged
+    // from before this feature).
     const workIncomplete =
       (gate && gate.blockers && gate.blockers.some((b) => b.type === 'git')) ||
-      hasInFlightSubagent(payload);
+      hasPendingBackgroundWork(payload);
     if (workIncomplete && isCloseReconfirmDeclined(transcriptPath)) {
       // The user already answered "아직" to the ambiguous close signal that
       // triggered this Stop turn — suppressing is a continue, not a

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -2758,29 +2758,50 @@ export function hasUserCloseSignal(transcriptPath) {
 }
 
 /**
- * True iff the Stop payload's `background_tasks` names an in-flight (not yet
- * terminal) delegated subagent. Read-only: used to widen the autoclose
- * reconfirm trigger (see hypo-auto-minimal-crystallize.mjs) to "work is
- * demonstrably still running", not just "the wiki has uncommitted changes".
+ * True iff the Stop payload shows work still pending in the background —
+ * either a non-terminal `background_tasks` entry OR a scheduled `session_crons`
+ * wake. Read-only: used to widen the autoclose reconfirm trigger (see
+ * hypo-auto-minimal-crystallize.mjs) to "work is demonstrably still running",
+ * not just "the wiki has uncommitted changes".
+ *
+ * ANY non-terminal `background_tasks` entry counts, not just delegated
+ * subagents. A Stop payload captured from a real session confirmed the field
+ * is genuinely sent (the older "grep turns up nothing / may not be sent" note
+ * is retired): a background Bash appears as
+ * `{id, type:'shell', status:'running', description, command}`, alongside
+ * `type:'subagent'` for delegations. Restricting to `type==='subagent'` missed
+ * shell background work (e.g. a `git push` / CI wait deferred behind a close
+ * signal), letting the reconfirm branch mis-classify the session as idle and
+ * re-nag every Stop turn.
  *
  * Defined as the NEGATION of a terminal status, not an enumeration of
- * "running" states — this repo has no `background_tasks` type definition
- * (grep turns up nothing), so the real status vocabulary is unverified. An
- * unrecognized/absent status is treated as in-flight; only a recognized
- * terminal status clears it.
+ * "running" states: the observed non-terminal status is "running", and a
+ * finished task is removed from the array entirely (it does NOT linger in a
+ * terminal state — the next Stop simply reports `background_tasks:[]`). An
+ * unrecognized/absent status is therefore treated as in-flight; only a
+ * recognized terminal status clears an entry that is still present.
  *
- * Fail-open: a missing or non-array `background_tasks` is treated as "no
- * in-flight subagent" (the field may simply not be sent by this Stop event),
- * so in-flight detection degrades gracefully to the git-uncommitted signal
- * alone rather than spuriously blocking.
+ * `session_crons`: a non-empty array means the session is waiting on a
+ * scheduled wake, which is itself pending work. A missing / non-array
+ * `session_crons` is ignored (fail-open).
+ *
+ * Fail-open overall: a missing or non-array `background_tasks` contributes no
+ * pending signal, so detection degrades gracefully to the git-uncommitted
+ * signal alone rather than spuriously blocking.
  */
-export function hasInFlightSubagent(payload) {
-  const tasks = payload && payload.background_tasks;
-  if (!Array.isArray(tasks)) return false;
+export function hasPendingBackgroundWork(payload) {
+  if (!payload || typeof payload !== 'object') return false;
   const TERMINAL = /^(completed|complete|done|finished|failed|error|errored|cancelled|canceled)$/i;
-  return tasks.some(
-    (t) => t && t.type === 'subagent' && (t.status == null || !TERMINAL.test(String(t.status))),
-  );
+  const tasks = payload.background_tasks;
+  if (
+    Array.isArray(tasks) &&
+    tasks.some((t) => t && (t.status == null || !TERMINAL.test(String(t.status))))
+  ) {
+    return true;
+  }
+  const crons = payload.session_crons;
+  if (Array.isArray(crons) && crons.length > 0) return true;
+  return false;
 }
 
 // The reconfirm reason (hypo-auto-minimal-crystallize.mjs emitBlock's

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1371,7 +1371,7 @@ const {
   isClosePattern,
   extractUserMessages,
   hasUserCloseSignal,
-  hasInFlightSubagent,
+  hasPendingBackgroundWork,
   isCloseReconfirmDeclined,
   CLOSE_RECONFIRM_MARK,
   resolveTranscriptBySessionId,
@@ -1883,41 +1883,66 @@ test('unreadable / missing transcript → false (fail-closed)', () => {
   assert.equal(hasUserCloseSignal(null), false);
 });
 
-// ── hasInFlightSubagent — read-only in-flight delegation check ──
-suite('hasInFlightSubagent()');
+// ── hasPendingBackgroundWork — read-only pending-work check ──
+suite('hasPendingBackgroundWork()');
 
 test('a subagent task with a non-terminal status → true', () => {
   assert.equal(
-    hasInFlightSubagent({ background_tasks: [{ type: 'subagent', status: 'running' }] }),
+    hasPendingBackgroundWork({ background_tasks: [{ type: 'subagent', status: 'running' }] }),
     true,
   );
 });
 
-test('a subagent task with a terminal status → false', () => {
+test('a shell background task with a running status → true', () => {
   assert.equal(
-    hasInFlightSubagent({ background_tasks: [{ type: 'subagent', status: 'completed' }] }),
-    false,
-  );
-});
-
-test('a subagent task with no status field → true (unknown = not yet terminal)', () => {
-  assert.equal(
-    hasInFlightSubagent({ background_tasks: [{ type: 'subagent' }] }),
+    hasPendingBackgroundWork({ background_tasks: [{ type: 'shell', status: 'running' }] }),
     true,
   );
 });
 
-test('a non-subagent task (any status) → false', () => {
+test('a task with a terminal status → false', () => {
   assert.equal(
-    hasInFlightSubagent({ background_tasks: [{ type: 'other', status: 'running' }] }),
+    hasPendingBackgroundWork({ background_tasks: [{ type: 'subagent', status: 'completed' }] }),
+    false,
+  );
+  assert.equal(
+    hasPendingBackgroundWork({ background_tasks: [{ type: 'shell', status: 'failed' }] }),
     false,
   );
 });
 
-test('missing/non-array background_tasks → false (fail-open)', () => {
-  assert.equal(hasInFlightSubagent({}), false);
-  assert.equal(hasInFlightSubagent({ background_tasks: 'not-an-array' }), false);
-  assert.equal(hasInFlightSubagent(null), false);
+test('a task with no status field → true (unknown = not yet terminal)', () => {
+  assert.equal(
+    hasPendingBackgroundWork({ background_tasks: [{ type: 'subagent' }] }),
+    true,
+  );
+});
+
+test('a non-subagent (shell) task counts too → true (widened past subagent-only)', () => {
+  assert.equal(
+    hasPendingBackgroundWork({ background_tasks: [{ type: 'other', status: 'running' }] }),
+    true,
+  );
+});
+
+test('missing/non-array/empty background_tasks → false (fail-open)', () => {
+  assert.equal(hasPendingBackgroundWork({}), false);
+  assert.equal(hasPendingBackgroundWork({ background_tasks: 'not-an-array' }), false);
+  assert.equal(hasPendingBackgroundWork({ background_tasks: [] }), false);
+  assert.equal(hasPendingBackgroundWork(null), false);
+});
+
+test('a non-empty session_crons → true (scheduled wake is pending work)', () => {
+  // No background_tasks key at all — must fire off the session_crons branch.
+  assert.equal(
+    hasPendingBackgroundWork({ session_crons: [{ id: 'c1', schedule: '* * * * *' }] }),
+    true,
+  );
+});
+
+test('an empty / non-array session_crons → false (fail-open, ignored)', () => {
+  assert.equal(hasPendingBackgroundWork({ session_crons: [] }), false);
+  assert.equal(hasPendingBackgroundWork({ session_crons: 'not-an-array' }), false);
 });
 
 // ── isCloseReconfirmDeclined — order-sensitive decline detection ──
@@ -14387,6 +14412,74 @@ test('git-clean + in-flight subagent in background_tasks → reconfirm block', (
     assert.equal(out.decision, 'block');
     assert.ok(/AskUserQuestion/.test(out.reason), `in-flight subagent must trigger reconfirm: ${out.reason}`);
     assert.ok(!/crystallize/.test(out.reason), `reconfirm must not name crystallize: ${out.reason}`);
+  });
+});
+
+test('git-clean + running shell background task → reconfirm block', () => {
+  // The reported failure mode: "publish then wrap up" defers the close behind
+  // a background Bash (e.g. a CI wait). Local tree is clean and there is no
+  // delegated subagent, yet work is still pending — the shell task must be
+  // recognized so this reconfirms instead of re-nagging with the plain marker
+  // wording every Stop turn.
+  withGrowthWiki((dir) => {
+    const transcript = writeTranscript(dir, [
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'user', message: { role: 'user', content: '퍼블리시 하고 세션 마무리하자' } },
+    ]);
+    const r = runAutoMinimal(dir, {
+      session_id: 's-shell-bg',
+      transcript_path: transcript,
+      stop_hook_active: false,
+      background_tasks: [
+        { id: 'b1', type: 'shell', status: 'running', description: 'ci', command: 'gh run watch' },
+      ],
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block');
+    assert.ok(/AskUserQuestion/.test(out.reason), `running shell task must trigger reconfirm: ${out.reason}`);
+    assert.ok(!/crystallize/.test(out.reason), `reconfirm must not name crystallize: ${out.reason}`);
+  });
+});
+
+test('git-clean + non-empty session_crons → reconfirm block', () => {
+  withGrowthWiki((dir) => {
+    const transcript = writeTranscript(dir, [
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'user', message: { role: 'user', content: '오늘은 이만 마무리하자' } },
+    ]);
+    const r = runAutoMinimal(dir, {
+      session_id: 's-cron',
+      transcript_path: transcript,
+      stop_hook_active: false,
+      session_crons: [{ id: 'c1', schedule: '0 9 * * *' }],
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block');
+    assert.ok(/AskUserQuestion/.test(out.reason), `scheduled cron wake must trigger reconfirm: ${out.reason}`);
+  });
+});
+
+test('git-clean + only terminal shell background task → existing crystallize wording (no reconfirm)', () => {
+  // A finished task normally drops out of the array, but if a terminal-status
+  // entry is still present it must NOT be read as pending work.
+  withGrowthWiki((dir) => {
+    const transcript = writeTranscript(dir, [
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'user', message: { role: 'user', content: '오늘은 이만 마무리하자' } },
+    ]);
+    const r = runAutoMinimal(dir, {
+      session_id: 's-shell-done',
+      transcript_path: transcript,
+      stop_hook_active: false,
+      background_tasks: [{ id: 'b1', type: 'shell', status: 'completed', command: 'gh run watch' }],
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'block');
+    assert.ok(/crystallize/.test(out.reason), `terminal shell task must keep crystallize wording: ${out.reason}`);
+    assert.ok(!/AskUserQuestion/.test(out.reason), `terminal shell task must NOT reconfirm: ${out.reason}`);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

The session-close reconfirm hook now treats **any** non-terminal background work as "still running", not just a delegated subagent. `hasInFlightSubagent` becomes `hasPendingBackgroundWork`: it counts any non-terminal `background_tasks` entry (a background shell as well as a subagent) and a non-empty `session_crons` scheduled wake.

## Why

When a close signal is deferred behind a background shell task (say "publish, then wrap up" while a background Bash waits on CI), the local tree is clean and no subagent is in flight. The old signal missed that case, so the reconfirm branch was skipped and the plain "write the marker" nudge fired on every Stop turn with no way to suppress it. Widening the signal routes the deferred close into the reconfirm prompt, which the user can decline once and have suppressed.

## How

`background_tasks` is a real Stop-payload field (a captured payload confirmed a background Bash appears as `type: 'shell', status: 'running'`, and a finished task is dropped from the array rather than left in a terminal state). The check is the negation of a terminal status, so a self-clearing array naturally re-arms the marker requirement once the work completes, leaving no risk of a permanent suppression. The close-intent gate (`isClosePattern`) and the marker writer's hard gate are untouched; suppression still requires a correlated user decline.

## Manual verification

- Captured a real Stop payload by temporarily dumping the hook's stdin: a `run_in_background` Bash showed up as `{ id, type: "shell", status: "running", description, command }`, and `session_crons: []` in an ordinary (no-cron) session. Confirmed the finished task is removed from the array on the next Stop.
- `node tests/runner.mjs`: 1218 passed, 0 failed (new unit cases: shell running to pending; terminal to not pending; empty array to not pending; non-empty `session_crons` to pending; plus three replay cases for the clean-tree branches).

## Migration notes

None. Behavior change is scoped to the Stop hook's reconfirm routing.

---

# 한국어

## 변경 내용

세션종료 재확인 훅이 이제 위임 서브에이전트뿐 아니라 **모든** non-terminal 백그라운드 작업을 "진행 중"으로 본다. `hasInFlightSubagent`를 `hasPendingBackgroundWork`로 바꿔, non-terminal `background_tasks` 항목(백그라운드 셸도 포함)과 non-empty `session_crons` 예약 wake를 인정한다.

## 이유

close 신호가 백그라운드 셸 작업에 유예된 경우("퍼블리시 하고 세션 마무리"처럼 백그라운드 Bash가 CI를 기다리는 동안)에는 로컬 트리가 clean이고 위임 서브에이전트도 없다. 기존 신호는 이 경우를 놓쳐 재확인 분기를 건너뛰고, 매 Stop 턴마다 평문 "마커 쓰라" 유도가 억제 수단 없이 반복 발화했다. 신호를 넓히면 유예된 close가 재확인 프롬프트로 라우팅되어, 사용자가 한 번 거절하면 이후 억제된다.

## 방법

`background_tasks`는 실재하는 Stop 페이로드 필드다(캡처한 페이로드에서 백그라운드 Bash가 `type: 'shell', status: 'running'`으로 뜨고, 끝난 작업은 terminal 상태로 남지 않고 배열에서 제거됨을 확인). 판정은 terminal 상태의 부정이라, 작업이 끝나 배열이 비면 마커 요구가 자연히 되살아난다(영구 억제 위험 없음). close 판별 게이트(`isClosePattern`)와 마커 writer의 hard gate는 그대로이고, 억제는 여전히 상관된 사용자 거절 이후에만 작동한다.

## 수동 검증

- 훅 stdin을 임시로 덤프해 실제 Stop 페이로드를 캡처: `run_in_background` Bash가 `{ id, type: "shell", status: "running", description, command }`로 잡혔고, 예약 없는 일반 세션에선 `session_crons: []`였다. 끝난 작업이 다음 Stop에서 배열에서 제거됨을 확인.
- `node tests/runner.mjs`: 1218 passed, 0 failed(신규 unit: shell running → pending, terminal → 아님, 빈 배열 → 아님, non-empty `session_crons` → pending, clean-tree 분기 replay 3종 추가).

## 마이그레이션 노트

None. 동작 변경은 Stop 훅의 재확인 라우팅에 국한된다.

---

## Changelog

- EN: Session-close reconfirm now recognizes a background shell task or scheduled wake as in-flight work, so a deferred close ("publish, then wrap up") no longer nags for the marker on every turn.
- KO: 세션종료 재확인이 백그라운드 셸 작업이나 예약된 wake도 진행 중 작업으로 인식해, 유예된 close("퍼블리시 하고 세션 마무리")가 매 턴 마커를 조르지 않습니다.

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally (pre-existing wiki-content wikilink errors only; no `.mjs` change)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (no doc surface affected)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
