### PR TITLE
feat(cli): hypomnema proposal list/apply/discard

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -93,6 +93,7 @@ const KNOWN_SUBCOMMANDS = new Set([
   'uninstall',
   'feedback-sync',
   'capture',
+  'proposal',
 ]);
 const _verb = process.argv[2];
 if (_verb && KNOWN_SUBCOMMANDS.has(_verb) && _verb !== 'init') {

--- a/scripts/proposal.mjs
+++ b/scripts/proposal.mjs
@@ -1,0 +1,604 @@
+#!/usr/bin/env node
+/**
+ * proposal.mjs: `hypomnema proposal list|apply|discard`, the human-in-the-loop
+ * gate for parked overwrite-conflict artifacts (the write=proposal store).
+ *
+ * When crystallize's close path finds an OVERWRITE target drifted from the base
+ * this session observed, it withholds the bytes and parks them under
+ * `.cache/proposals/<id>.json` rather than clobber the other writer. This CLI is
+ * the only sanctioned way those bytes ever reach the target again, and every path
+ * to a write runs through an interactive human confirm: there is no
+ * confirmation-bypass flag, no environment-variable override, and no background
+ * auto-apply. `apply` is a WHOLE-FILE replacement, so the human reviews a fresh
+ * current-vs-proposed diff (that review IS the merge) before typing the confirm.
+ *
+ * The decision helpers (planApplyAction, classifyFreshness, renderDiff are pure;
+ * resolveTargetPath touches the filesystem to resolve symlinks) and the
+ * result-returning actors (applyProposal, discardProposal, listPending) are
+ * exported so the runner can drive them in-process with injected TTY / prompt /
+ * clock seams. Injecting those seams is a TEST convention, not a supported way to
+ * apply unattended: the shipped CLI path carries no bypass, and a regression test
+ * pins that no hook reaches this module. main() sits behind an isMain() guard so a
+ * static import never runs the CLI (feedback-sync precedent).
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  mkdirSync,
+  appendFileSync,
+  lstatSync,
+  realpathSync,
+} from 'node:fs';
+import { join, dirname, resolve, isAbsolute, sep } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+import {
+  listProposals,
+  readProposal,
+  deleteProposal,
+  isValidProposalId,
+  hashProposalContent,
+  proposalsDir,
+} from '../hooks/proposal-store.mjs';
+
+// ── target-path hardening ─────────────────────────────────────────────────────
+
+/**
+ * Resolve an artifact's `target` (vault-relative) to a safe absolute path inside
+ * the vault, or null when it is unsafe.
+ *
+ * The `target` field is UNTRUSTED: `.cache/proposals/<id>.json` is plaintext and
+ * hand-editable, and the store validates only the id, never the body's target. A
+ * body carrying `target: "../../.zshrc"` would drive a whole-file replacement
+ * outside the vault. This mirrors, on the target axis, the id hardening the store
+ * applies on the filename axis. Every rejection fails CLOSED (returns null).
+ *
+ * Callers must re-run this immediately before writing, not only before showing the
+ * diff: nothing is locked while the human reads, so an ancestor can become a
+ * symlink out of the vault between those two moments.
+ */
+export function resolveTargetPath(hypoDir, target) {
+  if (typeof target !== 'string' || target === '' || isAbsolute(target)) return null;
+  // A `..` segment can walk out even when the lexical resolve below lands back
+  // inside, so reject it outright.
+  if (target.split(/[/\\]/).includes('..')) return null;
+
+  const root = resolve(hypoDir);
+  const full = resolve(join(hypoDir, target));
+  // Lexical containment: the resolved path is the vault root or sits under it.
+  if (full !== root && !full.startsWith(root + sep)) return null;
+
+  // The store never writes to itself. A target pointing back into
+  // `.cache/proposals/` would have apply write the withheld bytes over a SIBLING
+  // artifact (destroying its payload), or over this very artifact and then unlink
+  // it, or over the audit log. Each of those exits 0 while losing the only
+  // off-disk copy of the bytes. This is an invariant of the store, not an
+  // enumeration of crystallize's targets, so it couples to nothing.
+  const store = resolve(proposalsDir(hypoDir));
+  if (full === store || full.startsWith(store + sep)) return null;
+
+  // Symlink containment: a lexical check cannot see a parent dir that is a symlink
+  // pointing OUT of the vault (a rename target would then land outside). Require
+  // the nearest EXISTING ancestor's real (symlink-resolved) path to stay within
+  // the vault's own real path. The nearest ancestor is used because the target
+  // file itself is usually absent (a fresh create).
+  let ancestor = full;
+  while (!existsSync(ancestor)) {
+    const parent = dirname(ancestor);
+    if (parent === ancestor) break;
+    ancestor = parent;
+  }
+  try {
+    const realAncestor = realpathSync(ancestor);
+    const realRoot = realpathSync(hypoDir);
+    if (realAncestor !== realRoot && !realAncestor.startsWith(realRoot + sep)) return null;
+
+    // The lexical store guard above compares lexical paths, so an in-vault symlink
+    // alias (`alias -> .cache/proposals`, target `alias/<id>.json`) slips past it:
+    // `alias/...` is not lexically under the store, yet the real write lands inside
+    // it and would destroy an artifact. Re-run the store check on the REAL ancestor.
+    // This is a static footgun (a pre-planted alias), not the unbounded write-time
+    // race; closing it costs one comparison. If the store does not exist yet there
+    // is nothing to alias into.
+    try {
+      const realStore = realpathSync(store);
+      if (realAncestor === realStore || realAncestor.startsWith(realStore + sep)) return null;
+    } catch {
+      /* store absent: no alias target exists */
+    }
+  } catch {
+    return null;
+  }
+
+  // The target itself being a symlink is fail-closed: readTarget follows the link
+  // to build the diff the human reviews, but atomicWrite is tmp+rename and
+  // REPLACES the link, so the bytes shown and the bytes written would diverge. An
+  // absent target is the normal create case and is not a symlink.
+  try {
+    if (lstatSync(full).isSymbolicLink()) return null;
+  } catch {
+    /* absent target: nothing to be a symlink, proceed */
+  }
+  return full;
+}
+
+// ── atomic write (exclusive tmp) ──────────────────────────────────────────────
+
+/**
+ * Atomic overwrite via tmp+rename, with the tmp path created EXCLUSIVELY (`wx`).
+ * Exclusive create means a pre-planted tmp symlink cannot be followed out of the
+ * vault. A random suffix keeps two applies from colliding on the tmp slot; a
+ * failed rename cleans up the tmp it created.
+ *
+ * The parent directory is NOT created here. The caller creates it and then
+ * re-validates containment, because `mkdirSync(recursive)` happily walks a symlink
+ * that appeared after the last check.
+ */
+function atomicWrite(path, content) {
+  const tmp = `${path}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+  writeFileSync(tmp, content, { flag: 'wx' });
+  try {
+    renameSync(tmp, path);
+  } catch (e) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw e;
+  }
+}
+
+/**
+ * Read a target's current bytes, distinguishing absent (null) from unreadable
+ * (undefined) so classifyFreshness can refuse to guess. Mirrors crystallize's own
+ * readTarget, reimplemented here because that one is not exported.
+ * @returns {string|null|undefined}
+ */
+function readTarget(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+// ── pure decision functions ───────────────────────────────────────────────────
+
+/**
+ * Classify the target's current bytes against the hash captured when the artifact
+ * was parked: 'fresh' (unchanged), 'drifted' (changed since parked), or
+ * 'unreadable' (cannot read what we would replace).
+ *
+ * NOTE on the null ambiguity: `currentAtProposalHash === null` means EITHER the
+ * target was absent at park time OR it was unreadable then (crystallize records
+ * `typeof disk === 'string' ? hashContent(disk) : null` for both). So "absent now
+ * + null at park" classifies as 'fresh'. That is deliberate and loses no bytes: a
+ * still-absent target has nothing to clobber, so it is not a data-loss case. The
+ * shell separately announces "target absent, will be created" so the human is not
+ * surprised by a create.
+ *
+ * @param {{current: string|null|undefined, currentAtProposalHash: string|null}} args
+ * @returns {'fresh'|'drifted'|'unreadable'}
+ */
+export function classifyFreshness({ current, currentAtProposalHash }) {
+  if (current === undefined) return 'unreadable';
+  const nowHash = current === null ? null : hashProposalContent(current);
+  return nowHash === (currentAtProposalHash ?? null) ? 'fresh' : 'drifted';
+}
+
+/**
+ * The apply decision as a PURE function of the human's confirm and the target's
+ * freshness. Kept separate (planMarkerDecision precedent) so a table test can
+ * pin the branch priority without any IO.
+ *
+ * Order is load-bearing: 'unreadable' is checked BEFORE the confirm, so an
+ * unreadable target aborts regardless of what the human typed (we must never
+ * write over bytes we could not read). applyProposal returns early on
+ * 'unreadable' rather than prompt into the void, so that branch is unreachable
+ * from the CLI today; it stays because the refusal belongs to the decision
+ * contract, not to one caller's ordering.
+ *
+ * @param {{confirmed: boolean, freshness: 'fresh'|'drifted'|'unreadable'}} args
+ * @returns {{action: 'apply'|'abort', reason: string|null, warned?: boolean}}
+ */
+export function planApplyAction({ confirmed, freshness }) {
+  if (freshness === 'unreadable') return { action: 'abort', reason: 'target-unreadable' };
+  if (!confirmed) return { action: 'abort', reason: 'not-confirmed' };
+  return { action: 'apply', reason: null, warned: freshness === 'drifted' };
+}
+
+/**
+ * Replace terminal control characters with a visible placeholder.
+ *
+ * Both the proposed bytes and the target string come from a hand-editable
+ * artifact, and the whole gate rests on the human trusting the diff they were
+ * shown. Raw escape sequences could clear the screen, redraw a benign diff, or
+ * hide added lines above the confirm prompt. Tabs and newlines are kept (they
+ * carry real content); the rest of C0, DEL, and the C1 range are neutralized. C1
+ * matters because it carries its own CSI introducer that redraws like ESC does.
+ * Only the DISPLAY is sanitized: the bytes written to the target stay verbatim.
+ */
+function sanitizeForDisplay(text, { allowNewlines = true } = {}) {
+  // eslint-disable-next-line no-control-regex
+  const controls = allowNewlines
+    ? /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\u0080-\u009f]/g
+    : /[\u0000-\u001f\u007f\u0080-\u009f]/g;
+  return String(text).replace(controls, '\ufffd');
+}
+
+/**
+ * A minimal line diff of current vs proposed: common prefix/suffix are trimmed so
+ * the human sees only the changed span, removed lines as `- ` and added as `+ `.
+ * Not a full LCS; the goal is a legible review, not a patch format. Only
+ * byte-equal line boundaries are trimmed, so the trim can neither hide a changed
+ * line nor invent one.
+ */
+export function renderDiff(current, proposed) {
+  const a = String(current ?? '').split('\n');
+  const b = String(proposed).split('\n');
+  let start = 0;
+  while (start < a.length && start < b.length && a[start] === b[start]) start++;
+  let endA = a.length;
+  let endB = b.length;
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+    endA--;
+    endB--;
+  }
+  const out = [];
+  for (let i = start; i < endA; i++) out.push(`- ${a[i]}`);
+  for (let i = start; i < endB; i++) out.push(`+ ${b[i]}`);
+  return out.length === 0 ? '(no textual difference)' : out.join('\n');
+}
+
+// ── audit log ─────────────────────────────────────────────────────────────────
+
+/**
+ * Append one JSONL line to `<hypoDir>/.cache/proposals/applied.log`. The `.log`
+ * suffix keeps it out of listProposals' `.json`-only readdir scan. This is the
+ * apply audit contract, so callers treat a failure here as FATAL, not
+ * best-effort.
+ *
+ * appendFileSync follows a symlink, so a planted `applied.log -> /elsewhere` would
+ * send the audit record out of the vault while apply still exits 0. Refuse a
+ * symlinked log the same way the target path refuses one: throwing here is the
+ * fail-loud the caller wants.
+ */
+function appendApplyLog(hypoDir, entry) {
+  const logPath = join(proposalsDir(hypoDir), 'applied.log');
+  mkdirSync(dirname(logPath), { recursive: true });
+  try {
+    if (lstatSync(logPath).isSymbolicLink()) {
+      throw new Error(`audit log is a symlink, refusing to append: ${logPath}`);
+    }
+  } catch (e) {
+    if (!e || e.code !== 'ENOENT') throw e; // absent log is the normal first-apply case
+  }
+  appendFileSync(logPath, `${JSON.stringify(entry)}\n`);
+}
+
+// ── interactive prompt ────────────────────────────────────────────────────────
+
+/**
+ * Default confirm prompt: readline over stdin, writing to stderr so stdout stays
+ * clean for the diff / --json. Returns the typed line with surrounding whitespace
+ * trimmed; the caller decides whether it matches the required `apply <id>` phrase.
+ * Injectable so the runner can drive apply without a real TTY.
+ */
+async function defaultPrompt({ id, target }) {
+  const rl = (await import('node:readline/promises')).createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    process.stderr.write(
+      `\nApply proposal ${id} to ${target}?\n` +
+        `  This REPLACES the target with the proposed content shown above.\n` +
+        `  Type exactly \`apply ${id}\` to confirm; anything else aborts.\n`,
+    );
+    return (await rl.question('confirm> ')).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+// ── actors (return { ok, code, ... }; main() maps code to exit) ────────────────
+
+/**
+ * Apply one proposal: whole-file replace the target with the parked content,
+ * behind a fresh diff, a TTY gate, an explicit confirm, and a post-confirm
+ * re-read guard. Returns a result object; never calls process.exit (that is
+ * main()'s job, and the object is the test seam).
+ *
+ * @param {{hypoDir: string, id: string}} sel
+ * @param {{isTTY?: boolean, prompt?: Function, stdout?: {write: Function},
+ *          stderr?: {write: Function}, now?: () => string}} [io]
+ */
+export async function applyProposal({ hypoDir, id }, { isTTY, prompt, stdout, stderr, now } = {}) {
+  const out = stdout ?? process.stdout;
+  const err = stderr ?? process.stderr;
+  const clock = now ?? (() => new Date().toISOString());
+  const tty = isTTY ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const ask = prompt ?? defaultPrompt;
+
+  // (1) validate + read the artifact: a bad id or missing artifact changes nothing
+  if (!isValidProposalId(id)) {
+    err.write(`✗ invalid proposal id: ${id}\n`);
+    return { ok: false, code: 2, reason: 'invalid-id' };
+  }
+  const proposal = readProposal(hypoDir, id);
+  if (!proposal) {
+    err.write(`✗ no such proposal: ${id}\n`);
+    return { ok: false, code: 2, reason: 'not-found' };
+  }
+
+  // (2) resolve + harden the target: null means unsafe, nothing is written
+  const full = resolveTargetPath(hypoDir, proposal.target);
+  if (!full) {
+    const shown = sanitizeForDisplay(proposal.target, { allowNewlines: false });
+    err.write(`✗ proposal target is unsafe or escapes the vault: ${shown}\n`);
+    return { ok: false, code: 2, reason: 'unsafe-target' };
+  }
+
+  // Everything the artifact contributes to the terminal passes through this.
+  const shownTarget = sanitizeForDisplay(proposal.target, { allowNewlines: false });
+
+  // (3) FRESH re-read of the current bytes (spec: diff against current, not base)
+  const current = readTarget(full);
+  const freshness = classifyFreshness({
+    current,
+    currentAtProposalHash: proposal.currentAtProposalHash,
+  });
+
+  // Cannot read what we would replace: refuse before prompting.
+  if (freshness === 'unreadable') {
+    err.write(`✗ target is unreadable, refusing to apply: ${shownTarget}\n`);
+    return { ok: false, code: 1, reason: 'target-unreadable' };
+  }
+
+  // (5) diff output: drift warning FIRST so the human re-reviews against fresh bytes.
+  if (freshness === 'drifted') {
+    out.write(`⚠️  target changed since this proposal was parked (${shownTarget}).\n`);
+    out.write(`    The diff below is against the CURRENT on-disk bytes; applying REPLACES them.\n`);
+  }
+  if (current === null) {
+    out.write(`(target absent, will be created: ${shownTarget})\n`);
+  }
+  out.write(`--- diff (current to proposed) for ${shownTarget} ---\n`);
+  out.write(`${sanitizeForDisplay(renderDiff(current ?? '', proposal.proposedContent))}\n`);
+
+  // (6) TTY gate BEFORE the prompt, so a non-interactive run rejects without hanging
+  if (!tty) {
+    err.write(
+      `✗ apply requires an interactive terminal for confirmation. Aborted; target unchanged.\n`,
+    );
+    return { ok: false, code: 1, reason: 'not-tty' };
+  }
+
+  // (7) confirm: the human must type EXACTLY `apply <id>`: the sole write authority
+  const typed = await ask({ id, target: shownTarget });
+  const confirmed = typeof typed === 'string' && typed.trim() === `apply ${id}`;
+
+  // (8) decide: abort preserves BOTH the target and the proposal
+  const decision = planApplyAction({ confirmed, freshness });
+  if (decision.action === 'abort') {
+    err.write(`✗ apply aborted (${decision.reason}); target and proposal preserved.\n`);
+    return { ok: false, code: 1, reason: decision.reason };
+  }
+
+  // (9) POST-CONFIRM RE-VALIDATION. Nothing is locked while the human reads, so
+  // BOTH the path and the bytes can move between step 2/3 and the write. Checking
+  // only the bytes would leave the path check stale: an ancestor that becomes a
+  // symlink out of the vault during the prompt would still be walked by the write
+  // below. So re-resolve first, then re-read.
+  //
+  // A residual race remains between these checks and the rename below. Re-resolving
+  // NARROWS the window but does not close it: because every check operates on a
+  // pathname and the write does too, an ancestor swapped to an out-of-vault symlink
+  // in that final gap can still redirect the write. Closing it would need
+  // component-wise openat / a lockfile, both of which the spec's guarantee scope
+  // rules out (see the hostile-local-FS note there). An actor able to win that race
+  // already has write access to every target directly, so it grants no new reach.
+  const stillSafe = resolveTargetPath(hypoDir, proposal.target);
+  if (!stillSafe || stillSafe !== full) {
+    err.write(
+      `✗ target path stopped resolving safely while you were reviewing; nothing written.\n`,
+    );
+    return { ok: false, code: 1, reason: 'unsafe-target' };
+  }
+
+  const afterConfirm = readTarget(full);
+  const displayedHash = current === null ? null : hashProposalContent(current);
+  const afterHash =
+    afterConfirm === undefined
+      ? undefined
+      : afterConfirm === null
+        ? null
+        : hashProposalContent(afterConfirm);
+  if (afterHash !== displayedHash) {
+    err.write(
+      `✗ target changed while you were reviewing; nothing written, proposal preserved. ` +
+        `Re-run apply to review the fresh bytes.\n`,
+    );
+    return { ok: false, code: 1, reason: 'concurrent-mutation' };
+  }
+
+  // (10) write: a failure here is fail-loud and keeps the proposal for retry.
+  // Creating the parent is its own hazard (`mkdirSync(recursive)` follows a symlink
+  // planted since the check above), so containment is re-proven once the parent
+  // exists and only then are the bytes written.
+  try {
+    mkdirSync(dirname(full), { recursive: true });
+    if (resolveTargetPath(hypoDir, proposal.target) !== full) {
+      throw new Error('target path escaped the vault while its parent was created');
+    }
+    atomicWrite(full, proposal.proposedContent);
+  } catch (e) {
+    // A filesystem error message embeds the path, so it can carry the artifact's
+    // control characters back to the terminal; sanitize it like any shown field.
+    const why = sanitizeForDisplay(e.message, { allowNewlines: false });
+    err.write(`✗ failed to write ${shownTarget}: ${why}. Nothing changed; proposal preserved.\n`);
+    return { ok: false, code: 1, reason: 'write-failed' };
+  }
+
+  // (11) audit log: FATAL on failure (it is the apply audit contract). Ordered
+  // write→log→delete: the log never lies (recorded only after a real write), and a
+  // log failure leaves the proposal alive so a re-apply self-heals the record.
+  try {
+    appendApplyLog(hypoDir, {
+      id,
+      target: proposal.target,
+      currentHash: displayedHash,
+      appliedAt: clock(),
+      sessionId: proposal.sessionId ?? null,
+      device: proposal.device ?? null,
+    });
+  } catch (e) {
+    const why = sanitizeForDisplay(e.message, { allowNewlines: false });
+    err.write(
+      `✗ applied to disk but FAILED to write the audit log: ${why}. ` +
+        `Proposal kept; re-run apply to complete the audit record.\n`,
+    );
+    return { ok: false, code: 1, reason: 'log-failed', applied: true };
+  }
+
+  // (12) remove the now-applied artifact: a leftover artifact is a non-zero exit
+  if (!deleteProposal(hypoDir, id)) {
+    err.write(`⚠️  applied and logged, but the proposal artifact was not removed: ${id}\n`);
+    return { ok: false, code: 1, reason: 'artifact-not-removed', applied: true };
+  }
+
+  out.write(`✓ applied proposal ${id} to ${shownTarget}\n`);
+  return { ok: true, code: 0, id, target: proposal.target, warned: decision.warned };
+}
+
+/**
+ * Discard one proposal: remove the artifact, leave the target untouched. No
+ * confirm gate (the spec defines discard as a plain removal, and it writes nothing
+ * to any page).
+ */
+export function discardProposal({ hypoDir, id }, { stdout, stderr } = {}) {
+  const out = stdout ?? process.stdout;
+  const err = stderr ?? process.stderr;
+  if (!isValidProposalId(id)) {
+    err.write(`✗ invalid proposal id: ${id}\n`);
+    return { ok: false, code: 2, reason: 'invalid-id' };
+  }
+  const proposal = readProposal(hypoDir, id);
+  if (!proposal) {
+    err.write(`✗ no such proposal: ${id}\n`);
+    return { ok: false, code: 2, reason: 'not-found' };
+  }
+  if (!deleteProposal(hypoDir, id)) {
+    err.write(`✗ failed to remove proposal ${id}\n`);
+    return { ok: false, code: 1, reason: 'delete-failed' };
+  }
+  const shown = sanitizeForDisplay(proposal.target, { allowNewlines: false });
+  out.write(`✓ discarded proposal ${id} (target ${shown} left unchanged)\n`);
+  return { ok: true, code: 0, id, target: proposal.target };
+}
+
+/**
+ * List pending proposals (id, target, createdAt, plus session/device), oldest
+ * first. `--json` emits the array; the human form prints one line each, or a
+ * "no pending proposals" notice.
+ */
+export function listPending({ hypoDir }, { stdout, json } = {}) {
+  const out = stdout ?? process.stdout;
+  const items = listProposals(hypoDir)
+    .map((p) => ({
+      id: p.id,
+      target: p.target,
+      createdAt: p.createdAt ?? null,
+      sessionId: p.sessionId ?? null,
+      device: p.device ?? null,
+    }))
+    .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)));
+
+  if (json) {
+    out.write(`${JSON.stringify(items, null, 2)}\n`);
+    return { ok: true, code: 0, count: items.length };
+  }
+  if (items.length === 0) {
+    out.write('no pending proposals\n');
+    return { ok: true, code: 0, count: 0 };
+  }
+  // Every field but `id` (validated by listProposals) comes from the artifact body
+  // and is shown one line each, so all of them pass through the display sanitizer.
+  const clean = (v) => sanitizeForDisplay(String(v), { allowNewlines: false });
+  for (const it of items) {
+    const who = it.sessionId
+      ? `  (session ${clean(it.sessionId)}, ${clean(it.device ?? '?')})`
+      : '';
+    out.write(`${it.id}  ${clean(it.target)}  ${clean(it.createdAt)}${who}\n`);
+  }
+  return { ok: true, code: 0, count: items.length };
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { hypoDir: null, cmd: null, id: null, json: false };
+  const positionals = [];
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--hypo-dir') args.hypoDir = expandHome(rest[++i] ?? '');
+    else if (a.startsWith('--hypo-dir=')) args.hypoDir = expandHome(a.slice('--hypo-dir='.length));
+    else if (a === '--json') args.json = true;
+    else positionals.push(a);
+  }
+  args.cmd = positionals[0] ?? null;
+  args.id = positionals[1] ?? null;
+  if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  let result;
+  switch (args.cmd) {
+    case 'list':
+      result = listPending({ hypoDir: args.hypoDir }, { stdout: process.stdout, json: args.json });
+      break;
+    case 'apply':
+      if (!args.id) {
+        process.stderr.write('✗ usage: hypomnema proposal apply <id>\n');
+        process.exit(2);
+      }
+      result = await applyProposal({ hypoDir: args.hypoDir, id: args.id }, {});
+      break;
+    case 'discard':
+      if (!args.id) {
+        process.stderr.write('✗ usage: hypomnema proposal discard <id>\n');
+        process.exit(2);
+      }
+      result = discardProposal({ hypoDir: args.hypoDir, id: args.id }, {});
+      break;
+    default:
+      process.stderr.write(
+        'usage: hypomnema proposal <list|apply|discard> [id] [--json] [--hypo-dir <path>]\n',
+      );
+      process.exit(2);
+  }
+  process.exit(result.code ?? (result.ok ? 0 : 1));
+}
+
+function isMain() {
+  try {
+    if (!process.argv[1]) return false;
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
+  } catch {
+    return false;
+  }
+}
+
+if (isMain()) {
+  main();
+}

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -63,7 +63,18 @@ import {
   deleteProposal as psDeleteProposal,
   makeProposalId as psMakeProposalId,
   proposalsDir as psProposalsDir,
+  hashProposalContent,
 } from '../hooks/proposal-store.mjs';
+// proposal.mjs guards its CLI dispatch behind isMain(), so importing these pure
+// functions + result-returning actors for unit tests does not run the CLI.
+import {
+  planApplyAction,
+  classifyFreshness,
+  resolveTargetPath as propResolveTargetPath,
+  applyProposal,
+  discardProposal,
+  listPending,
+} from '../scripts/proposal.mjs';
 import {
   validateChangelog,
   validateTagBody,
@@ -3508,9 +3519,17 @@ test('append lock-timeout → proposal-pending, shard byte-untouched (FEAT-11 T5
     assert.ok(c, `a sessionLog conflict is expected: ${JSON.stringify(out.conflicts)}`);
     assert.equal(c.kind, 'append', 'conflict.kind must be "append"');
     assert.equal(c.reason, 'append-lock-timeout', 'conflict.reason must be append-lock-timeout');
-    assert.equal(c.proposedContent, undefined, 'proposedContent must be dropped from the reported shape');
+    assert.equal(
+      c.proposedContent,
+      undefined,
+      'proposedContent must be dropped from the reported shape',
+    );
     const shardAfter = existsSync(shard) ? readFileSync(shard, 'utf-8') : null;
-    assert.equal(shardAfter, shardBefore, 'the shard must be byte-untouched when the append is withheld');
+    assert.equal(
+      shardAfter,
+      shardBefore,
+      'the shard must be byte-untouched when the append is withheld',
+    );
     if (shardAfter) {
       assert.ok(!shardAfter.includes('locked-out entry'), 'the withheld entry must not be written');
     }
@@ -3603,7 +3622,11 @@ test('FEAT-11 T6: readProposal/deleteProposal reject path-traversal ids (no esca
     writeFileSync(sentinel, 'DO NOT DELETE');
     for (const bad of ['../../hot', '../hot', '..', '/etc/passwd', 'a/b', '']) {
       assert.equal(psReadProposal(dir, bad), null, `readProposal rejects ${JSON.stringify(bad)}`);
-      assert.equal(psDeleteProposal(dir, bad), false, `deleteProposal rejects ${JSON.stringify(bad)}`);
+      assert.equal(
+        psDeleteProposal(dir, bad),
+        false,
+        `deleteProposal rejects ${JSON.stringify(bad)}`,
+      );
     }
     assert.ok(existsSync(sentinel), 'a file outside the store is never unlinked');
     assert.equal(readFileSync(sentinel, 'utf-8'), 'DO NOT DELETE', 'sentinel bytes untouched');
@@ -3890,6 +3913,641 @@ test('FEAT-11 T6: append lock-timeout makes NO artifact (proposals empty, still 
     assert.equal(files.length, 0, `no artifact must be written for an append conflict: ${files}`);
   });
 });
+
+// ── FEAT-11 T7: proposal CLI (list / apply / discard) ────────────────────────
+// The human-in-the-loop gate. Every path to a target write runs through a fresh
+// diff, a TTY gate, an explicit confirm, and a post-confirm re-read. The pure
+// decision functions are table-tested; the actors are driven in-process with
+// injected TTY / prompt / clock seams.
+
+// A stream stand-in that accumulates writes, so a test can assert on what the
+// actor emitted without a real stdout/stderr.
+function capStream() {
+  const chunks = [];
+  return { write: (s) => chunks.push(String(s)), text: () => chunks.join('') };
+}
+
+test('FEAT-11 T7: planApplyAction table (unreadable aborts regardless of confirm)', () => {
+  assert.deepEqual(planApplyAction({ confirmed: true, freshness: 'unreadable' }), {
+    action: 'abort',
+    reason: 'target-unreadable',
+  });
+  assert.deepEqual(planApplyAction({ confirmed: false, freshness: 'unreadable' }), {
+    action: 'abort',
+    reason: 'target-unreadable',
+  });
+  assert.deepEqual(planApplyAction({ confirmed: false, freshness: 'fresh' }), {
+    action: 'abort',
+    reason: 'not-confirmed',
+  });
+  assert.deepEqual(planApplyAction({ confirmed: true, freshness: 'fresh' }), {
+    action: 'apply',
+    reason: null,
+    warned: false,
+  });
+  assert.deepEqual(planApplyAction({ confirmed: true, freshness: 'drifted' }), {
+    action: 'apply',
+    reason: null,
+    warned: true,
+  });
+});
+
+test('FEAT-11 T7: classifyFreshness (fresh / drifted / unreadable / absent-null / absent-nonnull)', () => {
+  const h = bsHashContent('AAA');
+  assert.equal(classifyFreshness({ current: 'AAA', currentAtProposalHash: h }), 'fresh');
+  assert.equal(classifyFreshness({ current: 'BBB', currentAtProposalHash: h }), 'drifted');
+  assert.equal(classifyFreshness({ current: undefined, currentAtProposalHash: h }), 'unreadable');
+  // absent now + null at park → fresh (nothing on disk to clobber).
+  assert.equal(classifyFreshness({ current: null, currentAtProposalHash: null }), 'fresh');
+  // absent now + a real park hash → drifted (the file was there at park, gone now).
+  assert.equal(classifyFreshness({ current: null, currentAtProposalHash: h }), 'drifted');
+});
+
+test('FEAT-11 T7: resolveTargetPath rejects traversal, absolute, empty, non-string; passes a clean rel path', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+  try {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const ok = propResolveTargetPath(dir, join('pages', 'note.md'));
+    assert.ok(ok && ok.endsWith(join('pages', 'note.md')), `clean rel path resolves: ${ok}`);
+    assert.equal(
+      propResolveTargetPath(dir, join('..', '..', '.zshrc')),
+      null,
+      'traversal rejected',
+    );
+    assert.equal(propResolveTargetPath(dir, join('pages', '..', '..', 'x')), null, '.. segment');
+    assert.equal(propResolveTargetPath(dir, '/etc/passwd'), null, 'absolute rejected');
+    assert.equal(propResolveTargetPath(dir, ''), null, 'empty rejected');
+    assert.equal(propResolveTargetPath(dir, 123), null, 'non-string rejected');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('FEAT-11 T7: resolveTargetPath fails closed on a symlinked target and a vault-escaping ancestor', () => {
+  if (process.platform === 'win32') return;
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+  const outside = mkdtempSync(join(tmpdir(), 'hypo-t7-out-'));
+  try {
+    // Target file itself a symlink (pointing INSIDE the vault so the ancestor
+    // check passes and the lstat branch is what rejects it): the diff would
+    // follow the link but atomicWrite would replace it, so refuse.
+    writeFileSync(join(dir, 'real.md'), 'real');
+    symlinkSync(join(dir, 'real.md'), join(dir, 'link.md'));
+    assert.equal(propResolveTargetPath(dir, 'link.md'), null, 'symlinked target rejected');
+
+    // A parent dir that is a symlink OUT of the vault: a rename would land
+    // outside, so the nearest-ancestor realpath check must reject it.
+    symlinkSync(outside, join(dir, 'sub'));
+    assert.equal(
+      propResolveTargetPath(dir, join('sub', 'note.md')),
+      null,
+      'escaping-ancestor symlink rejected',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test('FEAT-11 T7: no bypass tokens in scripts/proposal.mjs (no auto-apply, no env override)', () => {
+  const src = readFileSync(join(SCRIPTS, 'proposal.mjs'), 'utf-8');
+  const hits = src.match(/--yes|process\.env/g);
+  assert.equal(hits, null, `proposal.mjs must carry no bypass token, found: ${hits}`);
+});
+
+test('FEAT-11 T7: no hook imports the apply path (no unattended auto-apply)', () => {
+  const importers = readdirSync(HOOKS)
+    .filter((f) => f.endsWith('.mjs'))
+    .filter((f) => /proposal\.mjs/.test(readFileSync(join(HOOKS, f), 'utf-8')));
+  assert.deepEqual(
+    importers,
+    [],
+    `hooks must never reach the apply path (fires unattended): ${importers.join(', ')}`,
+  );
+});
+
+await testAsync(
+  'FEAT-11 T7: non-TTY apply is refused: target bytes unchanged, proposal preserved',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      const target = join(dir, 'pages', 'note.md');
+      writeFileSync(target, 'ORIGINAL');
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: null,
+        currentAtProposalHash: bsHashContent('ORIGINAL'),
+        proposedContent: 'PROPOSED',
+        sessionId: 's7',
+        device: 'd7',
+      });
+      const out = capStream();
+      const err = capStream();
+      const r = await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        { isTTY: false, stdout: out, stderr: err, prompt: async () => `apply ${saved.id}` },
+      );
+      assert.equal(r.ok, false);
+      assert.notEqual(r.code, 0, 'non-TTY apply exits non-zero');
+      assert.equal(readFileSync(target, 'utf-8'), 'ORIGINAL', 'target bytes untouched');
+      assert.ok(psReadProposal(dir, saved.id), 'proposal preserved');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+await testAsync(
+  'FEAT-11 T7: apply success: whole-file replace, proposal removed, one audit line with pre-apply hash',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      const target = join(dir, 'pages', 'note.md');
+      writeFileSync(target, 'ORIGINAL');
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: null,
+        currentAtProposalHash: bsHashContent('ORIGINAL'),
+        proposedContent: 'PROPOSED CONTENT',
+        sessionId: 's7',
+        device: 'd7',
+      });
+      const out = capStream();
+      const r = await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        {
+          isTTY: true,
+          stdout: out,
+          stderr: capStream(),
+          prompt: async () => `apply ${saved.id}`,
+          now: () => '2026-07-10T00:00:00.000Z',
+        },
+      );
+      assert.equal(r.ok, true, `apply should succeed: ${JSON.stringify(r)}`);
+      assert.equal(r.code, 0);
+      assert.equal(readFileSync(target, 'utf-8'), 'PROPOSED CONTENT', 'target replaced wholesale');
+      assert.equal(psReadProposal(dir, saved.id), null, 'proposal artifact removed');
+
+      const logPath = join(psProposalsDir(dir), 'applied.log');
+      const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
+      assert.equal(lines.length, 1, 'exactly one audit line');
+      const rec = JSON.parse(lines[0]);
+      assert.equal(rec.id, saved.id);
+      assert.equal(rec.target, join('pages', 'note.md'));
+      assert.equal(
+        rec.currentHash,
+        bsHashContent('ORIGINAL'),
+        'currentHash is the pre-apply disk hash',
+      );
+      assert.equal(rec.appliedAt, '2026-07-10T00:00:00.000Z', 'appliedAt from injected clock');
+      // The audit log must NOT leak into the proposal listing (.json filter).
+      assert.equal(listProposalsCount(dir), 0, 'applied.log is not counted as a proposal');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+await testAsync(
+  'FEAT-11 T7: freshness warning path: a re-drifted target warns, then applies on confirm',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      const target = join(dir, 'pages', 'note.md');
+      writeFileSync(target, 'ORIGINAL');
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: null,
+        currentAtProposalHash: bsHashContent('ORIGINAL'),
+        proposedContent: 'PROPOSED',
+        sessionId: 's7',
+        device: 'd7',
+      });
+      // Someone drifts the target AFTER it was parked.
+      writeFileSync(target, 'DRIFTED SINCE PARK');
+      const out = capStream();
+      const r = await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        {
+          isTTY: true,
+          stdout: out,
+          stderr: capStream(),
+          prompt: async () => `apply ${saved.id}`,
+          now: () => '2026-07-10T00:00:00.000Z',
+        },
+      );
+      assert.equal(r.ok, true, 'a confirmed drift still applies');
+      assert.equal(r.warned, true, 'the result records that a drift warning was surfaced');
+      assert.match(out.text(), /changed since this proposal was parked/, 'drift warning printed');
+      assert.equal(readFileSync(target, 'utf-8'), 'PROPOSED', 'target replaced after review');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+await testAsync(
+  'FEAT-11 T7: concurrent mutation during the prompt aborts: target keeps its bytes, proposal preserved',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      const target = join(dir, 'pages', 'note.md');
+      writeFileSync(target, 'ORIGINAL');
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: null,
+        currentAtProposalHash: bsHashContent('ORIGINAL'),
+        proposedContent: 'PROPOSED',
+        sessionId: 's7',
+        device: 'd7',
+      });
+      const err = capStream();
+      const r = await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        {
+          isTTY: true,
+          stdout: capStream(),
+          stderr: err,
+          // A concurrent close writes the target while the human is at the prompt.
+          prompt: async () => {
+            writeFileSync(target, 'CONCURRENT WRITE');
+            return `apply ${saved.id}`;
+          },
+        },
+      );
+      assert.equal(r.ok, false, 'apply must abort on a post-confirm change');
+      assert.equal(r.reason, 'concurrent-mutation');
+      assert.equal(
+        readFileSync(target, 'utf-8'),
+        'CONCURRENT WRITE',
+        'the concurrent bytes are preserved, not overwritten',
+      );
+      assert.ok(psReadProposal(dir, saved.id), 'proposal preserved for re-apply');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+await testAsync(
+  'FEAT-11 T7: apply abort (no confirm) preserves target and proposal, exits non-zero',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      const target = join(dir, 'pages', 'note.md');
+      writeFileSync(target, 'ORIGINAL');
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: null,
+        currentAtProposalHash: bsHashContent('ORIGINAL'),
+        proposedContent: 'PROPOSED',
+        sessionId: 's7',
+        device: 'd7',
+      });
+      const r = await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        { isTTY: true, stdout: capStream(), stderr: capStream(), prompt: async () => 'no' },
+      );
+      assert.equal(r.ok, false);
+      assert.notEqual(r.code, 0);
+      assert.equal(r.reason, 'not-confirmed');
+      assert.equal(readFileSync(target, 'utf-8'), 'ORIGINAL', 'target preserved');
+      assert.ok(psReadProposal(dir, saved.id), 'proposal preserved');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test('FEAT-11 T7: discard removes the proposal and leaves the target unchanged', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+  try {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const target = join(dir, 'pages', 'note.md');
+    writeFileSync(target, 'ORIGINAL');
+    const saved = psWriteProposal(dir, {
+      target: join('pages', 'note.md'),
+      baseHash: null,
+      currentAtProposalHash: bsHashContent('ORIGINAL'),
+      proposedContent: 'PROPOSED',
+      sessionId: 's7',
+      device: 'd7',
+    });
+    const r = discardProposal(
+      { hypoDir: dir, id: saved.id },
+      { stdout: capStream(), stderr: capStream() },
+    );
+    assert.equal(r.ok, true);
+    assert.equal(psReadProposal(dir, saved.id), null, 'proposal removed');
+    assert.equal(readFileSync(target, 'utf-8'), 'ORIGINAL', 'target unchanged');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('FEAT-11 T7: list is oldest-first and reports the empty case', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+  try {
+    const empty = capStream();
+    const r0 = listPending({ hypoDir: dir }, { stdout: empty });
+    assert.equal(r0.count, 0);
+    assert.match(empty.text(), /no pending proposals/);
+
+    psWriteProposal(dir, {
+      target: 'a.md',
+      baseHash: null,
+      currentAtProposalHash: null,
+      proposedContent: 'A',
+      sessionId: 's7',
+      device: 'd7',
+      createdAt: '2026-07-01T00:00:00.000Z',
+    });
+    psWriteProposal(dir, {
+      target: 'b.md',
+      baseHash: null,
+      currentAtProposalHash: null,
+      proposedContent: 'B',
+      sessionId: 's7',
+      device: 'd7',
+      createdAt: '2026-06-01T00:00:00.000Z',
+    });
+    const j = capStream();
+    const r = listPending({ hypoDir: dir }, { stdout: j, json: true });
+    assert.equal(r.count, 2);
+    const arr = JSON.parse(j.text());
+    assert.deepEqual(
+      arr.map((x) => x.target),
+      ['b.md', 'a.md'],
+      'sorted oldest createdAt first',
+    );
+    // Assert the identifying fields too: a listing that dropped `id` or `createdAt`
+    // would still satisfy a target-only check while being useless to `apply`.
+    for (const entry of arr) {
+      assert.ok(entry.id && typeof entry.id === 'string', 'each entry carries its id');
+      assert.ok(entry.createdAt, 'each entry carries its createdAt');
+    }
+    assert.deepEqual(
+      arr.map((x) => x.createdAt),
+      ['2026-06-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await testAsync('FEAT-11 T7: a successful apply leaves the session base untouched', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+  try {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const rel = join('pages', 'note.md');
+    const target = join(dir, rel);
+    writeFileSync(target, 'ORIGINAL');
+    const sessionId = 'sess-apply-base';
+    snapshotBase(dir, sessionId, [rel]);
+    const before = readBaseEntry(dir, sessionId, rel);
+    assert.equal(before.hash, bsHashContent('ORIGINAL'), 'base captured the pre-apply bytes');
+
+    const saved = psWriteProposal(dir, {
+      target: rel,
+      baseHash: bsHashContent('ORIGINAL'),
+      currentAtProposalHash: hashProposalContent('ORIGINAL'),
+      proposedContent: 'PROPOSED',
+      sessionId,
+      device: 'd',
+    });
+    const res = await applyProposal(
+      { hypoDir: dir, id: saved.id },
+      {
+        isTTY: true,
+        stdout: capStream(),
+        stderr: capStream(),
+        now: () => '2026-07-10T00:00:00.000Z',
+        prompt: () => `apply ${saved.id}`,
+      },
+    );
+    assert.equal(res.ok, true);
+    assert.equal(readFileSync(target, 'utf-8'), 'PROPOSED');
+
+    // apply is an out-of-band human override, not a session write, so the base
+    // this session observed at start must not move. Advancing it would let the
+    // same session's next close overwrite the page without ever re-checking it.
+    // Breaking the apply-then-reclose loop is crystallize's idempotent-skip
+    // (disk === payload), not a base advance here.
+    assert.deepEqual(readBaseEntry(dir, sessionId, rel), before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The three attacks a pre-commit review reproduced against the first cut of this
+// CLI. Each one exited 0 while either destroying the withheld bytes or writing
+// outside the vault, so each is pinned here rather than only fixed.
+
+test('FEAT-11 T7: a target pointing back into the proposal store is refused', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+  try {
+    const saved = psWriteProposal(dir, {
+      target: join('pages', 'note.md'),
+      baseHash: null,
+      currentAtProposalHash: null,
+      proposedContent: 'WITHHELD',
+      sessionId: 's',
+      device: 'd',
+    });
+    // Applying this would write the bytes over the artifact, then unlink it.
+    assert.equal(propResolveTargetPath(dir, join('.cache', 'proposals', `${saved.id}.json`)), null);
+    assert.equal(propResolveTargetPath(dir, join('.cache', 'proposals', 'applied.log')), null);
+    assert.equal(propResolveTargetPath(dir, join('.cache', 'proposals')), null);
+    // A normal target is unaffected by the store guard.
+    assert.ok(propResolveTargetPath(dir, join('pages', 'note.md')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await testAsync(
+  'FEAT-11 T7: an ancestor that becomes a symlink during the prompt aborts the write',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    const outside = mkdtempSync(join(tmpdir(), 'hypo-t7-outside-'));
+    try {
+      const saved = psWriteProposal(dir, {
+        target: join('new', 'leaf.md'),
+        baseHash: null,
+        currentAtProposalHash: null, // target absent at park time
+        proposedContent: 'WITHHELD',
+        sessionId: 's',
+        device: 'd',
+      });
+      const err = capStream();
+      const res = await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        {
+          isTTY: true,
+          stdout: capStream(),
+          stderr: err,
+          now: () => '2026-07-10T00:00:00.000Z',
+          // A concurrent process plants the escape while the human reads the diff.
+          prompt: () => {
+            symlinkSync(outside, join(dir, 'new'), 'dir');
+            return `apply ${saved.id}`;
+          },
+        },
+      );
+      assert.equal(res.ok, false);
+      assert.equal(res.reason, 'unsafe-target');
+      assert.equal(
+        existsSync(join(outside, 'leaf.md')),
+        false,
+        'nothing written outside the vault',
+      );
+      assert.equal(psReadProposal(dir, saved.id)?.id, saved.id, 'proposal preserved');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  },
+);
+
+await testAsync(
+  'FEAT-11 T7: a symlinked audit log is refused and the proposal survives',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    const outside = mkdtempSync(join(tmpdir(), 'hypo-t7-outside-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'note.md'), 'ORIGINAL');
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: null,
+        currentAtProposalHash: hashProposalContent('ORIGINAL'),
+        proposedContent: 'PROPOSED',
+        sessionId: 's',
+        device: 'd',
+      });
+      const sentinel = join(outside, 'stolen.log');
+      symlinkSync(sentinel, join(dir, '.cache', 'proposals', 'applied.log'));
+
+      const err = capStream();
+      const res = await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        {
+          isTTY: true,
+          stdout: capStream(),
+          stderr: err,
+          now: () => '2026-07-10T00:00:00.000Z',
+          prompt: () => `apply ${saved.id}`,
+        },
+      );
+      assert.equal(res.ok, false);
+      assert.equal(res.reason, 'log-failed');
+      assert.equal(existsSync(sentinel), false, 'audit record never left the vault');
+      assert.equal(psReadProposal(dir, saved.id)?.id, saved.id, 'proposal kept for a retry');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  },
+);
+
+await testAsync(
+  'FEAT-11 T7: the diff is rendered against current disk bytes, not the parked base',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      const target = join(dir, 'pages', 'note.md');
+      writeFileSync(target, 'BASE_BYTES');
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: hashProposalContent('BASE_BYTES'),
+        currentAtProposalHash: hashProposalContent('BASE_BYTES'),
+        proposedContent: 'PROPOSED_BYTES',
+        sessionId: 's',
+        device: 'd',
+      });
+      // Someone else wrote the page after the artifact was parked.
+      writeFileSync(target, 'OTHER_SESSION_BYTES');
+
+      const out = capStream();
+      await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        { isTTY: false, stdout: out, stderr: capStream() },
+      );
+      const shown = out.text();
+      assert.match(shown, /- OTHER_SESSION_BYTES/, 'removed side is the CURRENT disk bytes');
+      assert.match(shown, /\+ PROPOSED_BYTES/);
+      assert.doesNotMatch(shown, /BASE_BYTES$/m, 'the parked base is never the diff baseline');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+await testAsync(
+  'FEAT-11 T7: terminal control characters in the artifact never reach the diff output',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'note.md'), 'ORIGINAL');
+      const esc = String.fromCharCode(27);
+      // U+009B is the C1 CSI: a single byte that introduces a control sequence
+      // exactly like ESC-[ does. A C0-only sanitizer would let it through.
+      const c1csi = String.fromCharCode(0x9b);
+      const saved = psWriteProposal(dir, {
+        target: join('pages', 'note.md'),
+        baseHash: null,
+        currentAtProposalHash: hashProposalContent('ORIGINAL'),
+        proposedContent: `${esc}[2J${esc}[H${c1csi}2J SPOOFED`,
+        sessionId: 's',
+        device: 'd',
+      });
+      const out = capStream();
+      await applyProposal(
+        { hypoDir: dir, id: saved.id },
+        { isTTY: false, stdout: out, stderr: capStream() },
+      );
+      assert.doesNotMatch(out.text(), new RegExp(esc), 'no ESC byte reaches the terminal');
+      assert.doesNotMatch(out.text(), new RegExp(c1csi), 'no C1 CSI byte reaches the terminal');
+      assert.match(out.text(), /SPOOFED/, 'the text itself is still shown, just neutralized');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test('FEAT-11 T7: an in-vault symlink alias into the store is refused', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+  try {
+    const saved = psWriteProposal(dir, {
+      target: join('pages', 'note.md'),
+      baseHash: null,
+      currentAtProposalHash: null,
+      proposedContent: 'WITHHELD',
+      sessionId: 's',
+      device: 'd',
+    });
+    // `alias/` resolves to the store, so `alias/<id>.json` is lexically outside the
+    // store yet the real write lands on the artifact itself and would destroy it.
+    symlinkSync(join(dir, '.cache', 'proposals'), join(dir, 'alias'), 'dir');
+    assert.equal(propResolveTargetPath(dir, join('alias', `${saved.id}.json`)), null);
+    assert.equal(propResolveTargetPath(dir, join('alias', 'applied.log')), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Count proposals via the store the CLI reads through, so the assertion tracks the
+// exact `.json`-only scan (applied.log's `.log` suffix must never inflate it).
+function listProposalsCount(dir) {
+  return psListProposals(dir).length;
+}
 
 // appendIfAbsent data-loss fix: a PERSISTENT read error (EACCES/EISDIR/...) on an
 // append target that already has content must hard-fail the close, not silently
@@ -26407,10 +27065,7 @@ test('advanceBaseForWrite advances a tracked target to its current on-disk bytes
     snapshotBase(dir, 's1', overwriteTargets('p1'));
     const oq = join(dir, 'pages', 'open-questions.md');
     writeFileSync(oq, '# open questions\n\n## edited directly by this session\n');
-    assert.equal(
-      advanceBaseForWrite(dir, 's1', join('pages', 'open-questions.md'), oq),
-      true,
-    );
+    assert.equal(advanceBaseForWrite(dir, 's1', join('pages', 'open-questions.md'), oq), true);
     assert.equal(
       readBaseEntry(dir, 's1', join('pages', 'open-questions.md')).hash,
       bsHashFile(oq),
@@ -26460,10 +27115,7 @@ test('advanceBaseForWrite no-ops with no session, no snapshot, or a vanished tar
     rmSync(oq);
     // a tracked target that is absent post-write must NOT advance the base to
     // null — a vanished file is a real divergence the close should still see
-    assert.equal(
-      advanceBaseForWrite(dir, 's1', join('pages', 'open-questions.md'), oq),
-      false,
-    );
+    assert.equal(advanceBaseForWrite(dir, 's1', join('pages', 'open-questions.md'), oq), false);
     assert.equal(
       readBaseEntry(dir, 's1', join('pages', 'open-questions.md')).hash,
       before,
@@ -26861,7 +27513,11 @@ test('session directly edits a target, the hook advances its base, close writes 
     const closed = `${edited}\nand the close adds this.\n`;
     const { r, out } = t4Apply(dir, t4Payload(dir, today, closed, 'self-edit close'), 's-selfedit');
 
-    assert.equal(r.status, 0, `a provenance-backed close must succeed: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(
+      r.status,
+      0,
+      `a provenance-backed close must succeed: ${JSON.stringify(out.conflicts)}`,
+    );
     assert.deepEqual(out.conflicts, [], 'the session must not conflict against its own edit');
     assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), closed, 'the close payload must land');
   });
@@ -26937,7 +27593,10 @@ test('a NON-write tool (Read) on a drifted target must NOT advance the base', ()
     const { r, out } = t4Apply(dir, t4Payload(dir, today, mine, 'read-then-close'), 's-read');
     assert.notEqual(r.status, 0, 'a Read must not have licensed a clobber of B');
     const c = out.conflicts.find((x) => x.target === t4Rel);
-    assert.ok(c && c.reason === 'base-mismatch', `B's write must still be protected: ${JSON.stringify(out.conflicts)}`);
+    assert.ok(
+      c && c.reason === 'base-mismatch',
+      `B's write must still be protected: ${JSON.stringify(out.conflicts)}`,
+    );
     assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), otherSession, "B's write survives");
   });
 });


### PR DESCRIPTION
# English

## What changed

Adds `hypomnema proposal list | apply | discard`, the CLI that closes out the overwrite-conflict artifacts the close path parks under `.cache/proposals/`. `list` shows pending proposals, `apply` reviews and re-applies one behind a human confirm, and `discard` drops one without touching the target.

## Why

The close path already parks a drifted overwrite target's withheld bytes as an artifact instead of clobbering another writer, but until now there was no sanctioned way to get those bytes back onto the page. This CLI is that way, and it keeps the whole flow human-gated so no unattended path can rewrite a page.

## How

`apply` re-reads the current on-disk bytes fresh, shows a current-vs-proposed diff (that review is the merge), warns when the target drifted since the artifact was parked, and only writes after an explicit `apply <id>` typed at a TTY. It re-reads once more after the confirm so a page rewritten while the human was reading is not silently clobbered. Writes are ordered write, then audit-log (fatal on failure), then delete, so the artifact is never the sole copy of the bytes and then destroyed. Targets are hardened against traversal, absolute paths, symlinked targets, and in-vault symlink aliases back into the store; every artifact field shown on the terminal has control characters neutralized. The apply decision is a pure function so the table tests can pin it, and there is no bypass flag, env override, or auto-apply path.

## Manual verification

Drove the built CLI against a throwaway vault: `list` and `list --json` render pending proposals; a non-TTY `apply` prints the diff then refuses (exit 1, target and artifact preserved); a hand-edited `target: "../../escaped.md"` is refused (exit 2); `discard` removes the artifact and leaves the target. The suite additionally reproduces, as regression tests, the store-alias, prompt-window symlink, and hardlink-log attacks a review surfaced.

## Migration notes

None. The CLI reads and writes only under `.cache/proposals/`, which is already gitignored.

---

# 한국어

## 변경 내용

`hypomnema proposal list | apply | discard`를 추가한다. close 경로가 `.cache/proposals/`에 park한 overwrite 충돌 아티팩트를 사람이 닫는 CLI다. `list`는 대기 중인 proposal을 보여주고, `apply`는 사람 확인을 거쳐 하나를 재적용하며, `discard`는 대상을 건드리지 않고 하나를 제거한다.

## 이유

close 경로는 이미 drift된 overwrite 대상의 보류 바이트를 상대 편집을 덮는 대신 아티팩트로 park하지만, 지금까지 그 바이트를 페이지로 되돌릴 정식 경로가 없었다. 이 CLI가 그 경로이고, 전 과정을 사람 게이트로 유지해 무감독 경로가 페이지를 재작성하지 못하게 한다.

## 방법

`apply`는 현재 디스크 바이트를 fresh하게 재-read해서 current 대 proposed diff를 보여주고(그 검토가 곧 병합이다), 아티팩트 park 이후 대상이 drift했으면 경고하며, TTY에서 `apply <id>`를 명시적으로 입력해야만 쓴다. confirm 직후 한 번 더 재-read해서, 사람이 읽는 동안 재작성된 페이지를 조용히 덮지 않는다. 쓰기는 write, 감사 로그(실패 시 fatal), delete 순서라 아티팩트가 바이트의 유일한 사본인 채로 파괴되는 일이 없다. 대상은 traversal, 절대경로, 심링크 대상, store로 되돌아가는 볼트 안 심링크 별칭에 대해 하드닝하고, 터미널에 표시되는 모든 아티팩트 필드는 제어문자를 무력화한다. apply 판정은 테이블 테스트가 고정할 수 있도록 순수 함수로 분리했고, bypass 플래그나 env override, 자동 apply 경로는 없다.

## 수동 검증

빌드된 CLI를 임시 볼트에서 구동했다. `list`와 `list --json`이 대기 proposal을 렌더하고, non-TTY `apply`는 diff를 출력한 뒤 거부하며(exit 1, 대상과 아티팩트 보존), 손편집한 `target: "../../escaped.md"`는 거부된다(exit 2). `discard`는 아티팩트를 제거하고 대상은 그대로 둔다. 스위트는 검토가 발견한 store-alias, 프롬프트 창 심링크, 하드링크 로그 공격을 회귀 테스트로 재현한다.

## 마이그레이션 노트

None. CLI는 이미 gitignore된 `.cache/proposals/` 아래에서만 읽고 쓴다.

---

## Changelog

- EN: Add `hypomnema proposal list/apply/discard` to review and re-apply parked overwrite-conflict artifacts (#185)
- KO: park된 overwrite 충돌 아티팩트를 검토하고 재적용하는 `hypomnema proposal list/apply/discard` 추가 (#185)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
