### PR TITLE
feat(base-store): per-session observed-base snapshot for the write=proposal gate

### DIFF
--- a/hooks/base-store.mjs
+++ b/hooks/base-store.mjs
@@ -1,0 +1,208 @@
+// base-store.mjs: per-session observed-base hash snapshot
+//
+// Lives in hooks/ rather than scripts/lib/ because hypo-session-start.mjs must
+// stay self-contained within this directory (an npm consumer may vendor hooks/
+// alone). scripts/ already imports from hooks/, never the reverse.
+//
+// The write=proposal gate needs to know what a session OBSERVED on disk when it
+// started, so crystallize can tell "nobody touched this page" from "someone else
+// wrote it while this session was alive". crystallize runs as a separate process
+// from the session, so the observation has to be parked somewhere both can read:
+// `<hypoDir>/.cache/sessions/<sessionId>/base.json` (gitignored, never synced).
+//
+// SessionStart writes it, crystallize reads it. Two invariants carry the design:
+//
+//   1. Existence-check, not overwrite. SessionStart fires again on resume and on
+//      compact with the SAME session_id (verified by spike). Re-snapshotting
+//      there would advance the base to whatever another session had just written,
+//      so close would compare base-to-itself, see no drift, and clobber the other
+//      session's edits. Single-session tests pass either way, which is exactly
+//      why this is pinned by a regression test and not left to reviewer memory.
+//      `/clear` mints a NEW session_id, so it gets a fresh snapshot, which is right:
+//      a cleared session restarts its observation from disk.
+//
+//   2. Advance after a successful direct write. Once crystallize legitimately
+//      overwrites a target, that content IS the new observed base. Without this,
+//      a second close in the same session would diff against the stale original
+//      and raise a false-positive proposal against its own first write.
+//
+// Everything here is best-effort: a hook must never fail a session start because
+// a cache write did not land. Read failures degrade to "base unknown", which the
+// caller treats as fail-safe (proposal), never as "no conflict".
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  closeSync,
+  openSync,
+  writeSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+
+/** sha256 of a UTF-8 string, hex. */
+export function hashContent(content) {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+/**
+ * Hash of a file's bytes. Absent and unreadable are different answers: an absent
+ * file was genuinely observed as absent, while an unreadable one was not observed
+ * at all, and only the first makes "create it at close" safe.
+ * @returns {string|null|undefined} hex hash, `null` if absent, `undefined` if unreadable
+ */
+export function hashFile(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return hashContent(readFileSync(path, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+}
+
+/** `<hypoDir>/.cache/sessions/<sessionId>/base.json`. */
+export function basePath(hypoDir, sessionId) {
+  return join(hypoDir, '.cache', 'sessions', String(sessionId), 'base.json');
+}
+
+/** Atomic overwrite via tmp+rename, mirroring crystallize's atomicWrite. */
+function atomicWrite(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+}
+
+/** Read and parse base.json. Returns null when absent, unreadable, or malformed. */
+function readBaseFile(hypoDir, sessionId) {
+  const path = basePath(hypoDir, sessionId);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    if (!parsed.targets || typeof parsed.targets !== 'object') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Snapshot the observed base hashes for `relPaths`, ONCE per session.
+ *
+ * Existence-check (invariant 1): when base.json already exists for this session,
+ * this is a no-op: resume and compact must not move the base.
+ *
+ * A target that does not exist on disk is recorded as `null` (observed-absent),
+ * which is distinct from having no entry at all (observed-nothing). Close treats
+ * the first as "I saw no file, creating it is safe" and the second as fail-safe.
+ *
+ * @param {string} hypoDir
+ * @param {string} sessionId
+ * @param {string[]} relPaths vault-relative target paths
+ * @returns {{created: boolean, reason?: string}}
+ */
+export function snapshotBase(hypoDir, sessionId, relPaths) {
+  if (!sessionId) return { created: false, reason: 'no-session-id' };
+  const path = basePath(hypoDir, sessionId);
+  if (existsSync(path)) return { created: false, reason: 'already-snapshotted' };
+
+  const targets = {};
+  for (const rel of relPaths) {
+    if (!rel) continue;
+    const h = hashFile(join(hypoDir, rel));
+    // `undefined` (unreadable) is left OUT of the map on purpose: no entry means
+    // "unknown", and close fails safe into a proposal rather than assuming a
+    // file it could not read was unchanged.
+    if (h !== undefined) targets[rel] = h;
+  }
+
+  const body = JSON.stringify(
+    { session_id: String(sessionId), created_at: new Date().toISOString(), targets },
+    null,
+    2,
+  );
+
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    // Exclusive create IS the existence-check, closing the gap between the
+    // existsSync above and the write below when two hooks race on one session.
+    const fd = openSync(path, 'wx');
+    try {
+      writeSync(fd, body);
+    } finally {
+      closeSync(fd);
+    }
+    return { created: true };
+  } catch (e) {
+    if (e && e.code === 'EEXIST') return { created: false, reason: 'already-snapshotted' };
+    // best-effort: a hook must never break a session start over a cache write
+    return { created: false, reason: `write-failed: ${e && e.message}` };
+  }
+}
+
+/**
+ * Look up one target's observed base, as a discriminated state.
+ *
+ *   'hash'     this session observed content; `hash` holds it
+ *   'absent'   this session observed the file missing, so creating it is safe
+ *   'unknown'  this session never observed it: no snapshot, wrong session,
+ *              unreadable at snapshot time, or a target set that shifted
+ *              mid-session because cwd moved
+ *
+ * `state` is the discriminator on purpose. An earlier shape returned
+ * `{known, hash}` where BOTH 'absent' and 'unknown' carried `hash: null`, so a
+ * consumer branching on `if (!entry.hash)` would read never-observed as
+ * safe-to-write and quietly defeat the guard. Branch on `state`, never on the
+ * truthiness of `hash`.
+ *
+ * @returns {{state: 'hash'|'absent'|'unknown', hash: string|null}}
+ */
+export function readBaseEntry(hypoDir, sessionId, relPath) {
+  const unknown = { state: 'unknown', hash: null };
+  if (!sessionId) return unknown;
+  const parsed = readBaseFile(hypoDir, sessionId);
+  if (!parsed) return unknown;
+  if (!Object.prototype.hasOwnProperty.call(parsed.targets, relPath)) return unknown;
+  const hash = parsed.targets[relPath];
+  if (hash === null) return { state: 'absent', hash: null };
+  if (typeof hash !== 'string' || hash === '') return unknown;
+  return { state: 'hash', hash };
+}
+
+/**
+ * Move one target's base to `hash` after this session legitimately wrote it
+ * (invariant 2). No-op when the session has no snapshot: with no base there is
+ * no guard to keep honest.
+ *
+ * @returns {boolean} true when the base file was updated
+ */
+export function advanceBase(hypoDir, sessionId, relPath, hash) {
+  if (!sessionId) return false;
+  const parsed = readBaseFile(hypoDir, sessionId);
+  if (!parsed) return false;
+  parsed.targets[relPath] = hash;
+  try {
+    atomicWrite(basePath(hypoDir, sessionId), JSON.stringify(parsed, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The four overwrite targets crystallize replaces wholesale. `project` may be
+ * null when cwd resolves to no project; the two project-scoped paths are then
+ * omitted and close falls back to proposal for them.
+ */
+export function overwriteTargets(project) {
+  const targets = ['hot.md', join('pages', 'open-questions.md')];
+  if (project) {
+    targets.unshift(join('projects', project, 'session-state.md'));
+    targets.unshift(join('projects', project, 'hot.md'));
+  }
+  return targets;
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -143,5 +143,5 @@
       }
     ]
   },
-  "shared": ["hypo-shared.mjs", "version-check.mjs", "version-check-fetch.mjs"]
+  "shared": ["hypo-shared.mjs", "version-check.mjs", "version-check-fetch.mjs", "base-store.mjs"]
 }

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -46,6 +46,7 @@ import {
   siblingAlreadyNotified,
   markSiblingNotified,
 } from './version-check.mjs';
+import { snapshotBase, overwriteTargets } from './base-store.mjs';
 
 // Privacy guard: refuse to read+inject .hypoignore-matched
 // wiki files into additionalContext. Without this, a user who lists
@@ -378,6 +379,18 @@ process.stdin.on('end', () => {
     const sessionId = data.session_id || 'default';
     const MARKER_FILE = sessionMarkerPath(sessionId);
     const hit = findProjectFiles(cwd);
+
+    // Observed-base snapshot for the write=proposal gate. Deliberately AFTER gitPull: the base must
+    // describe the tree this session actually starts from, remote merges
+    // included, or the first close would raise a proposal against content the
+    // session never had a chance to conflict with. Once per session
+    // (existence-check inside snapshotBase), so resume and compact leave it
+    // alone. `data.session_id` is used raw rather than the 'default' fallback
+    // above. A session with no id has no base and closes down the legacy
+    // direct-write path.
+    if (data.session_id) {
+      snapshotBase(HYPO_DIR, data.session_id, overwriteTargets(hit ? hit.proj : null));
+    }
 
     const ignorePatterns = loadHypoIgnore(HYPO_DIR);
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -46,6 +46,15 @@ import { parseFrontmatter as libParseFrontmatter } from '../scripts/lib/frontmat
 import { isHypomnemaPluginEnabled } from '../scripts/lib/plugin-detect.mjs';
 import { readPageUsage, aggregateColdCandidates } from '../scripts/lib/page-usage.mjs';
 import {
+  hashContent as bsHashContent,
+  hashFile as bsHashFile,
+  basePath as bsBasePath,
+  snapshotBase,
+  readBaseEntry,
+  advanceBase,
+  overwriteTargets,
+} from '../hooks/base-store.mjs';
+import {
   validateChangelog,
   validateTagBody,
   countHangul,
@@ -1915,10 +1924,7 @@ test('a task with a terminal status → false', () => {
 });
 
 test('a task with no status field → true (unknown = not yet terminal)', () => {
-  assert.equal(
-    hasPendingBackgroundWork({ background_tasks: [{ type: 'subagent' }] }),
-    true,
-  );
+  assert.equal(hasPendingBackgroundWork({ background_tasks: [{ type: 'subagent' }] }), true);
 });
 
 test('a non-subagent (shell) task counts too → true (widened past subagent-only)', () => {
@@ -1963,7 +1969,8 @@ test('a correlated "아직" AskUserQuestion answer → true (declined)', () => {
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
+              content:
+                'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
             },
           ],
         },
@@ -1985,7 +1992,8 @@ test('decline followed by a NEW user close signal → false (re-arm)', () => {
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
+              content:
+                'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
             },
           ],
         },
@@ -2075,7 +2083,8 @@ test('decline, then an ASSISTANT text block saying "세션 마무리" → still 
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
+              content:
+                'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
             },
           ],
         },
@@ -2084,7 +2093,9 @@ test('decline, then an ASSISTANT text block saying "세션 마무리" → still 
         type: 'assistant',
         message: {
           role: 'assistant',
-          content: [{ type: 'text', text: '알겠습니다, 아직 세션 마무리는 하지 않고 계속 진행하겠습니다.' }],
+          content: [
+            { type: 'text', text: '알겠습니다, 아직 세션 마무리는 하지 않고 계속 진행하겠습니다.' },
+          ],
         },
       },
     ]);
@@ -2108,7 +2119,8 @@ test('decline, then a tool_result containing a close phrase → still declined (
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
+              content:
+                'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
             },
           ],
         },
@@ -2151,7 +2163,8 @@ test('an UNRELATED AskUserQuestion answered with "나중" → false (does not co
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "어떤 색을 원하세요?"="나중에 정할게요". continue.',
+              content:
+                'Your questions have been answered: "어떤 색을 원하세요?"="나중에 정할게요". continue.',
             },
           ],
         },
@@ -2177,7 +2190,8 @@ test('the real close-reconfirm prompt ("지금 닫기" in input) + "아직, 계�
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "지금 세션을 닫을까요?"="아직, 계속". continue.',
+              content:
+                'Your questions have been answered: "지금 세션을 닫을까요?"="아직, 계속". continue.',
             },
           ],
         },
@@ -8730,9 +8744,7 @@ test('session-state with a stray working_dir → warn, not error', () => {
   );
   assert.equal(r.status, 0, `forbidden-field must be a warn, not a lint failure: ${r.stdout}`);
   assert.ok(
-    out.warns.some(
-      (w) => w.message.includes('working_dir') && w.message.includes('session-state'),
-    ),
+    out.warns.some((w) => w.message.includes('working_dir') && w.message.includes('session-state')),
     `expected working_dir forbidden-field warn: ${r.stdout}`,
   );
 });
@@ -14304,7 +14316,8 @@ test('a correlated "아직, 계속" decline suppresses the reconfirm → continu
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
+              content:
+                'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
             },
           ],
         },
@@ -14338,7 +14351,8 @@ test('a NEW user close signal after a decline re-arms the reconfirm → block ag
             {
               type: 'tool_result',
               tool_use_id: 'q1',
-              content: 'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
+              content:
+                'Your questions have been answered: "지금 닫을까요?"="아직, 계속". continue.',
             },
           ],
         },
@@ -14414,8 +14428,15 @@ test('genuine close-now + uncommitted, no decline → still reconfirm block (no 
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
-    assert.equal(out.decision, 'block', `close-now with uncommitted work must still reconfirm: ${JSON.stringify(out)}`);
-    assert.ok(/AskUserQuestion/.test(out.reason), `must still instruct AskUserQuestion: ${out.reason}`);
+    assert.equal(
+      out.decision,
+      'block',
+      `close-now with uncommitted work must still reconfirm: ${JSON.stringify(out)}`,
+    );
+    assert.ok(
+      /AskUserQuestion/.test(out.reason),
+      `must still instruct AskUserQuestion: ${out.reason}`,
+    );
   });
 });
 
@@ -14439,8 +14460,14 @@ test('non-work-incomplete blocker only (git-clean, close blocker) → existing c
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block');
-    assert.ok(/crystallize/.test(out.reason), `must keep the crystallize recovery command: ${out.reason}`);
-    assert.ok(!/AskUserQuestion/.test(out.reason), `must NOT reconfirm on a non-work-incomplete blocker: ${out.reason}`);
+    assert.ok(
+      /crystallize/.test(out.reason),
+      `must keep the crystallize recovery command: ${out.reason}`,
+    );
+    assert.ok(
+      !/AskUserQuestion/.test(out.reason),
+      `must NOT reconfirm on a non-work-incomplete blocker: ${out.reason}`,
+    );
   });
 });
 
@@ -14459,8 +14486,14 @@ test('git-clean + in-flight subagent in background_tasks → reconfirm block', (
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block');
-    assert.ok(/AskUserQuestion/.test(out.reason), `in-flight subagent must trigger reconfirm: ${out.reason}`);
-    assert.ok(!/crystallize/.test(out.reason), `reconfirm must not name crystallize: ${out.reason}`);
+    assert.ok(
+      /AskUserQuestion/.test(out.reason),
+      `in-flight subagent must trigger reconfirm: ${out.reason}`,
+    );
+    assert.ok(
+      !/crystallize/.test(out.reason),
+      `reconfirm must not name crystallize: ${out.reason}`,
+    );
   });
 });
 
@@ -14486,8 +14519,14 @@ test('git-clean + running shell background task → reconfirm block', () => {
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block');
-    assert.ok(/AskUserQuestion/.test(out.reason), `running shell task must trigger reconfirm: ${out.reason}`);
-    assert.ok(!/crystallize/.test(out.reason), `reconfirm must not name crystallize: ${out.reason}`);
+    assert.ok(
+      /AskUserQuestion/.test(out.reason),
+      `running shell task must trigger reconfirm: ${out.reason}`,
+    );
+    assert.ok(
+      !/crystallize/.test(out.reason),
+      `reconfirm must not name crystallize: ${out.reason}`,
+    );
   });
 });
 
@@ -14506,7 +14545,10 @@ test('git-clean + non-empty session_crons → reconfirm block', () => {
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block');
-    assert.ok(/AskUserQuestion/.test(out.reason), `scheduled cron wake must trigger reconfirm: ${out.reason}`);
+    assert.ok(
+      /AskUserQuestion/.test(out.reason),
+      `scheduled cron wake must trigger reconfirm: ${out.reason}`,
+    );
   });
 });
 
@@ -14527,8 +14569,14 @@ test('git-clean + only terminal shell background task → existing crystallize w
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block');
-    assert.ok(/crystallize/.test(out.reason), `terminal shell task must keep crystallize wording: ${out.reason}`);
-    assert.ok(!/AskUserQuestion/.test(out.reason), `terminal shell task must NOT reconfirm: ${out.reason}`);
+    assert.ok(
+      /crystallize/.test(out.reason),
+      `terminal shell task must keep crystallize wording: ${out.reason}`,
+    );
+    assert.ok(
+      !/AskUserQuestion/.test(out.reason),
+      `terminal shell task must NOT reconfirm: ${out.reason}`,
+    );
   });
 });
 
@@ -14550,7 +14598,10 @@ test('absent background_tasks + uncommitted → in-flight fails open, git alone 
     assert.equal(r.stderr, '', `no exception expected on absent background_tasks: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block');
-    assert.ok(/AskUserQuestion/.test(out.reason), `uncommitted alone must still reconfirm: ${out.reason}`);
+    assert.ok(
+      /AskUserQuestion/.test(out.reason),
+      `uncommitted alone must still reconfirm: ${out.reason}`,
+    );
   });
 });
 
@@ -14569,7 +14620,10 @@ test('absent background_tasks + git-clean + close blocker only → existing crys
     assert.equal(r.stderr, '', `no exception expected on absent background_tasks: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.equal(out.decision, 'block');
-    assert.ok(/crystallize/.test(out.reason), `git-clean + absent background_tasks must keep crystallize wording: ${out.reason}`);
+    assert.ok(
+      /crystallize/.test(out.reason),
+      `git-clean + absent background_tasks must keep crystallize wording: ${out.reason}`,
+    );
   });
 });
 
@@ -25082,8 +25136,15 @@ test('currentDevice: a CR/LF-only HYPO_DEVICE collapses to fallback, never empty
     // scopeVisible('machine:', device) pass and unhide the empty-owner page).
     process.env.HYPO_DEVICE = '\r\n';
     const d = currentDevice();
-    assert.ok(d.length > 0, `CR/LF-only device must fall back to non-empty, got ${JSON.stringify(d)}`);
-    assert.equal(scopeVisible('machine:', d), false, 'empty-owner machine: must stay hidden under the fallback device');
+    assert.ok(
+      d.length > 0,
+      `CR/LF-only device must fall back to non-empty, got ${JSON.stringify(d)}`,
+    );
+    assert.equal(
+      scopeVisible('machine:', d),
+      false,
+      'empty-owner machine: must stay hidden under the fallback device',
+    );
   } finally {
     if (prev === undefined) delete process.env.HYPO_DEVICE;
     else process.env.HYPO_DEVICE = prev;
@@ -25113,10 +25174,7 @@ test('scopeVisible: empty owner (machine:) hides everywhere', () => {
 suite('scope: readVisibilityScope reader');
 
 test('readVisibilityScope strips an inline YAML comment', () => {
-  assert.equal(
-    readVisibilityScope('---\nvisibility_scope: machine:a # note\n---\n'),
-    'machine:a',
-  );
+  assert.equal(readVisibilityScope('---\nvisibility_scope: machine:a # note\n---\n'), 'machine:a');
 });
 
 test('readVisibilityScope is first-wins on a repeated key', () => {
@@ -25215,8 +25273,14 @@ test('non-owning device whose only match is machine-scoped: clean miss, no leak,
     const out = JSON.parse(r.stdout);
     const ctx = out.additionalContext ?? '';
     assert.ok(!ctx.includes('devA-only'), `machine:devA slug must not leak: ${ctx}`);
-    assert.ok(!ctx.includes('files missing'), `a hidden-only match must not report "files missing": ${ctx}`);
-    assert.ok(ctx.includes('LOOKUP: miss'), `a hidden-only match must take the clean miss path: ${ctx}`);
+    assert.ok(
+      !ctx.includes('files missing'),
+      `a hidden-only match must not report "files missing": ${ctx}`,
+    );
+    assert.ok(
+      ctx.includes('LOOKUP: miss'),
+      `a hidden-only match must take the clean miss path: ${ctx}`,
+    );
   });
 });
 
@@ -25237,12 +25301,19 @@ test('miss path survives an unstat-able entry in the page tree (buildPageMap ski
   withTmpDir((dir) => {
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'index.md'), '# Index\n- [[real-note]] — apple banana cherry\n');
-    writeFileSync(join(dir, 'pages', 'real-note.md'), '---\ntype: page\ntitle: Real\n---\n# apple banana cherry\n');
+    writeFileSync(
+      join(dir, 'pages', 'real-note.md'),
+      '---\ntype: page\ntitle: Real\n---\n# apple banana cherry\n',
+    );
     // A dangling symlink makes statSync throw. Because the page tree is now
     // scanned BEFORE the miss branch, an unguarded throw would sink the whole
     // lookup into the silent outer catch instead of the clean miss message.
     symlinkSync(join(dir, 'pages', 'nonexistent-target.md'), join(dir, 'pages', 'dangling.md'));
-    const r = runHook('hypo-lookup.mjs', { prompt: 'zzqqxx nomatch' }, { HYPO_DIR: dir, HYPO_DEVICE: 'devB' });
+    const r = runHook(
+      'hypo-lookup.mjs',
+      { prompt: 'zzqqxx nomatch' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
     const ctx = JSON.parse(r.stdout).additionalContext ?? '';
     assert.ok(
       ctx.includes('LOOKUP: miss'),
@@ -25312,10 +25383,7 @@ test('hypo-file-watch: machine-scoped page is not injected on a non-owning devic
   const dir = mkdtempSync(join(tmpdir(), 'hypo-fw-'));
   try {
     const filePath = join(dir, 'hot.md');
-    writeFileSync(
-      filePath,
-      '---\nvisibility_scope: machine:devA\n---\n\n# hot\n\nbody text\n',
-    );
+    writeFileSync(filePath, '---\nvisibility_scope: machine:devA\n---\n\n# hot\n\nbody text\n');
     const r = runHook(
       'hypo-file-watch.mjs',
       { file_path: filePath },
@@ -25333,10 +25401,7 @@ test('hypo-file-watch: machine-scoped page is injected on its owning device', ()
   const dir = mkdtempSync(join(tmpdir(), 'hypo-fw-'));
   try {
     const filePath = join(dir, 'hot.md');
-    writeFileSync(
-      filePath,
-      '---\nvisibility_scope: machine:devA\n---\n\n# hot\n\nbody text\n',
-    );
+    writeFileSync(filePath, '---\nvisibility_scope: machine:devA\n---\n\n# hot\n\nbody text\n');
     const r = runHook(
       'hypo-file-watch.mjs',
       { file_path: filePath },
@@ -25450,7 +25515,10 @@ test('graph invariant: a shared page whose sole inbound link comes from a machin
     assert.equal(asDevB.status, 'ok');
     const inA = asDevA.candidates.some((c) => c.slug === 'pages/shared-target');
     const inB = asDevB.candidates.some((c) => c.slug === 'pages/shared-target');
-    assert.ok(inA, `shared-target must be a cold candidate on devA: ${JSON.stringify(asDevA.candidates)}`);
+    assert.ok(
+      inA,
+      `shared-target must be a cold candidate on devA: ${JSON.stringify(asDevA.candidates)}`,
+    );
     assert.equal(
       inA,
       inB,
@@ -25535,7 +25603,11 @@ function scopeVaultX10(dir, { withMachine = true } = {}) {
 }
 
 function lookupCtxX10(dir, device) {
-  const r = runHook('hypo-lookup.mjs', { prompt: 'xyzzy plover' }, { HYPO_DIR: dir, HYPO_DEVICE: device });
+  const r = runHook(
+    'hypo-lookup.mjs',
+    { prompt: 'xyzzy plover' },
+    { HYPO_DIR: dir, HYPO_DEVICE: device },
+  );
   return JSON.parse(r.stdout).additionalContext ?? '';
 }
 
@@ -25552,7 +25624,9 @@ function withDeviceX10(device, fn) {
 
 function querySlugsX10(dir, device, q = 'xyzzy') {
   return withDeviceX10(device, () =>
-    JSON.parse(run('query.mjs', [`--hypo-dir=${dir}`, `--q=${q}`, '--json']).stdout).map((x) => x.slug),
+    JSON.parse(run('query.mjs', [`--hypo-dir=${dir}`, `--q=${q}`, '--json']).stdout).map(
+      (x) => x.slug,
+    ),
   );
 }
 
@@ -25578,17 +25652,31 @@ test('injection surfaces (lookup + query + file-watch) withhold machine:devA fro
     const ctxB = lookupCtxX10(dir, 'devB');
     assert.ok(!ctxB.includes('devA-note'), `lookup must not inject machine:devA on devB: ${ctxB}`);
     assert.ok(ctxB.includes('shared-note'), 'lookup must still inject the fieldless page on devB');
-    assert.ok(lookupCtxX10(dir, 'devA').includes('devA-note'), 'lookup must inject machine:devA on devA');
+    assert.ok(
+      lookupCtxX10(dir, 'devA').includes('devA-note'),
+      'lookup must inject machine:devA on devA',
+    );
     const qB = querySlugsX10(dir, 'devB');
     assert.ok(!qB.includes('pages/devA-note'), `query must hide machine:devA on devB: ${qB}`);
     assert.ok(qB.includes('pages/shared-note'), 'query must keep the fieldless page on devB');
-    assert.ok(querySlugsX10(dir, 'devA').includes('pages/devA-note'), 'query must show machine:devA on devA');
+    assert.ok(
+      querySlugsX10(dir, 'devA').includes('pages/devA-note'),
+      'query must show machine:devA on devA',
+    );
     const fwB = JSON.parse(
-      runHook('hypo-file-watch.mjs', { file_path: join(dir, 'pages', 'devA-note.md') }, { HYPO_DIR: dir, HYPO_DEVICE: 'devB' }).stdout,
+      runHook(
+        'hypo-file-watch.mjs',
+        { file_path: join(dir, 'pages', 'devA-note.md') },
+        { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+      ).stdout,
     );
     assert.ok(!('additionalContext' in fwB), 'file-watch must not inject machine:devA on devB');
     const fwA = JSON.parse(
-      runHook('hypo-file-watch.mjs', { file_path: join(dir, 'pages', 'devA-note.md') }, { HYPO_DIR: dir, HYPO_DEVICE: 'devA' }).stdout,
+      runHook(
+        'hypo-file-watch.mjs',
+        { file_path: join(dir, 'pages', 'devA-note.md') },
+        { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
+      ).stdout,
     );
     assert.ok('additionalContext' in fwA, 'file-watch must inject machine:devA on devA');
   });
@@ -25599,19 +25687,32 @@ test('aggregation surfaces (crystallize candidate + cold) withhold machine:devA 
     // hub gives the machine page an inbound link (cold candidacy) while the
     // machine page keeps no outbound links (crystallize `unlinked` candidacy).
     mkdirSync(join(dir, 'pages'), { recursive: true });
-    writeFileSync(join(dir, 'pages', 'hub.md'), '---\ntype: page\ntitle: Hub\n---\n# Hub\n[[machine-page]]\n');
+    writeFileSync(
+      join(dir, 'pages', 'hub.md'),
+      '---\ntype: page\ntitle: Hub\n---\n# Hub\n[[machine-page]]\n',
+    );
     writeFileSync(
       join(dir, 'pages', 'machine-page.md'),
       '---\ntype: page\ntitle: Machine Page\nvisibility_scope: machine:devA\n---\n# Machine Page body\n',
     );
     const unlinkedB = withDeviceX10('devB', () =>
-      JSON.parse(run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']).stdout).unlinked.map((p) => p.slug),
+      JSON.parse(run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']).stdout).unlinked.map(
+        (p) => p.slug,
+      ),
     );
-    assert.ok(!unlinkedB.includes('pages/machine-page'), `crystallize must not surface machine:devA on devB: ${unlinkedB}`);
+    assert.ok(
+      !unlinkedB.includes('pages/machine-page'),
+      `crystallize must not surface machine:devA on devB: ${unlinkedB}`,
+    );
     const unlinkedA = withDeviceX10('devA', () =>
-      JSON.parse(run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']).stdout).unlinked.map((p) => p.slug),
+      JSON.parse(run('crystallize.mjs', [`--hypo-dir=${dir}`, '--json']).stdout).unlinked.map(
+        (p) => p.slug,
+      ),
     );
-    assert.ok(unlinkedA.includes('pages/machine-page'), `crystallize must surface machine:devA on devA: ${unlinkedA}`);
+    assert.ok(
+      unlinkedA.includes('pages/machine-page'),
+      `crystallize must surface machine:devA on devA: ${unlinkedA}`,
+    );
     const nowX10 = Date.parse('2026-07-04T00:00:00Z');
     mkdirSync(join(dir, '.cache'), { recursive: true });
     writeFileSync(
@@ -25621,10 +25722,20 @@ test('aggregation surfaces (crystallize candidate + cold) withhold machine:devA 
         JSON.stringify({ ts: new Date(nowX10 - 86400000).toISOString(), slug: 'anchor2' }) +
         '\n',
     );
-    const coldB = aggregateColdCandidates(dir, { now: nowX10, device: 'devB' }).candidates.map((c) => c.slug);
-    assert.ok(!coldB.includes('pages/machine-page'), `cold aggregation must exclude machine:devA on devB: ${coldB}`);
-    const coldA = aggregateColdCandidates(dir, { now: nowX10, device: 'devA' }).candidates.map((c) => c.slug);
-    assert.ok(coldA.includes('pages/machine-page'), `cold aggregation must include machine:devA on devA: ${coldA}`);
+    const coldB = aggregateColdCandidates(dir, { now: nowX10, device: 'devB' }).candidates.map(
+      (c) => c.slug,
+    );
+    assert.ok(
+      !coldB.includes('pages/machine-page'),
+      `cold aggregation must exclude machine:devA on devB: ${coldB}`,
+    );
+    const coldA = aggregateColdCandidates(dir, { now: nowX10, device: 'devA' }).candidates.map(
+      (c) => c.slug,
+    );
+    assert.ok(
+      coldA.includes('pages/machine-page'),
+      `cold aggregation must include machine:devA on devA: ${coldA}`,
+    );
   });
 });
 
@@ -25643,6 +25754,277 @@ test('inline-comment machine:devA # note is honored on its own machine and hidde
       !querySlugsX10(dir, 'devB', 'grault').includes('pages/commented'),
       'inline-comment machine:devA must hide on devB',
     );
+  });
+});
+
+// ── hooks.json shared coverage ───────────────────────────────────────────────
+
+suite('hooks/hooks.json — "shared" covers every intra-hooks import');
+
+test('every relative import of a registered hook resolves to a file upgrade actually copies', () => {
+  // `init.mjs installHooks` readdir-copies every hooks/*.mjs, but `upgrade.mjs
+  // checkHookFiles` only walks HOOK_MAP command targets + hooks.json "shared".
+  // A helper missing from "shared" therefore installs fine on a FRESH vault and
+  // breaks only on `upgrade --apply` for existing users: the refreshed hook lands
+  // without its import and Node dies on module resolution, before any best-effort
+  // guard can run. The list is hand-maintained, so pin it mechanically.
+  const cfg = JSON.parse(readFileSync(join(HOOKS, 'hooks.json'), 'utf-8'));
+  const commandFiles = new Set();
+  for (const groups of Object.values(cfg.hooks)) {
+    for (const group of groups) {
+      const hooks = typeof group === 'string' ? [{ command: group }] : group.hooks;
+      for (const h of hooks) {
+        const m = String(h.command).match(/([\w.-]+\.mjs)/);
+        if (m) commandFiles.add(m[1]);
+      }
+    }
+  }
+  const covered = new Set([...commandFiles, ...cfg.shared]);
+  const missing = [];
+  for (const file of covered) {
+    const src = join(HOOKS, file);
+    if (!existsSync(src)) continue;
+    const text = readFileSync(src, 'utf-8');
+    for (const m of text.matchAll(/from\s+'\.\/([\w.-]+\.mjs)'/g)) {
+      if (!covered.has(m[1])) missing.push(`${file} imports ./${m[1]}`);
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    `intra-hooks imports not covered by hooks.json (add to "shared"): ${missing.join(', ')}`,
+  );
+});
+
+// ── FEAT-11 base-store (T2) ──────────────────────────────────────────────────
+
+suite('base-store.mjs — per-session observed-base snapshot (FEAT-11 T2)');
+
+function withBaseWiki(fn) {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'projects', 'p1'), { recursive: true });
+    writeFileSync(join(dir, 'hypo-config.md'), '# config\n');
+    writeFileSync(join(dir, 'hot.md'), '# root hot\n');
+    writeFileSync(join(dir, 'pages', 'open-questions.md'), '# open questions\n');
+    writeFileSync(join(dir, 'projects', 'p1', 'hot.md'), '# p1 hot\n');
+    writeFileSync(join(dir, 'projects', 'p1', 'session-state.md'), '# p1 state\n');
+    fn(dir);
+  });
+}
+
+test('hashContent is stable and hashFile returns null for an absent file', () => {
+  assert.equal(bsHashContent('abc'), bsHashContent('abc'));
+  assert.notEqual(bsHashContent('abc'), bsHashContent('abd'));
+  withBaseWiki((dir) => {
+    assert.equal(bsHashFile(join(dir, 'nope.md')), null, 'absent file must hash to null');
+    assert.equal(bsHashFile(join(dir, 'hot.md')), bsHashContent('# root hot\n'));
+  });
+});
+
+test('overwriteTargets covers the four overwrite pages, and omits project pages with no project', () => {
+  assert.deepEqual(overwriteTargets('p1').sort(), [
+    'hot.md',
+    join('pages', 'open-questions.md'),
+    join('projects', 'p1', 'hot.md'),
+    join('projects', 'p1', 'session-state.md'),
+  ]);
+  assert.deepEqual(overwriteTargets(null), ['hot.md', join('pages', 'open-questions.md')]);
+});
+
+test('snapshotBase records a hash per target and an observed-absent target as null', () => {
+  withBaseWiki((dir) => {
+    rmSync(join(dir, 'pages', 'open-questions.md'));
+    const r = snapshotBase(dir, 's1', overwriteTargets('p1'));
+    assert.equal(r.created, true);
+    const parsed = JSON.parse(readFileSync(bsBasePath(dir, 's1'), 'utf-8'));
+    assert.equal(parsed.session_id, 's1');
+    assert.equal(parsed.targets['hot.md'], bsHashContent('# root hot\n'));
+    assert.equal(
+      parsed.targets[join('pages', 'open-questions.md')],
+      null,
+      'observed-absent target must be recorded as null, not omitted',
+    );
+  });
+});
+
+test('snapshotBase is existence-checked: a second call does not move the base (정합성 요건)', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    const before = readBaseEntry(dir, 's1', 'hot.md').hash;
+    // another session (or another machine's pull) rewrites the page
+    writeFileSync(join(dir, 'hot.md'), '# rewritten by someone else\n');
+    const r = snapshotBase(dir, 's1', overwriteTargets('p1'));
+    assert.equal(r.created, false);
+    assert.equal(r.reason, 'already-snapshotted');
+    assert.equal(
+      readBaseEntry(dir, 's1', 'hot.md').hash,
+      before,
+      'resume/compact must NOT re-snapshot: doing so silently clobbers the other writer',
+    );
+  });
+});
+
+test('snapshotBase with no session id is a no-op', () => {
+  withBaseWiki((dir) => {
+    const r = snapshotBase(dir, '', overwriteTargets('p1'));
+    assert.equal(r.created, false);
+    assert.equal(r.reason, 'no-session-id');
+    assert.equal(existsSync(join(dir, '.cache', 'sessions')), false);
+  });
+});
+
+test('readBaseEntry discriminates hash / absent / unknown so consumers cannot collapse them', () => {
+  withBaseWiki((dir) => {
+    rmSync(join(dir, 'pages', 'open-questions.md'));
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    assert.deepEqual(readBaseEntry(dir, 's1', join('pages', 'open-questions.md')), {
+      state: 'absent',
+      hash: null,
+    });
+    assert.equal(readBaseEntry(dir, 's1', join('projects', 'p1', 'hot.md')).state, 'hash');
+    assert.equal(readBaseEntry(dir, 's1', 'projects/other/hot.md').state, 'unknown');
+    assert.equal(readBaseEntry(dir, 'no-such-session', 'hot.md').state, 'unknown');
+    assert.equal(readBaseEntry(dir, '', 'hot.md').state, 'unknown');
+    // the whole point of the discriminator: both non-'hash' states carry
+    // hash === null, so a consumer must never branch on hash truthiness
+    assert.equal(readBaseEntry(dir, 's1', join('pages', 'open-questions.md')).hash, null);
+    assert.equal(readBaseEntry(dir, 's1', 'projects/other/hot.md').hash, null);
+  });
+});
+
+test('readBaseEntry treats a malformed base.json as unknown, not as unchanged', () => {
+  withBaseWiki((dir) => {
+    const p = bsBasePath(dir, 's1');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, 'not json at all');
+    assert.equal(readBaseEntry(dir, 's1', 'hot.md').state, 'unknown');
+    // a structurally valid file whose entry is not a hash is equally untrusted
+    writeFileSync(p, JSON.stringify({ targets: { 'hot.md': 42, 'log.md': '' } }));
+    assert.equal(readBaseEntry(dir, 's1', 'hot.md').state, 'unknown');
+    assert.equal(readBaseEntry(dir, 's1', 'log.md').state, 'unknown');
+  });
+});
+
+test('advanceBase moves one target and no-ops when the session has no snapshot', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    const next = bsHashContent('# written by this session\n');
+    assert.equal(advanceBase(dir, 's1', 'hot.md', next), true);
+    assert.equal(readBaseEntry(dir, 's1', 'hot.md').hash, next);
+    assert.equal(
+      readBaseEntry(dir, 's1', join('projects', 'p1', 'hot.md')).hash,
+      bsHashContent('# p1 hot\n'),
+      'advancing one target must not disturb the others',
+    );
+    assert.equal(advanceBase(dir, 'no-snapshot-session', 'hot.md', next), false);
+  });
+});
+
+// ── FEAT-11 SessionStart base snapshot (T3) ──────────────────────────────────
+
+suite('hypo-session-start.mjs — observed-base snapshot once per session (FEAT-11 T3)');
+
+function withBaseProject(fn) {
+  withBaseWiki((dir) => {
+    const work = mkdtempSync(join(tmpdir(), 'hypo-base-work-'));
+    writeFileSync(
+      join(dir, 'projects', 'p1', 'index.md'),
+      `---\ntitle: p1\ntype: project-index\nupdated: 2026-07-08\nworking_dir: "${work}"\n---\n# P1\n`,
+    );
+    try {
+      fn(dir, work);
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+}
+
+test('first SessionStart snapshots all four overwrite targets', () => {
+  withBaseProject((dir, work) => {
+    const r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'ss-1' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const parsed = JSON.parse(readFileSync(bsBasePath(dir, 'ss-1'), 'utf-8'));
+    assert.deepEqual(Object.keys(parsed.targets).sort(), [
+      'hot.md',
+      join('pages', 'open-questions.md'),
+      join('projects', 'p1', 'hot.md'),
+      join('projects', 'p1', 'session-state.md'),
+    ]);
+    assert.equal(parsed.targets[join('projects', 'p1', 'hot.md')], bsHashContent('# p1 hot\n'));
+  });
+});
+
+test('resume (same session_id) after an external write does NOT re-snapshot the base', () => {
+  // The whole gate hinges on this. T1's spike showed SessionStart fires again on
+  // resume AND on compact with the same session_id; re-snapshotting there would
+  // adopt the other writer's content as this session's base, so close would see
+  // no drift and overwrite it. A single-session test passes either way, which is
+  // why this regression exists.
+  withBaseProject((dir, work) => {
+    runHook('hypo-session-start.mjs', { cwd: work, session_id: 'ss-2' }, { HYPO_DIR: dir });
+    const before = readBaseEntry(dir, 'ss-2', 'hot.md').hash;
+    writeFileSync(join(dir, 'hot.md'), '# the OTHER session wrote this\n');
+    const r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'ss-2', source: 'resume' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(
+      readBaseEntry(dir, 'ss-2', 'hot.md').hash,
+      before,
+      'resume must not move the base',
+    );
+    assert.notEqual(
+      readBaseEntry(dir, 'ss-2', 'hot.md').hash,
+      bsHashContent('# the OTHER session wrote this\n'),
+    );
+  });
+});
+
+test('a NEW session_id (what /clear mints) snapshots fresh from disk', () => {
+  withBaseProject((dir, work) => {
+    runHook('hypo-session-start.mjs', { cwd: work, session_id: 'ss-3a' }, { HYPO_DIR: dir });
+    writeFileSync(join(dir, 'hot.md'), '# post-clear disk state\n');
+    runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'ss-3b', source: 'clear' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(
+      readBaseEntry(dir, 'ss-3b', 'hot.md').hash,
+      bsHashContent('# post-clear disk state\n'),
+      'a cleared session restarts its observation from disk',
+    );
+  });
+});
+
+test('SessionStart with no session_id writes no base and still succeeds', () => {
+  withBaseProject((dir, work) => {
+    const r = runHook('hypo-session-start.mjs', { cwd: work }, { HYPO_DIR: dir });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(existsSync(join(dir, '.cache', 'sessions')), false);
+  });
+});
+
+test('SessionStart outside any project still snapshots the two global targets', () => {
+  withBaseProject((dir) => {
+    const outside = mkdtempSync(join(tmpdir(), 'hypo-base-nowhere-'));
+    try {
+      runHook('hypo-session-start.mjs', { cwd: outside, session_id: 'ss-4' }, { HYPO_DIR: dir });
+      const parsed = JSON.parse(readFileSync(bsBasePath(dir, 'ss-4'), 'utf-8'));
+      assert.deepEqual(Object.keys(parsed.targets).sort(), [
+        'hot.md',
+        join('pages', 'open-questions.md'),
+      ]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`SessionStart` now records a sha256 of the four pages that session close overwrites (project `session-state.md`, project `hot.md`, root `hot.md`, `pages/open-questions.md`) into `<hypoDir>/.cache/sessions/<session_id>/base.json`. New helper `hooks/base-store.mjs` owns that file: snapshot, read, advance. Nothing consumes the snapshot yet; the guard that does lands in a follow-up.

`base-store.mjs` is also added to `hooks/hooks.json` `"shared"`, and a new test derives the intra-hooks import graph and fails when any edge escapes that list.

## Why

`crystallize --apply-session-close` replaces those four pages wholesale with no check on what is currently on disk. Two sessions open at once, or one session closing after a `git pull` brought in another machine's edits, and the later writer silently destroys the earlier one. There is no record of what the losing side wrote.

Detecting that needs one fact the code does not currently have: what this session saw on disk when it started. `crystallize` runs as a separate process from the session, so the observation has to be parked somewhere both can read.

## How

Two invariants do the work.

**Existence-check, not overwrite.** A spike confirmed that `SessionStart` fires again on resume and on compact carrying the *same* `session_id`, and that `/clear` mints a new one. Re-snapshotting on resume would adopt whatever another session had just written as this session's base, so close would compare the base against itself, see no drift, and clobber the other session's edits. `snapshotBase` is therefore a no-op when the session already has a snapshot (exclusive `wx` create closes the check-then-write gap). A cleared session gets a new id and correctly restarts its observation from disk.

This is the kind of bug a single-session test cannot see: it passes either way. So it is pinned by a regression test that fails when the existence-check is removed.

**A discriminated read.** `readBaseEntry` returns `{state: 'hash' | 'absent' | 'unknown'}`. Observed-absent (the file was genuinely missing, so creating it is safe) and never-observed (no snapshot, unreadable, wrong session) both carry `hash === null`. A consumer branching on `if (!entry.hash)` would read never-observed as safe-to-write and quietly defeat the guard. `'unknown'` has to fail safe into a proposal, so the state is the discriminator, not the hash.

The snapshot is taken after `gitPull`, so the base describes the tree the session actually starts from. `data.session_id` is used raw rather than the `'default'` fallback the marker path uses: a session with no id has no base and stays on the legacy direct-write path.

Everything is best-effort. A hook must never fail a session start because a cache write did not land, and read failures degrade to `'unknown'`, never to "no conflict".

**Placement.** `base-store.mjs` lives in `hooks/`, not `scripts/lib/`. `tests/runner.mjs`'s `withFakeNpmInstall` vendors `hooks/` alone ("hooks are self-contained"), and the existing dependency direction is `scripts/` importing from `hooks/`, never the reverse.

**The `"shared"` entry is load-bearing.** `init.mjs installHooks` readdir-copies every `hooks/*.mjs`, but `upgrade.mjs checkHookFiles` only walks `HOOK_MAP` command targets plus `hooks.json` `"shared"`. Without the entry, a fresh install works and an existing user's `upgrade --apply` installs the new `hypo-session-start.mjs` *without* its import, and Node dies on module resolution before any best-effort handling runs. The list is hand-maintained, so the new guard test checks it mechanically.

## Manual verification

```
node tests/runner.mjs          # 1261 passed, 0 failed (baseline on main: 1247)
npx prettier --check tests/runner.mjs hooks/base-store.mjs hooks/hooks.json   # clean
```

Mutation checks, since the two riskiest invariants are ones a passing suite would not notice:

- Removed the existence-check (`existsSync` guard + `wx` to `w`): exactly two tests fail, `snapshotBase is existence-checked` and `resume ... does NOT re-snapshot the base`. Restored: green.
- Removed `base-store.mjs` from `"shared"`: the new import-graph test fails with `hypo-session-start.mjs imports ./base-store.mjs`. Restored: green.

Hook behavior on a real deploy: committing this ran the repo's post-commit sync, which reported `base-store.mjs [not found in ~/.claude/hooks/]` and then copied it alongside the refreshed `hypo-session-start.mjs`. That is the upgrade path the `"shared"` entry fixes, observed end to end.

The `tests/runner.mjs` diff carries prettier normalization of pre-existing lines: the repo's own pre-commit formatter reformats files the commit touches, and that file was not prettier-clean on `main`. No content was changed in those hunks.

## Migration notes

None. `.cache/` is already gitignored in the vault and in the `templates/gitignore` scaffold, so `base.json` is never committed or synced. Existing installs pick up the new helper through `upgrade --apply` because of the `"shared"` entry. Sessions that never close a vault still write a small two-hash snapshot; it is cheap and follows the same pattern as the existing per-session close markers.

---

# 한국어

## 변경 내용

`SessionStart`가 세션 종료 시 통째로 덮어쓰는 네 페이지(프로젝트 `session-state.md`, 프로젝트 `hot.md`, 루트 `hot.md`, `pages/open-questions.md`)의 sha256을 `<hypoDir>/.cache/sessions/<session_id>/base.json`에 기록합니다. 새 헬퍼 `hooks/base-store.mjs`가 그 파일의 스냅샷, 조회, 전진을 맡습니다. 아직 이 스냅샷을 읽는 코드는 없고, 그걸 쓰는 가드는 후속 PR에서 들어옵니다.

`base-store.mjs`를 `hooks/hooks.json`의 `"shared"`에도 추가했고, hooks 내부 import 그래프를 뽑아 그 목록을 벗어나는 간선이 있으면 실패하는 테스트를 넣었습니다.

## 이유

`crystallize --apply-session-close`는 지금 디스크에 뭐가 있는지 보지 않고 네 페이지를 통째로 교체합니다. 세션 두 개가 동시에 열려 있거나, `git pull`로 다른 머신의 편집분이 들어온 뒤 한 세션이 닫히면, 나중에 쓰는 쪽이 앞의 것을 조용히 지웁니다. 진 쪽이 무엇을 썼는지는 어디에도 남지 않습니다.

이걸 감지하려면 코드에 지금 없는 사실 하나가 필요합니다. 이 세션이 시작할 때 디스크에서 무엇을 봤는가. `crystallize`는 세션과 별개 프로세스라서, 그 관측을 양쪽이 읽을 수 있는 곳에 세워 둬야 합니다.

## 방법

두 가지 불변식이 일을 합니다.

**덮어쓰기가 아니라 존재-검사.** 스파이크로 확인한 결과, `SessionStart`는 resume과 compact에서 *같은* `session_id`로 다시 발화하고 `/clear`만 새 id를 발급합니다. resume에서 다시 스냅샷을 뜨면 방금 다른 세션이 쓴 내용을 이 세션의 base로 삼게 되고, 그러면 close가 base를 자기 자신과 비교해 변경 없음으로 판단한 뒤 상대의 편집분을 덮어씁니다. 그래서 `snapshotBase`는 이미 스냅샷이 있는 세션에서 아무것도 하지 않습니다(검사와 쓰기 사이 틈은 배타적 `wx` 생성으로 닫았습니다). 지워진 세션은 새 id를 받아 디스크에서 관측을 다시 시작하는데, 이게 맞는 동작입니다.

이건 단일 세션 테스트가 볼 수 없는 종류의 버그입니다. 어느 쪽이든 통과하니까요. 그래서 존재-검사를 제거하면 깨지는 회귀 테스트로 못 박았습니다.

**분별 가능한 조회.** `readBaseEntry`는 `{state: 'hash' | 'absent' | 'unknown'}`을 돌려줍니다. 관측된 부재(파일이 정말 없었으니 새로 만들어도 안전)와 미관측(스냅샷 없음, 읽기 실패, 다른 세션)은 둘 다 `hash === null`입니다. 소비자가 `if (!entry.hash)`로 분기하면 미관측을 안전한 쓰기로 읽어 가드를 조용히 무력화합니다. `'unknown'`은 반드시 proposal로 fail-safe해야 하므로, 판별자는 해시가 아니라 state입니다.

스냅샷은 `gitPull` 다음에 뜹니다. base가 세션이 실제로 출발한 트리를 가리켜야 하니까요. `data.session_id`는 마커 경로가 쓰는 `'default'` 폴백 대신 원본을 씁니다. id 없는 세션은 base도 없고 기존 직접 쓰기 경로에 남습니다.

전부 best-effort입니다. 캐시 쓰기가 실패했다고 훅이 세션 시작을 막으면 안 되고, 읽기 실패는 "충돌 없음"이 아니라 `'unknown'`으로 떨어집니다.

**위치.** `base-store.mjs`는 `scripts/lib/`가 아니라 `hooks/`에 있습니다. `tests/runner.mjs`의 `withFakeNpmInstall`이 `hooks/`만 복사하면서 "hooks are self-contained"라고 못 박았고, 기존 의존 방향도 `scripts/`가 `hooks/`를 import하는 쪽이지 그 반대가 아닙니다.

**`"shared"` 항목이 결정적입니다.** `init.mjs installHooks`는 `hooks/*.mjs`를 readdir로 전부 복사하지만, `upgrade.mjs checkHookFiles`는 `HOOK_MAP` 명령 대상과 `hooks.json`의 `"shared"`만 훑습니다. 이 항목이 없으면 신규 설치는 멀쩡하고, 기존 사용자의 `upgrade --apply`가 새 `hypo-session-start.mjs`를 import 없이 설치해 best-effort 처리가 돌기도 전에 Node가 module resolution에서 죽습니다. 목록을 손으로 관리하는 구조라 새 가드 테스트가 기계적으로 검사합니다.

## 수동 검증

```
node tests/runner.mjs          # 1261 passed, 0 failed (main 기준선 1247)
npx prettier --check tests/runner.mjs hooks/base-store.mjs hooks/hooks.json   # clean
```

가장 위험한 두 불변식은 통과하는 스위트가 알아채지 못하는 종류라, 뮤테이션으로 확인했습니다.

- 존재-검사 제거(`existsSync` 가드와 `wx`를 `w`로): 정확히 두 테스트가 실패합니다. `snapshotBase is existence-checked`와 `resume ... does NOT re-snapshot the base`. 복구하니 green.
- `"shared"`에서 `base-store.mjs` 제거: 새 import 그래프 테스트가 `hypo-session-start.mjs imports ./base-store.mjs`로 실패합니다. 복구하니 green.

실제 배포 경로에서의 훅 동작: 이 커밋을 찍자 레포의 post-commit 동기화가 돌면서 `base-store.mjs [not found in ~/.claude/hooks/]`를 보고한 뒤, 갱신된 `hypo-session-start.mjs`와 함께 복사했습니다. `"shared"` 항목이 고치는 업그레이드 경로를 그대로 관찰한 셈입니다.

`tests/runner.mjs` diff에는 기존 라인의 prettier 정규화가 섞여 있습니다. 레포 자체 pre-commit 포매터가 커밋이 건드린 파일을 다시 포매팅하는데, 그 파일이 `main`에서 prettier-clean이 아니었습니다. 해당 hunk에서 내용이 바뀐 건 없습니다.

## 마이그레이션 노트

없음. `.cache/`는 볼트와 `templates/gitignore` 스캐폴드 양쪽에서 이미 gitignore되어 있어 `base.json`은 커밋도 동기화도 되지 않습니다. 기존 설치는 `"shared"` 항목 덕에 `upgrade --apply`로 새 헬퍼를 받습니다. 볼트를 닫을 일이 없는 세션도 해시 두 개짜리 작은 스냅샷을 남기는데, 저렴하고 기존 세션별 close 마커와 같은 패턴입니다.

---

## Changelog

- EN: None (internal foundation; no user-visible behavior change yet)
- KO: 없음 (내부 기반 작업, 아직 사용자에게 보이는 동작 변화 없음)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
