### PR TITLE
fix(write-proposal): advance observed-base on a session's own direct edits

### DIFF
--- a/hooks/base-store.mjs
+++ b/hooks/base-store.mjs
@@ -194,6 +194,63 @@ export function advanceBase(hypoDir, sessionId, relPath, hash) {
 }
 
 /**
+ * Advance a target's base to its current on-disk bytes after the session edited
+ * it DIRECTLY (Write/Edit tool), not through crystallize. Invariant 2 covers
+ * crystallize's own overwrites; this covers the other way a session legitimately
+ * changes a guarded target.
+ *
+ * Without it, a direct edit looks — at close time — exactly like a DIFFERENT
+ * session having written the page: base != disk, so the guard fails safe into a
+ * false proposal against the session's own work. `open-questions.md` is the most
+ * exposed target, because `/hypo:crystallize` tells the model to fold same-session
+ * edits into the close payload. A PostToolUse hook calls this after each wiki
+ * write to give the session's own edits provenance.
+ *
+ * Scoped by tracked-ness, NOT by a target list: `relPath` advances only when the
+ * session already has a base entry for it (one of the four overwrite targets
+ * snapshotted at start, for the active project). A write to any other wiki file
+ * is a no-op, so this never mints a new base key and cannot widen the guard's
+ * surface. The file is hashed only once the target is confirmed tracked, so an
+ * unrelated write costs one small base.json read and no content hash.
+ *
+ * An absent or unreadable post-write file leaves the base untouched (returns
+ * false) rather than advancing it to null: a target that vanished is a real
+ * divergence the close should still fail safe on, not a provenance claim.
+ *
+ * `knownHash`: when the caller already has the exact bytes the tool wrote (the
+ * Write tool carries its full `content`), pass their hash. The base then advances
+ * to what the SESSION wrote, not to a fresh disk read — race-safe: if another
+ * session overwrote the target in the window between the tool and this call,
+ * base = my-bytes ≠ disk, so the close still sees drift and preserves the other
+ * write. Callers without the full bytes (Edit/MultiEdit) pass null and take a
+ * post-write disk read, which carries a narrow tool→hook race (documented
+ * residual in the spec's 보증 범위).
+ *
+ * This does not weaken the base contract's "no read-just-before-write as base"
+ * rule (spec line 40): only the session's OWN writes advance, so a concurrent
+ * writer's change to the same target is still observed as drift.
+ *
+ * @returns {boolean} true when the base file was updated
+ */
+export function advanceBaseForWrite(hypoDir, sessionId, relPath, absPath, knownHash = null) {
+  if (!sessionId) return false;
+  const parsed = readBaseFile(hypoDir, sessionId);
+  if (!parsed) return false;
+  // Only a tracked target advances. hasOwnProperty, not truthiness: an
+  // observed-absent entry is `null` but still a legitimate key to advance from.
+  if (!Object.prototype.hasOwnProperty.call(parsed.targets, relPath)) return false;
+  const hash = typeof knownHash === 'string' ? knownHash : hashFile(absPath);
+  if (typeof hash !== 'string') return false; // absent/unreadable → leave base as-is
+  parsed.targets[relPath] = hash;
+  try {
+    atomicWrite(basePath(hypoDir, sessionId), JSON.stringify(parsed, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * The four overwrite targets crystallize replaces wholesale. `project` may be
  * null when cwd resolves to no project; the two project-scoped paths are then
  * omitted and close falls back to proposal for them.

--- a/hooks/hypo-auto-stage.mjs
+++ b/hooks/hypo-auto-stage.mjs
@@ -6,7 +6,17 @@
  */
 
 import { spawnSync } from 'child_process';
+import { relative } from 'path';
 import { HYPO_DIR, loadHypoIgnore, isIgnored } from './hypo-shared.mjs';
+import { advanceBaseForWrite, hashContent } from './base-store.mjs';
+
+// Tools that REPLACE file bytes. The base advance below must fire only for these:
+// this hook has no matcher in hooks.json (it runs on every PostToolUse), and a
+// read-only tool like Read also carries `tool_input.file_path`. Without this
+// allowlist, merely Reading a target another session had drifted would advance
+// the base to that other session's bytes — silently defeating the write=proposal
+// guard at close. tool_name, not file_path, is the write signal.
+const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit']);
 
 let input = {};
 try {
@@ -28,6 +38,26 @@ if (filePath.startsWith(HYPO_DIR + '/') || filePath === HYPO_DIR) {
   const patterns = loadHypoIgnore(HYPO_DIR);
   if (patterns.length === 0 || !isIgnored(filePath, HYPO_DIR, patterns)) {
     spawnSync('git', ['-C', HYPO_DIR, 'add', filePath], { stdio: 'ignore' });
+  }
+
+  // Write=proposal gate provenance: when this session's own write lands on one of
+  // the overwrite targets it snapshotted at start, advance that target's base so
+  // the close guard reads the change as "I wrote this", not "someone else did"
+  // (which would fail safe into a false proposal against the session's own edit).
+  // Self-scoping — a no-op unless the path is a tracked base key — so it runs
+  // regardless of .hypoignore (provenance is independent of privacy). Best-effort.
+  //
+  // The Write tool carries its full `content`, so advance to the bytes THIS
+  // session wrote (race-safe: a concurrent write landing between the tool and
+  // this hook cannot be adopted as our base). Edit/MultiEdit have no full content
+  // in the payload, so they fall back to a post-write disk read.
+  if (WRITE_TOOLS.has(input.tool_name) && input.session_id) {
+    const rel = relative(HYPO_DIR, filePath);
+    const known =
+      input.tool_name === 'Write' && typeof input.tool_input?.content === 'string'
+        ? hashContent(input.tool_input.content)
+        : null;
+    advanceBaseForWrite(HYPO_DIR, input.session_id, rel, filePath, known);
   }
 }
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -52,6 +52,7 @@ import {
   snapshotBase,
   readBaseEntry,
   advanceBase,
+  advanceBaseForWrite,
   overwriteTargets,
 } from '../hooks/base-store.mjs';
 import {
@@ -25921,6 +25922,102 @@ test('advanceBase moves one target and no-ops when the session has no snapshot',
   });
 });
 
+test('advanceBaseForWrite advances a tracked target to its current on-disk bytes', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    const oq = join(dir, 'pages', 'open-questions.md');
+    writeFileSync(oq, '# open questions\n\n## edited directly by this session\n');
+    assert.equal(
+      advanceBaseForWrite(dir, 's1', join('pages', 'open-questions.md'), oq),
+      true,
+    );
+    assert.equal(
+      readBaseEntry(dir, 's1', join('pages', 'open-questions.md')).hash,
+      bsHashFile(oq),
+      "the session's own direct edit becomes the new observed base",
+    );
+    assert.equal(
+      readBaseEntry(dir, 's1', 'hot.md').hash,
+      bsHashContent('# root hot\n'),
+      'advancing one target must not disturb the others',
+    );
+  });
+});
+
+test('advanceBaseForWrite no-ops for an untracked path — it never mints a new base key', () => {
+  // The scoping guard. A write to any wiki file that is NOT one of the four
+  // snapshotted targets must leave the base map exactly as it was, so this can
+  // never widen the guard's surface. Mutation target: dropping the hasOwnProperty
+  // check makes this fail.
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    const before = readFileSync(bsBasePath(dir, 's1'), 'utf-8');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const other = join(dir, 'pages', 'some-note.md');
+    writeFileSync(other, '# an unrelated page\n');
+    assert.equal(advanceBaseForWrite(dir, 's1', join('pages', 'some-note.md'), other), false);
+    assert.equal(
+      readFileSync(bsBasePath(dir, 's1'), 'utf-8'),
+      before,
+      'an untracked write must not touch base.json at all',
+    );
+  });
+});
+
+test('advanceBaseForWrite no-ops with no session, no snapshot, or a vanished target', () => {
+  withBaseWiki((dir) => {
+    const oq = join(dir, 'pages', 'open-questions.md');
+    // no session id → outside the guard lifecycle
+    assert.equal(advanceBaseForWrite(dir, '', join('pages', 'open-questions.md'), oq), false);
+    // session with no snapshot on record
+    assert.equal(
+      advanceBaseForWrite(dir, 'no-snap', join('pages', 'open-questions.md'), oq),
+      false,
+    );
+
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    const before = readBaseEntry(dir, 's1', join('pages', 'open-questions.md')).hash;
+    rmSync(oq);
+    // a tracked target that is absent post-write must NOT advance the base to
+    // null — a vanished file is a real divergence the close should still see
+    assert.equal(
+      advanceBaseForWrite(dir, 's1', join('pages', 'open-questions.md'), oq),
+      false,
+    );
+    assert.equal(
+      readBaseEntry(dir, 's1', join('pages', 'open-questions.md')).hash,
+      before,
+      'an absent post-write file must leave the base untouched, not advance to null',
+    );
+  });
+});
+
+test('advanceBaseForWrite with a knownHash advances to it, ignoring on-disk bytes', () => {
+  // The Write race-safe path: the caller supplies the hash of the exact bytes the
+  // tool wrote, so the base tracks those even if disk already drifted.
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    const oq = join(dir, 'pages', 'open-questions.md');
+    writeFileSync(oq, '# a concurrent write already on disk\n');
+    const intended = bsHashContent('# what my Write actually wrote\n');
+    assert.equal(
+      advanceBaseForWrite(dir, 's1', join('pages', 'open-questions.md'), oq, intended),
+      true,
+    );
+    assert.equal(
+      readBaseEntry(dir, 's1', join('pages', 'open-questions.md')).hash,
+      intended,
+      'knownHash wins over the on-disk hash',
+    );
+    // untracked scoping still applies even with a knownHash
+    assert.equal(
+      advanceBaseForWrite(dir, 's1', join('pages', 'nope.md'), oq, intended),
+      false,
+      'a knownHash must not let an untracked path mint a base key',
+    );
+  });
+});
+
 // ── FEAT-11 SessionStart base snapshot (T3) ──────────────────────────────────
 
 suite('hypo-session-start.mjs — observed-base snapshot once per session (FEAT-11 T3)');
@@ -26230,6 +26327,164 @@ test('a conflicted close registers no pending tags — no silent SCHEMA.md side 
       readFileSync(join(dir, 'SCHEMA.md'), 'utf-8'),
       schemaBefore,
       'a withheld close must not mutate SCHEMA.md behind the caller’s back',
+    );
+  });
+});
+
+// ── FEAT-11 self-edit provenance seam (PostToolUse → crystallize) ────────────
+//
+// The self-conflict a session hits when it edits an overwrite target DIRECTLY
+// (Write/Edit tool) and then closes. SessionStart snapshots the base; the direct
+// edit moves disk away from it; without provenance the close guard reads the
+// session's own edit as another writer's and fails safe into a false proposal.
+//
+// This crosses the REAL process seam the unit tests skip: the actual
+// hypo-auto-stage PostToolUse hook, invoked as a subprocess, is what must read
+// `session_id` + `tool_input.file_path` from the payload and advance the base.
+// The control arm (no hook run) reproduces the bug first, so the fix arm cannot
+// pass for an unrelated reason.
+// [[pages/learnings/mutation-check-invariants-a-passing-suite-cannot-see]]
+
+suite('crystallize.mjs — self-edit provenance via PostToolUse hook (FEAT-11)');
+
+// Run the real auto-stage hook the way Claude Code does: a subprocess fed a
+// PostToolUse payload on stdin, with HYPO_DIR pinned to the test vault. toolName
+// and content mirror what the real Write/Edit/Read payloads carry.
+function runAutoStageHook(dir, sessionId, filePath, toolName = 'Edit', content = null) {
+  const tool_input = { file_path: filePath };
+  if (content !== null) tool_input.content = content;
+  return spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-stage.mjs')], {
+    input: JSON.stringify({ session_id: sessionId, tool_name: toolName, tool_input }),
+    encoding: 'utf-8',
+    env: { ...process.env, HYPO_DIR: dir },
+  });
+}
+
+test('session directly edits a target, the hook advances its base, close writes cleanly', () => {
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-selfedit', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+
+    // the session edits the target itself, mid-session, with the Edit tool
+    const edited = `${observed}\ndirectly edited by this session.\n`;
+    writeFileSync(t4ProjectHot(dir), edited);
+    const hook = runAutoStageHook(dir, 's-selfedit', t4ProjectHot(dir), 'Edit');
+    assert.equal(hook.status, 0, `hook must not fail: ${hook.stderr}`);
+    assert.equal(
+      readBaseEntry(dir, 's-selfedit', t4Rel).hash,
+      bsHashContent(edited),
+      'the PostToolUse hook must advance the base to the bytes the session just wrote',
+    );
+
+    // close folds a further line onto that edit, so the payload differs from disk
+    // and the guard is actually consulted (not short-circuited by idempotent skip)
+    const closed = `${edited}\nand the close adds this.\n`;
+    const { r, out } = t4Apply(dir, t4Payload(dir, today, closed, 'self-edit close'), 's-selfedit');
+
+    assert.equal(r.status, 0, `a provenance-backed close must succeed: ${JSON.stringify(out.conflicts)}`);
+    assert.deepEqual(out.conflicts, [], 'the session must not conflict against its own edit');
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), closed, 'the close payload must land');
+  });
+});
+
+test('control: WITHOUT the hook the very same flow self-conflicts (bug reproduced)', () => {
+  // Proves the hook subprocess is what prevents the conflict. Identical to the
+  // test above except the auto-stage step is omitted, so the base never advances.
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-noprov', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+
+    const edited = `${observed}\ndirectly edited by this session.\n`;
+    writeFileSync(t4ProjectHot(dir), edited); // no hook → base stays at the pre-edit bytes
+
+    const closed = `${edited}\nand the close adds this.\n`;
+    const { r, out } = t4Apply(dir, t4Payload(dir, today, closed, 'no-prov close'), 's-noprov');
+
+    assert.notEqual(r.status, 0, 'without provenance the close must fail safe');
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(c, `the self-edit must be misread as drift: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(c.reason, 'base-mismatch');
+    assert.equal(
+      readFileSync(t4ProjectHot(dir), 'utf-8'),
+      edited,
+      'a withheld close leaves the target at the session-edited bytes',
+    );
+  });
+});
+
+test('the hook does not advance the base for a write to a non-target wiki page', () => {
+  // Scoping across the real process boundary: a Write/Edit to an ordinary wiki
+  // page must not touch base.json, so the hook cannot widen the guard's surface.
+  withWiki(null, (dir) => {
+    snapshotBase(dir, 's-scope', overwriteTargets(T4_PROJECT));
+    const before = readFileSync(bsBasePath(dir, 's-scope'), 'utf-8');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const note = join(dir, 'pages', 'a-random-note.md');
+    writeFileSync(note, '# just a note\n');
+    const hook = runAutoStageHook(dir, 's-scope', note, 'Edit');
+    assert.equal(hook.status, 0, `hook must not fail: ${hook.stderr}`);
+    assert.equal(
+      readFileSync(bsBasePath(dir, 's-scope'), 'utf-8'),
+      before,
+      'a write to a non-target page must leave base.json byte-for-byte unchanged',
+    );
+  });
+});
+
+test('a NON-write tool (Read) on a drifted target must NOT advance the base', () => {
+  // The guard-defeating path codex found: the hook has no matcher, so it fires on
+  // every tool — including Read, whose tool_input also carries file_path. If Read
+  // advanced the base, merely LOOKING at a page another session wrote would adopt
+  // that other session's bytes as ours, and the close would clobber it with no
+  // conflict. Only Write/Edit/MultiEdit may advance.
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-read', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+    const otherSession = `${observed}\nthe OTHER session wrote this.\n`;
+    writeFileSync(t4ProjectHot(dir), otherSession); // B's write drifts disk from base
+
+    // this session merely READS the drifted target
+    const hook = runAutoStageHook(dir, 's-read', t4ProjectHot(dir), 'Read');
+    assert.equal(hook.status, 0, `hook must not fail: ${hook.stderr}`);
+    assert.equal(
+      readBaseEntry(dir, 's-read', t4Rel).hash,
+      bsHashContent(observed),
+      'Read must leave the base at the pre-drift bytes — it is not a write',
+    );
+
+    // and the close must therefore still fail safe against B's write
+    const mine = `${observed}\nmy stale payload.\n`;
+    const { r, out } = t4Apply(dir, t4Payload(dir, today, mine, 'read-then-close'), 's-read');
+    assert.notEqual(r.status, 0, 'a Read must not have licensed a clobber of B');
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(c && c.reason === 'base-mismatch', `B's write must still be protected: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), otherSession, "B's write survives");
+  });
+});
+
+test('a Write advances the base to the bytes it wrote, not a racy disk re-read', () => {
+  // Race-safety: the Write tool carries its full content, so the hook advances to
+  // THAT, not to whatever is on disk when the subprocess gets around to reading.
+  // Simulated by handing the hook a payload whose content differs from the bytes
+  // currently on disk (as if a concurrent write landed in between). The base must
+  // track the payload content, so a close still detects the concurrent bytes.
+  withWiki(null, (dir) => {
+    snapshotBase(dir, 's-write', overwriteTargets(T4_PROJECT));
+    const myContent = `${readFileSync(t4ProjectHot(dir), 'utf-8')}\nwhat THIS session's Write wrote.\n`;
+    const raced = `${readFileSync(t4ProjectHot(dir), 'utf-8')}\na concurrent write that landed first.\n`;
+    writeFileSync(t4ProjectHot(dir), raced); // disk != my Write's content
+
+    const hook = runAutoStageHook(dir, 's-write', t4ProjectHot(dir), 'Write', myContent);
+    assert.equal(hook.status, 0, `hook must not fail: ${hook.stderr}`);
+    assert.equal(
+      readBaseEntry(dir, 's-write', t4Rel).hash,
+      bsHashContent(myContent),
+      'Write must advance to its own content hash, never to the raced disk bytes',
+    );
+    assert.notEqual(
+      readBaseEntry(dir, 's-write', t4Rel).hash,
+      bsHashContent(raced),
+      'the concurrent bytes must not become our base',
     );
   });
 });


### PR DESCRIPTION
# English

## What changed

The observed-base guard (the per-session write=proposal gate) no longer misreads a session's OWN direct edit of an overwrite target as a different session's write. A session's own writes now get provenance, so a direct edit via the Write/Edit tool (outside crystallize) does not raise a false `base-mismatch` proposal at close.

## Why

The base only advanced when crystallize itself overwrote a target. So a session that edited an overwrite target directly (the crystallize skill folds same-session edits into the close payload, and `pages/open-questions.md` was the most exposed) left `base != disk` at close, and the guard read that as another session's write. Result: a false proposal blocked the close. No data loss (the guard fails safe by preserving bytes), but it broke single-session frictionlessness.

## How

Provenance rides the existing `hypo-auto-stage` PostToolUse hook:

- `hooks/base-store.mjs` (`advanceBaseForWrite`): advances a target's base ONLY when the path is already a tracked key in this session's snapshot (self-scoping to the four overwrite targets; never mints a new key). An absent or unreadable post-write file leaves the base untouched.
- `hooks/hypo-auto-stage.mjs`: calls it after each wiki write, gated to `WRITE_TOOLS` (`Write`/`Edit`/`MultiEdit`) by `tool_name`. The hook has no matcher and fires on every tool, so a read-only tool like `Read` also carries `file_path`; without the gate, merely reading a drifted target would adopt another session's bytes as the base and defeat the guard. `Write` carries its full `content`, so it advances to the bytes THIS session wrote (race-safe); `Edit`/`MultiEdit` re-read disk, leaving a narrow tool-to-hook race documented as a residual.

## Manual verification

Changed hooks (`base-store.mjs`, `hypo-auto-stage.mjs`), so beyond the suite: a cross-process seam suite runs the REAL hook subprocess and then real crystallize (control arm reproduces the bug with the hook skipped; a `Read` on a drifted target does not advance the base and the close still protects the other session's write; a `Write` advances to its own content hash, not a raced disk re-read). The full live Stop chain in a deployed session was not separately exercised.

## Migration notes

None. Provenance applies from this change forward; a session that started before it is unaffected (an un-advanced base fails safe into a withheld target, never a silent overwrite). Callers without `--session-id` are outside the guard lifecycle and unchanged.

---

# 한국어

## 변경 내용

observed-base 가드(세션별 write=proposal 게이트)가 세션 자신의 overwrite 대상 직접 편집을 다른 세션의 쓰기로 오인하지 않는다. 세션 자기 쓰기에 provenance가 생겨서, crystallize 밖에서 Write/Edit 툴로 직접 편집해도 close에서 거짓 `base-mismatch` proposal이 뜨지 않는다.

## 이유

base는 crystallize가 직접 대상을 overwrite할 때만 전진했다. 그래서 세션이 overwrite 대상을 직접 편집하면(crystallize 스킬이 같은 세션 편집을 close payload에 접어 넣고, `pages/open-questions.md`가 가장 노출됐다) close 시점에 `base != disk`가 남았고, 가드가 이를 남의 쓰기로 읽었다. 결과는 거짓 proposal이 close를 막는 것. 데이터 유실은 없지만(가드가 바이트를 보존해 fail-safe) 단일 세션 무마찰이 깨졌다.

## 방법

provenance는 기존 `hypo-auto-stage` PostToolUse 훅을 탄다.

- `hooks/base-store.mjs`(`advanceBaseForWrite`): 경로가 이미 이 세션 스냅샷의 tracked key일 때만 base를 전진한다(overwrite 대상 네 개로 자기 스코핑. 새 key를 절대 만들지 않는다). 쓰기 후 파일이 부재/판독불가면 base를 건드리지 않는다.
- `hooks/hypo-auto-stage.mjs`: 각 위키 쓰기 뒤에 이를 호출하되 `tool_name`으로 `WRITE_TOOLS`(`Write`/`Edit`/`MultiEdit`)에 게이트한다. 훅에 matcher가 없어 모든 툴에 발화하므로 `Read` 같은 읽기 전용 툴도 `file_path`를 싣는다. 게이트가 없으면 드리프트된 대상을 보기만 해도 남의 바이트가 base로 채택돼 가드가 무력해진다. `Write`는 full `content`를 실어 이 세션이 쓴 바이트로 전진한다(race-safe). `Edit`/`MultiEdit`는 디스크를 재-read해 좁은 tool-to-hook race를 잔여로 남긴다.

## 수동 검증

훅(`base-store.mjs`, `hypo-auto-stage.mjs`)을 바꿨으므로 스위트 외에: cross-process seam 스위트가 실제 훅 서브프로세스를 돌린 뒤 실제 crystallize를 돌린다(control arm은 훅을 뺀 채 버그를 재현하고, 드리프트된 대상에 `Read`는 base를 전진시키지 않으며 close는 여전히 남의 쓰기를 보호하고, `Write`는 raced 디스크 재-read가 아니라 자기 content 해시로 전진한다). 배포 세션에서 전체 라이브 Stop 체인은 별도로 검증하지 않았다.

## 마이그레이션 노트

없음. provenance는 이 변경 이후로 적용된다. 그 전에 시작한 세션은 영향받지 않는다(전진되지 않은 base는 조용한 덮어쓰기가 아니라 보류로 fail-safe한다). `--session-id` 없는 호출은 가드 생명주기 밖이라 그대로다.

---

## Changelog

- EN: A session's own direct edit of a close target no longer triggers a false write-conflict that blocked the session close (#181).
- KO: 세션이 close 대상을 직접 편집해도 close를 막던 거짓 쓰기 충돌이 더 이상 뜨지 않는다 (#181).

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally (exits on ambient vault content errors unrelated to this change; CI lint is green)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
