### PR TITLE
feat(crystallize): observed-base guard on overwrite path with base advance

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -105,6 +105,7 @@ import {
   scopeVisible,
   readVisibilityScope,
 } from '../hooks/hypo-shared.mjs';
+import { hashContent, readBaseEntry, advanceBase } from '../hooks/base-store.mjs';
 
 // This script's own absolute path. Used to print copy-pasteable recovery
 // commands as `node <SELF_SCRIPT> ...` rather than a bare `crystallize` bin,
@@ -422,17 +423,51 @@ function atomicWrite(path, content) {
   renameSync(tmp, path);
 }
 
-/** Atomic write that skips when on-disk bytes already match `content`. */
-function writeIfChanged(path, content) {
-  if (existsSync(path)) {
-    try {
-      if (readFileSync(path, 'utf-8') === content) return false; // idempotent skip
-    } catch {
-      /* fall through to overwrite */
-    }
+/**
+ * Read a target's current bytes, distinguishing "absent" from "unreadable" the
+ * same way base-store's hashFile does. The overwrite guard needs all three
+ * answers: content to compare, `null` to know creating is safe, `undefined` to
+ * refuse to guess.
+ * @returns {string|null|undefined} bytes, `null` if absent, `undefined` if unreadable
+ */
+function readTarget(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return undefined;
   }
-  atomicWrite(path, content);
-  return true;
+}
+
+/**
+ * Has the target drifted away from what this session observed at start?
+ *
+ * Branches on base-store's `state` discriminator, never on the truthiness of
+ * `hash`: 'absent' and 'unknown' both carry `hash: null`, and collapsing them
+ * would read never-observed as safe-to-write, defeating the guard entirely.
+ *
+ * @param {{state: 'hash'|'absent'|'unknown', hash: string|null}} entry
+ * @param {string|null|undefined} disk current bytes / absent / unreadable
+ * @returns {string|null} a conflict reason, or null when this session may write
+ */
+function overwriteConflictReason(entry, disk) {
+  // Cannot read what we are about to replace: fail safe, never assume unchanged.
+  if (disk === undefined) return 'target-unreadable';
+  switch (entry.state) {
+    case 'unknown':
+      // No snapshot for this (session, target). Someone else's edits could be
+      // sitting on disk and we would have no way to tell.
+      return 'base-unknown';
+    case 'absent':
+      // We observed no file. Creating it is safe; finding one now means another
+      // writer got there first.
+      return disk === null ? null : 'base-absent-target-exists';
+    case 'hash':
+      if (disk === null) return 'base-hash-target-missing';
+      return hashContent(disk) === entry.hash ? null : 'base-mismatch';
+    default:
+      return 'base-unknown';
+  }
 }
 
 /**
@@ -719,7 +754,7 @@ export function closeResultContradiction({ ok, markerWritten, markerSkipReason }
 function applySessionClose(args) {
   // Option D: early-exit fires only when NO payload was supplied.
   // Rationale: payload presence is explicit close intent and must always run
-  // the full apply path — the per-entry idempotency (writeIfChanged +
+  // the full apply path — the per-entry idempotency (overwrite's step-1 skip +
   // exact-entry append dedup) keeps re-apply cheap without short-circuiting,
   // and avoids silent-success when a same-day second close brings new bytes.
   // Payload-less invocation is treated as a cheap "already complete?" probe.
@@ -885,6 +920,10 @@ function applySessionClose(args) {
   // Append targets (session-log, log.md) are NOT filtered: appending can't
   // repair existing corruption, so a corrupt session-log must still block.
   // Warns are informational (not gated) in either pass.
+  //
+  // The filter says "about to be replaced", and the observed-base guard can later
+  // decline to replace one of these. Preflight runs before the guard, so it cannot
+  // know. Harmless: post-apply lint re-scopes the same file and blocks on it there.
   const overwriteTargets = new Set();
   if (payload.sessionState) overwriteTargets.add(join('projects', project, 'session-state.md'));
   if (payload.projectHot) overwriteTargets.add(join('projects', project, 'hot.md'));
@@ -954,11 +993,63 @@ function applySessionClose(args) {
 
   const applied = [];
   const skipped = [];
+  // Overwrite targets this apply refused to write because the page moved under
+  // it. T6 turns these into `.cache/proposals/` artifacts; here they are already
+  // enough to withhold the bytes and fail the close.
+  const conflicts = [];
 
+  /**
+   * Replace a whole page, guarded by the base this session observed at start.
+   *
+   * The step order is load-bearing, not stylistic:
+   *
+   *   1. idempotent skip (disk already equals the payload)
+   *   2. conflict (base unknown, or disk drifted away from base)
+   *   3. direct write, then advance the base
+   *
+   * Step 1 must come first for two reasons. It keeps every existing
+   * `--apply-session-close --session-id` test green (they read the payload
+   * straight off disk, so they land here before any base lookup). And it breaks
+   * the apply-then-reclose loop: once a human applies proposal P, disk == proposed
+   * == payload.content, so the next close skips before it can re-raise a conflict.
+   *
+   * Callers without `--session-id` (legacy / manual apply) sit outside the guard
+   * lifecycle: they never observed a base, so there is nothing to keep honest and
+   * they keep writing directly.
+   */
   const overwrite = (key, relPath, field) => {
     if (!field || typeof field.content !== 'string') return; // optional / absent
-    const wrote = writeIfChanged(join(args.hypoDir, relPath), field.content);
-    (wrote ? applied : skipped).push(`${key} (${relPath})`);
+    const full = join(args.hypoDir, relPath);
+    const disk = readTarget(full);
+
+    // (1) idempotent skip — preserves writeIfChanged's contract
+    if (disk === field.content) {
+      skipped.push(`${key} (${relPath})`);
+      return;
+    }
+
+    // (2) conflict, only where a session context makes a base observable
+    if (args.sessionId) {
+      const entry = readBaseEntry(args.hypoDir, args.sessionId, relPath);
+      const reason = overwriteConflictReason(entry, disk);
+      if (reason) {
+        conflicts.push({
+          key,
+          target: relPath,
+          reason,
+          baseHash: entry.hash,
+          currentHash: typeof disk === 'string' ? hashContent(disk) : null,
+          proposedContent: field.content,
+        });
+        return; // target bytes untouched
+      }
+    }
+
+    // (3) write, then the content we just wrote IS this session's new base
+    atomicWrite(full, field.content);
+    if (args.sessionId)
+      advanceBase(args.hypoDir, args.sessionId, relPath, hashContent(field.content));
+    applied.push(`${key} (${relPath})`);
   };
 
   overwrite('sessionState', join('projects', project, 'session-state.md'), payload.sessionState);
@@ -1101,7 +1192,16 @@ function applySessionClose(args) {
     const m = unknownTagRe.exec(w.message || '');
     if (m && !checkForbidden(m[1])) pendingTags.push(m[1]);
   }
-  if (pendingTags.length > 0) appendPendingTags(args.hypoDir, pendingTags);
+  // Withheld a target? Then register nothing. This close is going to be re-run
+  // once a human resolves the conflict, and its `ok:false` skips the commit below
+  // (`if (ok && args.sessionId)`) — so registering here would leave SCHEMA.md
+  // mutated, uncommitted, and absent from `applied`, i.e. a silent side effect of
+  // a close whose whole point was to write nothing. Registration is
+  // eventually-consistent by design, so deferring it to the next close costs
+  // nothing (codex W2 CONCERN).
+  if (pendingTags.length > 0 && conflicts.length === 0) {
+    appendPendingTags(args.hypoDir, pendingTags);
+  }
 
   // Post-apply lint: payload may have introduced a malformed body or
   // bad frontmatter. Surface as a distinct `stage` so caller can tell "lint
@@ -1140,7 +1240,12 @@ function applySessionClose(args) {
   const postLintOk = !postApplyCrashed && postBlocking.length === 0;
   // `let` (not const): the close-result invariant self-check below may flip this
   // to false when the settled close result is internally contradictory.
-  let ok = verification.ok && postLintOk;
+  //
+  // A withheld conflict target must fail the close on its own, not merely via the
+  // freshness gate. If the other session already touched that page TODAY, freshness
+  // sees a fresh file and passes — and the close would report ok:true, write the
+  // marker, and drop this session's payload silently. `conflicts` closes that hole.
+  let ok = verification.ok && postLintOk && conflicts.length === 0;
 
   // Scope the non-blocking notice to the close-target project: debt under
   // projects/<project>/ stays listed; debt elsewhere folds to a count so the
@@ -1214,13 +1319,18 @@ function applySessionClose(args) {
       }
     }
   }
+  // A conflict outranks the downstream gates: verification and lint both describe
+  // a tree this apply declined to finish writing, so naming them would point the
+  // reader at the wrong repair.
   let stage = ok
     ? null
-    : !verification.ok && !postLintOk
-      ? 'post-apply-verification+lint'
-      : !verification.ok
-        ? 'post-apply-verification'
-        : 'post-apply-lint';
+    : conflicts.length > 0
+      ? 'proposal-pending'
+      : !verification.ok && !postLintOk
+        ? 'post-apply-verification+lint'
+        : !verification.ok
+          ? 'post-apply-verification'
+          : 'post-apply-lint';
   // Runtime close-result invariant self-check. When a
   // marker-write path (args.sessionId present) settles into an internally
   // contradictory shape — ok:true with the marker silently withheld and no
@@ -1251,6 +1361,10 @@ function applySessionClose(args) {
     date,
     applied,
     skipped,
+    // Targets withheld because the page drifted from this session's observed base.
+    // `proposedContent` is dropped from the reported shape (it is the whole payload
+    // field, and T6 parks it in the proposal artifact instead).
+    conflicts: conflicts.map(({ proposedContent: _drop, ...rest }) => rest),
     verification,
     // Surface the marker outcome instead of skipping silently, so the
     // caller can tell "closed" from "applied but not marked".
@@ -1276,6 +1390,13 @@ function applySessionClose(args) {
     console.log(`Session-close apply (project: ${project}, date: ${date}):`);
     for (const a of applied) console.log(`  ✓ wrote ${a}`);
     for (const s of skipped) console.log(`  · skipped ${s} (already current)`);
+    // Never let a withheld target read as a skip: `skipped` means "already current",
+    // this means "your bytes are NOT on disk and someone else's are".
+    for (const c of conflicts) {
+      console.log(
+        `  ⚠ WITHHELD ${c.key} (${c.target}) — ${c.reason}; the page changed since this session read it`,
+      );
+    }
     if (ok) {
       // When the marker was withheld, qualify the success line so a reader scanning
       // stdout alone cannot mistake "verified" for "fully closed". markerSkipReason

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -26028,6 +26028,212 @@ test('SessionStart outside any project still snapshots the two global targets', 
   });
 });
 
+// ── FEAT-11 overwrite observed-base guard (T4) ───────────────────────────────
+
+suite('crystallize.mjs — overwrite observed-base guard (FEAT-11 T4)');
+
+const T4_PROJECT = 'test-project';
+const t4ProjectHot = (dir) => join(dir, 'projects', T4_PROJECT, 'hot.md');
+const t4Rel = join('projects', T4_PROJECT, 'hot.md');
+
+/**
+ * An apply payload whose sessionState / rootHot mirror disk (so they hit the
+ * idempotent skip and stay out of the way) and whose projectHot carries
+ * `projectHotContent` — the single target each T4 test exercises.
+ */
+function t4Payload(dir, today, projectHotContent, tag) {
+  return {
+    project: T4_PROJECT,
+    date: today,
+    sessionState: {
+      content: readFileSync(join(dir, 'projects', T4_PROJECT, 'session-state.md'), 'utf-8'),
+    },
+    projectHot: { content: projectHotContent },
+    rootHot: { content: readFileSync(join(dir, 'hot.md'), 'utf-8') },
+    sessionLog: { entry: `## [${today}] ${tag}\n` },
+    log: { entry: `## [${today}] session | ${T4_PROJECT} — ${tag}\n` },
+  };
+}
+
+function t4Apply(dir, payload, sessionId) {
+  const payloadPath = join(dir, `.payload-${sessionId || 'none'}.json`);
+  writeFileSync(payloadPath, JSON.stringify(payload));
+  const argv = [`--hypo-dir=${dir}`, '--apply-session-close', `--payload=${payloadPath}`, '--json'];
+  if (sessionId) argv.push(`--session-id=${sessionId}`);
+  const r = run('crystallize.mjs', argv);
+  return { r, out: JSON.parse(r.stdout) };
+}
+
+test('base matches disk → direct write, no conflict, and the base advances', () => {
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-clean', overwriteTargets(T4_PROJECT));
+    const next = `${readFileSync(t4ProjectHot(dir), 'utf-8')}\nthis session wrote this.\n`;
+    const { out } = t4Apply(dir, t4Payload(dir, today, next, 'clean write'), 's-clean');
+
+    assert.deepEqual(out.conflicts, [], `no drift → no conflict: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), next, 'payload bytes must land');
+    assert.equal(
+      readBaseEntry(dir, 's-clean', t4Rel).hash,
+      bsHashContent(next),
+      'a successful direct write becomes the new observed base',
+    );
+  });
+});
+
+test('base snapshotted, then another session writes the page → conflict, target untouched', () => {
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-conf', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+    const otherSession = `${observed}\nthe OTHER session wrote this.\n`;
+    writeFileSync(t4ProjectHot(dir), otherSession);
+
+    const mine = `${observed}\nMY payload, built from the stale read.\n`;
+    const { r, out } = t4Apply(dir, t4Payload(dir, today, mine, 'conflict'), 's-conf');
+
+    assert.notEqual(r.status, 0, 'a withheld target must fail the close');
+    assert.equal(
+      readFileSync(t4ProjectHot(dir), 'utf-8'),
+      otherSession,
+      "the other session's edit must survive",
+    );
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(c, `conflicts must name the target: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(c.reason, 'base-mismatch');
+    assert.ok(!('proposedContent' in c), 'the reported shape must not echo the whole payload');
+    assert.equal(
+      existsSync(join(dir, '.cache', 'session-closed-s-conf.marker')),
+      false,
+      'a conflicted close must not mark the session closed',
+    );
+  });
+});
+
+test('session-id present but NO snapshot → fail-safe conflict (base-unknown, not "no base = safe")', () => {
+  // Guards the discriminated union. `readBaseEntry` returns hash:null for BOTH
+  // observed-absent and never-observed; a consumer branching on `if (!entry.hash)`
+  // would treat never-observed as safe-to-write and silently defeat the gate.
+  withWiki(null, (dir, today) => {
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+    const mine = `${observed}\nwritten with no base on record.\n`;
+    const { r, out } = t4Apply(dir, t4Payload(dir, today, mine, 'no base'), 's-nobase');
+
+    assert.notEqual(r.status, 0);
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), observed, 'target must stay untouched');
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(c, `an unobserved base must fail safe: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(c.reason, 'base-unknown');
+  });
+});
+
+test('idempotent-first: payload equals disk → no write, no conflict, even with no base', () => {
+  // Pins the guard ORDER. The six existing --apply-session-close --session-id tests
+  // read their payload straight off disk and carry no base, so they only stay green
+  // while the idempotent skip runs BEFORE the base check. It also breaks the
+  // apply-then-reclose loop: after a human applies a proposal, disk == payload.
+  withWiki(null, (dir, today) => {
+    const onDisk = readFileSync(t4ProjectHot(dir), 'utf-8');
+    const { out } = t4Apply(dir, t4Payload(dir, today, onDisk, 'idempotent'), 's-idem');
+
+    assert.deepEqual(out.conflicts, [], 'identical bytes are not a conflict');
+    assert.ok(
+      out.skipped.some((s) => s.includes('projectHot')),
+      `projectHot must be skipped as already-current: ${JSON.stringify(out.skipped)}`,
+    );
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), onDisk);
+  });
+});
+
+test('same session closing twice does not raise a false-positive against its own first write', () => {
+  // The ONLY test that fails when advanceBase is removed. A single apply passes
+  // either way, which is exactly why this exists:
+  // [[pages/learnings/mutation-check-invariants-a-passing-suite-cannot-see]]
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-twice', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+
+    const first = `${observed}\nfirst close.\n`;
+    const a = t4Apply(dir, t4Payload(dir, today, first, 'first close'), 's-twice');
+    assert.deepEqual(a.out.conflicts, [], 'first close writes cleanly');
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), first);
+
+    const second = `${observed}\nsecond close, same session.\n`;
+    const b = t4Apply(dir, t4Payload(dir, today, second, 'second close'), 's-twice');
+    assert.deepEqual(
+      b.out.conflicts,
+      [],
+      'without advanceBase the session diffs against its own stale base and self-conflicts',
+    );
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), second);
+  });
+});
+
+test('no --session-id → legacy direct write, outside the guard lifecycle', () => {
+  // Plan risk #70: a caller that never had a session could not have observed a
+  // base, so there is nothing to keep honest. Manual/legacy apply keeps writing.
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-unused', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+    writeFileSync(t4ProjectHot(dir), `${observed}\nsomeone else.\n`);
+
+    const mine = `${observed}\nlegacy manual apply.\n`;
+    const { out } = t4Apply(dir, t4Payload(dir, today, mine, 'legacy'), null);
+
+    assert.deepEqual(out.conflicts, [], 'no session id → no guard');
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), mine, 'legacy path writes directly');
+  });
+});
+
+test('a conflicted close registers no pending tags — no silent SCHEMA.md side effect', () => {
+  // codex W2 CONCERN: a withheld close skips commitWikiChanges (ok:false), so any
+  // SCHEMA.md write it made would sit mutated, uncommitted, and unlisted in
+  // `applied`. The control arm proves the fixture really does drive a registration,
+  // so this cannot pass by simply never registering.
+  const seedUnknownTag = (dir, today) => {
+    writeFileSync(
+      join(dir, 'SCHEMA.md'),
+      `---\ntitle: Wiki Schema\ntype: schema\nupdated: ${today}\nversion: 2.1\n---\n\n` +
+        '## 3. Tag Taxonomy\n\n### Domain — Test\n`concept`\n\n### Forbidden Patterns\n',
+    );
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(
+      join(dir, 'pages', 'x.md'),
+      `---\ntitle: X\ntype: concept\ntags: [zzz-unregistered-tag]\nupdated: ${today}\n---\n\n# X\n`,
+    );
+  };
+
+  // control: a clean close DOES register the tag
+  withWiki(seedUnknownTag, (dir, today) => {
+    snapshotBase(dir, 's-tag-ok', overwriteTargets(T4_PROJECT));
+    const next = `${readFileSync(t4ProjectHot(dir), 'utf-8')}\nclean.\n`;
+    t4Apply(dir, t4Payload(dir, today, next, 'tag control'), 's-tag-ok');
+    assert.ok(
+      readFileSync(join(dir, 'SCHEMA.md'), 'utf-8').includes('zzz-unregistered-tag'),
+      'control arm must actually register, else the assertion below is vacuous',
+    );
+  });
+
+  // conflicted close: registers nothing
+  withWiki(seedUnknownTag, (dir, today) => {
+    snapshotBase(dir, 's-tag-conf', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+    writeFileSync(t4ProjectHot(dir), `${observed}\nthe OTHER session.\n`);
+    const schemaBefore = readFileSync(join(dir, 'SCHEMA.md'), 'utf-8');
+
+    const { out } = t4Apply(
+      dir,
+      t4Payload(dir, today, `${observed}\nmine.\n`, 'tag'),
+      's-tag-conf',
+    );
+
+    assert.equal(out.conflicts.length, 1, 'fixture must actually conflict');
+    assert.equal(
+      readFileSync(join(dir, 'SCHEMA.md'), 'utf-8'),
+      schemaBefore,
+      'a withheld close must not mutate SCHEMA.md behind the caller’s back',
+    );
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
# English

## What changed

`crystallize --apply-session-close` no longer replaces a wiki page whose bytes moved since this session first read it. Each overwrite target (session-state.md, the project and root hot.md, open-questions.md) is compared against the base hash this session's SessionStart recorded. A drifted target is withheld, listed under a new `conflicts` field, and fails the close.

## Why

The overwrite path was last-write-wins. A session that read `session-state.md` at 09:00 and closed at 11:00 buried whatever another session wrote at 10:00, with no signal that anything was lost. Two concurrent sessions on one machine, or a local close landing on top of content git had already pulled, both hit this.

The silent part was the dangerous part: if the other session touched that page today, the freshness gate saw a fresh file and passed, so the close reported `ok:true`, wrote the session-closed marker, and dropped this session's payload without a word.

## How

`overwrite()` runs three steps, in an order that carries weight:

1. disk equals payload, so skip (the existing idempotent contract)
2. base unknown, or base differs from disk, so withhold and record a conflict
3. otherwise write, then advance the base to the bytes just written

Step 1 must precede step 2. It keeps the existing `--session-id` apply tests green (they read their payload straight off disk and carry no base), and it breaks the apply-then-reclose loop: once a human applies a proposal, disk equals payload again.

Step 3's advance matters when one session closes twice. Without it, the second close diffs against the original base and raises a false-positive conflict against its own first write.

Branching is on base-store's `state` discriminator (`'hash' | 'absent' | 'unknown'`), never on the truthiness of `hash`. Observed-absent and never-observed both carry `hash: null`, so `if (!entry.hash)` would read never-observed as safe-to-write and defeat the guard.

Callers without `--session-id` never observed a base, so there is nothing to keep honest; they stay on the legacy direct write.

A conflicted close also registers no pending SCHEMA.md tags. It skips `commitWikiChanges` (because `ok:false`), so a registration would sit mutated, uncommitted, and unlisted in `applied`: a silent side effect of a close whose whole point was to write nothing. Registration is eventually-consistent, so the next close picks it up.

Proposal artifacts and the `hypomnema proposal` CLI land in later slices. This one only withholds.

## Manual verification

No hook, no `hooks/hypo-shared.mjs`, no template or init flow changed, so the template's mandatory manual-verification cases do not apply. `hooks/base-store.mjs` is imported, not modified.

Beyond the suite, four mutations confirm the invariants are pinned by tests rather than by reviewer memory. Each was applied to a clean tree, the suite was run, and the tree was restored:

```
remove advanceBase                      -> 2 failed (incl. the same-session second close)
branch on `if (!entry.hash)`            -> 1 failed (base-unknown fail-safe)
invert steps 1 and 2                    -> 7 failed (6 pre-existing --session-id apply tests + idempotent-first)
drop the conflicts gate on pending tags -> 1 failed (SCHEMA.md side effect)
```

The 7-failure count matches the prediction made when this slice was scoped: exactly the six existing `--apply-session-close --session-id` tests depend on idempotent-first.

```
node tests/runner.mjs   -> 1268 passed, 0 failed
npx prettier --check scripts/crystallize.mjs tests/runner.mjs -> clean
```

`npm run lint` exits 1 on this branch and on `main` alike: it lints the ambient vault, which carries six pre-existing content errors unrelated to this change.

## Migration notes

None. A session whose SessionStart never recorded a base (an older install, or a hook that did not fire) resolves to `state: 'unknown'` and fails safe into a withheld target rather than a silent overwrite. Callers without `--session-id` are unaffected.

---

# 한국어

## 변경 내용

`crystallize --apply-session-close`가 이 세션이 처음 읽은 뒤로 내용이 바뀐 위키 페이지를 더 이상 덮어쓰지 않는다. overwrite 대상 네 개(session-state.md, 프로젝트·루트 hot.md, open-questions.md)를 이 세션의 SessionStart가 기록해 둔 base 해시와 비교한다. 어긋난 대상은 쓰지 않고 새 `conflicts` 필드에 실어 close를 실패시킨다.

## 이유

기존 overwrite 경로는 마지막에 쓴 쪽이 이기는 구조였다. 09시에 `session-state.md`를 읽고 11시에 닫는 세션이 10시에 다른 세션이 쓴 내용을 묻어버렸고, 무언가 사라졌다는 신호조차 없었다. 한 머신의 동시 세션, 또는 git이 이미 pull해 온 내용 위에 로컬 close가 얹히는 경우가 모두 여기 걸린다.

위험한 건 조용하다는 점이었다. 상대 세션이 그 페이지를 오늘 건드렸다면 freshness 게이트는 신선한 파일을 보고 통과하므로, close는 `ok:true`를 보고하고 session-closed 마커까지 쓰면서 이 세션의 payload를 한마디 없이 버렸다.

## 방법

`overwrite()`는 세 단계를 도는데, 그 순서가 load-bearing이다.

1. 디스크가 payload와 같으면 skip (기존 idempotent 계약)
2. base가 미상이거나 base와 디스크가 다르면 보류하고 conflict로 기록
3. 아니면 쓰고, 방금 쓴 내용으로 base를 전진

1단계가 2단계보다 먼저여야 한다. 기존 `--session-id` apply 테스트들이 payload를 디스크에서 그대로 읽어 넣고 base가 없는 채로 도는데 그게 green으로 남고, apply 후 재close 루프도 끊긴다. 사람이 proposal을 apply하고 나면 디스크가 다시 payload와 같아지기 때문이다.

3단계의 전진은 한 세션이 두 번 닫을 때 걸린다. 이게 없으면 두 번째 close가 원래 base와 비교해서 자기 첫 쓰기를 상대로 false-positive conflict를 낸다.

분기는 base-store의 `state` 판별자(`'hash' | 'absent' | 'unknown'`)로만 한다. `hash`의 참거짓으로는 절대 하지 않는다. 관측-부재와 미관측이 둘 다 `hash: null`이라, `if (!entry.hash)`로 갈랐다가는 미관측을 "써도 안전"으로 읽어 가드가 통째로 무력해진다.

`--session-id` 없는 호출은 관측한 base가 있을 수 없어 지킬 것도 없다. 기존 직접 쓰기 그대로 둔다.

충돌이 난 close는 SCHEMA.md pending 태그도 등록하지 않는다. `ok:false`라 `commitWikiChanges`를 건너뛰므로, 등록해 봐야 SCHEMA.md가 수정된 채 커밋되지도 `applied`에 잡히지도 않는다. 아무것도 안 쓰는 게 목적인 close가 남기는 조용한 부작용이 된다. 태그 등록은 원래 eventual-consistent라 다음 close가 주워 간다.

proposal 아티팩트와 `hypomnema proposal` CLI는 다음 슬라이스다. 이번 건은 보류만 한다.

## 수동 검증

훅도, `hooks/hypo-shared.mjs`도, 템플릿이나 init 흐름도 건드리지 않아 템플릿이 요구하는 필수 수동 검증 항목에 해당하지 않는다. `hooks/base-store.mjs`는 import만 하고 수정하지 않았다.

스위트 외에, 뮤테이션 4건으로 불변식이 리뷰어의 기억이 아니라 테스트에 실제로 붙잡혀 있음을 확인했다. 각각 깨끗한 트리에 적용하고 스위트를 돌린 뒤 되돌렸다.

```
advanceBase 삭제                    -> 2 실패 (같은 세션 두 번째 close 포함)
`if (!entry.hash)`로 분기            -> 1 실패 (base-unknown fail-safe)
1단계와 2단계 순서 뒤집기            -> 7 실패 (기존 --session-id apply 6건 + idempotent-first)
pending 태그의 conflicts 게이트 제거 -> 1 실패 (SCHEMA.md 부작용)
```

7이라는 숫자는 이 슬라이스를 설계할 때의 예측과 일치한다. 정확히 기존 `--apply-session-close --session-id` 테스트 6개가 idempotent-first에 의존한다.

```
node tests/runner.mjs   -> 1268 passed, 0 failed
npx prettier --check scripts/crystallize.mjs tests/runner.mjs -> clean
```

`npm run lint`는 이 브랜치에서도 `main`에서도 1로 끝난다. 주변 볼트를 린트하는데 그 볼트에 이번 변경과 무관한 기존 콘텐츠 에러 6건이 있다.

## 마이그레이션 노트

없음. SessionStart가 base를 기록한 적 없는 세션(구버전 설치, 또는 훅이 발화하지 않은 경우)은 `state: 'unknown'`으로 떨어져 조용한 덮어쓰기 대신 보류로 fail-safe한다. `--session-id` 없는 호출은 영향받지 않는다.

---

## Changelog

- EN: Session close no longer silently overwrites a wiki page that another session changed while this one was open: the drifted page is left alone and the close reports it (#180).
- KO: 세션 종료가 이 세션이 열려 있는 동안 다른 세션이 바꾼 위키 페이지를 조용히 덮어쓰지 않는다. 어긋난 페이지는 그대로 두고 close가 이를 보고한다 (#180).

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally (exits 1 on `main` too: pre-existing vault content errors, unrelated to this change)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (no user-facing surface yet; the CLI lands with the proposal slices)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
