### PR TITLE
feat(surface): pending-proposal count in doctor and session-start

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -47,6 +47,7 @@ import {
   markSiblingNotified,
 } from './version-check.mjs';
 import { snapshotBase, overwriteTargets } from './base-store.mjs';
+import { listProposals } from './proposal-store.mjs';
 
 // Privacy guard: refuse to read+inject .hypoignore-matched
 // wiki files into additionalContext. Without this, a user who lists
@@ -272,6 +273,24 @@ function syncStateNotice(pullOk) {
   }
   return `[WIKI: last sync failed: ${last.op || '?'} — ${last.error || 'unknown'}]`;
 }
+/**
+ * Surface the vault-wide count of parked write-proposals (T8). Routed
+ * exactly like syncStateNotice: the line joins the `notices` array (→
+ * additionalContext) and is also written to stderr, so both the model and the
+ * user's transcript see it. NOT a systemMessage banner (that channel is
+ * reserved for the update/sibling notices). Pure read (listProposals never
+ * mutates); best-effort so a store read failure never breaks SessionStart. '' when
+ * there are no pending proposals, so nothing surfaces on the empty path.
+ */
+function pendingProposalNotice() {
+  try {
+    const n = listProposals(HYPO_DIR).length;
+    if (n === 0) return '';
+    return `[WIKI: 대기 proposal ${n}건 (검토: hypomnema proposal list)]`;
+  } catch {
+    return '';
+  }
+}
 const GLOBAL_HOT = join(HYPO_DIR, 'hot.md');
 const HOT_CHARS = 2000;
 const STATE_CHARS = 2000;
@@ -347,6 +366,7 @@ process.stdin.on('end', () => {
 
     const pullOk = gitPull(HYPO_DIR);
     const syncLine = syncStateNotice(pullOk);
+    const proposalLine = pendingProposalNotice();
     const growthLine = readLastGrowthLine();
     // On source='clear', surface the dying
     // session's identity that hypo-session-end stashed so Claude can recover
@@ -365,11 +385,17 @@ process.stdin.on('end', () => {
     // transcript/--verbose only and out of this banner's scope.)
     const userMessage = [updateLine, siblingLine].filter(Boolean).join('\n\n');
     if (userMessage) outExtra = { ...outExtra, systemMessage: userMessage };
-    const notices = [syncLine, growthLine, clearRecoveryLine, updateLine, siblingLine].filter(
-      Boolean,
-    );
+    const notices = [
+      syncLine,
+      proposalLine,
+      growthLine,
+      clearRecoveryLine,
+      updateLine,
+      siblingLine,
+    ].filter(Boolean);
     let noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
     if (syncLine) process.stderr.write(`\n\x1b[33m${syncLine}\x1b[0m\n`);
+    if (proposalLine) process.stderr.write(`\n\x1b[33m${proposalLine}\x1b[0m\n`);
     if (growthLine) process.stderr.write(`\n\x1b[36m${growthLine}\x1b[0m\n`);
     if (clearRecoveryLine)
       process.stderr.write(`\n\x1b[33m${clearRecoveryLine.split('\n')[0]}\x1b[0m\n`);

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -25,6 +25,7 @@ import {
   projectSuggestionsPath,
   collectProjectWorkingDirs,
 } from '../hooks/hypo-shared.mjs';
+import { listProposals } from '../hooks/proposal-store.mjs';
 import {
   discoverExtensions,
   parseManifest,
@@ -669,6 +670,24 @@ function checkProjectSuggestions(hypoDir) {
   }
 }
 
+function checkProposals(hypoDir) {
+  // Vault-wide count of parked write-proposals (T8). listProposals is the
+  // count source rather than a raw readdir: it already skips malformed and
+  // spoofed-id artifacts, so the number matches exactly what `hypomnema proposal
+  // list/apply/discard` can act on. Surface only: warn (never fail), pass at 0,
+  // because a pending proposal is a normal state awaiting review, not a broken
+  // install, and the check discovers without changing any state.
+  const count = listProposals(hypoDir).length;
+  if (count === 0) {
+    pass('Pending proposals', 'No parked write-proposals');
+  } else {
+    warn(
+      'Pending proposals',
+      `${count} parked write-proposal(s) awaiting review; inspect with \`hypomnema proposal list\``,
+    );
+  }
+}
+
 function checkCodexPaths() {
   const codexHooks = join(HOME, '.codex', 'hooks');
   const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
@@ -1209,6 +1228,7 @@ if (rootOk && args.codex) checkExtensions(args.hypoDir, args.claudeHome, 'codex'
 if (rootOk) checkProjectIndexAnchors(args.hypoDir);
 if (rootOk) checkSyncState(args.hypoDir);
 if (rootOk) checkProjectSuggestions(args.hypoDir);
+if (rootOk) checkProposals(args.hypoDir);
 if (rootOk) checkFeedbackProjection(args.hypoDir, args.claudeHome, args.projectId);
 checkGit(args.hypoDir);
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -27780,6 +27780,116 @@ await testAsync('N concurrent appends lose nothing and dedup an exact duplicate'
   }
 });
 
+// ── FEAT-11 pending-proposal surface (T8) ────────────────────────────────────
+
+suite('doctor.mjs / hypo-session-start.mjs — pending-proposal surface (FEAT-11 T8)');
+
+// A valid vault root (config + the three scanned dirs) so rootOk=true and
+// checkProposals actually runs — otherwise the check is silently skipped and the
+// assertion passes vacuously.
+function scaffoldVaultRoot(dir) {
+  writeFileSync(join(dir, 'hypo-config.md'), '# config');
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  mkdirSync(join(dir, 'projects'), { recursive: true });
+  mkdirSync(join(dir, 'sources'), { recursive: true });
+}
+
+test('FEAT-11 T8: doctor passes when no proposals are parked', () => {
+  withTmpDir((dir) => {
+    scaffoldVaultRoot(dir);
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Pending proposals');
+    assert.ok(check, 'Pending proposals check not found');
+    assert.equal(check.status, 'pass', `expected pass: ${check.detail}`);
+  });
+});
+
+test('FEAT-11 T8: doctor warns with the count when proposals are parked', () => {
+  withTmpDir((dir) => {
+    scaffoldVaultRoot(dir);
+    psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b',
+      currentAtProposalHash: 'c',
+      proposedContent: 'A',
+      sessionId: 's',
+      device: 'd',
+    });
+    psWriteProposal(dir, {
+      target: join('pages', 'open-questions.md'),
+      baseHash: 'b',
+      currentAtProposalHash: 'c',
+      proposedContent: 'Q',
+      sessionId: 's',
+      device: 'd',
+    });
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Pending proposals');
+    assert.ok(check, 'Pending proposals check not found');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+    assert.ok(/\b2\b/.test(check.detail), `count 2 should appear: ${check.detail}`);
+    // Surface only — doctor must not change the store.
+    assert.equal(psListProposals(dir).length, 2, 'doctor must not change the proposal count');
+  });
+});
+
+test('FEAT-11 T8: session-start surfaces the count on stderr and mutates nothing', () => {
+  withTmpDir((dir) => {
+    scaffoldVaultRoot(dir);
+    const targetRel = join('pages', 'open-questions.md');
+    const targetAbs = join(dir, targetRel);
+    writeFileSync(targetAbs, '# open questions original\n');
+    psWriteProposal(dir, {
+      target: targetRel,
+      baseHash: 'b',
+      currentAtProposalHash: 'c',
+      proposedContent: '# proposed replacement\n',
+      sessionId: 's',
+      device: 'd',
+    });
+    const beforeStore = JSON.stringify(
+      psListProposals(dir).map((p) => ({ id: p.id, content: p.proposedContent })),
+    );
+    // A cwd that matches no project → MISS path, which exercises the same
+    // path-independent stderr write as HIT. No session_id, so snapshotBase is a
+    // no-op and the invariance assertion stays honest.
+    const outside = mkdtempSync(join(tmpdir(), 'hypo-t8-cwd-'));
+    try {
+      const r = runHook('hypo-session-start.mjs', { cwd: outside }, { HYPO_DIR: dir });
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.ok(/대기 proposal 1건/.test(r.stderr), `expected the count line: ${r.stderr}`);
+      assert.equal(
+        readFileSync(targetAbs, 'utf-8'),
+        '# open questions original\n',
+        'surface must not touch the target page',
+      );
+      assert.equal(
+        JSON.stringify(psListProposals(dir).map((p) => ({ id: p.id, content: p.proposedContent }))),
+        beforeStore,
+        'surface must not change the proposal store',
+      );
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+test('FEAT-11 T8: session-start emits no proposal line when none are parked', () => {
+  withTmpDir((dir) => {
+    scaffoldVaultRoot(dir);
+    const outside = mkdtempSync(join(tmpdir(), 'hypo-t8-cwd-'));
+    try {
+      const r = runHook('hypo-session-start.mjs', { cwd: outside }, { HYPO_DIR: dir });
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.ok(!/대기 proposal/.test(r.stderr), `no proposal line expected: ${r.stderr}`);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
# English

## What changed

Surface the vault-wide count of parked write-proposals in two places:

- `doctor`: a new `Pending proposals` check warns with the count when one or more proposals are parked under `.cache/proposals/`, and passes when there are none.
- session start: a `대기 proposal N건` line is injected the same way the sync-state notice is (into the notices prefix and stderr), and nothing appears when the count is zero.

## Why

Parked proposals were only discoverable by running `hypomnema proposal list` from memory. A pending review now shows up on the two surfaces a user already looks at each session, so withheld bytes don't sit unnoticed.

## How

Both surfaces count via `listProposals()`, so malformed or spoofed-id artifacts the CLI cannot act on are excluded and the number matches what `proposal list/apply/discard` can touch. The doctor check is warn-level only (never fail): a pending proposal is a normal state awaiting review, not a broken install. The session-start notice is computed before the notices prefix is built and written to stderr before the HIT/MISS branch, so it appears exactly once on both paths and is never routed into the user-banner (`systemMessage`) channel. Surface is read-only: it changes no proposal artifact or target page.

## Manual verification

Seeded a vault with one proposal and ran doctor directly:

```
⚠ Pending proposals  — 1 parked write-proposal(s) awaiting review; inspect with `hypomnema proposal list`
```

With the proposals removed:

```
✓ Pending proposals  — No parked write-proposals
```

Session-start path is covered by the new runner tests (stderr carries the count line on a MISS-path cwd; absent when the store is empty; store and target bytes unchanged after the run). `node tests/runner.mjs` → 1319 passed, 0 failed. `prettier --check` clean on the changed files.

## Migration notes

None.

---

# 한국어

## 변경 내용

보류된 write-proposal의 볼트 전체 건수를 두 곳에 노출한다.

- `doctor`: `.cache/proposals/`에 proposal이 하나라도 있으면 새 `Pending proposals` 체크가 건수와 함께 warn을 내고, 없으면 pass한다.
- 세션 시작: sync-state 알림과 같은 방식으로(notices prefix + stderr) `대기 proposal N건` 줄을 넣고, 0건이면 아무것도 뜨지 않는다.

## 이유

보류된 proposal은 지금까지 `hypomnema proposal list`를 기억해서 직접 쳐야만 보였다. 이제 사용자가 매 세션 이미 보는 두 표면에 대기 건수가 떠서, 보류된 바이트가 눈에 안 띄고 방치되지 않는다.

## 방법

두 표면 모두 `listProposals()`로 센다. 그래서 CLI가 다룰 수 없는 malformed·위조 id 아티팩트는 빠지고, 건수가 `proposal list/apply/discard`가 실제로 손댈 수 있는 대상과 일치한다. doctor 체크는 warn 레벨만(fail 없음)이다. 보류 proposal은 깨진 설치가 아니라 검토를 기다리는 정상 상태다. 세션-start 알림은 notices prefix를 만들기 전에 계산하고 HIT/MISS 분기 전에 stderr로 쓴다. 그래서 두 경로 모두에서 정확히 한 번 뜨고, 사용자 배너(`systemMessage`) 채널로는 절대 가지 않는다. surface는 읽기 전용이라 proposal 아티팩트나 대상 페이지를 바꾸지 않는다.

## 수동 검증

proposal 하나를 심은 볼트로 doctor를 직접 실행:

```
⚠ Pending proposals  — 1 parked write-proposal(s) awaiting review; inspect with `hypomnema proposal list`
```

proposal을 지운 뒤:

```
✓ Pending proposals  — No parked write-proposals
```

세션-start 경로는 새 runner 테스트가 커버한다(MISS 경로 cwd에서 stderr에 건수 줄, 스토어가 비면 부재, 실행 후 스토어·대상 바이트 불변). `node tests/runner.mjs` → 1319 passed, 0 failed. 변경 파일에 `prettier --check` clean.

## 마이그레이션 노트

None.

---

## Changelog

- EN: `doctor` and session start now show the count of pending write-proposals awaiting review (#186).
- KO: `doctor`와 세션 시작이 검토 대기 중인 write-proposal 건수를 표시한다 (#186).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
