### PR TITLE
feat(scope): machine-scoped visibility namespace (FEAT-5 first slice)

### DIFF
--- a/hooks/hypo-file-watch.mjs
+++ b/hooks/hypo-file-watch.mjs
@@ -8,7 +8,14 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { HYPO_DIR, loadHypoIgnore, isIgnored } from './hypo-shared.mjs';
+import {
+  HYPO_DIR,
+  loadHypoIgnore,
+  isIgnored,
+  currentDevice,
+  scopeVisible,
+  readVisibilityScope,
+} from './hypo-shared.mjs';
 
 const MAX_CHARS = 2000;
 
@@ -43,7 +50,19 @@ process.stdin.on('end', () => {
       return;
     }
 
-    const content = readFileSync(filePath, 'utf-8').slice(0, MAX_CHARS);
+    const fileRaw = readFileSync(filePath, 'utf-8');
+
+    // Visibility guard: a machine-scoped page (visibility_scope: machine:<owner>)
+    // must not be re-injected on a machine other than its owner. Read the scope
+    // from the raw, unsliced content — slicing to MAX_CHARS first could cut the
+    // frontmatter off and silently make every scoped page pass fail-open.
+    const scope = readVisibilityScope(fileRaw);
+    if (!scopeVisible(scope, currentDevice())) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    const content = fileRaw.slice(0, MAX_CHARS);
     const relPath = filePath.replace(HYPO_DIR + '/', '');
 
     console.log(

--- a/hooks/hypo-lookup.mjs
+++ b/hooks/hypo-lookup.mjs
@@ -35,7 +35,16 @@ function buildPageMap(dir, root = dir, map = {}, ignorePatterns = [], hypoDir = 
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (isIgnored(full, hypoDir, ignorePatterns)) continue;
-    if (statSync(full).isDirectory()) {
+    // Skip an entry we can't stat (dangling symlink, race, permission) instead
+    // of throwing: the map is now built before the miss branch too, so one bad
+    // entry must not sink the whole lookup into the silent outer catch.
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
       buildPageMap(full, root, map, ignorePatterns, hypoDir);
     } else if (entry.endsWith('.md')) {
       const rel = full.slice(root.length + 1).replace(/\.md$/, '');

--- a/hooks/hypo-lookup.mjs
+++ b/hooks/hypo-lookup.mjs
@@ -19,6 +19,9 @@ import {
   staleMarkerFor,
   pageUsageLoggingAllowed,
   recordLookupUsage,
+  currentDevice,
+  scopeVisible,
+  readVisibilityScope,
 } from './hypo-shared.mjs';
 
 const INDEX_PATH = join(HYPO_DIR, 'index.md');
@@ -208,25 +211,6 @@ process.stdin.on('end', () => {
     const topScore = scored[0]?.score ?? 0;
     const matched = scored.filter((e) => e.score >= topScore * 0.5);
 
-    if (matched.length === 0) {
-      const topic = keywords.slice(0, 5).join(', ');
-      const closest = bm25Score(keywords, entries)
-        .map((e) => ({ ...e, score: e.score * typePrior(e.slug) }))
-        .sort((a, c) => c.score - a.score)
-        .slice(0, 3)
-        .map((e) => `[[${e.slug}]]`)
-        .join(', ');
-      console.log(
-        JSON.stringify(
-          buildOutput(`[WIKI LOOKUP: miss] "${topic}" — no match. Closest: ${closest || 'none'}`, {
-            continue: true,
-            suppressOutput: true,
-          }),
-        ),
-      );
-      return;
-    }
-
     const ignorePatterns = loadHypoIgnore(HYPO_DIR);
     const pageMap = {
       ...buildPageMap(
@@ -245,19 +229,81 @@ process.stdin.on('end', () => {
       ),
     };
 
+    // Single device snapshot for the whole prompt (currentDevice() itself stays
+    // uncached upstream so tests can override via HYPO_DEVICE; this hook only
+    // needs one read per lookup, not one per candidate).
+    const device = currentDevice();
+
+    // Resolve a slug to its on-disk path the same way the injection loop does.
+    const resolveSlugPath = (slug) =>
+      pageMap[slug] ?? pageMap[slug.replace(/^(pages|projects)\//, '')] ?? pageMap[basename(slug)];
+
+    // Read a page's raw content at most once per lookup: the visibility gate and
+    // the injection loop both need it, so memoize to avoid a double read.
+    const rawCache = new Map();
+    const readRaw = (path) => {
+      if (rawCache.has(path)) return rawCache.get(path);
+      let raw = null;
+      try {
+        raw = readFileSync(path, 'utf-8');
+      } catch {
+        raw = null;
+      }
+      rawCache.set(path, raw);
+      return raw;
+    };
+
+    // Visibility gate: MUST read raw content and go through readVisibilityScope
+    // (never a local frontmatter parser) so first-wins + comment-strip stay in
+    // step with the write side — a local last-wins/no-comment parser would miss
+    // `machine:devA # note` on devA itself. An unresolved/unreadable slug passes
+    // through (nothing to leak; the missing-file paths handle it downstream).
+    const isSlugVisible = (slug) => {
+      const path = resolveSlugPath(slug);
+      if (!path || !existsSync(path)) return true;
+      const raw = readRaw(path);
+      if (raw === null) return true;
+      return scopeVisible(readVisibilityScope(raw), device);
+    };
+
+    // Filter BEFORE the miss decision so a device that matches only machine-other
+    // pages takes the clean miss path (with closest VISIBLE suggestions), not the
+    // "index hit but files missing" branch. Hidden pages never reach injection,
+    // the empty-injection slug branch, or the "+N more" count — all read only
+    // visibleMatched, so no machine-other slug can leak through any path.
+    const visibleMatched = matched.filter((e) => isSlugVisible(e.slug));
+
+    if (visibleMatched.length === 0) {
+      const topic = keywords.slice(0, 5).join(', ');
+      const closest = bm25Score(keywords, entries)
+        .map((e) => ({ ...e, score: e.score * typePrior(e.slug) }))
+        .sort((a, c) => c.score - a.score)
+        .filter((e) => isSlugVisible(e.slug))
+        .slice(0, 3)
+        .map((e) => `[[${e.slug}]]`)
+        .join(', ');
+      console.log(
+        JSON.stringify(
+          buildOutput(`[WIKI LOOKUP: miss] "${topic}" — no match. Closest: ${closest || 'none'}`, {
+            continue: true,
+            suppressOutput: true,
+          }),
+        ),
+      );
+      return;
+    }
+
     // UTC to match doctor.mjs' overdue set (D1/D2). STALE is advisory, so a
     // one-day UTC/local skew never misleads.
     const TODAY = new Date().toISOString().slice(0, 10);
 
     const injected = [];
     const injectedSlugs = [];
-    for (const { slug } of matched.slice(0, MAX_HITS)) {
-      const path =
-        pageMap[slug] ??
-        pageMap[slug.replace(/^(pages|projects)\//, '')] ??
-        pageMap[basename(slug)];
+    for (const { slug } of visibleMatched.slice(0, MAX_HITS)) {
+      const path = resolveSlugPath(slug);
       if (path && existsSync(path)) {
-        const raw = readFileSync(path, 'utf-8');
+        const raw = readRaw(path);
+        if (raw === null) continue;
         // Compute the marker on raw (pre-slice) so a long body can't truncate
         // frontmatter out of reach. fail-open: a marker failure drops the marker,
         // never the page.
@@ -275,7 +321,7 @@ process.stdin.on('end', () => {
     }
 
     if (injected.length === 0) {
-      const slugs = matched
+      const slugs = visibleMatched
         .slice(0, MAX_HITS)
         .map((e) => e.slug)
         .join(', ');
@@ -297,9 +343,11 @@ process.stdin.on('end', () => {
       recordLookupUsage(HYPO_DIR, { sessionId, slugs: injectedSlugs });
     }
 
+    // visibleMatched (not matched): a hidden count would still name a "+N more"
+    // total that includes machine-other pages this device can never see.
     const overflow =
-      matched.length > MAX_HITS
-        ? `\n(+${matched.length - MAX_HITS} more matches — search wiki index for more)`
+      visibleMatched.length > MAX_HITS
+        ? `\n(+${visibleMatched.length - MAX_HITS} more matches — search wiki index for more)`
         : '';
 
     console.log(

--- a/hooks/hypo-session-record.mjs
+++ b/hooks/hypo-session-record.mjs
@@ -12,8 +12,7 @@
 
 import { existsSync, mkdirSync, appendFileSync } from 'fs';
 import { dirname, join } from 'path';
-import { hostname } from 'os';
-import { HYPO_DIR } from './hypo-shared.mjs';
+import { HYPO_DIR, currentDevice } from './hypo-shared.mjs';
 
 const INDEX_PATH = join(HYPO_DIR, '.cache', 'sessions', 'index.jsonl');
 
@@ -54,7 +53,7 @@ process.stdin.on('end', () => {
       // machine identity for multi-machine audit. index.jsonl lives
       // under .cache/ (gitignored in a normal vault), so this is a LOCAL-only
       // per-session record — accurate for every session, no sync/privacy cost.
-      device: hostname() || 'unknown',
+      device: currentDevice(),
     };
     appendFileSync(INDEX_PATH, JSON.stringify(entry) + '\n');
   } catch (err) {

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -3089,7 +3089,15 @@ export function isIgnored(filePath, hypoDir, patterns) {
 // (os.hostname is not mockable). CR/LF are stripped so the value stays a single
 // frontmatter token.
 export function currentDevice() {
-  return String(process.env.HYPO_DEVICE || hostname() || 'unknown').replace(/[\r\n]/g, '');
+  // Strip CR/LF BEFORE the fallback chain, not after: a HYPO_DEVICE of only
+  // CR/LF is truthy, so stripping after `||` would yield '' and make
+  // scopeVisible('machine:', '') pass — the empty-owner page must hide
+  // everywhere. Stripping first collapses such a value to '' so it falls through
+  // to hostname, keeping the result non-empty on every path.
+  const env = String(process.env.HYPO_DEVICE || '').replace(/[\r\n]/g, '');
+  if (env) return env;
+  const host = String(hostname() || '').replace(/[\r\n]/g, '');
+  return host || 'unknown';
 }
 
 // Extract the top-level `visibility_scope` from a page's raw content. Mirrors

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -3079,3 +3079,57 @@ export function isIgnored(filePath, hypoDir, patterns) {
   }
   return false;
 }
+
+// ── visibility scope ─────────────────────────────────────────────────────────
+// The machine-scoped visibility namespace (`visibility_scope: machine:<device>`)
+// requires that the SAME device string is produced at write time (audit device
+// stamps) and at lookup time (the visibility filter) — otherwise a page never
+// matches its own machine. So this is the single source for both. NOT cached:
+// each call reads env fresh so in-process tests can override via HYPO_DEVICE
+// (os.hostname is not mockable). CR/LF are stripped so the value stays a single
+// frontmatter token.
+export function currentDevice() {
+  return String(process.env.HYPO_DEVICE || hostname() || 'unknown').replace(/[\r\n]/g, '');
+}
+
+// Extract the top-level `visibility_scope` from a page's raw content. Mirrors
+// scripts/lib/frontmatter.mjs normalization (top-level only, first-wins, strip a
+// whitespace-led trailing YAML comment, strip surrounding quotes) rather than
+// importing it: hooks deploy to ~/.claude/hooks/ with no external imports. The
+// five consumers must call this instead of a local last-wins/no-comment parser,
+// else a `machine:devA # note` value fails to match on its own machine. Returns
+// '' when absent (which scopeVisible treats as shared).
+export function readVisibilityScope(raw) {
+  const m = String(raw || '').match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return '';
+  for (const line of m[1].split(/\r?\n/)) {
+    if (/^\s/.test(line) || /^-(\s|$)/.test(line)) continue; // nested / list item
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    if (line.slice(0, idx).trim() !== 'visibility_scope') continue;
+    return line
+      .slice(idx + 1)
+      .trim()
+      .replace(/\s+#.*$/, '')
+      .replace(/^["']|["']$/g, '');
+  }
+  return '';
+}
+
+// The single visibility decision, shared by lookup / query / file-watch /
+// page-usage / crystallize. `scopeValue` is a readVisibilityScope() output,
+// `device` a currentDevice() output. Prefix dispatch, fail-open on anything
+// unrecognized so the field is purely additive:
+//   ''/'shared'       → visible (the implicit default of every pre-existing page)
+//   'machine:<owner>' → visible only on the owning machine. Empty owner
+//                       (`machine:`) hides everywhere: '' can never equal
+//                       currentDevice()'s non-empty fallback.
+//   'agent:<id>'      → visible; value space reserved, no writer yet (forward-compat)
+//   anything else     → visible (fail-open)
+export function scopeVisible(scopeValue, device) {
+  const v = String(scopeValue || '').trim();
+  if (v === '' || v === 'shared') return true;
+  if (v.startsWith('machine:')) return v.slice('machine:'.length) === device;
+  if (v.startsWith('agent:')) return true;
+  return true;
+}

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -75,7 +75,6 @@ import {
   realpathSync,
 } from 'fs';
 import { join, dirname } from 'path';
-import { hostname } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
@@ -102,6 +101,7 @@ import {
   resolveTranscriptBySessionId,
   hasUserCloseSignal,
   commitWikiChanges,
+  currentDevice,
 } from '../hooks/hypo-shared.mjs';
 
 // This script's own absolute path. Used to print copy-pasteable recovery
@@ -1014,7 +1014,7 @@ function applySessionClose(args) {
       // (.cache/, gitignored) index.jsonl written by hypo-session-record.mjs.
       // `session_id` is honest naming: the value is the Claude session UUID, and
       // it is present only on the Stop-chain close path that passes --session-id.
-      const device = String(hostname() || 'unknown').replace(/[\r\n]/g, '');
+      const device = currentDevice();
       const auditFm =
         (args.sessionId ? `session_id: ${String(args.sessionId).replace(/[\r\n]/g, '')}\n` : '') +
         `device: ${device}\n`;

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -102,6 +102,8 @@ import {
   hasUserCloseSignal,
   commitWikiChanges,
   currentDevice,
+  scopeVisible,
+  readVisibilityScope,
 } from '../hooks/hypo-shared.mjs';
 
 // This script's own absolute path. Used to print copy-pasteable recovery
@@ -1430,6 +1432,7 @@ function main() {
     } catch {
       continue;
     }
+    if (!scopeVisible(readVisibilityScope(content), currentDevice())) continue;
     const fm = parseFrontmatter(content);
     if (!fm) continue;
 

--- a/scripts/lib/page-usage.mjs
+++ b/scripts/lib/page-usage.mjs
@@ -11,6 +11,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { collectPagesCrystallize, extractWikilinks, slugForms } from './wikilink.mjs';
 import { parseFrontmatter } from './frontmatter.mjs';
+import { currentDevice, scopeVisible, readVisibilityScope } from '../../hooks/hypo-shared.mjs';
 
 const PAGE_USAGE_REL = '.cache/page-usage.jsonl';
 const DAY_MS = 86400000;
@@ -69,7 +70,13 @@ export function readPageUsage(hypoDir) {
 // within the last thresholdDays.
 export function aggregateColdCandidates(
   hypoDir,
-  { thresholdDays = 90, minLogSpanDays = 14, now = Date.now(), ignorePatterns = [] } = {},
+  {
+    thresholdDays = 90,
+    minLogSpanDays = 14,
+    now = Date.now(),
+    ignorePatterns = [],
+    device = currentDevice(),
+  } = {},
 ) {
   const records = readPageUsage(hypoDir);
   if (records.length === 0) return { status: 'insufficient-data', reason: 'no-records' };
@@ -110,6 +117,7 @@ export function aggregateColdCandidates(
       title: fm.title || slug,
       forms: formSet(slug),
       links: extractWikilinks(body),
+      scope: readVisibilityScope(content),
     });
   }
 
@@ -134,7 +142,10 @@ export function aggregateColdCandidates(
   }
 
   const candidates = pageList
-    .filter((p) => hasInbound.has(p.slug) && !intersects(p.forms, recentForms))
+    .filter(
+      (p) =>
+        hasInbound.has(p.slug) && !intersects(p.forms, recentForms) && scopeVisible(p.scope, device),
+    )
     .map((p) => ({ slug: p.slug, title: p.title }));
 
   return { status: 'ok', candidates };

--- a/scripts/query.mjs
+++ b/scripts/query.mjs
@@ -20,6 +20,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, extname } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
+import { currentDevice, scopeVisible, readVisibilityScope } from '../hooks/hypo-shared.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -101,6 +102,7 @@ const scanDirs = ['pages', 'projects'].map((d) => join(args.hypoDir, d));
 const files = scanDirs.flatMap((d) => collectMdFiles(d, args.hypoDir, [], ignorePatterns));
 
 const results = [];
+const device = currentDevice();
 
 for (const { path, rel } of files) {
   let content;
@@ -112,6 +114,7 @@ for (const { path, rel } of files) {
   const { score, excerpt } = scoreAndExcerpt(content, terms);
   if (score === 0) continue;
   const fm = parseFrontmatter(content);
+  if (!scopeVisible(readVisibilityScope(content), device)) continue;
   results.push({
     slug: rel.replace(/\.md$/, ''),
     title: fm.title || rel,

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -91,10 +91,22 @@ Optional fields (add as needed):
 confidence: high | medium | low | speculative
 evidence_strength: direct | inferred | hearsay
 scope: always | project | session
+visibility_scope: shared | machine:<device>
 source: <slug or URL>
 verify_by: <question to re-check at next review>
 verify_by_date: YYYY-MM-DD
 ```
+
+`visibility_scope` is a different axis from `scope`: `scope` is memory lifetime,
+`visibility_scope` is where a page may surface. Omitting it means `shared` (the
+implicit default of every pre-existing page), so lookup/query/injection stay
+unchanged. `machine:<device>` hides the page from every machine except the one
+whose `currentDevice()` output equals `<device>`. Copy that exact string from the
+newest `device` value in `.cache/sessions/index.jsonl`, or from a recent
+session-log shard's `device:` frontmatter (both are `currentDevice()` outputs); a
+hand-typed value that does not match will hide the page on its own machine too.
+An empty owner (`machine:`) hides the page everywhere. `agent:<id>` is a reserved
+forward-compat value that is not filtered yet.
 
 ### 3.1. `feedback` type — projection fields
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -25233,6 +25233,24 @@ test('owning device whose only match is machine-scoped: page is injected', () =>
   });
 });
 
+test('miss path survives an unstat-able entry in the page tree (buildPageMap skips it)', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'index.md'), '# Index\n- [[real-note]] — apple banana cherry\n');
+    writeFileSync(join(dir, 'pages', 'real-note.md'), '---\ntype: page\ntitle: Real\n---\n# apple banana cherry\n');
+    // A dangling symlink makes statSync throw. Because the page tree is now
+    // scanned BEFORE the miss branch, an unguarded throw would sink the whole
+    // lookup into the silent outer catch instead of the clean miss message.
+    symlinkSync(join(dir, 'pages', 'nonexistent-target.md'), join(dir, 'pages', 'dangling.md'));
+    const r = runHook('hypo-lookup.mjs', { prompt: 'zzqqxx nomatch' }, { HYPO_DIR: dir, HYPO_DEVICE: 'devB' });
+    const ctx = JSON.parse(r.stdout).additionalContext ?? '';
+    assert.ok(
+      ctx.includes('LOOKUP: miss'),
+      `a dangling symlink must not suppress the clean miss message: ${JSON.stringify(ctx)}`,
+    );
+  });
+});
+
 // ── query.mjs — visibility_scope filtering ──────────────────────────────────
 // query.mjs must gate results through readVisibilityScope(raw) + scopeVisible()
 // (the shared frontmatter reader, not a local last-wins parser) so a

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1398,6 +1398,9 @@ const {
   pageUsageGuardCachePath,
   recordLookupUsage,
   PAGE_USAGE_REL,
+  currentDevice,
+  scopeVisible,
+  readVisibilityScope,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
@@ -3563,6 +3566,52 @@ test('PRAC-17: hypo-session-record stamps device on the index.jsonl entry', () =
       typeof entry.device === 'string' && entry.device.length > 0,
       `device must be recorded on the index entry: ${JSON.stringify(entry)}`,
     );
+  });
+});
+
+// currentDevice() routing: both audit write sites must now emit the SAME device
+// string that the visibility filter reads at lookup time. Proven by overriding
+// HYPO_DEVICE and asserting the written stamp equals it — one assert per write
+// site so a divergence on either path is caught.
+test('scope: index.jsonl device stamp is routed through currentDevice (HYPO_DEVICE honored)', () => {
+  withTmpDir((dir) => {
+    const r = runHook(
+      'hypo-session-record.mjs',
+      { session_id: 'rec-dev', transcript_path: '/tmp/t.jsonl', cwd: '/tmp/work' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'dev-index' },
+    );
+    assert.equal(r.status, 0, `hook failed: ${r.stderr}`);
+    const idx = join(dir, '.cache', 'sessions', 'index.jsonl');
+    const entry = JSON.parse(readFileSync(idx, 'utf-8').trim().split('\n').pop());
+    assert.equal(
+      entry.device,
+      'dev-index',
+      `currentDevice() must route the index device stamp: ${JSON.stringify(entry)}`,
+    );
+  });
+});
+
+test('scope: daily shard device stamp is routed through currentDevice (HYPO_DEVICE honored)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog = { entry: `## [${today}] scope device entry\n\nbody\n` };
+    // run() inherits process.env (only HYPO_DIR/HOME are overridden), so the
+    // spawned crystallize sees this HYPO_DEVICE. Save/restore to keep it hermetic.
+    const prev = process.env.HYPO_DEVICE;
+    try {
+      process.env.HYPO_DEVICE = 'dev-shard';
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 0, `apply failed: ${r.stdout}\n${r.stderr}`);
+      const shard = join(dir, 'projects', 'test-project', 'session-log', `${today}.md`);
+      const fm = readFileSync(shard, 'utf-8');
+      assert.ok(
+        /^device: dev-shard$/m.test(fm),
+        `currentDevice() must route the shard device stamp: ${fm}`,
+      );
+    } finally {
+      if (prev === undefined) delete process.env.HYPO_DEVICE;
+      else process.env.HYPO_DEVICE = prev;
+    }
   });
 });
 
@@ -24985,6 +25034,86 @@ test('adopt failure rolls back the wiki hook writes (sidecar install path blocke
       );
     });
   });
+});
+
+// ── visibility scope: currentDevice / predicate / reader ─────────────────────
+
+suite('scope: currentDevice source');
+
+test('currentDevice reads HYPO_DEVICE override', () => {
+  const prev = process.env.HYPO_DEVICE;
+  try {
+    process.env.HYPO_DEVICE = 'dev-a';
+    assert.equal(currentDevice(), 'dev-a');
+  } finally {
+    if (prev === undefined) delete process.env.HYPO_DEVICE;
+    else process.env.HYPO_DEVICE = prev;
+  }
+});
+
+test('currentDevice strips CR/LF from the device token', () => {
+  const prev = process.env.HYPO_DEVICE;
+  try {
+    process.env.HYPO_DEVICE = 'x\ny';
+    assert.equal(currentDevice(), 'xy');
+  } finally {
+    if (prev === undefined) delete process.env.HYPO_DEVICE;
+    else process.env.HYPO_DEVICE = prev;
+  }
+});
+
+test('currentDevice falls back to a non-empty string without HYPO_DEVICE', () => {
+  const prev = process.env.HYPO_DEVICE;
+  try {
+    delete process.env.HYPO_DEVICE;
+    const d = currentDevice();
+    assert.equal(typeof d, 'string');
+    assert.ok(d.length > 0, 'fallback device is non-empty');
+  } finally {
+    if (prev === undefined) delete process.env.HYPO_DEVICE;
+    else process.env.HYPO_DEVICE = prev;
+  }
+});
+
+suite('scope: scopeVisible predicate');
+
+test('scopeVisible: no field and shared are visible', () => {
+  assert.equal(scopeVisible('', 'a'), true);
+  assert.equal(scopeVisible('shared', 'a'), true);
+});
+
+test('scopeVisible: machine matches only the owning device', () => {
+  assert.equal(scopeVisible('machine:a', 'a'), true);
+  assert.equal(scopeVisible('machine:b', 'a'), false);
+});
+
+test('scopeVisible: agent prefix is reserved and passes (forward-compat)', () => {
+  assert.equal(scopeVisible('agent:x', 'a'), true);
+});
+
+test('scopeVisible: empty owner (machine:) hides everywhere', () => {
+  assert.equal(scopeVisible('machine:', 'a'), false);
+});
+
+suite('scope: readVisibilityScope reader');
+
+test('readVisibilityScope strips an inline YAML comment', () => {
+  assert.equal(
+    readVisibilityScope('---\nvisibility_scope: machine:a # note\n---\n'),
+    'machine:a',
+  );
+});
+
+test('readVisibilityScope is first-wins on a repeated key', () => {
+  assert.equal(
+    readVisibilityScope('---\nvisibility_scope: machine:a\nvisibility_scope: machine:b\n---\n'),
+    'machine:a',
+  );
+});
+
+test('readVisibilityScope returns empty when the field is absent', () => {
+  assert.equal(readVisibilityScope('---\ntype: note\n---\nbody'), '');
+  assert.equal(readVisibilityScope('no frontmatter at all'), '');
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -25075,6 +25075,21 @@ test('currentDevice falls back to a non-empty string without HYPO_DEVICE', () =>
   }
 });
 
+test('currentDevice: a CR/LF-only HYPO_DEVICE collapses to fallback, never empty', () => {
+  const prev = process.env.HYPO_DEVICE;
+  try {
+    // A truthy-but-whitespace value must NOT yield '' (which would make
+    // scopeVisible('machine:', device) pass and unhide the empty-owner page).
+    process.env.HYPO_DEVICE = '\r\n';
+    const d = currentDevice();
+    assert.ok(d.length > 0, `CR/LF-only device must fall back to non-empty, got ${JSON.stringify(d)}`);
+    assert.equal(scopeVisible('machine:', d), false, 'empty-owner machine: must stay hidden under the fallback device');
+  } finally {
+    if (prev === undefined) delete process.env.HYPO_DEVICE;
+    else process.env.HYPO_DEVICE = prev;
+  }
+});
+
 suite('scope: scopeVisible predicate');
 
 test('scopeVisible: no field and shared are visible', () => {
@@ -25114,6 +25129,503 @@ test('readVisibilityScope is first-wins on a repeated key', () => {
 test('readVisibilityScope returns empty when the field is absent', () => {
   assert.equal(readVisibilityScope('---\ntype: note\n---\nbody'), '');
   assert.equal(readVisibilityScope('no frontmatter at all'), '');
+});
+
+// ── T4: hypo-lookup.mjs visibility_scope filtering ───────────────────────────
+suite('hypo-lookup.mjs — visibility_scope filtering (T4)');
+
+function visibilityScopeVaultT4(dir) {
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  // machine:devA page — must be invisible on devB, visible on devA.
+  writeFileSync(
+    join(dir, 'pages', 'devA-secret.md'),
+    '---\ntype: page\ntitle: DevA Secret\nvisibility_scope: machine:devA\n---\n' +
+      '# body about gizmo frobnication\n',
+  );
+  // fieldless page — must always pass through unfiltered (golden invariant).
+  writeFileSync(
+    join(dir, 'pages', 'plain-notes.md'),
+    '---\ntype: page\ntitle: Plain Notes\n---\n# body about gizmo frobnication\n',
+  );
+  writeFileSync(
+    join(dir, 'index.md'),
+    [
+      '# Index',
+      '- [[devA-secret]] — gizmo frobnication machine-only notes',
+      '- [[plain-notes]] — gizmo frobnication general notes',
+    ].join('\n'),
+  );
+}
+
+// A prompt matching ONLY the machine-scoped page (never the fieldless one), so
+// that on a non-owning device `matched` is non-empty but `visibleMatched` is
+// empty. Because the miss decision is made on visibleMatched, this must take the
+// clean miss path (closest = none, since the only match is hidden) — NOT the
+// misleading "index hit but files missing" branch — and of course leak no slug.
+function machineOnlyVaultT4(dir) {
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  writeFileSync(
+    join(dir, 'pages', 'devA-only.md'),
+    '---\ntype: page\ntitle: DevA Only\nvisibility_scope: machine:devA\n---\n' +
+      '# body about quibbleflux widgetry\n',
+  );
+  writeFileSync(
+    join(dir, 'index.md'),
+    ['# Index', '- [[devA-only]] — quibbleflux widgetry machine-only notes'].join('\n'),
+  );
+}
+
+test('non-owning device: machine-scoped slug excluded from injection, fieldless slug still injected', () => {
+  withTmpDir((dir) => {
+    visibilityScopeVaultT4(dir);
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'gizmo frobnication' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    assert.ok(!ctx.includes('devA-secret'), `machine:devA slug must not leak on devB: ${ctx}`);
+    assert.ok(ctx.includes('plain-notes'), `fieldless page must still be injected: ${ctx}`);
+  });
+});
+
+test('owning device: machine-scoped slug is injected', () => {
+  withTmpDir((dir) => {
+    visibilityScopeVaultT4(dir);
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'gizmo frobnication' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
+    );
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    assert.ok(ctx.includes('devA-secret'), `machine:devA slug must be injected on devA: ${ctx}`);
+  });
+});
+
+test('non-owning device whose only match is machine-scoped: clean miss, no leak, no "files missing"', () => {
+  withTmpDir((dir) => {
+    machineOnlyVaultT4(dir);
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'quibbleflux widgetry' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    const out = JSON.parse(r.stdout);
+    const ctx = out.additionalContext ?? '';
+    assert.ok(!ctx.includes('devA-only'), `machine:devA slug must not leak: ${ctx}`);
+    assert.ok(!ctx.includes('files missing'), `a hidden-only match must not report "files missing": ${ctx}`);
+    assert.ok(ctx.includes('LOOKUP: miss'), `a hidden-only match must take the clean miss path: ${ctx}`);
+  });
+});
+
+test('owning device whose only match is machine-scoped: page is injected', () => {
+  withTmpDir((dir) => {
+    machineOnlyVaultT4(dir);
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'quibbleflux widgetry' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
+    );
+    const ctx = JSON.parse(r.stdout).additionalContext ?? '';
+    assert.ok(ctx.includes('devA-only'), `machine:devA page must inject on devA: ${ctx}`);
+  });
+});
+
+// ── query.mjs — visibility_scope filtering ──────────────────────────────────
+// query.mjs must gate results through readVisibilityScope(raw) + scopeVisible()
+// (the shared frontmatter reader, not a local last-wins parser) so a
+// `machine:<owner>` page only surfaces on its own machine, an inline-comment
+// value (`machine:devA # note`) still matches on devA, and a page with no
+// visibility_scope field is unaffected on every machine.
+
+suite('query.mjs — visibility_scope filtering');
+
+test('visibility_scope: machine-scoped page hidden on a different device, visible on its own', () => {
+  withTmpDir((dirT5) => {
+    mkdirSync(join(dirT5, 'pages'), { recursive: true });
+    writeFileSync(
+      join(dirT5, 'pages', 'machine-a-t5.md'),
+      '---\ntitle: machine a\ntype: note\nvisibility_scope: machine:devA # note\n---\nscopewordT5 machine-only body\n',
+    );
+    writeFileSync(
+      join(dirT5, 'pages', 'no-scope-t5.md'),
+      '---\ntitle: no scope\ntype: note\n---\nscopewordT5 unscoped body\n',
+    );
+
+    const origDevice = process.env.HYPO_DEVICE;
+    try {
+      process.env.HYPO_DEVICE = 'devB';
+      const rOther = run('query.mjs', [`--hypo-dir=${dirT5}`, '--q=scopewordT5', '--json']);
+      assert.equal(rOther.status, 0, `should exit 0: ${rOther.stderr}`);
+      const slugsOther = JSON.parse(rOther.stdout).map((r) => r.slug);
+      assert.ok(
+        !slugsOther.includes('pages/machine-a-t5'),
+        `machine:devA page must be hidden on devB: ${rOther.stdout}`,
+      );
+      assert.ok(
+        slugsOther.includes('pages/no-scope-t5'),
+        `unscoped page must remain visible on devB: ${rOther.stdout}`,
+      );
+
+      process.env.HYPO_DEVICE = 'devA';
+      const rOwn = run('query.mjs', [`--hypo-dir=${dirT5}`, '--q=scopewordT5', '--json']);
+      assert.equal(rOwn.status, 0, `should exit 0: ${rOwn.stderr}`);
+      const slugsOwn = JSON.parse(rOwn.stdout).map((r) => r.slug);
+      assert.ok(
+        slugsOwn.includes('pages/machine-a-t5'),
+        `inline-comment machine:devA page must match on devA (readVisibilityScope path): ${rOwn.stdout}`,
+      );
+      assert.ok(
+        slugsOwn.includes('pages/no-scope-t5'),
+        `unscoped page must remain visible on devA: ${rOwn.stdout}`,
+      );
+    } finally {
+      if (origDevice === undefined) delete process.env.HYPO_DEVICE;
+      else process.env.HYPO_DEVICE = origDevice;
+    }
+  });
+});
+
+suite('hypo-file-watch: visibility scope gate');
+
+test('hypo-file-watch: machine-scoped page is not injected on a non-owning device', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-fw-'));
+  try {
+    const filePath = join(dir, 'hot.md');
+    writeFileSync(
+      filePath,
+      '---\nvisibility_scope: machine:devA\n---\n\n# hot\n\nbody text\n',
+    );
+    const r = runHook(
+      'hypo-file-watch.mjs',
+      { file_path: filePath },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true);
+    assert.ok(!('additionalContext' in out), 'scoped page must not inject on a foreign device');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('hypo-file-watch: machine-scoped page is injected on its owning device', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-fw-'));
+  try {
+    const filePath = join(dir, 'hot.md');
+    writeFileSync(
+      filePath,
+      '---\nvisibility_scope: machine:devA\n---\n\n# hot\n\nbody text\n',
+    );
+    const r = runHook(
+      'hypo-file-watch.mjs',
+      { file_path: filePath },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true);
+    assert.ok('additionalContext' in out, 'owning device must still get the injection');
+    assert.ok(out.additionalContext.includes('body text'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('hypo-file-watch: a page with no visibility_scope field injects regardless of device', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-fw-'));
+  try {
+    const filePath = join(dir, 'hot.md');
+    writeFileSync(filePath, '# hot\n\nno scope field here\n');
+
+    const r1 = runHook(
+      'hypo-file-watch.mjs',
+      { file_path: filePath },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    const out1 = JSON.parse(r1.stdout);
+    assert.ok('additionalContext' in out1, 'unscoped page must inject on any device (devB)');
+
+    const r2 = runHook(
+      'hypo-file-watch.mjs',
+      { file_path: filePath },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
+    );
+    const out2 = JSON.parse(r2.stdout);
+    assert.ok('additionalContext' in out2, 'unscoped page must inject on any device (devA)');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+suite('page-usage.mjs — visibility scope filtering of cold candidates (T7)');
+
+test('aggregateColdCandidates excludes a machine-scoped page for a non-owning device, includes it for the owner', () => {
+  withTmpDir((dir) => {
+    const nowT7 = Date.parse('2026-07-04T00:00:00Z');
+    const dayT7 = 86400000;
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    // Shared page carries the only inbound link to the machine-scoped page.
+    writeFileSync(
+      join(dir, 'pages', 'hub.md'),
+      '---\ntype: page\ntitle: Hub\n---\n# Hub\n[[machine-page]]\n',
+    );
+    writeFileSync(
+      join(dir, 'pages', 'machine-page.md'),
+      '---\ntype: page\ntitle: Machine Page\nvisibility_scope: machine:devA\n---\n# Machine Page\n',
+    );
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'page-usage.jsonl'),
+      [
+        JSON.stringify({ ts: new Date(nowT7 - 20 * dayT7).toISOString(), slug: 'anchor' }),
+        JSON.stringify({ ts: new Date(nowT7 - 1 * dayT7).toISOString(), slug: 'anchor2' }),
+      ].join('\n') + '\n',
+    );
+
+    const asDevB = aggregateColdCandidates(dir, { now: nowT7, device: 'devB' });
+    assert.equal(asDevB.status, 'ok');
+    assert.ok(
+      !asDevB.candidates.some((c) => c.slug === 'pages/machine-page'),
+      `machine:devA page must be excluded for devB: ${JSON.stringify(asDevB.candidates)}`,
+    );
+
+    const asDevA = aggregateColdCandidates(dir, { now: nowT7, device: 'devA' });
+    assert.equal(asDevA.status, 'ok');
+    assert.ok(
+      asDevA.candidates.some((c) => c.slug === 'pages/machine-page'),
+      `machine:devA page must be a normal cold candidate on its own device: ${JSON.stringify(asDevA.candidates)}`,
+    );
+  });
+});
+
+test('graph invariant: a shared page whose sole inbound link comes from a machine-scoped page has identical cold candidacy across devices', () => {
+  withTmpDir((dir) => {
+    const nowT7 = Date.parse('2026-07-04T00:00:00Z');
+    const dayT7 = 86400000;
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    // machine-source is visible only on devA, but its outbound link must still
+    // count toward shared-target's inbound-link graph on EVERY device — the
+    // scope filter applies only at the final candidate step, never at graph
+    // construction (formOwners / hasInbound).
+    writeFileSync(
+      join(dir, 'pages', 'machine-source.md'),
+      '---\ntype: page\ntitle: Machine Source\nvisibility_scope: machine:devA\n---\n# Machine Source\n[[shared-target]]\n',
+    );
+    writeFileSync(
+      join(dir, 'pages', 'shared-target.md'),
+      '---\ntype: page\ntitle: Shared Target\n---\n# Shared Target\n',
+    );
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'page-usage.jsonl'),
+      [
+        JSON.stringify({ ts: new Date(nowT7 - 20 * dayT7).toISOString(), slug: 'anchor' }),
+        JSON.stringify({ ts: new Date(nowT7 - 1 * dayT7).toISOString(), slug: 'anchor2' }),
+      ].join('\n') + '\n',
+    );
+
+    const asDevA = aggregateColdCandidates(dir, { now: nowT7, device: 'devA' });
+    const asDevB = aggregateColdCandidates(dir, { now: nowT7, device: 'devB' });
+    assert.equal(asDevA.status, 'ok');
+    assert.equal(asDevB.status, 'ok');
+    const inA = asDevA.candidates.some((c) => c.slug === 'pages/shared-target');
+    const inB = asDevB.candidates.some((c) => c.slug === 'pages/shared-target');
+    assert.ok(inA, `shared-target must be a cold candidate on devA: ${JSON.stringify(asDevA.candidates)}`);
+    assert.equal(
+      inA,
+      inB,
+      `shared-target's cold candidacy must not depend on device (graph invariant): devA=${inA} devB=${inB}`,
+    );
+  });
+});
+
+suite('crystallize.mjs — visibility_scope filters candidate scan (T8)');
+
+test('unlinked candidates respect visibility_scope: machine-scoped pages stay off other devices, fieldless pages stay visible', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(
+      join(dir, 'pages', 'machine-a-page.md'),
+      '---\ntype: page\ntitle: Machine A Page\nvisibility_scope: machine:devA\n---\n# Machine A Page\nNo links here.\n',
+    );
+    writeFileSync(
+      join(dir, 'pages', 'shared-page.md'),
+      '---\ntype: page\ntitle: Shared Page\n---\n# Shared Page\nNo links here either.\n',
+    );
+
+    const prevDevice = process.env.HYPO_DEVICE;
+    try {
+      process.env.HYPO_DEVICE = 'devB';
+      const rOther = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']);
+      assert.equal(rOther.status, 0);
+      const slugsOther = JSON.parse(rOther.stdout).unlinked.map((p) => p.slug);
+      assert.ok(
+        !slugsOther.includes('pages/machine-a-page'),
+        `machine:devA page must be hidden on devB: ${rOther.stdout}`,
+      );
+      assert.ok(
+        slugsOther.includes('pages/shared-page'),
+        `fieldless page must remain visible: ${rOther.stdout}`,
+      );
+
+      process.env.HYPO_DEVICE = 'devA';
+      const rOwn = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']);
+      assert.equal(rOwn.status, 0);
+      const slugsOwn = JSON.parse(rOwn.stdout).unlinked.map((p) => p.slug);
+      assert.ok(
+        slugsOwn.includes('pages/machine-a-page'),
+        `machine:devA page must be visible on devA: ${rOwn.stdout}`,
+      );
+    } finally {
+      if (prevDevice === undefined) delete process.env.HYPO_DEVICE;
+      else process.env.HYPO_DEVICE = prevDevice;
+    }
+  });
+});
+
+// ── cross-consumer visibility regression ─────────────────────────────────────
+// Ties the five consumers together: (a) a fieldless-only vault is device-
+// invariant (golden), (b) one machine:devA page is withheld from a non-owning
+// device on every surface, (c) the inline-comment value matches on its own
+// machine (readVisibilityScope unification). Kept alongside the per-consumer
+// tests on purpose: this suite survives if any single per-task test is later
+// changed, so a regression in cross-cutting behavior still trips a gate.
+
+suite('cross-consumer visibility regression');
+
+// Indexed vault: both pages are discoverable by lookup (index.md entries) and
+// query (body match on "xyzzy plover"). The machine page carries no outbound
+// wikilinks so it is also a crystallize `unlinked` candidate. withMachine off
+// yields a fieldless-only vault for the golden check.
+function scopeVaultX10(dir, { withMachine = true } = {}) {
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  if (withMachine) {
+    writeFileSync(
+      join(dir, 'pages', 'devA-note.md'),
+      '---\ntype: page\ntitle: DevA Note\nvisibility_scope: machine:devA\n---\n# xyzzy plover machine-only body\n',
+    );
+  }
+  writeFileSync(
+    join(dir, 'pages', 'shared-note.md'),
+    '---\ntype: page\ntitle: Shared Note\n---\n# xyzzy plover shared body\n',
+  );
+  const idx = ['# Index', '- [[shared-note]] — xyzzy plover shared notes'];
+  if (withMachine) idx.splice(1, 0, '- [[devA-note]] — xyzzy plover machine notes');
+  writeFileSync(join(dir, 'index.md'), idx.join('\n') + '\n');
+}
+
+function lookupCtxX10(dir, device) {
+  const r = runHook('hypo-lookup.mjs', { prompt: 'xyzzy plover' }, { HYPO_DIR: dir, HYPO_DEVICE: device });
+  return JSON.parse(r.stdout).additionalContext ?? '';
+}
+
+function withDeviceX10(device, fn) {
+  const prev = process.env.HYPO_DEVICE;
+  try {
+    process.env.HYPO_DEVICE = device;
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.HYPO_DEVICE;
+    else process.env.HYPO_DEVICE = prev;
+  }
+}
+
+function querySlugsX10(dir, device, q = 'xyzzy') {
+  return withDeviceX10(device, () =>
+    JSON.parse(run('query.mjs', [`--hypo-dir=${dir}`, `--q=${q}`, '--json']).stdout).map((x) => x.slug),
+  );
+}
+
+test('golden: a fieldless-only vault yields device-invariant lookup + query output', () => {
+  withTmpDir((dir) => {
+    scopeVaultX10(dir, { withMachine: false });
+    assert.equal(
+      lookupCtxX10(dir, 'devA'),
+      lookupCtxX10(dir, 'devB'),
+      'lookup injection must not depend on device when no page is scoped',
+    );
+    assert.deepEqual(
+      querySlugsX10(dir, 'devA').sort(),
+      querySlugsX10(dir, 'devB').sort(),
+      'query results must not depend on device when no page is scoped',
+    );
+  });
+});
+
+test('injection surfaces (lookup + query + file-watch) withhold machine:devA from devB, keep it for devA', () => {
+  withTmpDir((dir) => {
+    scopeVaultX10(dir);
+    const ctxB = lookupCtxX10(dir, 'devB');
+    assert.ok(!ctxB.includes('devA-note'), `lookup must not inject machine:devA on devB: ${ctxB}`);
+    assert.ok(ctxB.includes('shared-note'), 'lookup must still inject the fieldless page on devB');
+    assert.ok(lookupCtxX10(dir, 'devA').includes('devA-note'), 'lookup must inject machine:devA on devA');
+    const qB = querySlugsX10(dir, 'devB');
+    assert.ok(!qB.includes('pages/devA-note'), `query must hide machine:devA on devB: ${qB}`);
+    assert.ok(qB.includes('pages/shared-note'), 'query must keep the fieldless page on devB');
+    assert.ok(querySlugsX10(dir, 'devA').includes('pages/devA-note'), 'query must show machine:devA on devA');
+    const fwB = JSON.parse(
+      runHook('hypo-file-watch.mjs', { file_path: join(dir, 'pages', 'devA-note.md') }, { HYPO_DIR: dir, HYPO_DEVICE: 'devB' }).stdout,
+    );
+    assert.ok(!('additionalContext' in fwB), 'file-watch must not inject machine:devA on devB');
+    const fwA = JSON.parse(
+      runHook('hypo-file-watch.mjs', { file_path: join(dir, 'pages', 'devA-note.md') }, { HYPO_DIR: dir, HYPO_DEVICE: 'devA' }).stdout,
+    );
+    assert.ok('additionalContext' in fwA, 'file-watch must inject machine:devA on devA');
+  });
+});
+
+test('aggregation surfaces (crystallize candidate + cold) withhold machine:devA from devB', () => {
+  withTmpDir((dir) => {
+    // hub gives the machine page an inbound link (cold candidacy) while the
+    // machine page keeps no outbound links (crystallize `unlinked` candidacy).
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'hub.md'), '---\ntype: page\ntitle: Hub\n---\n# Hub\n[[machine-page]]\n');
+    writeFileSync(
+      join(dir, 'pages', 'machine-page.md'),
+      '---\ntype: page\ntitle: Machine Page\nvisibility_scope: machine:devA\n---\n# Machine Page body\n',
+    );
+    const unlinkedB = withDeviceX10('devB', () =>
+      JSON.parse(run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']).stdout).unlinked.map((p) => p.slug),
+    );
+    assert.ok(!unlinkedB.includes('pages/machine-page'), `crystallize must not surface machine:devA on devB: ${unlinkedB}`);
+    const unlinkedA = withDeviceX10('devA', () =>
+      JSON.parse(run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']).stdout).unlinked.map((p) => p.slug),
+    );
+    assert.ok(unlinkedA.includes('pages/machine-page'), `crystallize must surface machine:devA on devA: ${unlinkedA}`);
+    const nowX10 = Date.parse('2026-07-04T00:00:00Z');
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'page-usage.jsonl'),
+      JSON.stringify({ ts: new Date(nowX10 - 20 * 86400000).toISOString(), slug: 'anchor' }) +
+        '\n' +
+        JSON.stringify({ ts: new Date(nowX10 - 86400000).toISOString(), slug: 'anchor2' }) +
+        '\n',
+    );
+    const coldB = aggregateColdCandidates(dir, { now: nowX10, device: 'devB' }).candidates.map((c) => c.slug);
+    assert.ok(!coldB.includes('pages/machine-page'), `cold aggregation must exclude machine:devA on devB: ${coldB}`);
+    const coldA = aggregateColdCandidates(dir, { now: nowX10, device: 'devA' }).candidates.map((c) => c.slug);
+    assert.ok(coldA.includes('pages/machine-page'), `cold aggregation must include machine:devA on devA: ${coldA}`);
+  });
+});
+
+test('inline-comment machine:devA # note is honored on its own machine and hidden elsewhere (query)', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(
+      join(dir, 'pages', 'commented.md'),
+      '---\ntype: page\ntitle: Commented\nvisibility_scope: machine:devA # personal\n---\n# grault garply body\n',
+    );
+    assert.ok(
+      querySlugsX10(dir, 'devA', 'grault').includes('pages/commented'),
+      'inline-comment machine:devA must match on devA (readVisibilityScope strips the comment)',
+    );
+    assert.ok(
+      !querySlugsX10(dir, 'devB', 'grault').includes('pages/commented'),
+      'inline-comment machine:devA must hide on devB',
+    );
+  });
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# English

## What changed

An optional `visibility_scope: shared | machine:<device>` frontmatter field. A `machine:<owner>` page is withheld from every device except its owner; a page with no field behaves exactly as before (device-invariant). This is the first slice of the current minor and lands unreleased on `main`.

## Why

Some wiki pages are machine-local (per-device notes, host-specific state) and should not surface on other machines that sync the same vault. Without a scope field every synced page shows everywhere. This adds an opt-in namespace so a page can be pinned to its owning device.

## How

`hooks/hypo-shared.mjs` gains three exports as the single source of truth:

- `currentDevice()`: `HYPO_DEVICE || hostname || 'unknown'`, CR/LF stripped before the fallback chain (never returns `''`), uncached so tests can override.
- `readVisibilityScope(raw)`: top-level first-wins reader with YAML inline-comment and quote stripping (mirrors `scripts/lib/frontmatter.mjs`; hooks cannot import from `scripts/`, so it is replicated, not imported).
- `scopeVisible(scopeValue, device)`: the one visibility decision; prefix dispatch, fail-open (`agent:` reserved, empty-owner `machine:` hides everywhere).

Five consumers filter through these on raw content (never a local last-wins parser): `hypo-lookup` (all emission paths), `query`, `hypo-file-watch`, `page-usage` (final cold-candidate step only; the graph stays device-independent), and `crystallize` (candidate scan). The two audit device write sites now route through `currentDevice()` so write-time and lookup-time strings match.

## Manual verification

Changed hooks (`hypo-shared.mjs`, `hypo-lookup`, `hypo-file-watch`, `hypo-session-record`), so beyond the suite: verified via the automated tests only (per-consumer exclusion/inclusion, a cross-consumer regression suite covering device-invariance, five-surface withholding, and inline-comment on-machine match, plus a currentDevice CR/LF fallback and a dangling-symlink miss-path regression). The deployed `~/.claude/hooks/` copy firing on a live session was not separately exercised.

## Migration notes

`templates/SCHEMA.md` documents the new optional field. Existing pages without `visibility_scope` are unaffected (device-invariant). No manual step is required on upgrade.

---

# 한국어

## 변경 내용

선택적 `visibility_scope: shared | machine:<device>` frontmatter 필드. `machine:<owner>` 페이지는 소유 device를 제외한 모든 device에서 숨겨지고, 필드가 없는 페이지는 이전과 완전히 동일하게 동작한다(device 불변). 이번은 현재 minor의 첫 슬라이스이며 `main`에 미릴리스로 얹힌다.

## 이유

일부 위키 페이지는 머신 로컬(device별 노트, 호스트 특정 상태)이라 같은 볼트를 동기화하는 다른 머신에 뜨면 안 된다. scope 필드가 없으면 동기화된 모든 페이지가 어디서나 보인다. 이 변경은 페이지를 소유 device에 고정할 수 있는 opt-in 네임스페이스를 추가한다.

## 방법

`hooks/hypo-shared.mjs`에 단일 정본으로 세 export를 추가한다.

- `currentDevice()`: `HYPO_DEVICE || hostname || 'unknown'`, fallback 체인 앞에서 CR/LF를 제거해 `''`를 절대 반환하지 않으며, 테스트가 override할 수 있도록 캐시하지 않는다.
- `readVisibilityScope(raw)`: top-level first-wins 리더로 YAML 인라인 주석과 따옴표를 벗긴다(`scripts/lib/frontmatter.mjs`를 반영한다. 훅은 `scripts/`에서 import할 수 없어 import가 아니라 복제한다).
- `scopeVisible(scopeValue, device)`: 단일 가시성 판정. prefix dispatch에 fail-open(`agent:`는 예약, 소유자 없는 `machine:`은 어디서나 숨김).

다섯 consumer가 raw 내용으로 이들을 통과시킨다(로컬 last-wins 파서를 절대 안 쓴다): `hypo-lookup`(모든 emission 경로), `query`, `hypo-file-watch`, `page-usage`(마지막 cold-candidate 단계만. graph는 device 독립으로 둔다), `crystallize`(candidate scan). audit device 쓰기 두 곳도 이제 `currentDevice()`를 거쳐 write 시점과 lookup 시점 문자열이 맞는다.

## 수동 검증

훅(`hypo-shared.mjs`, `hypo-lookup`, `hypo-file-watch`, `hypo-session-record`)을 바꿨으므로 스위트 외에: 자동 테스트로만 검증했다(consumer별 배제/포함, device 불변성과 다섯 표면 withholding과 인라인 주석 on-machine 매치를 다루는 cross-consumer 회귀 스위트, currentDevice CR/LF fallback, dangling-symlink miss-path 회귀). 배포된 `~/.claude/hooks/` 사본이 라이브 세션에서 발화하는 것은 별도로 검증하지 않았다.

## 마이그레이션 노트

`templates/SCHEMA.md`가 새 선택 필드를 문서화한다. `visibility_scope`가 없는 기존 페이지는 영향받지 않는다(device 불변). 업그레이드 시 수동 조작은 필요 없다.

---

## Changelog

- EN: Wiki pages can opt into a machine-scoped visibility namespace (`visibility_scope: machine:<device>`) so a page shows only on its owning device (#178).
- KO: 위키 페이지가 머신 범위 visibility 네임스페이스(`visibility_scope: machine:<device>`)를 선택해 소유 머신에서만 보이게 할 수 있다 (#178).

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally (exits on ambient vault content errors unrelated to this change; CI lint is green)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
