### PR TITLE
docs(cli): list `capture` command in `hypomnema --help`

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -132,6 +132,9 @@ Commands:
   uninstall               Remove hooks and registrations (dry-run by default; pass --apply)
   feedback-sync           Project feedback (SoT) → MEMORY.md / CLAUDE.md learned-behaviors
                           projection (--check default, --write to apply)
+  capture                 Reverse-capture ~/.claude/{commands,agents} extensions and
+                          settings.json hooks into the wiki for cross-machine sync
+                          (pass names or --all; --dry-run to preview)
 
   Running \`hypomnema\` with no command is equivalent to \`hypomnema init\`.
 
@@ -152,8 +155,8 @@ Init options:
   --dry-run              Show what would be done without making changes
   --help, -h             Show this help message
 
-Subcommand-specific flags (upgrade/doctor/uninstall) live in the
-docstring at the top of scripts/<command>.mjs.`);
+Subcommand-specific flags (upgrade/doctor/uninstall/capture) live in the
+docstring at the top of scripts/<command>.mjs; capture also accepts \`--help\`.`);
       process.exit(0);
     } else if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--no-hooks') args.hooks = false;


### PR DESCRIPTION
# English

## What changed

Add the `capture` subcommand to the `hypomnema --help` Commands block, and rewrite the footer note about subcommand-specific flags.

## Why

`capture` is a real, dispatched subcommand (it's in `KNOWN_SUBCOMMANDS` and routes to `scripts/capture.mjs`), but it was absent from the top-level `--help` output. A user reading `hypomnema --help` had no way to discover it. The old footer also pointed all subcommand flags at docstrings only, which undersold that `capture` has its own `--help`.

## How

- Insert a `capture` entry after `feedback-sync`, matching the existing column layout: it reverse-captures `~/.claude/{commands,agents}` extensions and `settings.json` hooks into the wiki for cross-machine sync (pass names or `--all`; `--dry-run` to preview).
- Scope the footer's `--help` mention to `capture` only. A codex cross-review caught that `upgrade`/`doctor`/`uninstall` do NOT parse `--help` (passing it just runs the command), so promising `hypomnema <command> --help` for all of them would have been wrong.

## Manual verification

```
$ node scripts/init.mjs --help        # capture now listed under Commands
$ node scripts/init.mjs capture --help # routes to capture's own usage
$ npm test                            # 1218 passed, 0 failed
```

## Migration notes

None.

---

# 한국어

## 변경 내용

`hypomnema --help`의 Commands 블록에 `capture` 서브커맨드를 추가하고, 서브커맨드 플래그 안내 푸터 문구를 다시 썼습니다.

## 이유

`capture`는 실제로 디스패치되는 서브커맨드인데(`KNOWN_SUBCOMMANDS`에 등록되어 `scripts/capture.mjs`로 라우팅됨) 최상위 `--help` 출력에는 빠져 있었습니다. `hypomnema --help`만 본 사용자는 이 명령을 발견할 방법이 없었습니다. 기존 푸터는 모든 서브커맨드 플래그를 docstring으로만 안내해, `capture`가 자체 `--help`를 가진다는 점을 드러내지 못했습니다.

## 방법

- `feedback-sync` 다음에 기존 컬럼 정렬에 맞춰 `capture` 항목 추가: `~/.claude/{commands,agents}` 확장과 `settings.json` 훅을 위키로 역캡처해 크로스머신 sync에 태우는 명령(이름 또는 `--all` 전달, `--dry-run`으로 미리보기).
- 푸터의 `--help` 언급을 `capture`로만 한정. codex 교차검토에서 `upgrade`/`doctor`/`uninstall`은 `--help`를 파싱하지 않고(전달해도 그냥 실행됨) `capture`만 지원한다는 사실을 잡아냈습니다. 세 명령에까지 `--help`를 약속하면 거짓이 됩니다.

## 수동 검증

```
$ node scripts/init.mjs --help        # Commands에 capture 노출
$ node scripts/init.mjs capture --help # capture 자체 usage로 라우팅
$ npm test                            # 1218 passed, 0 failed
```

## 마이그레이션 노트

None.

---

## Changelog

- EN: List the `capture` subcommand in `hypomnema --help` so it is discoverable (#177)
- KO: `hypomnema --help`에 `capture` 서브커맨드를 노출해 발견 가능하게 함 (#177)

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally (pre-existing wiki broken-wikilink failures, unrelated)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (help text is the doc surface here)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
