### PR TITLE
feat(proposal-store): park drifted overwrite targets as reviewable proposal artifacts

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -143,5 +143,11 @@
       }
     ]
   },
-  "shared": ["hypo-shared.mjs", "version-check.mjs", "version-check-fetch.mjs", "base-store.mjs"]
+  "shared": [
+    "hypo-shared.mjs",
+    "version-check.mjs",
+    "version-check-fetch.mjs",
+    "base-store.mjs",
+    "proposal-store.mjs"
+  ]
 }

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1260,8 +1260,9 @@ function atomicWriteShared(path, content) {
  * the `unlinkSync`, the holder can release and a fresh holder grab the same path,
  * whose lock we then remove. `staleMs` is set well above a normal close (seconds)
  * to make both extreme-low-probability. If the lock cannot be acquired within
- * `timeoutMs`, throw so the caller can fall back to the write=proposal gate
- * (architecturally consistent with the existing fail-safe).
+ * `timeoutMs`, throw so the caller can fall back to the write=proposal gate — for
+ * an append that means blocking the close (proposal-pending) with no artifact; the
+ * next close re-appends (architecturally consistent with the existing fail-safe).
  *
  * @param {string} targetPath file being guarded (lock is a sibling `.lock`)
  * @param {() => T} fn critical section

--- a/hooks/proposal-store.mjs
+++ b/hooks/proposal-store.mjs
@@ -1,0 +1,276 @@
+// proposal-store.mjs: parked overwrite-conflict artifacts (the write=proposal gate)
+//
+// Lives in hooks/ rather than scripts/lib/ for the same reason base-store does: a
+// SessionStart-chain hook (T8's session-start surface) counts pending proposals,
+// so the store must sit where a hook can import it without reaching up into
+// scripts/. scripts/ (crystallize, the T7 CLI) already imports from hooks/, never
+// the reverse. Registered in hooks.json `shared` alongside base-store.
+//
+// When crystallize's close path finds that an OVERWRITE target drifted away from
+// the base this session observed at start, it withholds the bytes rather than
+// clobber the other writer's edits (base-store's guard). Those withheld bytes have
+// to go somewhere a human can review and re-apply them later, out of band from the
+// session that produced them — that is this artifact:
+// `<hypoDir>/.cache/proposals/<id>.json` (gitignored, never synced, same .cache/
+// neighborhood as base-store's per-session snapshots).
+//
+// Two invariants shape the store:
+//
+//   1. Overwrite only. APPEND conflicts (session-log / log.md lock-timeouts) do
+//      NOT become artifacts. A lock-timeout is transient, so the next close
+//      self-heals by re-appending; and T7 applies a proposal by REPLACING the
+//      whole target, which for an append-only history file would drop every other
+//      entry. crystallize filters `kind: 'append'` out before it ever calls here.
+//
+//   2. One artifact per target. Each close re-derives the same drifted target, so
+//      without supersede a fresh random id would accumulate a stale artifact on
+//      every close and inflate the pending count. writeProposal writes the new
+//      artifact durably FIRST, then deletes any older same-target sibling — so a
+//      crash between the two leaves an extra artifact (harmless, superseded next
+//      time), never zero. A same-target close that is byte-identical reuses the
+//      existing id instead of writing at all (idempotent).
+//
+// Everything is best-effort on the read side (a malformed artifact is skipped, not
+// fatal) and atomic on the write side (tmp+rename), mirroring base-store.
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  readdirSync,
+  unlinkSync,
+  realpathSync,
+} from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+
+/** `<hypoDir>/.cache/proposals/`. */
+export function proposalsDir(hypoDir) {
+  return join(hypoDir, '.cache', 'proposals');
+}
+
+/** `<hypoDir>/.cache/proposals/<id>.json`. */
+export function proposalPath(hypoDir, id) {
+  return join(proposalsDir(hypoDir), `${id}.json`);
+}
+
+// A generated id is `<digits>-<slug>-<rand>`: filename-safe tokens joined by
+// hyphens, never a path separator, `.`, or `..`. The T7 CLI takes an id straight
+// off the command line, so an unvalidated id would let `../../hot` resolve to
+// `<hypoDir>/hot.json` and drive readProposal/deleteProposal against a file
+// outside the store. Reject anything that is not the generated shape.
+const PROPOSAL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
+
+/** True only for the filename-safe id shape makeProposalId emits. */
+export function isValidProposalId(id) {
+  return typeof id === 'string' && PROPOSAL_ID_RE.test(id);
+}
+
+/**
+ * Resolve `<id>.json` and confirm it sits DIRECTLY inside the proposals dir.
+ * Returns the absolute path, or null when the id is malformed or the resolved
+ * path escapes the store — defense in depth behind isValidProposalId, so even a
+ * validator gap cannot read or unlink a file elsewhere in the vault.
+ */
+function resolvedProposalPath(hypoDir, id) {
+  if (!isValidProposalId(id)) return null;
+  const p = resolve(proposalPath(hypoDir, id));
+  if (dirname(p) !== resolve(proposalsDir(hypoDir))) return null;
+  // A lexical resolve+dirname check cannot see a SYMLINKED store: if
+  // `.cache/proposals` (or a parent) is a symlink to outside the vault, the id is
+  // valid but the path still escapes. When the store exists, require its real
+  // (symlink-resolved) path to be the vault's own `.cache/proposals`. When it does
+  // not exist yet there is nothing to read or unlink, so the lexical guard stands.
+  try {
+    if (
+      realpathSync(proposalsDir(hypoDir)) !== join(realpathSync(hypoDir), '.cache', 'proposals')
+    ) {
+      return null;
+    }
+  } catch {
+    /* store or vault not present yet — nothing to escape to */
+  }
+  return p;
+}
+
+/** Slug a vault-relative path into a filename-safe token (no separators). */
+function slugTarget(target) {
+  return (
+    String(target)
+      .replace(/[^A-Za-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase() || 'target'
+  );
+}
+
+/**
+ * Build an artifact id: `<compressed-createdAt>-<targetSlug>-<rand>`.
+ *
+ * createdAt is an ISO string stripped of the characters a filename cannot carry
+ * (`-`, `:`, `.`), so it stays human-sortable; targetSlug keeps the id legible in
+ * `ls`; rand disambiguates two closes that land in the same millisecond. The id is
+ * only an on-disk key — the artifact body carries the authoritative fields.
+ */
+export function makeProposalId(createdAt, target) {
+  const ts = String(createdAt)
+    .replace(/[-:.]/g, '')
+    .replace(/[^A-Za-z0-9]/g, '');
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${ts}-${slugTarget(target)}-${rand}`;
+}
+
+/** Atomic overwrite via tmp+rename, mirroring base-store's atomicWrite. */
+function atomicWrite(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+}
+
+/**
+ * Read+parse one artifact file by absolute path. Returns null when absent,
+ * unreadable, or malformed (best-effort: a corrupt artifact must never crash a
+ * listing or a supersede scan).
+ */
+function readArtifactFile(path) {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    if (typeof parsed.id !== 'string' || typeof parsed.target !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List parked proposals, newest artifacts included, malformed ones skipped.
+ * Each entry is the parsed body plus `_path` (absolute) so callers (the T7 CLI)
+ * can act on the exact file without re-deriving the path.
+ *
+ * @returns {Array<object>} parsed artifacts; empty when the dir is absent/empty
+ */
+export function listProposals(hypoDir) {
+  const dir = proposalsDir(hypoDir);
+  if (!existsSync(dir)) return [];
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const path = join(dir, name);
+    const parsed = readArtifactFile(path);
+    // A well-formed artifact's `id` field equals its filename stem and is itself
+    // id-safe. A mismatch means the body was hand-edited or corrupt; trusting its
+    // `id` would let a spoofed value drive supersede or T7 apply against the wrong
+    // file, so skip it (it stays on disk but is never acted on).
+    if (parsed && isValidProposalId(parsed.id) && parsed.id === name.slice(0, -'.json'.length)) {
+      out.push({ ...parsed, _path: path });
+    }
+  }
+  return out;
+}
+
+/**
+ * Read one proposal by id. Returns null when the id is unsafe, or the file is
+ * absent, unreadable, or malformed.
+ */
+export function readProposal(hypoDir, id) {
+  const path = resolvedProposalPath(hypoDir, id);
+  if (!path) return null; // reject unsafe id — never read outside the store
+  return readArtifactFile(path);
+}
+
+/**
+ * Delete one proposal by id. Returns true when the file is gone afterwards
+ * (whether this call removed it or it was already absent), false when the id is
+ * unsafe or the unlink itself failed for another reason.
+ */
+export function deleteProposal(hypoDir, id) {
+  const path = resolvedProposalPath(hypoDir, id);
+  if (!path) return false; // reject unsafe id — never unlink outside the store
+  try {
+    unlinkSync(path);
+    return true;
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return true; // already gone — the desired end state
+    return false;
+  }
+}
+
+/**
+ * Park a drifted overwrite target as a proposal artifact.
+ *
+ * @param {string} hypoDir
+ * @param {object} fields
+ * @param {string} fields.target vault-relative path the payload wanted to write
+ * @param {string|null} fields.baseHash hash this session observed at start (may be null)
+ * @param {string|null} fields.currentAtProposalHash disk hash at withhold time
+ * @param {string} fields.proposedContent the full page bytes this close withheld
+ * @param {string} fields.sessionId owning session
+ * @param {string} fields.device machine identifier (crystallize passes currentDevice())
+ * @param {string} [fields.createdAt] ISO timestamp; defaults to now
+ * @returns {{id: string, target: string, path: string, supersedeWarnings: string[]}}
+ *   `supersedeWarnings` is non-empty only when the new artifact WAS written but an
+ *   older same-target sibling could not be removed — a non-fatal condition (the
+ *   payload is parked), reported separately from a write failure (which throws).
+ */
+export function writeProposal(hypoDir, fields) {
+  const { target, baseHash, currentAtProposalHash, proposedContent, sessionId, device } = fields;
+  const createdAt = fields.createdAt || new Date().toISOString();
+
+  // Match on the parsed `target` field, never on the filename slug: two distinct
+  // rel paths can slug-collide, and a slug-prefix scan could delete an unrelated
+  // target's artifact. Reading the body is the only safe discriminator.
+  const sameTarget = listProposals(hypoDir).filter((p) => p.target === target);
+
+  // Idempotent reuse: a re-close that withholds the SAME bytes against the SAME
+  // base and disk state reuses the existing id rather than minting a new artifact,
+  // so an unchanged close does not churn the store or move the id T7 apply keys on.
+  const identical = sameTarget.find(
+    (p) =>
+      p.baseHash === (baseHash ?? null) &&
+      p.currentAtProposalHash === (currentAtProposalHash ?? null) &&
+      p.proposedContent === proposedContent,
+  );
+  if (identical) {
+    return { id: identical.id, target, path: identical._path, supersedeWarnings: [] };
+  }
+
+  const id = makeProposalId(createdAt, target);
+  const path = proposalPath(hypoDir, id);
+  const body = {
+    id,
+    target,
+    baseHash: baseHash ?? null,
+    currentAtProposalHash: currentAtProposalHash ?? null,
+    proposedContent,
+    sessionId: sessionId != null ? String(sessionId) : null,
+    device: device != null ? String(device) : null,
+    createdAt,
+  };
+  // Write the new artifact DURABLY before removing the old one: a crash in the
+  // gap leaves a stale sibling (superseded next close), never a lost payload.
+  atomicWrite(path, JSON.stringify(body, null, 2));
+
+  const supersedeWarnings = [];
+  for (const p of sameTarget) {
+    if (p.id === id) continue; // never delete what we just wrote
+    if (!deleteProposal(hypoDir, p.id)) {
+      supersedeWarnings.push(`could not supersede stale proposal ${p.id} for ${target}`);
+    }
+  }
+  return { id, target, path, supersedeWarnings };
+}
+
+/** sha256 of a UTF-8 string, hex — the same hashing base-store uses for targets. */
+export function hashProposalContent(content) {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -107,6 +107,7 @@ import {
   withFileLock,
 } from '../hooks/hypo-shared.mjs';
 import { hashContent, readBaseEntry, advanceBase } from '../hooks/base-store.mjs';
+import { writeProposal } from '../hooks/proposal-store.mjs';
 
 // This script's own absolute path. Used to print copy-pasteable recovery
 // commands as `node <SELF_SCRIPT> ...` rather than a bare `crystallize` bin,
@@ -416,7 +417,9 @@ function readPayload(source) {
 }
 
 // How long an append waits for its per-target lock before withholding to the
-// proposal gate (see withFileLock). Default 5s is generous for a real close;
+// proposal-pending gate (see withFileLock). A withheld append blocks the close but
+// is NOT parked as a proposal artifact — the next close re-appends. Default 5s is
+// generous for a real close;
 // the env override exists ONLY so tests can force a fast timeout instead of
 // spinning the full 5s. Not a documented production knob.
 const APPEND_LOCK_TIMEOUT_MS = Number(process.env.HYPO_APPEND_LOCK_TIMEOUT_MS) || 5000;
@@ -1149,9 +1152,11 @@ function applySessionClose(args) {
       if (err?.code !== 'ELOCKTIMEOUT') throw err;
       // Lock-timeout: withhold rather than lose the entry. Recorded as a conflict
       // so the close goes proposal-pending (ok:false, no marker) and the next
-      // close re-applies. `kind: 'append'` marks it for T6's append-proposal
-      // handling — proposedContent is the entry to append, not a whole-file
-      // replacement.
+      // close re-applies. `kind: 'append'` is what T6 branches on to SKIP parking
+      // this: an append conflict never becomes a `.cache/proposals/` artifact —
+      // the lock-timeout is transient and the next close self-heals by
+      // re-appending, whereas a whole-file re-apply would drop this shard's other
+      // entries. It still blocks the close; it just gets no artifact.
       conflicts.push({
         key: 'sessionLog',
         target: rel,
@@ -1228,7 +1233,9 @@ function applySessionClose(args) {
       // `derived: true` discriminates this from the payload.log conflict above:
       // here proposedContent is the session-log entry to RE-DERIVE root-log lines
       // from (via rootLogEntry over its dated headings), NOT append-ready bytes.
-      // T6 must branch on this to know how to turn proposedContent into log.md.
+      // Like every `kind: 'append'` conflict, this is NOT parked as an artifact —
+      // it blocks the close and the next close re-derives + re-appends. The derived
+      // shape only matters to the retry, never to T6's overwrite proposal store.
       conflicts.push({
         key: 'log',
         target: 'log.md',
@@ -1241,6 +1248,56 @@ function applySessionClose(args) {
       });
     }
   }
+
+  // T6: park drifted OVERWRITE targets as `.cache/proposals/` artifacts.
+  //
+  // Runs regardless of --json AND regardless of args.sessionId: writing the
+  // artifact is a SIDE EFFECT, not output, so it is conditioned on neither the
+  // report format nor a session context. (In practice an overwrite conflict only
+  // arises with a session id, so a session-less apply just finds no overwrite
+  // conflicts to park — but the loop is unconditional to match that contract.)
+  // Only overwrite conflicts (`kind !== 'append'`) become artifacts. An append
+  // conflict is a transient lock-timeout the NEXT close self-heals by
+  // re-appending; parking it as a whole-file artifact and later re-applying it
+  // (T7 replaces the whole target) would drop every OTHER entry in that
+  // append-only history file. Append conflicts still sit in `conflicts`, so the
+  // close still goes proposal-pending — they just get no artifact and no
+  // human-apply step.
+  const proposals = [];
+  const proposalStoreFailures = [];
+  const device = currentDevice();
+  for (const c of conflicts) {
+    if (c.kind === 'append') continue; // append conflicts are never parked (see above)
+    try {
+      const saved = writeProposal(args.hypoDir, {
+        target: c.target,
+        baseHash: c.baseHash,
+        currentAtProposalHash: c.currentHash,
+        proposedContent: c.proposedContent, // internal (pre-drop) full page bytes
+        sessionId: args.sessionId, // may be null; writeProposal coerces it
+        device,
+      });
+      proposals.push({ id: saved.id, target: saved.target, path: saved.path });
+      // Supersede-delete failure is NON-fatal: the new artifact IS parked, only
+      // a stale sibling lingers (superseded next close). Surface it, don't fail.
+      for (const w of saved.supersedeWarnings) {
+        process.stderr.write(`\n⚠️  ${w} (stale artifact left behind, not fatal)\n`);
+      }
+    } catch (err) {
+      // fail-loud: the target was withheld AND its bytes are now on neither disk
+      // NOR a proposal artifact — a genuine data-loss risk. Never swallow this.
+      const error = (err && err.message) || String(err);
+      proposalStoreFailures.push({ target: c.target, key: c.key, error });
+      process.stderr.write(
+        `\n🛑 PROPOSAL STORE FAILED for ${c.key} (${c.target}): ${error}\n` +
+          `    This close WITHHELD the target (it drifted from your observed base) but\n` +
+          `    could NOT write the .cache/proposals/ artifact either. The payload bytes\n` +
+          `    are on NEITHER disk NOR a proposal — re-run the close once the .cache/\n` +
+          `    directory is writable so the withheld content is not lost.\n`,
+      );
+    }
+  }
+  const proposalStoreFailed = proposalStoreFailures.length > 0;
 
   // Same-date-tie fix: verify against the SAME project this apply just wrote
   // (`project` = payload.project || probe.project, resolved at the top). Without
@@ -1399,16 +1456,19 @@ function applySessionClose(args) {
   }
   // A conflict outranks the downstream gates: verification and lint both describe
   // a tree this apply declined to finish writing, so naming them would point the
-  // reader at the wrong repair.
+  // reader at the wrong repair. A proposal-STORE failure outranks even that: the
+  // withheld bytes never reached an artifact, so it is the most urgent repair.
   let stage = ok
     ? null
-    : conflicts.length > 0
-      ? 'proposal-pending'
-      : !verification.ok && !postLintOk
-        ? 'post-apply-verification+lint'
-        : !verification.ok
-          ? 'post-apply-verification'
-          : 'post-apply-lint';
+    : proposalStoreFailed
+      ? 'proposal-store-failed'
+      : conflicts.length > 0
+        ? 'proposal-pending'
+        : !verification.ok && !postLintOk
+          ? 'post-apply-verification+lint'
+          : !verification.ok
+            ? 'post-apply-verification'
+            : 'post-apply-lint';
   // Runtime close-result invariant self-check. When a
   // marker-write path (args.sessionId present) settles into an internally
   // contradictory shape — ok:true with the marker silently withheld and no
@@ -1440,10 +1500,28 @@ function applySessionClose(args) {
     applied,
     skipped,
     // Targets withheld: an overwrite drifted from this session's observed base, or
-    // an append could not take the file lock in time (`kind: 'append'`).
-    // `proposedContent` is dropped from the reported shape (it is the whole payload
-    // field / the entry to append, and T6 parks it in the proposal artifact instead).
+    // an append could not take the file lock in time (`kind: 'append'`). Two
+    // channels resolve these, and `proposals` vs `conflicts[].kind` are the sole
+    // discriminators: an OVERWRITE conflict is parked as a `.cache/proposals/`
+    // artifact (below) for a human to review and re-apply; an APPEND conflict gets
+    // NO artifact and is re-tried automatically by the next close. `proposedContent`
+    // is dropped from the reported shape either way (the artifact / the next close
+    // holds the bytes; a whole page or an append entry does not belong in the JSON).
     conflicts: conflicts.map(({ proposedContent: _drop, ...rest }) => rest),
+    // Parked overwrite proposals (id/target/path), one per drifted overwrite
+    // target. Empty when only append conflicts (or none) occurred. The T7 CLI
+    // lists and applies these; append conflicts never appear here.
+    proposals,
+    ...(proposalStoreFailed ? { proposalStoreFailures } : {}),
+    // Partial close: some overwrite direct-writes (and/or appends) already landed
+    // on disk while at least one conflict withheld the rest. Because the close is
+    // ok:false, commitWikiChanges + the marker are skipped — so those written
+    // files sit on disk UNCOMMITTED until the conflict is resolved and the close
+    // re-runs. Named honestly: `appliedUncommitted` covers every write that landed
+    // (overwrite or append), not overwrites alone.
+    ...(applied.length > 0 && conflicts.length > 0
+      ? { partialConflict: true, appliedUncommitted: [...applied] }
+      : {}),
     verification,
     // Surface the marker outcome instead of skipping silently, so the
     // caller can tell "closed" from "applied but not marked".
@@ -1479,6 +1557,18 @@ function applySessionClose(args) {
           ? 'could not acquire the append lock in time; the next close re-applies'
           : 'the page changed since this session read it';
       console.log(`  ⚠ WITHHELD ${c.key} (${c.target}) — ${c.reason}; ${why}`);
+    }
+    for (const p of proposals) {
+      console.log(
+        `  · parked proposal ${p.id} for ${p.target} (review with \`hypomnema proposal\`)`,
+      );
+    }
+    if (applied.length > 0 && conflicts.length > 0) {
+      console.log(
+        '\n· partial close: the writes above ARE on disk but NOT committed — this close is\n' +
+          '  ok:false, so no commit and no session-close marker run until the withheld\n' +
+          '  target(s) are resolved and the close re-runs.',
+      );
     }
     if (ok) {
       // When the marker was withheld, qualify the success line so a reader scanning

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -57,6 +57,14 @@ import {
   overwriteTargets,
 } from '../hooks/base-store.mjs';
 import {
+  writeProposal as psWriteProposal,
+  listProposals as psListProposals,
+  readProposal as psReadProposal,
+  deleteProposal as psDeleteProposal,
+  makeProposalId as psMakeProposalId,
+  proposalsDir as psProposalsDir,
+} from '../hooks/proposal-store.mjs';
+import {
   validateChangelog,
   validateTagBody,
   countHangul,
@@ -3506,6 +3514,380 @@ test('append lock-timeout → proposal-pending, shard byte-untouched (FEAT-11 T5
     if (shardAfter) {
       assert.ok(!shardAfter.includes('locked-out entry'), 'the withheld entry must not be written');
     }
+  });
+});
+
+// ── FEAT-11 T6: proposal artifacts + proposal-pending close contract ──────────
+// These drive the REAL close path. An OVERWRITE drift withholds the target AND
+// parks its bytes in `.cache/proposals/`; an APPEND conflict withholds but parks
+// NOTHING (transient — the next close re-appends).
+
+// The direct unit surface of the store: round-trip, supersede-by-target (matched
+// on the parsed `target` field, not the filename slug), idempotent reuse, delete,
+// and malformed-artifact tolerance on the read side.
+test('FEAT-11 T6: proposal-store round-trip, supersede-by-target, idempotent reuse, delete', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-ps-'));
+  try {
+    const a = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'c1',
+      proposedContent: 'AAA',
+      sessionId: 's1',
+      device: 'dev1',
+    });
+    assert.ok(a.id && a.path, 'writeProposal returns an id + path');
+    assert.equal(psListProposals(dir).length, 1);
+    const read = psReadProposal(dir, a.id);
+    assert.equal(read.proposedContent, 'AAA');
+    assert.equal(read.target, 'hot.md');
+    assert.equal(read.baseHash, 'b1');
+
+    // Same target, NEW bytes → the old artifact is superseded (one remains).
+    const b = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'c2',
+      proposedContent: 'BBB',
+      sessionId: 's1',
+      device: 'dev1',
+    });
+    assert.notEqual(b.id, a.id, 'a genuinely different withhold mints a new id');
+    const list2 = psListProposals(dir);
+    assert.equal(list2.length, 1, 'same-target supersede keeps exactly one artifact');
+    assert.equal(list2[0].proposedContent, 'BBB');
+
+    // A DIFFERENT target coexists — supersede is per-target, not global.
+    psWriteProposal(dir, {
+      target: join('pages', 'open-questions.md'),
+      baseHash: null,
+      currentAtProposalHash: 'x',
+      proposedContent: 'Q',
+      sessionId: 's1',
+      device: 'dev1',
+    });
+    assert.equal(psListProposals(dir).length, 2, 'a different target is not superseded');
+
+    // Identical fields → id reuse, no second artifact.
+    const b2 = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'c2',
+      proposedContent: 'BBB',
+      sessionId: 's1',
+      device: 'dev1',
+    });
+    assert.equal(b2.id, b.id, 'identical re-write reuses the existing id');
+    assert.equal(psListProposals(dir).length, 2, 'idempotent re-write adds no artifact');
+
+    assert.equal(psDeleteProposal(dir, b.id), true);
+    assert.equal(psReadProposal(dir, b.id), null);
+    assert.equal(psListProposals(dir).length, 1);
+
+    // A corrupt artifact is skipped by listing, never fatal.
+    writeFileSync(join(psProposalsDir(dir), 'junk.json'), '{ not json');
+    assert.equal(psListProposals(dir).length, 1, 'malformed artifact is skipped, not fatal');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('FEAT-11 T6: readProposal/deleteProposal reject path-traversal ids (no escape from the store)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-ps-'));
+  try {
+    // A sentinel two levels above the proposals dir: `../../hot` from
+    // <dir>/.cache/proposals resolves to <dir>/hot.json. The T7 CLI takes an id
+    // straight off the command line, so an unvalidated id here would read or
+    // unlink this file outside the store.
+    const sentinel = join(dir, 'hot.json');
+    writeFileSync(sentinel, 'DO NOT DELETE');
+    for (const bad of ['../../hot', '../hot', '..', '/etc/passwd', 'a/b', '']) {
+      assert.equal(psReadProposal(dir, bad), null, `readProposal rejects ${JSON.stringify(bad)}`);
+      assert.equal(psDeleteProposal(dir, bad), false, `deleteProposal rejects ${JSON.stringify(bad)}`);
+    }
+    assert.ok(existsSync(sentinel), 'a file outside the store is never unlinked');
+    assert.equal(readFileSync(sentinel, 'utf-8'), 'DO NOT DELETE', 'sentinel bytes untouched');
+    // A normally generated id still round-trips (no regression on the happy path).
+    const saved = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: null,
+      currentAtProposalHash: null,
+      proposedContent: 'x',
+      sessionId: 's',
+      device: 'd',
+    });
+    assert.ok(psReadProposal(dir, saved.id), 'a valid generated id still reads back');
+    assert.equal(psDeleteProposal(dir, saved.id), true, 'a valid generated id still deletes');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('FEAT-11 T6: a symlinked proposals dir cannot escape the vault (read/delete)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-ps-'));
+  const outside = mkdtempSync(join(tmpdir(), 'hypo-outside-'));
+  try {
+    // Point .cache/proposals at a directory OUTSIDE the vault and drop a
+    // validly-named artifact inside it. A lexical guard would let a valid id
+    // read/delete through the symlink; realpath containment must reject it.
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    symlinkSync(outside, join(dir, '.cache', 'proposals'));
+    const sentinel = join(outside, 'safeid.json');
+    writeFileSync(sentinel, JSON.stringify({ id: 'safeid', target: 'x' }));
+    assert.equal(psReadProposal(dir, 'safeid'), null, 'no read through a symlinked store');
+    assert.equal(psDeleteProposal(dir, 'safeid'), false, 'no delete through a symlinked store');
+    assert.ok(existsSync(sentinel), 'the file outside the vault survives');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test('FEAT-11 T6: makeProposalId is filename-safe and carries the target slug', () => {
+  const id = psMakeProposalId('2026-07-09T12:34:56.789Z', join('projects', 'p', 'hot.md'));
+  assert.ok(/^[A-Za-z0-9-]+$/.test(id), `id must be filename-safe: ${id}`);
+  assert.ok(id.includes('projects-p-hot-md'), `id must carry the target slug: ${id}`);
+});
+
+// spec success criterion: an overwrite conflict parks a `.cache/proposals/`
+// artifact carrying every required field, the close reports proposal-pending, and
+// the marker is NOT written.
+test('FEAT-11 T6: overwrite conflict parks an artifact with all required fields, marker withheld', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    // No base snapshot for this session → the overwrite guard sees base-unknown and
+    // withholds rootHot (hot.md) rather than clobber. Only rootHot differs from disk;
+    // the other overwrite fields are byte-identical (idempotent skip, no conflict).
+    payload.rootHot = { content: `---\ntitle: Hot\nupdated: ${today}\n---\n# Hot DRIFTED\n` };
+    const r = runApply(dir, payload, { sessionId: 's-t6-artifact' });
+    assert.notEqual(
+      r.status,
+      0,
+      `a withheld overwrite must exit non-zero: ${r.stdout}\n${r.stderr}`,
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(out.stage, 'proposal-pending');
+    assert.equal(out.markerWritten, false, 'the marker must NOT be written on a withheld close');
+    assert.equal(
+      out.proposals.length,
+      1,
+      `exactly one proposal expected: ${JSON.stringify(out.proposals)}`,
+    );
+    assert.equal(out.proposals[0].target, 'hot.md');
+
+    const dirp = join(dir, '.cache', 'proposals');
+    const files = readdirSync(dirp).filter((f) => f.endsWith('.json'));
+    assert.equal(files.length, 1, `exactly one artifact on disk: ${files}`);
+    const art = JSON.parse(readFileSync(join(dirp, files[0]), 'utf-8'));
+    for (const k of [
+      'id',
+      'target',
+      'baseHash',
+      'currentAtProposalHash',
+      'proposedContent',
+      'sessionId',
+      'device',
+      'createdAt',
+    ]) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(art, k),
+        `artifact must carry ${k}: ${JSON.stringify(art)}`,
+      );
+    }
+    assert.equal(art.target, 'hot.md');
+    assert.equal(art.sessionId, 's-t6-artifact');
+    assert.ok(art.device, 'device must be stamped from currentDevice()');
+    assert.ok(art.proposedContent.includes('DRIFTED'), 'proposedContent holds the withheld bytes');
+    assert.ok(
+      !readFileSync(join(dir, 'hot.md'), 'utf-8').includes('DRIFTED'),
+      'the withheld target must stay unclobbered on disk',
+    );
+  });
+});
+
+// spec success criterion: partial conflict is per-target — non-drifted overwrites
+// write directly, only the drifted one parks, and the result says so honestly.
+test('FEAT-11 T6: partial conflict — non-drifted overwrites write, drifted one parks', () => {
+  withWiki(null, (dir, today) => {
+    const sid = 's-t6-partial';
+    // Snapshot the base from the committed clean tree.
+    snapshotBase(dir, sid, overwriteTargets('test-project'));
+    // Another writer drifts ONE target (project hot.md) AFTER the snapshot.
+    const projHot = join(dir, 'projects', 'test-project', 'hot.md');
+    writeFileSync(
+      projHot,
+      `---\ntitle: hot\ntype: reference\nupdated: ${today}\n---\n\n# Hot DRIFTED BY OTHER\n`,
+    );
+    const driftedBytes = readFileSync(projHot, 'utf-8');
+
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionState = {
+      content: `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n## 다음 작업\n\n- new next\n`,
+    };
+    payload.rootHot = {
+      content: readFileSync(join(dir, 'hot.md'), 'utf-8').replace('# Hot', '# Hot UPDATED'),
+    };
+    payload.projectHot = {
+      content: `---\ntitle: hot\ntype: reference\nupdated: ${today}\n---\n\n# Hot FROM PAYLOAD\n`,
+    };
+    const r = runApply(dir, payload, { sessionId: sid });
+    assert.notEqual(r.status, 0, `a partial conflict must exit non-zero: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(out.stage, 'proposal-pending');
+    assert.equal(out.partialConflict, true, `partialConflict expected: ${r.stdout}`);
+    assert.ok(
+      Array.isArray(out.appliedUncommitted) && out.appliedUncommitted.length > 0,
+      'appliedUncommitted lists the writes that landed but are not committed',
+    );
+    assert.equal(out.proposals.length, 1, `exactly one proposal: ${JSON.stringify(out.proposals)}`);
+    assert.equal(out.proposals[0].target, join('projects', 'test-project', 'hot.md'));
+    assert.ok(
+      readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8').includes(
+        'new next',
+      ),
+      'the non-drifted sessionState was written directly',
+    );
+    assert.ok(
+      readFileSync(join(dir, 'hot.md'), 'utf-8').includes('UPDATED'),
+      'the non-drifted rootHot was written directly',
+    );
+    assert.equal(
+      readFileSync(projHot, 'utf-8'),
+      driftedBytes,
+      'the drifted target keeps the other writer bytes — the payload must not clobber it',
+    );
+    assert.equal(out.markerWritten, false);
+  });
+});
+
+// spec success criterion (fail-closed): a proposal-store WRITE failure must not
+// write the target, must surface loudly, and must stage proposal-store-failed.
+test('FEAT-11 T6: proposal-store write failure → proposal-store-failed, fail-loud, target unwritten', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.rootHot = { content: `---\ntitle: Hot\nupdated: ${today}\n---\n# Hot DRIFTED\n` };
+    // Occupy `.cache/proposals` with a regular FILE so writeProposal's mkdir fails.
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, '.cache', 'proposals'), 'blocker');
+    const r = runApply(dir, payload, { sessionId: 's-t6-failloud' });
+    assert.notEqual(r.status, 0, `store failure must exit non-zero: ${r.stdout}\n${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(out.stage, 'proposal-store-failed');
+    assert.ok(
+      Array.isArray(out.proposalStoreFailures) && out.proposalStoreFailures.length === 1,
+      `proposalStoreFailures expected: ${r.stdout}`,
+    );
+    assert.equal(out.proposalStoreFailures[0].target, 'hot.md');
+    assert.equal(out.proposals.length, 0, 'no proposal is recorded when the store write fails');
+    assert.ok(/PROPOSAL STORE FAILED/.test(r.stderr), `loud stderr expected: ${r.stderr}`);
+    assert.ok(
+      !readFileSync(join(dir, 'hot.md'), 'utf-8').includes('DRIFTED'),
+      'the target must stay unwritten when its proposal could not be parked',
+    );
+  });
+});
+
+// supersede across closes: a drift BETWEEN two closes changes currentAtProposalHash,
+// forcing a genuinely new artifact that must supersede (not accumulate beside) the
+// first — otherwise every close would leave a stale artifact and inflate the count.
+test('FEAT-11 T6: repeated closes on a re-drifting target keep exactly one artifact', () => {
+  withWiki(null, (dir, today) => {
+    const sid = 's-t6-supersede';
+    const rootHotPath = join(dir, 'hot.md');
+    const dirp = join(dir, '.cache', 'proposals');
+
+    const p1 = payloadForCleanWiki(dir, today);
+    p1.rootHot = { content: `${readFileSync(rootHotPath, 'utf-8')}\n<!-- close1 -->\n` };
+    const r1 = runApply(dir, p1, { sessionId: sid });
+    assert.notEqual(r1.status, 0);
+    assert.equal(
+      readdirSync(dirp).filter((f) => f.endsWith('.json')).length,
+      1,
+      'one artifact after close 1',
+    );
+    const id1 = JSON.parse(r1.stdout).proposals[0].id;
+
+    // Another writer drifts the disk so the next close withholds FRESH bytes.
+    writeFileSync(rootHotPath, `${readFileSync(rootHotPath, 'utf-8')}\n<!-- other drift -->\n`);
+    const p2 = payloadForCleanWiki(dir, today);
+    p2.rootHot = { content: `${readFileSync(rootHotPath, 'utf-8')}\n<!-- close2 -->\n` };
+    const r2 = runApply(dir, p2, { sessionId: sid });
+    assert.notEqual(r2.status, 0);
+    const files2 = readdirSync(dirp).filter((f) => f.endsWith('.json'));
+    assert.equal(files2.length, 1, `still one artifact after close 2 (supersede): ${files2}`);
+    const art = JSON.parse(readFileSync(join(dirp, files2[0]), 'utf-8'));
+    assert.ok(
+      art.proposedContent.includes('close2'),
+      'the surviving artifact is the newest withhold',
+    );
+    assert.notEqual(
+      JSON.parse(r2.stdout).proposals[0].id,
+      id1,
+      'a genuinely new withhold gets a new id (supersede, not reuse)',
+    );
+  });
+});
+
+// idempotent-reuse (the OTHER supersede path): an identical re-close — same base,
+// same disk, same bytes — reuses the existing id and writes no second artifact.
+test('FEAT-11 T6: identical re-close reuses the artifact id (idempotent, one file)', () => {
+  withWiki(null, (dir, today) => {
+    const sid = 's-t6-idem';
+    const payload = payloadForCleanWiki(dir, today);
+    payload.rootHot = {
+      content: readFileSync(join(dir, 'hot.md'), 'utf-8').replace('# Hot', '# Hot DRIFT'),
+    };
+    const r1 = runApply(dir, payload, { sessionId: sid });
+    const r2 = runApply(dir, payload, { sessionId: sid });
+    const dirp = join(dir, '.cache', 'proposals');
+    assert.equal(
+      readdirSync(dirp).filter((f) => f.endsWith('.json')).length,
+      1,
+      'an identical re-close must not add a second artifact',
+    );
+    assert.equal(
+      JSON.parse(r1.stdout).proposals[0].id,
+      JSON.parse(r2.stdout).proposals[0].id,
+      'the same id is reused for an identical withhold',
+    );
+  });
+});
+
+// D1: an append lock-timeout blocks the close (proposal-pending) but parks NO
+// artifact — proposals stays empty and `.cache/proposals/` has no files.
+test('FEAT-11 T6: append lock-timeout makes NO artifact (proposals empty, still pending)', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionLog = { entry: `## [${today}] append-only lockout\n\nbody\n` };
+    const shard = join(dir, 'projects', 'test-project', 'session-log', `${today}.md`);
+    mkdirSync(dirname(shard), { recursive: true });
+    writeFileSync(`${shard}.lock`, '');
+    process.env.HYPO_APPEND_LOCK_TIMEOUT_MS = '300';
+    let r;
+    try {
+      r = runApply(dir, payload, { sessionId: 's-t6-append-only' });
+    } finally {
+      delete process.env.HYPO_APPEND_LOCK_TIMEOUT_MS;
+      try {
+        unlinkSync(`${shard}.lock`);
+      } catch {
+        /* already gone */
+      }
+    }
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(out.stage, 'proposal-pending');
+    assert.deepEqual(
+      out.proposals,
+      [],
+      `an append conflict must not create a proposal: ${JSON.stringify(out.proposals)}`,
+    );
+    const dirp = join(dir, '.cache', 'proposals');
+    const files = existsSync(dirp) ? readdirSync(dirp).filter((f) => f.endsWith('.json')) : [];
+    assert.equal(files.length, 0, `no artifact must be written for an append conflict: ${files}`);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

Adds `hooks/proposal-store.mjs` and wires it into the crystallize close path. When a session close finds that an overwrite target (session-state.md, hot.md, open-questions.md) has drifted from the base the session observed at start, the withheld bytes are now parked as an atomic artifact at `.cache/proposals/<id>.json`, instead of only blocking the close with no record of what it wanted to write. A later step (the T7 CLI, separate) lets a human review and apply or discard those artifacts.

## Why

The observed-base guard (already shipped) stops a close from clobbering another session's edits, but until now the withheld payload had nowhere to go: the close blocked and the bytes were dropped. Parking them as reviewable artifacts is what turns "refuse to clobber" into "refuse to clobber, and keep what you refused so a human can reconcile it."

## How

- **Overwrite only.** Append conflicts (session-log / log.md lock-timeouts) get NO artifact: they are transient and self-heal on the next close's re-append, and applying an append entry as a whole-file replacement would drop the file's other entries. crystallize filters `kind: 'append'` out before it reaches the store.
- **One artifact per target.** Supersede on re-close (write the new artifact durably first, then delete the older same-target sibling), id reuse when byte-identical, so the pending count does not inflate.
- **Path-hardened.** Ids are validated to a filename-safe shape, and both lexical and realpath containment reject any id (`../../hot`) or symlinked store that would read or unlink a file outside `.cache/proposals`. The T7 CLI will take an id straight off the command line, so this boundary is enforced in the store, not the caller.
- **Fail-loud.** A proposal-store write failure surfaces a distinct `proposal-store-failed` stage (not `proposal-pending`) and a loud stderr banner, so a withheld payload that is on neither disk nor a proposal cannot pass as a clean close. Partial conflicts (some targets written, one parked) are reported with `partialConflict` + `appliedUncommitted`.

The proposal-pending close contract (ok:false, no marker) was already in place from the base-guard slices; this change adds the artifact, the failure channel, and the partial-conflict reporting on top of it.

## Manual verification

Covered by the test suite (1295 passed): proposal round-trip, supersede, idempotent reuse, delete, partial conflict, fail-loud (write failure yields proposal-store-failed with the target unwritten), append-conflict-makes-no-artifact, and two path-escape tests (a `../../hot` id and a symlinked `.cache/proposals` both leave an outside sentinel file untouched).

## Migration notes

None. `.cache/proposals/` lives under the already-gitignored `.cache/` (same neighborhood as base-store's per-session snapshots); nothing is synced or committed. No existing install needs action on upgrade.

---

# 한국어

## 변경 내용

`hooks/proposal-store.mjs`를 추가하고 crystallize close 경로에 배선한다. 세션 close가 overwrite 대상(session-state.md, hot.md, open-questions.md)이 세션 시작 시 관측한 base에서 drift했음을 발견하면, 보류한 바이트를 이제 `.cache/proposals/<id>.json`에 원자적 아티팩트로 park한다. 예전엔 close만 막고 무엇을 쓰려 했는지 기록이 없었다. 이후 단계(T7 CLI, 별도)가 사람이 그 아티팩트를 검토하고 apply 또는 discard하게 한다.

## 이유

observed-base 가드(이미 출하)는 close가 다른 세션의 편집을 덮는 것을 막지만, 지금까지 보류한 payload는 갈 곳이 없었다. close가 막히고 바이트는 버려졌다. 이를 검토 가능한 아티팩트로 park하는 것이 "덮기 거부"를 "덮기 거부하되 거부한 것을 보존해 사람이 조정 가능"으로 바꾼다.

## 방법

- **overwrite 전용.** append conflict(session-log / log.md lock-timeout)는 아티팩트를 만들지 않는다. transient라 다음 close의 재-append로 self-heal하고, append entry를 통째 교체로 적용하면 그 파일의 다른 엔트리를 잃는다. crystallize가 store에 닿기 전에 `kind: 'append'`를 걸러낸다.
- **대상당 하나.** 재-close 시 supersede(새 아티팩트를 먼저 durably 쓰고 옛 same-target 삭제), byte 동일하면 id 재사용, 그래서 대기 건수가 부풀지 않는다.
- **경로 하드닝.** id를 filename-safe 형식으로 검증하고, lexical + realpath containment로 `.cache/proposals` 밖을 읽거나 지우려는 id(`../../hot`)나 symlink된 store를 거부한다. T7 CLI가 id를 명령줄에서 받을 것이라, 이 경계를 호출부가 아니라 store에서 강제한다.
- **fail-loud.** proposal-store write 실패는 `proposal-store-failed`라는 별도 stage(‘proposal-pending’ 아님)와 크게 뜨는 stderr 배너로 드러난다. 보류한 payload가 디스크에도 proposal에도 없는데 clean close로 통과하지 못하게. partial conflict(일부 대상은 쓰고 하나는 park)는 `partialConflict` + `appliedUncommitted`로 보고한다.

proposal-pending close 계약(ok:false, marker 미작성)은 base-guard 슬라이스에서 이미 있었다. 이 변경은 그 위에 아티팩트, 실패 채널, partial-conflict 보고를 얹는다.

## 수동 검증

테스트 스위트가 커버(1295 passed): proposal round-trip, supersede, idempotent 재사용, delete, partial conflict, fail-loud(write 실패 시 proposal-store-failed와 대상 미기록), append conflict는 아티팩트 안 만듦, 그리고 경로 탈출 테스트 2건(`../../hot` id와 symlink된 `.cache/proposals`가 둘 다 store 밖 sentinel 파일을 안 건드림).

## 마이그레이션 노트

None. `.cache/proposals/`는 이미 gitignore된 `.cache/` 아래(base-store의 세션별 스냅샷과 같은 자리)라 동기화·커밋되지 않는다. 기존 설치는 업그레이드 시 조치 불요.

---

## Changelog

- EN: New Features: a session close that would clobber another session's overwrite edits now parks the withheld bytes as a reviewable `.cache/proposals/` artifact (path-hardened, fails loud, one per target) instead of dropping them.
- KO: 새 기능: 다른 세션의 overwrite 편집을 덮을 close가 이제 보류한 바이트를 버리는 대신 검토 가능한 `.cache/proposals/` 아티팩트로 park한다(경로 하드닝, fail-loud, 대상당 하나).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
