### PR TITLE
feat(crystallize): serialize close-path append writes with a per-target lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ specs/
 # live in the maintainer's own ~/.claude/commands/, not here.
 .claude/
 
+# Append-lock files (transient <target>.lock around session-log / log.md writes)
+*.lock
+
 # Node
 node_modules/
 dist/

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -16,8 +16,12 @@ import {
   rmSync,
   readdirSync,
   realpathSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+  renameSync,
 } from 'fs';
-import { join, relative, basename } from 'path';
+import { join, relative, basename, dirname } from 'path';
 import { homedir, hostname, tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 
@@ -1203,6 +1207,132 @@ export function rootLogEntry(slug, date, headingTail) {
  * @param {string} hypoDir
  * @returns {number} count of entries appended to log.md
  */
+// ── append-only file lock ───────────────────────────────────────────────────
+// Serializes the read → dedup → rebuild → temp+rename sequence on append-only
+// history files (session-log shards, log.md) so two concurrent session closes
+// never lose an entry. The lock does NOT replace the existing write-isolation:
+// each writer still rebuilds the full content and commits via atomicWrite
+// (temp write + rename), so a partial write lands on a throwaway temp and the
+// target is never torn. The lock only makes the read-modify-write exclusive, so
+// the second closer re-reads the first's committed bytes and appends onto them
+// (last-writer-wins can no longer drop the earlier entry), and exact-entry dedup
+// becomes precise rather than best-effort.
+//
+// Why not O_APPEND: an in-place append that short-writes (ENOSPC / EDQUOT /
+// RLIMIT_FSIZE / a split write() killed mid-loop) leaves a torn dated heading on
+// the real file that the freshness gate mis-reads as valid close evidence, and
+// it cannot be rolled back once a concurrent appender has written past it. That
+// is a normal-operation regression temp+rename does not have (a failed temp
+// write never runs the rename, so the target stays untouched). Confirmed against
+// Node/libuv write-loop behavior and POSIX write(2) partial-write semantics.
+//
+// Local-FS only: `openSync(lock, 'wx')` is not atomic on NFS — the same caveat
+// the vault already carries. Power-loss durability is unchanged from today
+// (atomicWrite never fsync'd), so it is out of scope here.
+function sleepSync(ms) {
+  // Synchronous sleep with no busy-spin: block this thread on an Atomics.wait
+  // against a private SharedArrayBuffer that is never signaled, so it always
+  // times out after `ms`. Hooks run in a short-lived sync context.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, ms | 0));
+}
+
+// Commit `content` via temp write + rename so a partial/failed write lands on a
+// throwaway temp and the target is never torn (mirrors crystallize.mjs's
+// atomicWrite). Rename atomicity swaps the directory entry; it is NOT power-loss
+// durable (no fsync) — same as everything else in the vault.
+function atomicWriteShared(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+}
+
+/**
+ * Run `fn` while holding an exclusive lock on `<targetPath>.lock`.
+ *
+ * Acquire is a spin on `openSync(lock, 'wx')`: EEXIST means another writer holds
+ * it, so poll until it frees. A lock whose holder looks dead (mtime older than
+ * `staleMs`) is stolen. Steal is recoverable friction in the normal case (the
+ * stealer re-reads the committed bytes before writing), but NOT loss-free in two
+ * edge cases, both requiring the lock to sit untouched for `staleMs`: (1) a LIVE
+ * holder preempted past `staleMs` gets stolen from, so two writers run the
+ * critical section and one update is lost; (2) between the stale `statSync` and
+ * the `unlinkSync`, the holder can release and a fresh holder grab the same path,
+ * whose lock we then remove. `staleMs` is set well above a normal close (seconds)
+ * to make both extreme-low-probability. If the lock cannot be acquired within
+ * `timeoutMs`, throw so the caller can fall back to the write=proposal gate
+ * (architecturally consistent with the existing fail-safe).
+ *
+ * @param {string} targetPath file being guarded (lock is a sibling `.lock`)
+ * @param {() => T} fn critical section
+ * @param {{timeoutMs?: number, staleMs?: number, pollMs?: number}} [opts]
+ * @returns {T} whatever `fn` returns
+ * @template T
+ */
+export function withFileLock(targetPath, fn, opts = {}) {
+  const { timeoutMs = 5000, staleMs = 30000, pollMs = 50 } = opts;
+  const lockPath = `${targetPath}.lock`;
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const start = Date.now();
+  let fd;
+  for (;;) {
+    try {
+      fd = openSync(lockPath, 'wx');
+      break;
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      // Held by another writer. Steal ONLY a demonstrably stale lock; otherwise
+      // wait and eventually time out. The stat and the unlink are handled
+      // separately on purpose: an un-removable stale lock (EACCES/EPERM/EBUSY)
+      // and a fresh lock must both fall through to the timeout check — never
+      // `continue` past it, or an un-unlinkable lock spins forever and violates
+      // the timeoutMs → ELOCKTIMEOUT contract (caller falls to the proposal gate).
+      let stale = false;
+      try {
+        // Steal a lock whose holder looks dead. Loss-free unless the holder is
+        // actually live-but-preempted past staleMs (see JSDoc edge cases).
+        stale = Date.now() - statSync(lockPath).mtimeMs > staleMs;
+      } catch (statErr) {
+        if (statErr.code === 'ENOENT') continue; // lock vanished; retry create now
+        throw statErr; // unexpected stat failure — surface it, don't mask
+      }
+      if (stale) {
+        try {
+          unlinkSync(lockPath);
+          continue; // stole it; retry the create immediately
+        } catch (unlinkErr) {
+          if (unlinkErr.code === 'ENOENT') continue; // another stealer won; retry
+          // Cannot remove it: do NOT spin — fall through to timeout/sleep so
+          // acquisition eventually throws ELOCKTIMEOUT instead of hanging.
+        }
+      }
+      if (Date.now() - start > timeoutMs) {
+        // Tagged so callers can distinguish "could not get the lock" (fall to the
+        // proposal gate) from a real fn() write error (mkdir/openSync/disk-full),
+        // which must NOT be masked as a timeout.
+        const e = new Error(`lock-timeout: ${lockPath}`);
+        e.code = 'ELOCKTIMEOUT';
+        throw e;
+      }
+      sleepSync(pollMs);
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* fd already gone */
+    }
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      /* lock already stolen/removed */
+    }
+  }
+}
+
 export function deriveRootLogEntries(hypoDir) {
   const logPath = join(hypoDir, 'log.md');
   if (!existsSync(logPath)) return 0;
@@ -1259,19 +1389,44 @@ export function deriveRootLogEntries(hypoDir) {
         const { heading, block } = rootLogEntry(slug, date, m[1]);
         if (seenHeadings.has(heading)) continue; // exact-line dedup (log.md + queued)
         seenHeadings.add(heading);
-        additions.push(block);
+        additions.push({ heading, block });
       }
     }
   }
 
   if (additions.length === 0) return 0;
-  const sep = logContent.endsWith('\n') ? '\n' : '\n\n';
+
+  // Serialize the read-modify-write on log.md: a concurrent session close (its
+  // own crystallize apply, or another project's derive) may commit between the
+  // read above and the write below. Under the lock we RE-READ the latest
+  // committed log.md and re-run exact-heading dedup, so this derive appends onto
+  // the other writer's entry instead of a full-file overwrite dropping it. The
+  // same lock guards crystallize.mjs's per-close log.md append, so the two
+  // paths never race. On lock-timeout, skip (best-effort backfill; the next
+  // close re-derives) rather than risk a lost update.
   try {
-    writeFileSync(logPath, logContent + sep + additions.join('\n\n') + '\n');
+    return withFileLock(logPath, () => {
+      let current;
+      try {
+        current = readFileSync(logPath, 'utf-8');
+      } catch {
+        return 0;
+      }
+      const seen = new Set((current || '').split(/\r?\n/));
+      const fresh = additions.filter(({ heading }) => {
+        if (seen.has(heading)) return false;
+        seen.add(heading);
+        return true;
+      });
+      if (fresh.length === 0) return 0;
+      const sep = current.endsWith('\n') ? '\n' : '\n\n';
+      atomicWriteShared(logPath, current + sep + fresh.map((a) => a.block).join('\n\n') + '\n');
+      return fresh.length;
+    });
   } catch {
+    // lock-timeout or unexpected lock error: skip this backfill pass.
     return 0;
   }
-  return additions.length;
 }
 
 // ── sync-state ────────────────────────────────────────────

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -104,6 +104,7 @@ import {
   currentDevice,
   scopeVisible,
   readVisibilityScope,
+  withFileLock,
 } from '../hooks/hypo-shared.mjs';
 import { hashContent, readBaseEntry, advanceBase } from '../hooks/base-store.mjs';
 
@@ -413,6 +414,12 @@ function readPayload(source) {
     throw new Error(`payload is not valid JSON: ${e.message}`);
   }
 }
+
+// How long an append waits for its per-target lock before withholding to the
+// proposal gate (see withFileLock). Default 5s is generous for a real close;
+// the env override exists ONLY so tests can force a fast timeout instead of
+// spinning the full 5s. Not a documented production knob.
+const APPEND_LOCK_TIMEOUT_MS = Number(process.env.HYPO_APPEND_LOCK_TIMEOUT_MS) || 5000;
 
 /** Atomic write via tmp+rename. `<path>.<pid>.<rand>.tmp` so concurrent helpers
  * don't fight over the same shared `<path>.tmp` slot. */
@@ -1069,59 +1076,83 @@ function applySessionClose(args) {
     const rel = join('projects', project, 'session-log', `${date}.md`);
     const full = join(args.hypoDir, rel);
     const isPresent = entryAlreadyPresent(payload.sessionLog.entry);
-    // Fallback-aware idempotency (hybrid cutover): during the month the
-    // shard takes over, today's entry may already live in the legacy monthly
-    // file from an earlier (pre-cutover) close. Treat presence in EITHER the
-    // daily shard or the legacy monthly file as "already written" so a same-day
-    // second close does not duplicate an identical entry across both files —
-    // and so an idempotent re-apply stays a true no-op (no shard is created).
-    let alreadyThere = false;
-    for (const cand of sessionLogReadCandidates(project, date)) {
-      const cf = join(args.hypoDir, cand);
-      if (!existsSync(cf)) continue;
-      try {
-        if (isPresent(readFileSync(cf, 'utf-8'))) {
-          alreadyThere = true;
-          break;
+    // Serialize dedup + create/append on the daily shard so two concurrent
+    // closes never lose an entry: the second closer takes the lock only after
+    // the first committed, re-reads the shard under the lock, and appends onto
+    // the committed bytes (temp+rename write-isolation is preserved — a partial
+    // write never tears the target). Create and append share ONE lock, so the
+    // "seed a new shard" and "append to an existing shard" branches can't race
+    // each other — only one closer is ever in the create path (closes the
+    // wx-window a bare exclusive-create would leave open).
+    try {
+      const outcome = withFileLock(full, () => {
+        // Fallback-aware idempotency (hybrid cutover): during the month the
+        // shard takes over, today's entry may already live in the legacy monthly
+        // file from an earlier (pre-cutover) close. Treat presence in EITHER the
+        // daily shard or the legacy monthly file as "already written" so a same-day
+        // second close does not duplicate an identical entry across both files —
+        // and so an idempotent re-apply stays a true no-op (no shard is created).
+        for (const cand of sessionLogReadCandidates(project, date)) {
+          const cf = join(args.hypoDir, cand);
+          if (!existsSync(cf)) continue;
+          try {
+            if (isPresent(readFileSync(cf, 'utf-8'))) return 'skipped';
+          } catch {
+            /* unreadable candidate — fall through to the write path */
+          }
         }
-      } catch {
-        /* unreadable candidate — fall through to the write path */
-      }
-    }
-    if (alreadyThere) {
-      skipped.push(`sessionLog (${rel})`);
-    } else if (!existsSync(full)) {
-      // A daily shard is a new file most days. Seed minimal valid frontmatter
-      // (title + type, the two REQUIRED_FIELDS) so the shard is a first-class
-      // wiki page rather than a W1 "no frontmatter" warning, and write the header
-      // AND the first entry in ONE atomic write — never leave a header-only shard
-      // on disk, which freshness would skip (no dated heading) while derive could
-      // otherwise mistake it for the evidence file. The dated `## [date] ...`
-      // heading lives inside the entry, so freshness / derive / design-history
-      // are unchanged.
-      // Audit fields (device, session_id). The shard frontmatter is git-tracked and synced, so
-      // `device` is an INTENTIONAL synced multi-machine identifier (privacy note:
-      // docs/ARCHITECTURE.md). It is a CREATOR-only stamp — only the session/
-      // machine that first seeds the daily shard is recorded; later same-day
-      // appends do not touch it. The per-session-accurate store is the LOCAL
-      // (.cache/, gitignored) index.jsonl written by hypo-session-record.mjs.
-      // `session_id` is honest naming: the value is the Claude session UUID, and
-      // it is present only on the Stop-chain close path that passes --session-id.
-      const device = currentDevice();
-      const auditFm =
-        (args.sessionId ? `session_id: ${String(args.sessionId).replace(/[\r\n]/g, '')}\n` : '') +
-        `device: ${device}\n`;
-      const header =
-        `---\ntitle: Session Log ${date} (${project})\n` +
-        `type: session-log\nupdated: ${date}\n${auditFm}---\n\n` +
-        `# Session Log ${date} (${project})\n`;
-      const entry = payload.sessionLog.entry;
-      const body = entry.endsWith('\n') ? entry : `${entry}\n`;
-      atomicWrite(full, `${header}\n${body}`);
-      applied.push(`sessionLog (${rel})`);
-    } else {
-      const wrote = appendIfAbsent(full, payload.sessionLog.entry, isPresent);
-      (wrote ? applied : skipped).push(`sessionLog (${rel})`);
+        if (!existsSync(full)) {
+          // A daily shard is a new file most days. Seed minimal valid frontmatter
+          // (title + type, the two REQUIRED_FIELDS) so the shard is a first-class
+          // wiki page rather than a W1 "no frontmatter" warning, and write the header
+          // AND the first entry in ONE atomic write — never leave a header-only shard
+          // on disk, which freshness would skip (no dated heading) while derive could
+          // otherwise mistake it for the evidence file. The dated `## [date] ...`
+          // heading lives inside the entry, so freshness / derive / design-history
+          // are unchanged.
+          // Audit fields (device, session_id). The shard frontmatter is git-tracked and synced, so
+          // `device` is an INTENTIONAL synced multi-machine identifier (privacy note:
+          // docs/ARCHITECTURE.md). It is a CREATOR-only stamp — only the session/
+          // machine that first seeds the daily shard is recorded; later same-day
+          // appends do not touch it. The per-session-accurate store is the LOCAL
+          // (.cache/, gitignored) index.jsonl written by hypo-session-record.mjs.
+          // `session_id` is honest naming: the value is the Claude session UUID, and
+          // it is present only on the Stop-chain close path that passes --session-id.
+          const device = currentDevice();
+          const auditFm =
+            (args.sessionId ? `session_id: ${String(args.sessionId).replace(/[\r\n]/g, '')}\n` : '') +
+            `device: ${device}\n`;
+          const header =
+            `---\ntitle: Session Log ${date} (${project})\n` +
+            `type: session-log\nupdated: ${date}\n${auditFm}---\n\n` +
+            `# Session Log ${date} (${project})\n`;
+          const entry = payload.sessionLog.entry;
+          const body = entry.endsWith('\n') ? entry : `${entry}\n`;
+          atomicWrite(full, `${header}\n${body}`);
+          return 'created';
+        }
+        return appendIfAbsent(full, payload.sessionLog.entry, isPresent) ? 'appended' : 'skipped';
+      }, { timeoutMs: APPEND_LOCK_TIMEOUT_MS });
+      (outcome === 'skipped' ? skipped : applied).push(`sessionLog (${rel})`);
+    } catch (err) {
+      // Only a lock-TIMEOUT is withheld as a conflict. A real fn() write error
+      // (disk-full, EACCES, mkdir failure) must NOT be masked as a proposal-
+      // pending timeout — rethrow so it hard-fails like the overwrite path does.
+      if (err?.code !== 'ELOCKTIMEOUT') throw err;
+      // Lock-timeout: withhold rather than lose the entry. Recorded as a conflict
+      // so the close goes proposal-pending (ok:false, no marker) and the next
+      // close re-applies. `kind: 'append'` marks it for T6's append-proposal
+      // handling — proposedContent is the entry to append, not a whole-file
+      // replacement.
+      conflicts.push({
+        key: 'sessionLog',
+        target: rel,
+        reason: 'append-lock-timeout',
+        kind: 'append',
+        baseHash: null,
+        currentHash: null,
+        proposedContent: payload.sessionLog.entry,
+      });
     }
   }
 
@@ -1139,29 +1170,68 @@ function applySessionClose(args) {
   // append onto a deliberately custom payload.log (codex pre-commit review). The
   // two payload paths are mutually exclusive: deriving on top of a present-but-
   // malformed payload.log would mask it and weaken the verifier's fail-loud.
+  // log.md is shared across projects and also written by deriveRootLogEntries
+  // (the Stop-hook backfill in hypo-shared.mjs). Both take the SAME lock on
+  // log.md, so a concurrent close's append and this close's append serialize
+  // instead of overwriting each other.
+  const logFull = join(args.hypoDir, 'log.md');
   if (payload.log) {
-    const wrote = appendIfAbsent(
-      join(args.hypoDir, 'log.md'),
-      payload.log.entry,
-      entryAlreadyPresent(payload.log.entry),
-    );
-    (wrote ? applied : skipped).push('log (log.md)');
+    try {
+      const wrote = withFileLock(
+        logFull,
+        () => appendIfAbsent(logFull, payload.log.entry, entryAlreadyPresent(payload.log.entry)),
+        { timeoutMs: APPEND_LOCK_TIMEOUT_MS },
+      );
+      (wrote ? applied : skipped).push('log (log.md)');
+    } catch (err) {
+      if (err?.code !== 'ELOCKTIMEOUT') throw err;
+      // proposedContent is append-ready root-log bytes (the custom log line).
+      conflicts.push({
+        key: 'log',
+        target: 'log.md',
+        reason: 'append-lock-timeout',
+        kind: 'append',
+        baseHash: null,
+        currentHash: null,
+        proposedContent: payload.log.entry,
+      });
+    }
   } else {
     // matchAll (not exec) mirrors deriveRootLogEntries: a payload that carried
     // more than one dated heading derives one canonical line each, symmetric with
     // the global path. Exact-line dedup on the heading keeps a second apply (or a
     // titleless vs titled same-day pair) from duplicating.
-    const logFull = join(args.hypoDir, 'log.md');
     const headingRe = new RegExp(`^#{1,6} \\[${date}\\]\\s*(.*)$`, 'gm');
-    let wroteAny = false;
-    for (const m of (payload.sessionLog.entry || '').matchAll(headingRe)) {
-      const { heading, block } = rootLogEntry(project, date, m[1]);
-      const wrote = appendIfAbsent(logFull, block, (c) =>
-        (c || '').split(/\r?\n/).includes(heading),
-      );
-      wroteAny = wroteAny || wrote;
+    try {
+      const wroteAny = withFileLock(logFull, () => {
+        let w = false;
+        for (const m of (payload.sessionLog.entry || '').matchAll(headingRe)) {
+          const { heading, block } = rootLogEntry(project, date, m[1]);
+          const wrote = appendIfAbsent(logFull, block, (c) =>
+            (c || '').split(/\r?\n/).includes(heading),
+          );
+          w = w || wrote;
+        }
+        return w;
+      }, { timeoutMs: APPEND_LOCK_TIMEOUT_MS });
+      (wroteAny ? applied : skipped).push('log (log.md, derived)');
+    } catch (err) {
+      if (err?.code !== 'ELOCKTIMEOUT') throw err;
+      // `derived: true` discriminates this from the payload.log conflict above:
+      // here proposedContent is the session-log entry to RE-DERIVE root-log lines
+      // from (via rootLogEntry over its dated headings), NOT append-ready bytes.
+      // T6 must branch on this to know how to turn proposedContent into log.md.
+      conflicts.push({
+        key: 'log',
+        target: 'log.md',
+        reason: 'append-lock-timeout',
+        kind: 'append',
+        derived: true,
+        baseHash: null,
+        currentHash: null,
+        proposedContent: payload.sessionLog.entry,
+      });
     }
-    (wroteAny ? applied : skipped).push('log (log.md, derived)');
   }
 
   // Same-date-tie fix: verify against the SAME project this apply just wrote
@@ -1361,9 +1431,10 @@ function applySessionClose(args) {
     date,
     applied,
     skipped,
-    // Targets withheld because the page drifted from this session's observed base.
+    // Targets withheld: an overwrite drifted from this session's observed base, or
+    // an append could not take the file lock in time (`kind: 'append'`).
     // `proposedContent` is dropped from the reported shape (it is the whole payload
-    // field, and T6 parks it in the proposal artifact instead).
+    // field / the entry to append, and T6 parks it in the proposal artifact instead).
     conflicts: conflicts.map(({ proposedContent: _drop, ...rest }) => rest),
     verification,
     // Surface the marker outcome instead of skipping silently, so the
@@ -1391,11 +1462,15 @@ function applySessionClose(args) {
     for (const a of applied) console.log(`  ✓ wrote ${a}`);
     for (const s of skipped) console.log(`  · skipped ${s} (already current)`);
     // Never let a withheld target read as a skip: `skipped` means "already current",
-    // this means "your bytes are NOT on disk and someone else's are".
+    // this means "your bytes are NOT on disk". Overwrite conflicts drifted from base;
+    // an append conflict is a lock-timeout (someone else held the file's lock), which
+    // is transient — the next close re-applies.
     for (const c of conflicts) {
-      console.log(
-        `  ⚠ WITHHELD ${c.key} (${c.target}) — ${c.reason}; the page changed since this session read it`,
-      );
+      const why =
+        c.kind === 'append'
+          ? 'could not acquire the append lock in time; the next close re-applies'
+          : 'the page changed since this session read it';
+      console.log(`  ⚠ WITHHELD ${c.key} (${c.target}) — ${c.reason}; ${why}`);
     }
     if (ok) {
       // When the marker was withheld, qualify the success line so a reader scanning

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -479,6 +479,10 @@ const GITIGNORE_REQUIRED_ENTRIES = [
     pattern: '.cache/',
     comment: '# Hypomnema runtime cache (page-usage log, session growth metrics)',
   },
+  {
+    pattern: '*.lock',
+    comment: '# Append-lock files (transient <target>.lock; a crashed holder can leave a stale one)',
+  },
 ];
 
 function checkGitignore(hypoDir) {

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -3,3 +3,8 @@
 
 # Runtime cache: sync-state.json contains hostname() and timestamps
 .cache/
+
+# Append-lock files: transient <target>.lock guards around session-log / log.md
+# writes (crystallize apply, deriveRootLogEntries). Normally deleted immediately;
+# a crashed holder can leave a stale one, which must never be committed.
+*.lock

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -6,7 +6,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, spawn } from 'node:child_process';
 import {
   mkdtempSync,
   mkdirSync,
@@ -20,6 +20,7 @@ import {
   statSync,
   unlinkSync,
   utimesSync,
+  chmodSync,
   cpSync,
   realpathSync,
 } from 'node:fs';
@@ -3466,6 +3467,47 @@ function runApply(dir, payload, { force = false, sessionId = null } = {}) {
   if (sessionId) flags.push(`--session-id=${sessionId}`);
   return run('crystallize.mjs', flags);
 }
+
+// FEAT-11 T5 fail-safe: drives the REAL close path (not a worker reimplementation
+// of append). Pre-hold a fresh lock on the daily shard so crystallize's append
+// cannot acquire it → the close must withhold to proposal-pending WITHOUT touching
+// the shard, and the conflict must carry the T6 seam fields (kind:'append').
+test('append lock-timeout → proposal-pending, shard byte-untouched (FEAT-11 T5)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog = { entry: `## [${today}] locked-out entry\n\nbody\n` };
+    const shard = join(dir, 'projects', 'test-project', 'session-log', `${today}.md`);
+    const shardLock = `${shard}.lock`;
+    mkdirSync(dirname(shard), { recursive: true });
+    const shardBefore = existsSync(shard) ? readFileSync(shard, 'utf-8') : null;
+    writeFileSync(shardLock, ''); // fresh lock "held" by another writer, never released
+    process.env.HYPO_APPEND_LOCK_TIMEOUT_MS = '300'; // fast timeout instead of the 5s default
+    let r;
+    try {
+      r = runApply(dir, payload, { sessionId: 's-lockout' });
+    } finally {
+      delete process.env.HYPO_APPEND_LOCK_TIMEOUT_MS;
+      try {
+        unlinkSync(shardLock);
+      } catch {
+        /* already gone */
+      }
+    }
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false, `lock-timeout must withhold (ok:false): ${r.stdout}`);
+    assert.equal(out.stage, 'proposal-pending', `stage must be proposal-pending: ${r.stdout}`);
+    const c = (out.conflicts || []).find((x) => x.key === 'sessionLog');
+    assert.ok(c, `a sessionLog conflict is expected: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(c.kind, 'append', 'conflict.kind must be "append"');
+    assert.equal(c.reason, 'append-lock-timeout', 'conflict.reason must be append-lock-timeout');
+    assert.equal(c.proposedContent, undefined, 'proposedContent must be dropped from the reported shape');
+    const shardAfter = existsSync(shard) ? readFileSync(shard, 'utf-8') : null;
+    assert.equal(shardAfter, shardBefore, 'the shard must be byte-untouched when the append is withheld');
+    if (shardAfter) {
+      assert.ok(!shardAfter.includes('locked-out entry'), 'the withheld entry must not be written');
+    }
+  });
+});
 
 test('clean-wiki payload → ok:true, new entries appended (apply dedup is exact-entry, not date-based)', () => {
   withWiki(null, (dir, today) => {
@@ -26487,6 +26529,158 @@ test('a Write advances the base to the bytes it wrote, not a racy disk re-read',
       'the concurrent bytes must not become our base',
     );
   });
+});
+
+// ── hypo-shared.mjs — withFileLock (FEAT-11 T5) ──────────────────────────────
+// The lock's guarantee is mutual exclusion (mechanism), not a green test. These
+// deterministic unit tests pin acquire/release/steal/timeout; the concurrent
+// smoke below exercises no-loss + exact-dedup across real processes.
+
+suite('hypo-shared.mjs — withFileLock (FEAT-11 T5)');
+
+const { withFileLock: wfl } = await import(`${REPO}/hooks/hypo-shared.mjs`);
+
+test('holds the lock during the critical section and removes it after', () => {
+  withTmpDir((dir) => {
+    const target = join(dir, 'log.md');
+    const lockPath = `${target}.lock`;
+    let lockedDuring = false;
+    const ret = wfl(target, () => {
+      lockedDuring = existsSync(lockPath);
+      return 'done';
+    });
+    assert.equal(ret, 'done', 'returns the critical section result');
+    assert.equal(lockedDuring, true, 'lock file exists while fn runs');
+    assert.equal(existsSync(lockPath), false, 'lock file removed after release');
+  });
+});
+
+test('steals a stale lock whose holder died (mtime older than staleMs)', () => {
+  withTmpDir((dir) => {
+    const target = join(dir, 'log.md');
+    const lockPath = `${target}.lock`;
+    writeFileSync(lockPath, ''); // a dead holder's leftover lock
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, old, old); // backdate well past the stale threshold
+    let ran = false;
+    wfl(
+      target,
+      () => {
+        ran = true;
+      },
+      { staleMs: 1000, timeoutMs: 500 },
+    );
+    assert.equal(ran, true, 'stole the stale lock and ran');
+    assert.equal(existsSync(lockPath), false, 'lock cleaned up after the run');
+  });
+});
+
+test('throws lock-timeout when a fresh lock is held past timeoutMs', () => {
+  withTmpDir((dir) => {
+    const target = join(dir, 'log.md');
+    const lockPath = `${target}.lock`;
+    writeFileSync(lockPath, ''); // fresh mtime, never released
+    assert.throws(
+      () => wfl(target, () => {}, { timeoutMs: 200, staleMs: 60_000, pollMs: 20 }),
+      /lock-timeout/,
+      'gives up after timeoutMs instead of blocking forever (caller falls to proposal)',
+    );
+    assert.equal(existsSync(lockPath), true, 'the held lock is left intact, not stolen');
+  });
+});
+
+test('does not hang when a STALE lock cannot be removed — times out instead', () => {
+  // root ignores directory perms, and Windows chmod-on-dir doesn't block unlink,
+  // so the unlink would succeed and there'd be nothing to time out against —
+  // skip rather than assert a false negative.
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withTmpDir((dir) => {
+    const sub = join(dir, 'sub');
+    mkdirSync(sub);
+    const target = join(sub, 'log.md');
+    const lockPath = `${target}.lock`;
+    writeFileSync(lockPath, '');
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, old, old); // make it stale (steal-eligible)
+    chmodSync(sub, 0o555); // dir non-writable → unlinkSync(lockPath) fails EACCES
+    try {
+      // Before the fix this spun forever (the broad catch swallowed the unlink
+      // failure and `continue`d past the timeout check). It must now fall through
+      // to the timeout and throw ELOCKTIMEOUT.
+      assert.throws(
+        () => wfl(target, () => {}, { staleMs: 1000, timeoutMs: 300, pollMs: 20 }),
+        /lock-timeout/,
+        'an un-removable stale lock must time out, not hang',
+      );
+    } finally {
+      chmodSync(sub, 0o755); // restore so withTmpDir cleanup can remove it
+    }
+  });
+});
+
+// ── crystallize — concurrent append no-loss + exact-dedup (FEAT-11 T5) ────────
+// Barrier-synchronized real processes: N workers each take the SAME file lock
+// and append a distinct entry, plus one duplicate to prove dedup. Under the lock
+// every distinct entry survives (no last-writer-wins drop) and the duplicate
+// collapses to one. This is a smoke check — the no-loss guarantee rests on the
+// lock's serialization, not on this test always tripping the race.
+const T5_WORKER_SRC = `
+import { withFileLock } from ${JSON.stringify(join(REPO, 'hooks', 'hypo-shared.mjs'))};
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+const [, , target, entry, barrier] = process.argv;
+const t0 = Date.now();
+while (!existsSync(barrier) && Date.now() - t0 < 10000) { /* spin to the barrier */ }
+withFileLock(target, () => {
+  const cur = existsSync(target) ? readFileSync(target, 'utf-8') : '';
+  if (cur.includes(entry)) return; // exact-entry dedup (matches appendIfAbsent)
+  const sep = cur === '' ? '' : cur.endsWith('\\n') ? '' : '\\n';
+  writeFileSync(target, cur + sep + entry + '\\n');
+});
+`;
+
+function spawnT5Worker(workerPath, target, entry, barrier) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(process.execPath, [workerPath, target, entry, barrier], { stdio: 'ignore' });
+    p.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`worker exit ${code}`))));
+    p.on('error', reject);
+  });
+}
+
+suite('crystallize — concurrent append (FEAT-11 T5)');
+
+await testAsync('N concurrent appends lose nothing and dedup an exact duplicate', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t5-'));
+  try {
+    const workerPath = join(dir, 'worker.mjs');
+    writeFileSync(workerPath, T5_WORKER_SRC);
+    const target = join(dir, 'session-log.md');
+    const N = 12;
+    const ROUNDS = 3;
+    for (let r = 0; r < ROUNDS; r++) {
+      // Alternate the starting state so BOTH races run: an absent target makes
+      // workers contend on create-under-lock; an existing (empty) target makes
+      // them contend on append-under-lock.
+      if (r % 2 === 0) rmSync(target, { force: true });
+      else writeFileSync(target, '');
+      const barrier = join(dir, `barrier-${r}`);
+      // Entries are [[e0]]..[[eN-1]] (none a substring of another) plus a repeat
+      // of [[e0]] to exercise dedup under contention.
+      const entries = [];
+      for (let i = 0; i < N; i++) entries.push(`[[e${i}]]`);
+      entries.push('[[e0]]');
+      const procs = entries.map((e) => spawnT5Worker(workerPath, target, e, barrier));
+      writeFileSync(barrier, 'go'); // release all workers together
+      await Promise.all(procs);
+      const content = readFileSync(target, 'utf-8');
+      for (let i = 0; i < N; i++) {
+        assert.ok(content.includes(`[[e${i}]]`), `round ${r}: [[e${i}]] must survive (no-loss)`);
+      }
+      const dupCount = content.split('[[e0]]').length - 1;
+      assert.equal(dupCount, 1, `round ${r}: duplicate [[e0]] deduped to exactly one`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ── summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# English

## What changed

Session-close appends to the daily session-log shard and root `log.md` are now serialized by a per-target lockfile (`withFileLock` in `hooks/hypo-shared.mjs`). The three append sites in `crystallize.mjs` and `deriveRootLogEntries` all take the same per-target lock, re-read under it, and commit via tmp+rename.

## Why

Under concurrency the appends were last-writer-wins: two closes could read the same bytes and the second `rename` would drop the first's entry. `deriveRootLogEntries` runs on every Stop, so two ordinary sessions on one vault were enough to lose a `log.md` entry. This makes close-path appends lose-nothing and makes exact-entry dedup precise instead of best-effort.

## How

The lock wraps (does not replace) the existing tmp+rename write-isolation, so crash-atomicity is kept: a partial write still lands on a throwaway temp and the target is never torn. `O_APPEND` was rejected because an in-place partial write (ENOSPC / RLIMIT) leaves a torn dated heading the freshness gate mis-reads and cannot roll back. A lock-timeout withholds to `proposal-pending` (conflict `kind:'append'`); a real write error (disk-full / EACCES) still hard-fails instead of masquerading as a timeout. No-loss is scoped to close-path writers: `feedback.mjs`, `lib/project-create.mjs`, and `lint.mjs --fix` remain lock-bypassing residuals (deferred).

## Manual verification

Not yet run in a real deployed session. Verified via the automated suite only: a barrier-synchronized concurrent-append test across real `node` processes (create and append races, no-loss and exact-dedup), plus a fail-safe integration test that drives the real `crystallize --apply-session-close` path with a pre-held lock and asserts `proposal-pending` with the shard left byte-untouched. The deployed `~/.claude/hooks/` copy firing on a live Stop was NOT separately exercised.

## Migration notes

`*.lock` added to `templates/gitignore` and to the upgrade `.gitignore` migration, so upgraded vaults ignore stale lock files. No manual step required on upgrade.

---

# 한국어

## 변경 내용

세션 종료 시 daily session-log 샤드와 루트 `log.md`에 대한 append가 이제 대상별 lockfile(`hooks/hypo-shared.mjs`의 `withFileLock`)로 직렬화된다. `crystallize.mjs`의 세 append 지점과 `deriveRootLogEntries`가 같은 per-target lock을 잡고, lock 안에서 재-read한 뒤 tmp+rename으로 커밋한다.

## 이유

동시 실행에서 append가 last-writer-wins였다: 두 close가 같은 바이트를 읽고 두 번째 `rename`이 첫 엔트리를 덮었다. `deriveRootLogEntries`는 매 Stop마다 돌기 때문에 한 볼트의 일상적인 두 세션만으로도 `log.md` 엔트리가 유실될 수 있었다. 이 변경으로 close 경로 append가 무손실이 되고, exact-entry dedup이 best-effort가 아니라 정확해진다.

## 방법

lock은 기존 tmp+rename write-isolation을 대체하지 않고 감싸므로 crash-atomicity가 유지된다: partial write는 여전히 throwaway temp에만 떨어지고 대상은 안 찢긴다. `O_APPEND`는 기각했다. in-place partial write(ENOSPC / RLIMIT)가 대상에 torn dated heading을 남겨 freshness가 오인하고 되돌릴 수 없기 때문이다. lock-timeout은 `proposal-pending`(conflict `kind:'append'`)으로 보류하고, 실제 write 에러(disk-full / EACCES)는 timeout으로 위장하지 않고 hard-fail한다. 무손실은 close 경로 writer에 한정된다: `feedback.mjs`, `lib/project-create.mjs`, `lint.mjs --fix`는 lock 미참여 잔여로 남는다(defer).

## 수동 검증

실제 배포 세션에서는 아직 안 돌렸다. 자동 스위트로만 검증했다: 실 `node` 프로세스 간 barrier 동기 concurrent-append 테스트(create와 append race, 무손실과 exact-dedup), 그리고 pre-held lock으로 실제 `crystallize --apply-session-close` 경로를 구동해 `proposal-pending` + 샤드 byte-untouched를 단언하는 fail-safe 통합 테스트. 배포된 `~/.claude/hooks/` 사본이 라이브 Stop에서 발화하는 것은 별도로 검증하지 않았다.

## 마이그레이션 노트

`*.lock`을 `templates/gitignore`와 upgrade `.gitignore` 마이그레이션에 추가해 업그레이드된 볼트가 stale lock 파일을 무시한다. 업그레이드 시 수동 조작은 필요 없다.

---

## Changelog

- EN: Session-close appends to session-log and log.md no longer lose entries under concurrent closes (#182).
- KO: 동시 세션 종료 시 session-log와 log.md append 엔트리가 더 이상 유실되지 않는다 (#182).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
