### PR TITLE
fix(crystallize): hard-fail on unreadable append target instead of silent overwrite

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -488,8 +488,16 @@ function appendIfAbsent(path, entry, alreadyPresent) {
   if (existsSync(path)) {
     try {
       content = readFileSync(path, 'utf-8');
-    } catch {
-      content = '';
+    } catch (err) {
+      // ENOENT here is a narrow existsSync-then-readFileSync race (the file
+      // vanished between the two calls) — content='' is safe, we would create
+      // it fresh anyway. Anything else (EACCES/EISDIR/...) is a PERSISTENT
+      // read failure: retrying (the caller's lock-timeout conflict path) would
+      // never fix it, and swallowing it here would fall through to the
+      // atomicWrite below and silently replace the existing file's bytes with
+      // just this one entry — a data-loss overwrite. So rethrow and let the
+      // withFileLock/call-site catch hard-fail the close instead.
+      if (err?.code !== 'ENOENT') throw err;
     }
   }
   if (alreadyPresent(content)) return false;

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3509,6 +3509,62 @@ test('append lock-timeout → proposal-pending, shard byte-untouched (FEAT-11 T5
   });
 });
 
+// appendIfAbsent data-loss fix: a PERSISTENT read error (EACCES/EISDIR/...) on an
+// append target that already has content must hard-fail the close, not silently
+// fall back to content='' and let atomicWrite's rename replace the file with just
+// the new entry. Unlike the lock-timeout case above (transient — the next close
+// retries), a persistent read error never resolves on retry, so this must throw
+// past the ELOCKTIMEOUT-only catch and crash the close instead of masking data
+// loss as success. root ignores the file's own permission bits (can still read
+// with mode 0), so this repro is skipped there — same rationale as the
+// withFileLock un-removable-stale-lock test above.
+test('append read failure (EACCES) hard-fails the close, log.md bytes preserved (FEAT-11 T5)', () => {
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    const logPath = join(dir, 'log.md');
+    const before = readFileSync(logPath, 'utf-8');
+    chmodSync(logPath, 0o000); // unreadable, but the parent dir stays writable
+    let r;
+    try {
+      r = runApply(dir, payload, { sessionId: 's-unreadable-log' });
+    } finally {
+      chmodSync(logPath, 0o644); // restore so cleanup (rmSync) can remove the tree
+    }
+    assert.notEqual(
+      r.status,
+      0,
+      `an unreadable log.md must hard-fail, not exit 0: ${r.stdout}\n${r.stderr}`,
+    );
+    const after = readFileSync(logPath, 'utf-8');
+    assert.equal(
+      after,
+      before,
+      'log.md must be byte-untouched — a swallowed read error must not let atomicWrite replace it with just the new entry',
+    );
+  });
+});
+
+// Sibling regression pin for the ENOENT branch of the same catch: a target that
+// simply does not exist yet (the common case, not the read-failure case above)
+// must still be created normally — the fix must not turn "no file yet" into a
+// hard-fail.
+test('append target absent (no prior log.md) → close still creates it (ENOENT stays tolerated)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    rmSync(join(dir, 'log.md'));
+    const r = runApply(dir, payload, { sessionId: 's-absent-log' });
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true, `expected ok:true: ${r.stdout}`);
+    assert.ok(existsSync(join(dir, 'log.md')), 'log.md must be created fresh when absent');
+    assert.ok(
+      readFileSync(join(dir, 'log.md'), 'utf-8').includes(payload.log.entry.trim()),
+      'the freshly created log.md must carry the new entry',
+    );
+  });
+});
+
 test('clean-wiki payload → ok:true, new entries appended (apply dedup is exact-entry, not date-based)', () => {
   withWiki(null, (dir, today) => {
     // payloadForCleanWiki uses NEW entry text ("re-applied"), not the fixture's


### PR DESCRIPTION
# English

## What changed

`appendIfAbsent` (used by every crystallize append path: session-log daily shards, `log.md` custom and derived) no longer swallows a read failure on an existing target. Only `ENOENT` keeps the empty-content fallback; every other read error rethrows and hard-fails the close.

## Why

When the target file existed but `readFileSync` failed with a persistent error (EACCES, EISDIR, a corrupt file), the old `catch { content = '' }` dropped the file's existing frontmatter and entries and then `atomicWrite`-replaced it with just the one new entry. As long as the parent directory stayed writable, the rename succeeded and the whole session-log shard or `log.md` was silently overwritten, reported as a successful close (exit 0). That is a data-loss bug: a session close could destroy accumulated history without any signal.

## How

The distinction the code was missing is transient vs persistent. A lock timeout is transient, so "the next close re-applies" is a true promise and the existing retryable-conflict path is correct. A read error (EACCES/EISDIR/corrupt) is persistent, so retrying would loop forever without healing, and the honest response is to fail loud. `appendIfAbsent` now keeps the empty-content fallback only for `ENOENT` (a narrow existsSync-then-read race where recreating the file is safe) and rethrows everything else. The rethrown error's code is not `ELOCKTIMEOUT`, so the existing `withFileLock` call-site catches (which already rethrow anything that is not a lock timeout) hard-fail the close with no new plumbing. This mirrors the rule already live on the write side.

## Manual verification

Reverting the fix to `catch { content = '' }` and running the new test confirms the old code reports `ok:true` and silently replaces an unreadable `log.md` with a single-entry file; the fixed code hard-fails and preserves the original bytes. Full suite: 1285 passed, 0 failed.

## Migration notes

None. The only behavior change is that a close which previously destroyed an unreadable append target's contents now fails loudly instead. Callers with readable targets are unaffected.

---

# 한국어

## 변경 내용

`appendIfAbsent`(crystallize의 모든 append 경로가 사용: session-log 일별 샤드, `log.md` custom·derived)가 기존 대상 파일의 read 실패를 더 이상 삼키지 않는다. `ENOENT`만 빈 내용 fallback을 유지하고, 그 외 모든 read 에러는 rethrow해서 close를 hard-fail시킨다.

## 이유

대상 파일이 존재하는데 `readFileSync`가 persistent 에러(EACCES, EISDIR, corrupt)를 내면, 기존 `catch { content = '' }`가 파일의 프론트매터와 누적 엔트리를 버리고 `atomicWrite`로 새 entry 하나짜리로 통째 교체했다. 부모 디렉터리 write 권한만 있으면 rename이 성공해, session-log 샤드나 `log.md` 전체가 조용히 덮이고 성공한 close(exit 0)로 보고됐다. 세션 close가 누적 이력을 아무 신호 없이 파괴할 수 있는 데이터 손실 결함이다.

## 방법

코드가 놓친 구분은 transient 대 persistent다. lock timeout은 transient라 "다음 close가 재시도"가 참인 약속이고 기존 retryable-conflict 경로가 옳다. read 에러(EACCES/EISDIR/corrupt)는 persistent라 재시도해도 안 낫고 무한 반복하니, 정직한 대응은 fail-loud다. 이제 `appendIfAbsent`는 `ENOENT`(existsSync 후 파일이 사라진 좁은 race, 재생성이 안전)에만 빈 내용 fallback을 두고 나머지는 rethrow한다. rethrow된 에러의 code는 `ELOCKTIMEOUT`이 아니라, lock timeout이 아닌 것을 이미 rethrow하는 기존 `withFileLock` 호출부 catch가 새 배관 없이 close를 hard-fail시킨다. write 경로에 이미 살아있던 규칙을 read 경로로 맞춘 것이다.

## 수동 검증

fix를 `catch { content = '' }`로 되돌려 신규 테스트를 돌리면, 기존 코드는 `ok:true`로 읽을 수 없는 `log.md`를 새 entry 하나짜리로 조용히 교체하고, 수정 코드는 hard-fail하며 원본 바이트를 보존한다. 전체 스위트: 1285 passed, 0 failed.

## 마이그레이션 노트

None. 유일한 동작 변화는, 이전에 읽을 수 없는 append 대상의 내용을 파괴하던 close가 이제 hard-fail한다는 것뿐이다. 대상이 읽히는 정상 호출은 영향 없다.

---

## Changelog

- EN: Bug Fixes: a session close no longer silently overwrites a session-log shard or log.md when the file exists but cannot be read; it now fails loudly instead of dropping accumulated entries.
- KO: 버그 수정: 세션 close가 session-log 샤드나 log.md가 존재하지만 읽을 수 없을 때 누적 엔트리를 버리고 조용히 덮어쓰던 문제를 고쳐, 이제 조용히 손실하는 대신 hard-fail한다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
