### PR TITLE
feat(extensions): sync directory skills with per-file ownership

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -36,6 +36,9 @@ import {
   resolveInstallFile,
   buildHookCommand,
   parseExtKey,
+  parseSkillKey,
+  parseSkillShaValue,
+  isFlatShaValue,
   EXT_TYPES,
   CODEX_TYPES,
 } from './lib/extensions.mjs';
@@ -824,6 +827,58 @@ function checkExtensions(hypoDir, claudeHome, target = 'claude') {
     // Skip keys outside this target's covered types (defensive: a Claude run records
     // skills/agents that a codex target never installs — don't false-flag them).
     if (!types.includes(key.split('/')[0])) continue;
+
+    // A directory skill records one key whose value is a per-file SHA map. Joining
+    // that key straight onto root would land on the skill DIRECTORY and report it
+    // as "not a regular file" on every run. Check the subtree file by file instead.
+    const skillKey = parseSkillKey(key);
+    if (skillKey) {
+      const nested = parseSkillShaValue(recSHA);
+      if (!nested) {
+        problems.push({
+          severity: 'warn',
+          msg: `${key} has a corrupt ownership record — run upgrade --apply`,
+        });
+        continue;
+      }
+      const skillRoot = join(root, 'skills', skillKey.installDir);
+      for (const [rel, sha] of Object.entries(nested)) {
+        const filePath = join(skillRoot, ...rel.split('/'));
+        const label = `${key}/${rel}`;
+        if (!existsSync(filePath)) {
+          problems.push({
+            severity: 'warn',
+            msg: `${label} recorded but not installed — run upgrade --apply`,
+          });
+          continue;
+        }
+        const buf = readFileIfRegular(filePath);
+        if (buf === null) {
+          problems.push({
+            severity: 'warn',
+            msg: `${label} is not a regular file — left untouched`,
+          });
+          continue;
+        }
+        if (sha256(buf) !== sha) {
+          problems.push({
+            severity: 'warn',
+            msg: `${label} modified since install (drift) — use --force-extensions`,
+          });
+        }
+      }
+      continue;
+    }
+
+    // A flat key must carry a plain hex SHA; a wrong-shaped value is a corrupt
+    // record, not a drifted file.
+    if (!isFlatShaValue(recSHA)) {
+      problems.push({
+        severity: 'warn',
+        msg: `${key} has a corrupt ownership record — run upgrade --apply`,
+      });
+      continue;
+    }
     const destPath = join(root, key);
     if (!existsSync(destPath)) {
       problems.push({

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -27,8 +27,10 @@ import {
   renameSync,
   unlinkSync,
   mkdirSync,
+  lstatSync,
+  rmdirSync,
 } from 'fs';
-import { join } from 'path';
+import { join, dirname, relative, resolve, posix, sep } from 'path';
 import { homedir } from 'os';
 import { sha256, isRegularFile, readFileIfRegular, writePkgJsonAtomic } from './pkg-json.mjs';
 import { loadHypoIgnore, isIgnored } from './hypo-ignore.mjs';
@@ -149,6 +151,46 @@ export function resolveInstallFile(ext) {
 }
 
 /**
+ * Resolve the install DIRECTORY segment for a directory skill. Deliberately NOT
+ * resolveInstallFile: that one appends TYPE_FILE_EXT (`foo.md`), which would both
+ * miss the directory key and regress the flat hypo-ext-*.md skills.
+ *
+ * Default: strip the `hypo-ext-` wiki storage prefix, so a skill keeps the name it
+ * is actually invoked by (`skills/gstack/`, not `skills/hypo-ext-gstack/`). Unlike
+ * commands/agents there is no shipped directory-skill behavior to stay compatible
+ * with — none were ever discovered — so the clean name is free to be the default.
+ * A sidecar manifest `installName` (with a matching `type`) overrides it.
+ *
+ * The resolved segment becomes a directory we create and delete under, so it gets
+ * the same injection defenses as a flat installName plus a trailing-dot rejection.
+ */
+export function resolveSkillInstallDir(ext) {
+  if (ext.manifestPath) {
+    const parsed = parseManifest(ext.manifestPath);
+    if (parsed.ok) {
+      const m = parsed.manifest;
+      if (m && m.type === TYPE_SINGULAR.skills && m.installName !== undefined) {
+        if (!isValidSkillDirSegment(m.installName)) {
+          return {
+            skip: true,
+            warn: `skills/${ext.file}: invalid installName "${m.installName}" — skill skipped`,
+          };
+        }
+        return { installDir: m.installName };
+      }
+    }
+  }
+  const stem = ext.file.startsWith(EXT_PREFIX) ? ext.file.slice(EXT_PREFIX.length) : ext.file;
+  if (!isValidSkillDirSegment(stem)) {
+    return {
+      skip: true,
+      warn: `skills/${ext.file} skipped (unsafe install directory name "${stem}")`,
+    };
+  }
+  return { installDir: stem };
+}
+
+/**
  * Parse + validate a recorded pkg-json extension key `${type}/${installFile}`
  * for destructive use (capture design §8 — uninstall traverses recorded keys, which
  * come from an on-disk JSON we do not fully control). Returns
@@ -183,6 +225,179 @@ export function parseExtKey(key, coveredTypes) {
   return { type, installFile };
 }
 
+// ── directory skills (skills-dir design) ─────────────────────────────────────
+//
+// A real Claude Code skill is a DIRECTORY (`skills/<name>/SKILL.md` + an
+// arbitrary subtree), not the flat single `.md` the rest of this module assumes.
+// The SHA map keeps its single-segment top-level key (`skills/<name>`) so
+// parseExtKey's no-slash rule — the capture design §8 traversal fix — stays shut;
+// only the VALUE widens to a per-relpath map. Everything below validates that
+// widened shape: a corrupt hypo-pkg.json can now express many paths under one key.
+
+// The file that makes a directory a skill. Absent (or not a regular file) → not a skill.
+export const SKILL_ROOT_FILE = 'SKILL.md';
+
+// Depth/length ceilings. A pathological subtree is skipped with a warning rather
+// than crashing the sync.
+const SKILL_MAX_DEPTH = 16;
+const SKILL_MAX_RELPATH_LEN = 400;
+
+const HEX_SHA = /^[0-9a-f]{64}$/;
+
+/**
+ * True iff `seg` is safe to use as an install DIRECTORY segment for a skill.
+ * Reuses the flat installName defenses (charset, `..`, reserved `hypo`
+ * namespace, Windows device names) and adds a trailing-dot rejection: Windows
+ * strips trailing dots from directory names, so `foo.` and `foo` alias.
+ */
+export function isValidSkillDirSegment(seg) {
+  if (!isValidInstallStem(seg)) return false;
+  if (seg.endsWith('.')) return false;
+  return true;
+}
+
+/**
+ * Parse a recorded pkg-json key for a DIRECTORY skill. parseExtKey rejects
+ * `skills/foo` outright (it demands the type's file extension), so a skill key
+ * must never be routed through it — uninstall validates every recorded key and
+ * would silently drop the record. Returns `{ type, installDir }` or null.
+ */
+export function parseSkillKey(key) {
+  if (typeof key !== 'string') return null;
+  const slash = key.indexOf('/');
+  if (slash === -1) return null;
+  if (key.slice(0, slash) !== 'skills') return null;
+  const installDir = key.slice(slash + 1);
+  if (installDir.includes('/') || installDir.includes('\\')) return null;
+  if (!isValidSkillDirSegment(installDir)) return null;
+  return { type: 'skills', installDir };
+}
+
+/**
+ * Validate one subtree-relative path (`SKILL.md`, `references/x.md`). Returns the
+ * canonical posix relpath, or null when unsafe. Rejects traversal, absolute and
+ * Windows-absolute forms, backslash separators, `.` segments, NUL, and anything
+ * past the depth/length ceiling. The canonical return value is what callers must
+ * key on: `references/./x.md` and `references/x.md` are the same destination, and
+ * treating them as distinct would manufacture a phantom orphan.
+ */
+export function normalizeSkillRelPath(rel) {
+  if (typeof rel !== 'string' || rel.length === 0) return null;
+  if (rel.length > SKILL_MAX_RELPATH_LEN) return null;
+  if (rel.includes('\0')) return null;
+  // Backslash is a separator on Windows; treat it as unsafe everywhere rather
+  // than letting `a\..\b` mean different things per platform.
+  if (rel.includes('\\')) return null;
+  if (rel.startsWith('/')) return null;
+  // Windows drive (`C:x`, `C:/x`) and UNC (`//host/share`) forms.
+  if (/^[A-Za-z]:/.test(rel)) return null;
+  if (rel.startsWith('//')) return null;
+  const segs = rel.split('/');
+  if (segs.length > SKILL_MAX_DEPTH) return null;
+  for (const s of segs) {
+    if (s === '' || s === '.' || s === '..') return null;
+    if (s.endsWith('.')) return null; // Windows directory-name aliasing
+  }
+  const norm = posix.normalize(rel);
+  // normalize() cannot escape given the segment checks above, but re-assert:
+  // a caller-supplied relpath must never resolve outside its own subtree.
+  if (norm.startsWith('..') || norm.startsWith('/')) return null;
+  return norm;
+}
+
+/**
+ * True iff `target` resolves strictly inside `root`. Boundary-aware: a raw
+ * `startsWith` would accept `/a/bc` as living under `/a/b`.
+ */
+export function isContainedUnder(root, target) {
+  const rel = relative(resolve(root), resolve(target));
+  if (rel === '' || rel.startsWith('..')) return false;
+  return !rel.split(sep).includes('..');
+}
+
+/**
+ * True iff `root` itself, or any path segment from `root` down to `target`
+ * (inclusive), is a symlink. Lexical containment alone cannot see this: a hostile
+ * `references -> /outside` directory symlink lets `references/x.md` pass every
+ * string check while the write or unlink lands outside the skill entirely.
+ * copyOne's leaf check (`isRegularFile`) only guards the FINAL component.
+ *
+ * `root` is checked too, not just what is below it. Skipping it left the whole
+ * guard bypassable by symlinking the boundary directory itself (`~/.claude/skills`),
+ * which is the one ancestor every install path shares (codex pre-commit BLOCKER).
+ *
+ * Callers must re-run this immediately before EVERY mutation (mkdir, copy,
+ * unlink, rmdir). The residual TOCTOU window between this check and the syscall
+ * is accepted (skills-dir design §7); re-checking per mutation keeps it from widening.
+ */
+export function hasSymlinkAncestor(root, target) {
+  const rootAbs = resolve(root);
+  const targetAbs = resolve(target);
+  if (!isContainedUnder(rootAbs, targetAbs)) return true; // treat as unsafe
+  try {
+    if (lstatSync(rootAbs).isSymbolicLink()) return true;
+  } catch {
+    // The boundary dir does not exist yet: nothing to escape through.
+  }
+  const rel = relative(rootAbs, targetAbs);
+  const segs = rel.split(sep).filter(Boolean);
+  let cur = rootAbs;
+  // Walk every intermediate segment AND the leaf: a symlinked leaf must not be
+  // written through or unlinked either.
+  for (const s of segs) {
+    cur = join(cur, s);
+    let st;
+    try {
+      st = lstatSync(cur);
+    } catch {
+      continue; // does not exist yet (fresh install) — nothing to escape through
+    }
+    if (st.isSymbolicLink()) return true;
+  }
+  return false;
+}
+
+/**
+ * True iff `value` is a plain hex SHA — the only shape a FLAT extension key may
+ * carry. A corrupt pkg-json that parks an object (or any other type) under a flat
+ * key must not be treated as ownership: under --force-extensions that would remove
+ * a file on the strength of a value we never wrote (codex pre-commit CONCERN).
+ */
+export function isFlatShaValue(value) {
+  return typeof value === 'string' && HEX_SHA.test(value);
+}
+
+/**
+ * A nested SHA map keyed by relpath. Null-prototype on purpose: relpaths come from
+ * the filesystem, so a file named `__proto__` would otherwise assign through the
+ * prototype setter instead of creating an own key (installed but never recorded,
+ * hence unowned and unreachable by uninstall), and a file named `constructor` would
+ * read back a truthy inherited value as if it were a recorded SHA. Codex found the
+ * `__proto__` case with a working repro.
+ */
+export function emptyShaMap() {
+  return Object.create(null);
+}
+
+/**
+ * Validate a recorded skill SHA value: a plain object mapping canonical relpaths
+ * to hex SHAs. Returns a clean map containing only the entries that pass; a
+ * corrupt or malicious entry is dropped rather than trusted. Returns null when
+ * the value is not a plain object at all (shape mismatch — e.g. a flat string
+ * SHA parked under a skill key).
+ */
+export function parseSkillShaValue(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const out = emptyShaMap();
+  for (const [rel, sha] of Object.entries(value)) {
+    if (typeof sha !== 'string' || !HEX_SHA.test(sha)) continue;
+    const norm = normalizeSkillRelPath(rel);
+    if (norm === null || norm !== rel) continue; // only canonical keys are trusted
+    out[norm] = sha;
+  }
+  return out;
+}
+
 // Claude Code hook events (D3 allowlist). A manifest with an event outside this
 // set is malformed → the whole extension is skipped (no copy, no registration).
 export const HOOK_EVENT_ALLOWLIST = new Set([
@@ -213,10 +428,113 @@ function pkgRootDir(target) {
 // ── read-only helpers ─────────────────────────────────────────────────────────
 
 /**
+ * True iff `p` is a directory and NOT a symlink to one. A symlinked directory in
+ * the wiki subtree (`references -> /etc`) would otherwise let the walker copy
+ * files from outside the vault into the install target.
+ */
+function isRealDir(p) {
+  try {
+    return lstatSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Walk a wiki skill directory and collect its owned files. lstat-based: symlinked
+ * files and symlinked directories are skipped with a warning, never followed.
+ *
+ * Returns `{ files: [{ rel, srcPath }], warnings, skip }`. `skip` is set when the
+ * whole skill must be dropped: no regular SKILL.md at the root, or two source
+ * paths that canonicalize to the same destination (case-fold aliasing), which
+ * would make ownership order-dependent.
+ */
+function walkSkillSubtree(skillDir, label, hypoDir, hypoignorePatterns) {
+  const files = [];
+  const warnings = [];
+  const seen = new Map(); // case-folded canonical rel -> first rel that claimed it
+
+  const rootFile = join(skillDir, SKILL_ROOT_FILE);
+  if (!isRegularFile(rootFile)) {
+    return {
+      files: [],
+      warnings: [`${label} skipped (no regular ${SKILL_ROOT_FILE} at the skill root)`],
+      skip: true,
+    };
+  }
+
+  const walk = (dir, prefix, depth) => {
+    if (depth > SKILL_MAX_DEPTH) {
+      warnings.push(`${label}/${prefix} skipped (subtree deeper than ${SKILL_MAX_DEPTH})`);
+      return;
+    }
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      warnings.push(`${label}/${prefix} skipped (unreadable directory)`);
+      return;
+    }
+    for (const name of entries) {
+      const full = join(dir, name);
+      const rel = prefix ? `${prefix}/${name}` : name;
+      if (isIgnored(full, hypoDir, hypoignorePatterns)) continue;
+      if (isRealDir(full)) {
+        // Propagate a collision found further down: ignoring this return value let a
+        // deep `references/A.md` vs `references/a.md` clash through while only the
+        // root level was poisoned (codex pre-commit NIT).
+        const sub = walk(full, rel, depth + 1);
+        if (sub && sub.collision) return sub;
+        continue;
+      }
+      if (!isRegularFile(full)) {
+        // Symlink, socket, or a symlinked dir: never followed, never owned.
+        warnings.push(`${label}/${rel} skipped (not a regular file)`);
+        continue;
+      }
+      // A sidecar manifest lives NEXT TO the skill dir, not inside it. Reserve the
+      // name inside the subtree so skill content can never be confused for install
+      // metadata later.
+      if (name.endsWith('.manifest.json')) {
+        warnings.push(`${label}/${rel} skipped (reserved manifest name inside a skill)`);
+        continue;
+      }
+      const norm = normalizeSkillRelPath(rel);
+      if (norm === null) {
+        warnings.push(`${label}/${rel} skipped (unsafe path)`);
+        continue;
+      }
+      // NFD and NFC spellings of the same name are one file on macOS, so collapse
+      // the unicode form before case-folding or the alias check misses them.
+      const fold = norm.normalize('NFC').toLowerCase();
+      if (seen.has(fold)) {
+        warnings.push(
+          `${label} skipped (${norm} and ${seen.get(fold)} collide on a case-insensitive filesystem)`,
+        );
+        // Poison the whole skill: which file wins would depend on readdir order.
+        files.length = 0;
+        return { collision: true };
+      }
+      seen.set(fold, norm);
+      files.push({ rel: norm, srcPath: full });
+    }
+    return null;
+  };
+
+  const res = walk(skillDir, '', 1);
+  if (res && res.collision) return { files: [], warnings, skip: true };
+  return { files, warnings, skip: false };
+}
+
+/**
  * Discover sync-eligible extensions under `extDir`. Returns a per-type map plus a
  * `warnings` array. Applies the `.hypoignore` filter, the basename
  * whitelist (plan §5 #9), and pairs each file with its optional `<name>.manifest.json`.
  * No-ops gracefully when extDir is absent (e.g. --from-remote clones, plan §5 #8).
+ *
+ * Skills come in two shapes. A directory (`skills/hypo-ext-<name>/SKILL.md` + a
+ * subtree) is the real Claude Code layout and carries a `files[]` list; a flat
+ * `hypo-ext-<name>.md` keeps working exactly as before (backward compatible).
  */
 export function discoverExtensions(extDir, hypoignorePatterns, hypoDir) {
   const result = { hooks: [], commands: [], skills: [], agents: [], warnings: [] };
@@ -238,6 +556,39 @@ export function discoverExtensions(extDir, hypoignorePatterns, hypoDir) {
       if (fname.endsWith('.manifest.json')) continue;
       const srcPath = join(typeDir, fname);
       if (isIgnored(srcPath, hypoDir, hypoignorePatterns)) continue;
+
+      // A directory under skills/ is the real skill layout. Everything else falls
+      // through to the flat single-file path below.
+      if (type === 'skills' && isRealDir(srcPath)) {
+        if (!SAFE_EXT_STEM.test(fname)) {
+          result.warnings.push(
+            `skills/${fname} skipped (extensions must use a 'hypo-ext-<name>' directory name)`,
+          );
+          continue;
+        }
+        const label = `skills/${fname}`;
+        const walked = walkSkillSubtree(srcPath, label, hypoDir, hypoignorePatterns);
+        result.warnings.push(...walked.warnings);
+        if (walked.skip) continue;
+        const manifestName = `${fname}.manifest.json`;
+        const manifestPath = join(typeDir, manifestName);
+        const hasSkillManifest =
+          existsSync(manifestPath) &&
+          isRegularFile(manifestPath) &&
+          !isIgnored(manifestPath, hypoDir, hypoignorePatterns);
+        result.skills.push({
+          type,
+          name: fname,
+          file: fname,
+          srcPath,
+          isDir: true,
+          files: walked.files,
+          manifestName,
+          manifestPath: hasSkillManifest ? manifestPath : null,
+        });
+        continue;
+      }
+
       if (!isRegularFile(srcPath)) continue;
       if (!fname.endsWith(fileExt)) continue;
       const stem = fname.slice(0, -fileExt.length);
@@ -563,6 +914,190 @@ function recordCopyOutcome(result, name, key, action, apply) {
   }
 }
 
+/** Join a canonical posix relpath onto a native base path. */
+function joinRel(base, rel) {
+  return join(base, ...rel.split('/'));
+}
+
+/**
+ * Sync one DIRECTORY skill: mirror its wiki subtree into the install directory and
+ * remove the files we own that the wiki no longer has.
+ *
+ * This is the only place forward-sync deletes anything. The gate is the same
+ * ownership rule the rest of the module uses for overwrite: a file is removed only
+ * when its on-disk SHA still matches the SHA we recorded when we installed it. A
+ * user-modified copy, an unowned file the user dropped in, and anything that is not
+ * a regular file are all preserved. The recorded SHA of a PRESERVED orphan is kept,
+ * not dropped — without it the file becomes unowned and --force-extensions could
+ * never clean it up.
+ *
+ * Every mutation (mkdir, copy, unlink, rmdir) re-runs the symlink-ancestor walk
+ * first: lexical containment alone cannot see a `references -> /outside` directory
+ * symlink, and both the write and the unlink would land outside the skill.
+ */
+function syncOneSkill({
+  ext,
+  installDir,
+  typeDir,
+  recorded,
+  newSHAs,
+  result,
+  target,
+  apply,
+  force,
+}) {
+  const key = `skills/${installDir}`;
+  const skillRoot = join(typeDir, installDir);
+  // A recorded value of the wrong shape (e.g. a flat string SHA parked under a
+  // skill key by a corrupt pkg-json) is not trusted as ownership of anything.
+  const recordedNested = parseSkillShaValue(recorded[key]) ?? emptyShaMap();
+  const newNested = emptyShaMap();
+
+  const unsafe = (destPath) =>
+    !isContainedUnder(skillRoot, destPath) || hasSymlinkAncestor(typeDir, destPath);
+
+  // (1) install / update every file the wiki subtree currently has.
+  const desired = new Set();
+  // A path we refuse to touch must KEEP whatever ownership it already had. Dropping
+  // the record here would silently disown a file we installed on an earlier run,
+  // putting it beyond doctor and uninstall (codex pre-commit CONCERN).
+  const refuse = (fileKey, rel) => {
+    result.conflicts.push({ name: ext.name, file: fileKey, action: 'skip-unsafe-path' });
+    result.warnings.push(`${fileKey} (skip-unsafe-path) — left untouched`);
+    if (recordedNested[rel] !== undefined) newNested[rel] = recordedNested[rel];
+  };
+  for (const f of ext.files) {
+    desired.add(f.rel);
+    const destPath = joinRel(skillRoot, f.rel);
+    const fileKey = `${key}/${f.rel}`; // display only — never a pkg-json key
+    if (unsafe(destPath)) {
+      refuse(fileKey, f.rel);
+      continue;
+    }
+    if (apply) {
+      const parent = dirname(destPath);
+      if (hasSymlinkAncestor(typeDir, parent)) {
+        refuse(fileKey, f.rel);
+        continue;
+      }
+      mkdirSync(parent, { recursive: true });
+    }
+    const res = copyOne({
+      srcPath: f.srcPath,
+      destPath,
+      key: fileKey,
+      recordedSHA: recordedNested[f.rel],
+      apply,
+      force,
+    });
+    if (res.sha != null) newNested[f.rel] = res.sha;
+    result.actions.push({ target, file: fileKey, action: res.action });
+    recordCopyOutcome(result, ext.name, fileKey, res.action, apply);
+  }
+
+  // (2) orphans: recorded, but the wiki subtree no longer carries them.
+  for (const [rel, sha] of Object.entries(recordedNested)) {
+    if (desired.has(rel)) continue;
+    const destPath = joinRel(skillRoot, rel);
+    const fileKey = `${key}/${rel}`;
+    const keep = (reason) => {
+      // Preserving the record is the point: drop it and the file goes unowned,
+      // which puts it beyond --force-extensions forever.
+      newNested[rel] = sha;
+      result.warnings.push(`${fileKey} (${reason}) — left untouched`);
+    };
+    if (unsafe(destPath)) {
+      keep('skip-unsafe-path');
+      continue;
+    }
+    if (!existsSync(destPath)) continue; // already gone: the record can go too
+    if (!isRegularFile(destPath)) {
+      keep('skip-non-regular');
+      continue;
+    }
+    const onDisk = readFileIfRegular(destPath);
+    if (onDisk === null) {
+      keep('skip-unreadable');
+      continue;
+    }
+    const onDiskSHA = sha256(onDisk);
+    if (onDiskSHA !== sha && !force) {
+      // Owned once, edited since. Same call as an overwrite drift: warn, preserve.
+      result.drifts.push({ name: ext.name, file: fileKey });
+      result.needsWork = true;
+      newNested[rel] = sha;
+      result.warnings.push(`${fileKey} (drift — user-modified orphan) — left untouched`);
+      continue;
+    }
+    if (!apply) {
+      // Check mode: the deletion is pending work, and nothing is written yet.
+      newNested[rel] = sha;
+      result.needsWork = true;
+      result.actions.push({ target, file: fileKey, action: 'delete' });
+      continue;
+    }
+    // CAS: re-read immediately before unlink. A save between the hash above and
+    // this syscall must not lose the user's bytes.
+    const verify = readFileIfRegular(destPath);
+    if (verify === null || (sha256(verify) !== sha && !force)) {
+      keep('skip-changed');
+      continue;
+    }
+    if (hasSymlinkAncestor(typeDir, destPath)) {
+      keep('skip-unsafe-path');
+      continue;
+    }
+    if (force && sha256(verify) !== sha) writeFreshAtomic(`${destPath}.bak`, verify);
+    try {
+      unlinkSync(destPath);
+    } catch {
+      keep('skip-unlink-failed');
+      continue;
+    }
+    result.actions.push({ target, file: fileKey, action: 'delete' });
+  }
+
+  // (3) prune directories the orphan removal emptied. The skill root itself stays:
+  // removing it is uninstall's job, not sync's.
+  if (apply) pruneEmptyDirs(skillRoot, typeDir, result);
+
+  if (Object.keys(newNested).length > 0) newSHAs[key] = newNested;
+}
+
+/**
+ * Remove now-empty directories under `skillRoot` (exclusive of the root itself),
+ * deepest first. Skips anything reachable through a symlinked ancestor.
+ */
+function pruneEmptyDirs(skillRoot, typeDir, result) {
+  const dirs = [];
+  const collect = (dir, depth) => {
+    if (depth > SKILL_MAX_DEPTH) return;
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      const full = join(dir, name);
+      if (!isRealDir(full)) continue;
+      collect(full, depth + 1);
+      dirs.push(full);
+    }
+  };
+  if (!isRealDir(skillRoot)) return;
+  collect(skillRoot, 1);
+  // Deepest first, so a parent emptied by its children is caught in the same pass.
+  for (const dir of dirs.reverse()) {
+    if (!isContainedUnder(skillRoot, dir) || hasSymlinkAncestor(typeDir, dir)) continue;
+    try {
+      if (readdirSync(dir).length === 0) rmdirSync(dir);
+    } catch {
+      result.warnings.push(`skills: could not prune empty directory ${dir}`);
+    }
+  }
+}
+
 /**
  * Sync all discovered extensions for one target ('claude' | 'codex').
  *
@@ -638,10 +1173,33 @@ export function syncExtensions({
   // WHOLE group — otherwise file traversal order would decide ownership and
   // overwrite/skip unpredictably. Keyed by ext object identity.
   const installFileByExt = new Map();
+  // Directory skills resolve to an install DIRECTORY segment, not a filename.
+  const installDirByExt = new Map();
   const dupSkip = new Set();
   for (const type of types) {
     const seen = new Map(); // case-folded `${type}/${installFile}` → first ext
     for (const ext of discovered[type]) {
+      if (ext.isDir) {
+        const dirRes = resolveSkillInstallDir(ext);
+        if (dirRes.skip) {
+          dupSkip.add(ext);
+          result.warnings.push(dirRes.warn);
+          continue;
+        }
+        installDirByExt.set(ext, dirRes.installDir);
+        const dirNorm = `skills/${dirRes.installDir.toLowerCase()}`;
+        const firstDir = seen.get(dirNorm);
+        if (firstDir !== undefined) {
+          dupSkip.add(ext);
+          dupSkip.add(firstDir);
+          result.warnings.push(
+            `skills/${dirRes.installDir} install target claimed by multiple extensions — all skipped (rename installName)`,
+          );
+        } else {
+          seen.set(dirNorm, ext);
+        }
+        continue;
+      }
       const res = resolveInstallFile(ext);
       if (res.skip) {
         dupSkip.add(ext);
@@ -669,6 +1227,15 @@ export function syncExtensions({
   // previously-owned installed copy — it would linger on disk, untracked by doctor
   // and unreachable by uninstall (codex pre-commit BLOCKER).
   for (const ext of dupSkip) {
+    if (ext.isDir) {
+      // Same reasoning for a directory skill: keep its whole nested record so the
+      // installed subtree stays owned (doctor sees it, uninstall can remove it).
+      const dir = installDirByExt.get(ext);
+      if (!dir) continue; // invalid installName: never owned
+      const key = `skills/${dir}`;
+      if (recorded[key] !== undefined && newSHAs[key] === undefined) newSHAs[key] = recorded[key];
+      continue;
+    }
     const inst = installFileByExt.get(ext);
     if (!inst) continue; // invalid-installName skip: never owned
     // Preserve BOTH ownership keys a hook records: the main `.mjs` AND its paired
@@ -689,6 +1256,25 @@ export function syncExtensions({
     const typeDir = join(targetRoot, type);
     for (const ext of discovered[type]) {
       if (dupSkip.has(ext)) continue;
+
+      // A directory skill mirrors a subtree (and prunes what the wiki dropped)
+      // rather than copying one file.
+      if (ext.isDir) {
+        if (apply) mkdirSync(typeDir, { recursive: true });
+        syncOneSkill({
+          ext,
+          installDir: installDirByExt.get(ext),
+          typeDir,
+          recorded,
+          newSHAs,
+          result,
+          target,
+          apply,
+          force,
+        });
+        continue;
+      }
+
       // Install under the manifest-declared installName (capture design §3) or, by
       // default, the wiki storage name (backward compatible).
       const installFile = installFileByExt.get(ext) ?? ext.file;

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -39,6 +39,12 @@ import {
   CODEX_TYPES,
   readExtensionPkgStateNoMutate,
   parseExtKey,
+  parseSkillKey,
+  parseSkillShaValue,
+  isFlatShaValue,
+  emptyShaMap,
+  isContainedUnder,
+  hasSymlinkAncestor,
   buildHookCommand,
 } from './lib/extensions.mjs';
 
@@ -105,8 +111,8 @@ function removeCommands(apply, force) {
 // map empties out, drop the target key; when the whole `extensions` object empties,
 // drop it too. Other targets' records (e.g. codex map during a Claude-only uninstall)
 // are never touched.
-function stripExtensionsFromPkg(pkgPath, target, removedKeys, apply) {
-  if (!existsSync(pkgPath) || removedKeys.length === 0) return false;
+function stripExtensionsFromPkg(pkgPath, target, removedKeys, apply, rewrittenKeys = new Map()) {
+  if (!existsSync(pkgPath) || (removedKeys.length === 0 && rewrittenKeys.size === 0)) return false;
   let pkg;
   try {
     pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
@@ -123,6 +129,15 @@ function stripExtensionsFromPkg(pkgPath, target, removedKeys, apply) {
   for (const key of removedKeys) {
     if (key in perTarget) {
       delete perTarget[key];
+      changed = true;
+    }
+  }
+  // A partially-uninstalled skill keeps only the files it still owns. Leaving the
+  // removed paths in the map would let a later --force run delete whatever the user
+  // has since put back at those paths.
+  for (const [key, nested] of rewrittenKeys) {
+    if (key in perTarget) {
+      perTarget[key] = nested;
       changed = true;
     }
   }
@@ -157,6 +172,46 @@ function stripExtensionsFromPkg(pkgPath, target, removedKeys, apply) {
 // file whose on-disk SHA differs from the recorded one is user-modified and
 // preserved unless --force-extensions; a symlink/non-regular target is always
 // preserved (force does not follow them, matching install/upgrade E3's guard).
+// Remove the directories a skill removal emptied, deepest first, and finally the
+// skill root itself. Anything still holding files (user-added, or copies we
+// refused to remove) is left standing — rmdir on a non-empty directory throws and
+// we swallow it, which is exactly the "never destroy what we don't own" behavior.
+//
+// Every rmdir is guarded by the same containment + symlink-ancestor walk the file
+// removals use. Without it, a corrupt `"skills/x": {}` record plus a symlinked
+// skill dir was enough to rmdir empty directories anywhere on disk: the record
+// granted no file ownership, yet the prune still ran (codex pre-commit BLOCKER).
+function pruneSkillDirs(skillsRoot, skillRoot) {
+  if (hasSymlinkAncestor(skillsRoot, skillRoot)) return;
+  const dirs = [];
+  const collect = (dir, depth) => {
+    if (depth > 16) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue; // isDirectory() is false for a symlink here
+      const full = join(dir, e.name);
+      collect(full, depth + 1);
+      dirs.push(full);
+    }
+  };
+  collect(skillRoot, 1);
+  dirs.push(skillRoot);
+  for (const dir of dirs) {
+    if (!isContainedUnder(skillsRoot, dir)) continue;
+    if (hasSymlinkAncestor(skillsRoot, dir)) continue;
+    try {
+      rmdirSync(dir);
+    } catch {
+      // not empty (or gone) — leave it
+    }
+  }
+}
+
 function removeExtensions(target, apply, force) {
   const targetRoot = target === 'codex' ? join(HOME, '.codex') : join(HOME, '.claude');
   const types = target === 'codex' ? CODEX_TYPES : EXT_TYPES;
@@ -167,11 +222,77 @@ function removeExtensions(target, apply, force) {
 
   const removed = [];
   const removedKeys = [];
+  // Skill keys that survive in reduced form: key → the nested map of files we still
+  // own after this run.
+  const rewrittenKeys = new Map();
   const skippedUserModified = [];
   const skippedNonRegular = [];
 
   for (const [key, recordedSHA] of Object.entries(recorded)) {
     if (!recordedSHA) continue; // no ownership baseline → nothing to remove
+
+    // A directory skill records one key (`skills/<name>`) whose value is a map of
+    // per-file SHAs. parseExtKey rejects that key by design (it demands the type's
+    // file extension), so without this branch every installed skill file would be
+    // silently stranded: owned on paper, unreachable by uninstall.
+    const skillKey = types.includes('skills') ? parseSkillKey(key) : null;
+    if (skillKey) {
+      const nested = parseSkillShaValue(recordedSHA);
+      // A corrupt value grants no ownership: remove nothing, and do NOT prune —
+      // pruning on an empty/invalid record is destructive power the record never
+      // earned.
+      if (!nested || Object.keys(nested).length === 0) continue;
+      const skillsRoot = join(targetRoot, 'skills');
+      const skillRoot = join(skillsRoot, skillKey.installDir);
+      // What the record must still claim after this run. A file we removed drops
+      // out; a file we preserved stays. Keeping a removed path in the record is not
+      // cosmetic: a later --force run deletes whatever now sits at that path,
+      // including a brand-new file the user created there (codex fix-verify BLOCKER).
+      const remaining = emptyShaMap();
+      let removedAny = false;
+      const preserve = (rel, sha, path, bucket) => {
+        remaining[rel] = sha;
+        bucket.push(path);
+      };
+      for (const [rel, sha] of Object.entries(nested)) {
+        const fullPath = join(skillRoot, ...rel.split('/'));
+        // Same containment + symlink-ancestor guard the sync path uses: a lexical
+        // check alone cannot see a symlinked directory in the middle of the path.
+        if (!isContainedUnder(skillRoot, fullPath) || hasSymlinkAncestor(skillsRoot, fullPath)) {
+          preserve(rel, sha, fullPath, skippedNonRegular);
+          continue;
+        }
+        if (!existsSync(fullPath)) continue; // already gone: the claim goes too
+        if (!isRegularFile(fullPath)) {
+          preserve(rel, sha, fullPath, skippedNonRegular);
+          continue;
+        }
+        const buf = readFileIfRegular(fullPath);
+        const fileSha = buf ? sha256(buf) : null;
+        if (fileSha === sha || force) {
+          if (apply) rmSync(fullPath);
+          removed.push(fullPath);
+          removedAny = true;
+        } else {
+          preserve(rel, sha, fullPath, skippedUserModified);
+        }
+      }
+      // Prune the directories we emptied, deepest first. A skill dir still holding
+      // user files (or files we refused to remove) is left in place.
+      if (apply && removedAny) pruneSkillDirs(skillsRoot, skillRoot);
+      // Retire the key outright only when nothing is left to claim. Otherwise rewrite
+      // it down to just the preserved files: dropping the whole key would disown them
+      // forever, and keeping the whole key would leave stale claims on paths we no
+      // longer own.
+      if (Object.keys(remaining).length === 0) removedKeys.push(key);
+      else rewrittenKeys.set(key, remaining);
+      continue;
+    }
+
+    // A flat key's value must be a plain hex SHA. Anything else (an object parked
+    // there by a corrupt pkg-json) grants no ownership — otherwise --force would
+    // remove the file on the strength of a value we never wrote.
+    if (!isFlatShaValue(recordedSHA)) continue;
     const parsed = parseExtKey(key, types);
     if (!parsed) continue; // untrusted / cross-target key → never join+rm
     const fullPath = join(targetRoot, parsed.type, parsed.installFile);
@@ -193,7 +314,7 @@ function removeExtensions(target, apply, force) {
       skippedUserModified.push(fullPath);
     }
   }
-  return { target, removed, removedKeys, skippedUserModified, skippedNonRegular };
+  return { target, removed, removedKeys, rewrittenKeys, skippedUserModified, skippedNonRegular };
 }
 
 // True iff `pkg.json` still holds extensions state for a target the current
@@ -478,6 +599,7 @@ let codexExtResult = {
   target: 'codex',
   removed: [],
   removedKeys: [],
+  rewrittenKeys: new Map(),
   skippedUserModified: [],
   skippedNonRegular: [],
 };
@@ -497,10 +619,23 @@ if (args.codex) {
   );
 }
 
-// Surgical per-target ext SHA strip — only for files we actually removed.
-stripExtensionsFromPkg(pkgJsonPath, 'claude', claudeExtResult.removedKeys, args.apply);
+// Surgical per-target ext SHA strip — only for files we actually removed. A skill
+// we uninstalled only partway is rewritten down to the files we still own.
+stripExtensionsFromPkg(
+  pkgJsonPath,
+  'claude',
+  claudeExtResult.removedKeys,
+  args.apply,
+  claudeExtResult.rewrittenKeys,
+);
 if (args.codex) {
-  stripExtensionsFromPkg(pkgJsonPath, 'codex', codexExtResult.removedKeys, args.apply);
+  stripExtensionsFromPkg(
+    pkgJsonPath,
+    'codex',
+    codexExtResult.removedKeys,
+    args.apply,
+    codexExtResult.rewrittenKeys,
+  );
 }
 
 // pkg.json metadata file removal — only when no user-tracked state remains.

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -7978,6 +7978,689 @@ test('doctor-extensions-integrity: --codex target', () => {
   });
 });
 
+// ── directory skills: forward-sync (ADR 0063, T2-T5) ──────────────────────────
+//
+// A real skill is skills/<name>/SKILL.md + a subtree, not a flat .md. These drive
+// the whole install → orphan-delete → preserve loop through the real upgrade CLI.
+
+suite('directory skills: forward-sync install + orphan removal');
+
+function writeSkillTree(hypoDir, dirName, files, manifest) {
+  const root = join(hypoDir, 'extensions', 'skills', dirName);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(root, ...rel.split('/'));
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  if (manifest !== undefined) {
+    mkdirSync(join(hypoDir, 'extensions', 'skills'), { recursive: true });
+    writeFileSync(
+      join(hypoDir, 'extensions', 'skills', `${dirName}.manifest.json`),
+      JSON.stringify(manifest, null, 2),
+    );
+  }
+  return root;
+}
+
+function withSkillWiki(fn) {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const sync = () => {
+        const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+        return r;
+      };
+      const pkgExt = () => {
+        const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+        return (pkg.extensions && pkg.extensions.claude) || {};
+      };
+      fn({ home, hypoDir, sync, pkgExt, skillsDir: join(home, '.claude', 'skills') });
+    });
+  });
+}
+
+test('a directory skill installs its whole subtree under its own name', () => {
+  withSkillWiki(({ hypoDir, sync, pkgExt, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+      'scripts/deep/run.sh': 'echo hi\n',
+    });
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+
+    // The wiki storage prefix is stripped: the skill installs as the name it is invoked by.
+    assert.ok(existsSync(join(skillsDir, 'demo', 'SKILL.md')), 'SKILL.md must install');
+    assert.ok(existsSync(join(skillsDir, 'demo', 'references', 'bar.md')), 'subtree must install');
+    assert.ok(existsSync(join(skillsDir, 'demo', 'scripts', 'deep', 'run.sh')), 'deep file');
+    assert.ok(
+      !existsSync(join(skillsDir, 'hypo-ext-demo')),
+      'must not install under the wiki name',
+    );
+
+    // One single-segment top-level key; the per-file SHAs live in the nested value.
+    const ext = pkgExt();
+    const val = ext['skills/demo'];
+    assert.equal(typeof val, 'object', 'skill value must be a nested map, not a string SHA');
+    assert.deepEqual(Object.keys(val).sort(), [
+      'SKILL.md',
+      'references/bar.md',
+      'scripts/deep/run.sh',
+    ]);
+    assert.ok(/^[0-9a-f]{64}$/.test(val['SKILL.md']));
+  });
+});
+
+test('a file dropped from the wiki subtree is removed from the install (owned + unmodified)', () => {
+  withSkillWiki(({ hypoDir, sync, pkgExt, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+    assert.ok(existsSync(join(skillsDir, 'demo', 'references', 'bar.md')));
+
+    rmSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-demo', 'references'), {
+      recursive: true,
+    });
+    const r = sync();
+    assert.equal(r.status, 0, `re-sync failed: ${r.stderr}`);
+
+    assert.ok(
+      !existsSync(join(skillsDir, 'demo', 'references', 'bar.md')),
+      'the orphan must be deleted',
+    );
+    assert.ok(existsSync(join(skillsDir, 'demo', 'SKILL.md')), 'SKILL.md must survive');
+    assert.ok(
+      !existsSync(join(skillsDir, 'demo', 'references')),
+      'the emptied directory must be pruned',
+    );
+    assert.deepEqual(Object.keys(pkgExt()['skills/demo']), ['SKILL.md']);
+  });
+});
+
+test('a user-modified orphan is preserved AND stays owned (so --force can still clean it)', () => {
+  withSkillWiki(({ hypoDir, sync, pkgExt, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    // The user edits the installed copy, then the wiki drops the file.
+    writeFileSync(join(skillsDir, 'demo', 'references', 'bar.md'), 'MY EDITS\n');
+    rmSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-demo', 'references'), {
+      recursive: true,
+    });
+    sync();
+
+    assert.equal(
+      readFileSync(join(skillsDir, 'demo', 'references', 'bar.md'), 'utf-8'),
+      'MY EDITS\n',
+      'a user-modified orphan must never be deleted',
+    );
+    // Dropping the record would make the file unowned — beyond --force-extensions forever.
+    assert.ok(
+      pkgExt()['skills/demo']['references/bar.md'],
+      'the preserved orphan must keep its ownership record',
+    );
+  });
+});
+
+test('a file the user added to the install directory is never touched (unowned)', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir, pkgExt }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', { 'SKILL.md': '# demo\n' });
+    sync();
+
+    writeFileSync(join(skillsDir, 'demo', 'notes.md'), 'my own notes\n');
+    sync();
+
+    assert.equal(
+      readFileSync(join(skillsDir, 'demo', 'notes.md'), 'utf-8'),
+      'my own notes\n',
+      'an unowned file is not an orphan and must survive',
+    );
+    assert.ok(!pkgExt()['skills/demo']['notes.md'], 'and we must not claim ownership of it');
+  });
+});
+
+test('a symlinked directory in the wiki subtree is never followed', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir, pkgExt }) => {
+    const root = writeSkillTree(hypoDir, 'hypo-ext-demo', { 'SKILL.md': '# demo\n' });
+    // references -> a directory outside the vault holding a secret.
+    const outside = join(hypoDir, '..', 'outside');
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, 'secret.md'), 'SECRET\n');
+    symlinkSync(outside, join(root, 'references'));
+
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+    assert.ok(existsSync(join(skillsDir, 'demo', 'SKILL.md')), 'the real file still installs');
+    assert.ok(
+      !existsSync(join(skillsDir, 'demo', 'references', 'secret.md')),
+      'a symlinked source directory must not be copied through',
+    );
+    assert.ok(!pkgExt()['skills/demo']['references/secret.md']);
+  });
+});
+
+test('a directory without a regular SKILL.md is not a skill (skipped, not installed)', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir, pkgExt }) => {
+    const root = join(hypoDir, 'extensions', 'skills', 'hypo-ext-nope');
+    mkdirSync(join(root, 'references'), { recursive: true });
+    writeFileSync(join(root, 'references', 'x.md'), 'x\n');
+
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+    assert.ok(!existsSync(join(skillsDir, 'nope')), 'no SKILL.md → not a skill');
+    assert.ok(!pkgExt()['skills/nope']);
+  });
+});
+
+// The headline destructive guard: lexical containment cannot see a symlink in the
+// MIDDLE of an install path. Without the lstat ancestor walk, an orphan unlink
+// would follow `~/.claude/skills/demo/references -> /outside` and delete a file
+// that was never ours. The SHA is made to MATCH on purpose — that is precisely the
+// case where every other gate (ownership, containment) says "safe to delete".
+test('an orphan is NOT unlinked through a symlinked ancestor in the install path', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    // The wiki drops the file → it becomes an orphan we own and would delete.
+    rmSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-demo', 'references'), {
+      recursive: true,
+    });
+
+    // Swap the installed subdir for a symlink to somewhere outside, holding a file
+    // whose bytes hash to the SHA we recorded.
+    const outside = join(hypoDir, '..', 'outside-del');
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, 'bar.md'), 'bar\n');
+    rmSync(join(skillsDir, 'demo', 'references'), { recursive: true });
+    symlinkSync(outside, join(skillsDir, 'demo', 'references'));
+
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+    assert.ok(
+      existsSync(join(outside, 'bar.md')),
+      'the unlink must not escape through the symlinked ancestor',
+    );
+  });
+});
+
+test('a copy is NOT written through a symlinked ancestor in the install path', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    // Point the installed subdir at an outside directory, then change the wiki file
+    // so sync wants to write it again.
+    const outside = join(hypoDir, '..', 'outside-write');
+    mkdirSync(outside, { recursive: true });
+    rmSync(join(skillsDir, 'demo', 'references'), { recursive: true });
+    symlinkSync(outside, join(skillsDir, 'demo', 'references'));
+    writeFileSync(
+      join(hypoDir, 'extensions', 'skills', 'hypo-ext-demo', 'references', 'bar.md'),
+      'CHANGED\n',
+    );
+
+    const r = sync();
+    assert.ok(
+      !existsSync(join(outside, 'bar.md')),
+      'the copy must not be written out through the symlinked ancestor',
+    );
+    // A path we cannot safely write is a hard conflict, exactly like a symlinked
+    // leaf: it blocks the install loudly rather than being skipped in silence.
+    assert.notEqual(r.status, 0, 'an unsafe install path must block, not pass quietly');
+    assert.ok(
+      (r.stdout + r.stderr).includes('skip-unsafe-path'),
+      `the refusal must be reported: ${r.stdout}${r.stderr}`,
+    );
+  });
+});
+
+test('uninstall does not delete through a symlinked ancestor either', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    const outside = join(hypoDir, '..', 'outside-uninstall');
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, 'bar.md'), 'bar\n');
+    rmSync(join(skillsDir, 'demo', 'references'), { recursive: true });
+    symlinkSync(outside, join(skillsDir, 'demo', 'references'));
+
+    const r = runWithHome('uninstall.mjs', ['--apply', '--yes'], home);
+    assert.equal(r.status, 0, `uninstall failed: ${r.stderr}`);
+    assert.ok(
+      existsSync(join(outside, 'bar.md')),
+      'uninstall must not follow a symlinked ancestor out of the skill dir',
+    );
+  });
+});
+
+test('--force-extensions cleans up a preserved (user-modified) orphan', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir, pkgExt }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    writeFileSync(join(skillsDir, 'demo', 'references', 'bar.md'), 'MY EDITS\n');
+    rmSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-demo', 'references'), {
+      recursive: true,
+    });
+    sync(); // preserved, still owned
+
+    const r = runWithHome(
+      'upgrade.mjs',
+      [`--hypo-dir=${hypoDir}`, '--apply', '--force-extensions'],
+      home,
+    );
+    assert.equal(r.status, 0, `force sync failed: ${r.stderr}`);
+    assert.ok(
+      !existsSync(join(skillsDir, 'demo', 'references', 'bar.md')),
+      '--force-extensions must be able to reach the orphan the record kept alive',
+    );
+    assert.ok(!pkgExt()['skills/demo']['references/bar.md'], 'and drop its record once removed');
+  });
+});
+
+test('a flat hypo-ext-*.md skill keeps its old install path (no regression)', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir, pkgExt }) => {
+    const dir = join(hypoDir, 'extensions', 'skills');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'hypo-ext-flat.md'), '# flat\n');
+
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+    // The flat shape predates directory skills; its install path must not move.
+    assert.ok(existsSync(join(skillsDir, 'hypo-ext-flat.md')), 'flat skill keeps the wiki name');
+    assert.equal(
+      typeof pkgExt()['skills/hypo-ext-flat.md'],
+      'string',
+      'a flat key keeps its plain string SHA',
+    );
+  });
+});
+
+test('a sidecar installName overrides the install directory name', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir, pkgExt }) => {
+    writeSkillTree(
+      hypoDir,
+      'hypo-ext-demo',
+      { 'SKILL.md': '# demo\n' },
+      {
+        type: 'skill',
+        installName: 'renamed',
+      },
+    );
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+    assert.ok(existsSync(join(skillsDir, 'renamed', 'SKILL.md')));
+    assert.ok(!existsSync(join(skillsDir, 'demo')));
+    assert.ok(pkgExt()['skills/renamed']);
+  });
+});
+
+test('an installName in the reserved hypo namespace is refused, not installed', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir, pkgExt }) => {
+    writeSkillTree(
+      hypoDir,
+      'hypo-ext-demo',
+      { 'SKILL.md': '# demo\n' },
+      {
+        type: 'skill',
+        installName: 'hypo-evil',
+      },
+    );
+    sync();
+    assert.ok(!existsSync(join(skillsDir, 'hypo-evil')), 'reserved namespace must be refused');
+    assert.ok(!existsSync(join(skillsDir, 'demo')), 'and it must not silently fall back');
+    assert.deepEqual(
+      Object.keys(pkgExt()).filter((k) => k.startsWith('skills/')),
+      [],
+    );
+  });
+});
+
+test('a corrupt recorded value (string SHA under a skill key) is ignored, not trusted', () => {
+  withSkillWiki(({ home, hypoDir, sync, pkgExt, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', { 'SKILL.md': '# demo\n' });
+    sync();
+
+    // Park a flat string SHA under the skill key, as a corrupt pkg-json would.
+    const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    pkg.extensions.claude['skills/demo'] = 'f'.repeat(64);
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+    const r = sync();
+    assert.equal(r.status, 0, `sync must not crash on a corrupt value: ${r.stderr}`);
+    // The bogus value grants no ownership, so nothing is deleted and the map re-forms.
+    assert.ok(existsSync(join(skillsDir, 'demo', 'SKILL.md')));
+    assert.equal(typeof pkgExt()['skills/demo'], 'object');
+  });
+});
+
+suite('directory skills: doctor + uninstall see the nested record');
+
+test('doctor reports a healthy skill as clean, and flags a drifted subtree file', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    const check = () => {
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      return JSON.parse(r.stdout).find((c) => c.label === 'Extensions integrity');
+    };
+
+    // Before this branch existed, doctor joined `skills/demo` onto the root, hit a
+    // DIRECTORY, and warned "not a regular file" on every healthy run.
+    assert.equal(check().status, 'pass', `healthy skill must be clean: ${check().detail}`);
+
+    writeFileSync(join(skillsDir, 'demo', 'references', 'bar.md'), 'user edit\n');
+    const drifted = check();
+    assert.equal(drifted.status, 'warn', 'an edited subtree file must surface as drift');
+    assert.ok(
+      drifted.detail.includes('references/bar.md'),
+      `drift must name the file: ${drifted.detail}`,
+    );
+  });
+});
+
+test('uninstall removes the owned subtree but preserves what it does not own', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+      'references/keep.md': 'keep\n',
+    });
+    sync();
+
+    // One file the user edited, one they added themselves.
+    writeFileSync(join(skillsDir, 'demo', 'references', 'keep.md'), 'MY EDITS\n');
+    writeFileSync(join(skillsDir, 'demo', 'mine.md'), 'mine\n');
+
+    const r = runWithHome('uninstall.mjs', ['--apply', '--yes'], home);
+    assert.equal(r.status, 0, `uninstall failed: ${r.stderr}\n${r.stdout}`);
+
+    assert.ok(!existsSync(join(skillsDir, 'demo', 'SKILL.md')), 'owned + unmodified → removed');
+    assert.ok(
+      !existsSync(join(skillsDir, 'demo', 'references', 'bar.md')),
+      'owned subtree file → removed',
+    );
+    assert.equal(
+      readFileSync(join(skillsDir, 'demo', 'references', 'keep.md'), 'utf-8'),
+      'MY EDITS\n',
+      'user-modified → preserved',
+    );
+    assert.equal(
+      readFileSync(join(skillsDir, 'demo', 'mine.md'), 'utf-8'),
+      'mine\n',
+      'unowned → preserved',
+    );
+    // The skill root cannot be pruned while it still holds the files we preserved.
+    assert.ok(existsSync(join(skillsDir, 'demo')), 'a dir holding preserved files stays');
+  });
+});
+
+// codex pre-commit BLOCKER: the guard skipped the boundary dir itself, so
+// symlinking ~/.claude/skills — the one ancestor every install path shares —
+// bypassed it entirely.
+test('a symlinked skills/ boundary directory is itself refused (guard covers the root)', () => {
+  withSkillWiki(({ hypoDir, sync, home }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    const skillsDir = join(home, '.claude', 'skills');
+    const outside = join(hypoDir, '..', 'outside-boundary');
+    mkdirSync(outside, { recursive: true });
+    // Move the real tree out and point skills/ at it: every install path now runs
+    // through a symlinked ancestor.
+    mkdirSync(join(outside, 'demo', 'references'), { recursive: true });
+    writeFileSync(join(outside, 'demo', 'SKILL.md'), '# demo\n');
+    writeFileSync(join(outside, 'demo', 'references', 'bar.md'), 'bar\n');
+    rmSync(skillsDir, { recursive: true });
+    symlinkSync(outside, skillsDir);
+
+    rmSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-demo', 'references'), {
+      recursive: true,
+    });
+    sync();
+
+    assert.ok(
+      existsSync(join(outside, 'demo', 'references', 'bar.md')),
+      'a symlinked skills/ boundary must not let the orphan unlink through',
+    );
+  });
+});
+
+// codex pre-commit BLOCKER (with a working repro): a corrupt `"skills/x": {}`
+// record granted no file ownership, yet uninstall still ran the directory prune —
+// which, through a symlinked skill dir, rmdir'd empty directories outside the tree.
+test('a corrupt empty skill record grants no pruning power (uninstall)', () => {
+  withSkillWiki(({ home, hypoDir, sync }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', { 'SKILL.md': '# demo\n' });
+    sync();
+
+    const skillsDir = join(home, '.claude', 'skills');
+    const outside = join(hypoDir, '..', 'outside-prune');
+    mkdirSync(join(outside, 'victim'), { recursive: true }); // empty → rmdir-able
+    rmSync(join(skillsDir, 'demo'), { recursive: true });
+    symlinkSync(outside, join(skillsDir, 'demo'));
+
+    const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    pkg.extensions.claude['skills/demo'] = {}; // owns nothing
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+    const r = runWithHome('uninstall.mjs', ['--apply', '--yes'], home);
+    assert.equal(r.status, 0, `uninstall failed: ${r.stderr}`);
+    assert.ok(
+      existsSync(join(outside, 'victim')),
+      'an empty record must not let uninstall rmdir outside the skill tree',
+    );
+  });
+});
+
+// A partial uninstall must rewrite the record down to exactly what it still owns:
+// keep the preserved file (dropping it disowns the file forever) but DROP the files
+// it removed. Keeping a removed path is a live data-loss path — see the next test.
+test('a partial uninstall rewrites the record to exactly the files it still owns', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/keep.md': 'keep\n',
+    });
+    sync();
+    writeFileSync(join(skillsDir, 'demo', 'references', 'keep.md'), 'MY EDITS\n');
+
+    const r = runWithHome('uninstall.mjs', ['--apply', '--yes'], home);
+    assert.equal(r.status, 0, `uninstall failed: ${r.stderr}`);
+    assert.ok(existsSync(join(skillsDir, 'demo', 'references', 'keep.md')), 'edited file survives');
+    assert.ok(!existsSync(join(skillsDir, 'demo', 'SKILL.md')), 'owned file removed');
+
+    const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+    assert.ok(existsSync(pkgPath), 'the pkg must survive: a preserved file still needs its record');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    const rec = pkg.extensions.claude['skills/demo'];
+    assert.deepEqual(
+      Object.keys(rec),
+      ['references/keep.md'],
+      'the record must claim the preserved file and ONLY that',
+    );
+  });
+});
+
+// codex fix-verify BLOCKER (with a working repro): the record kept a stale claim on
+// a path uninstall had already removed. Put a NEW file at that path and --force
+// deletes it, because --force bypasses the SHA gate and the stale claim points there.
+test('a stale record claim cannot make --force delete a file the user later created', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/keep.md': 'keep\n',
+    });
+    sync();
+
+    // Edit one file so uninstall preserves it and the skill is only partly removed.
+    writeFileSync(join(skillsDir, 'demo', 'references', 'keep.md'), 'MY EDITS\n');
+    runWithHome('uninstall.mjs', ['--apply', '--yes'], home);
+    assert.ok(!existsSync(join(skillsDir, 'demo', 'SKILL.md')), 'SKILL.md was removed');
+
+    // The user writes their OWN file at the path we used to own.
+    writeFileSync(join(skillsDir, 'demo', 'SKILL.md'), 'USER NEW FILE\n');
+
+    const r = runWithHome('uninstall.mjs', ['--apply', '--yes', '--force-extensions'], home);
+    assert.equal(r.status, 0, `force uninstall failed: ${r.stderr}`);
+    assert.equal(
+      readFileSync(join(skillsDir, 'demo', 'SKILL.md'), 'utf-8'),
+      'USER NEW FILE\n',
+      'a path we no longer own must not be deletable through a stale record claim',
+    );
+  });
+});
+
+test('a refused (unsafe-path) file keeps the ownership record it already had', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir, pkgExt }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+    const before = pkgExt()['skills/demo']['references/bar.md'];
+    assert.ok(before, 'precondition: the file is owned');
+
+    // Make the install path unsafe, then re-sync: the copy is refused.
+    const outside = join(hypoDir, '..', 'outside-refuse');
+    mkdirSync(outside, { recursive: true });
+    rmSync(join(skillsDir, 'demo', 'references'), { recursive: true });
+    symlinkSync(outside, join(skillsDir, 'demo', 'references'));
+    runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+
+    assert.equal(
+      pkgExt()['skills/demo']['references/bar.md'],
+      before,
+      'refusing to touch a path must not disown what we already installed there',
+    );
+  });
+});
+
+// codex final-review BLOCKER (with a working repro): the nested SHA maps were plain
+// objects, so a file literally named `__proto__` assigned through the prototype
+// setter instead of creating an own key. The file installed but was never recorded —
+// unowned, and uninstall could never remove it. `constructor` had the mirror problem:
+// a lookup returned a truthy inherited value as if it were a recorded SHA.
+test('a skill file named __proto__ or constructor is tracked, not swallowed by the prototype', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir, pkgExt }) => {
+    // Built with a null prototype on purpose: in an object LITERAL, `__proto__:`
+    // sets the prototype instead of creating an own key, so the fixture would
+    // silently not contain the file we mean to test.
+    const files = Object.create(null);
+    files['SKILL.md'] = '# demo\n';
+    files['__proto__'] = 'proto\n';
+    files['constructor'] = 'ctor\n';
+    writeSkillTree(hypoDir, 'hypo-ext-demo', files);
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+
+    assert.ok(existsSync(join(skillsDir, 'demo', '__proto__')), '__proto__ installs');
+    const rec = pkgExt()['skills/demo'];
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(rec, '__proto__'),
+      '__proto__ must be recorded as an OWN key, or the file is installed but unowned',
+    );
+    assert.ok(Object.prototype.hasOwnProperty.call(rec, 'constructor'));
+
+    // Being owned is what makes it removable.
+    const u = runWithHome('uninstall.mjs', ['--apply', '--yes'], home);
+    assert.equal(u.status, 0, `uninstall failed: ${u.stderr}`);
+    assert.ok(
+      !existsSync(join(skillsDir, 'demo', '__proto__')),
+      'uninstall must be able to reach a file it recorded',
+    );
+  });
+});
+
+test('a case-fold collision DEEP in the subtree still poisons the whole skill', () => {
+  withSkillWiki(({ hypoDir, sync, skillsDir, pkgExt }) => {
+    const root = writeSkillTree(hypoDir, 'hypo-ext-demo', { 'SKILL.md': '# demo\n' });
+    mkdirSync(join(root, 'references'), { recursive: true });
+    writeFileSync(join(root, 'references', 'A.md'), 'A\n');
+    try {
+      writeFileSync(join(root, 'references', 'a.md'), 'a\n');
+    } catch {
+      return; // case-insensitive FS: the clash cannot even be authored here
+    }
+    // On a case-insensitive FS the two names are one file — nothing to test.
+    if (readdirSync(join(root, 'references')).length < 2) return;
+
+    const r = sync();
+    assert.equal(r.status, 0, `sync failed: ${r.stderr}`);
+    assert.ok(
+      !pkgExt()['skills/demo'],
+      'a collision below the root must skip the whole skill, not just the root level',
+    );
+    assert.ok(!existsSync(join(skillsDir, 'demo')), 'and nothing may be installed');
+  });
+});
+
+test('a corrupt object value under a FLAT key grants no ownership (--force cannot use it)', () => {
+  withSkillWiki(({ home, hypoDir, sync }) => {
+    const dir = join(hypoDir, 'extensions', 'skills');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'hypo-ext-flat.md'), '# flat\n');
+    sync();
+
+    const flatPath = join(home, '.claude', 'skills', 'hypo-ext-flat.md');
+    const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    pkg.extensions.claude['skills/hypo-ext-flat.md'] = { 'x.md': 'f'.repeat(64) };
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+    const r = runWithHome('uninstall.mjs', ['--apply', '--yes', '--force-extensions'], home);
+    assert.equal(r.status, 0, `uninstall failed: ${r.stderr}`);
+    assert.ok(
+      existsSync(flatPath),
+      'a wrong-shaped flat value must not authorize removal, even under --force',
+    );
+  });
+});
+
+test('uninstall prunes the skill directory when nothing is left to preserve', () => {
+  withSkillWiki(({ home, hypoDir, sync, skillsDir }) => {
+    writeSkillTree(hypoDir, 'hypo-ext-demo', {
+      'SKILL.md': '# demo\n',
+      'references/bar.md': 'bar\n',
+    });
+    sync();
+
+    const r = runWithHome('uninstall.mjs', ['--apply', '--yes'], home);
+    assert.equal(r.status, 0, `uninstall failed: ${r.stderr}`);
+    assert.ok(!existsSync(join(skillsDir, 'demo')), 'a fully-owned skill dir is pruned');
+  });
+});
+
 // ── extensions settings.json mixed-group surgical write (ADR 0024 amend 2026-05-23) ──
 //
 // registerSettings used to ignore mixed-group occurrences of our command (any
@@ -24850,6 +25533,12 @@ const {
   buildHookCommand,
   parseCapturableHookCommand,
   scanSettingsHooks,
+  isValidSkillDirSegment,
+  parseSkillKey,
+  normalizeSkillRelPath,
+  isContainedUnder,
+  hasSymlinkAncestor,
+  parseSkillShaValue,
 } = await import(`${SCRIPTS}/lib/extensions.mjs`);
 const { planCapture, isCaptureCandidate, scanHookCandidates } = await import(
   `${SCRIPTS}/capture.mjs`
@@ -25004,6 +25693,110 @@ test('respects the covered-types scope (codex excludes skills/agents)', () => {
     type: 'commands',
     installFile: 'x.md',
   });
+});
+
+// ── directory skills: key + path validators (ADR 0063, T1) ──────────────
+
+suite('skills-dir: isValidSkillDirSegment');
+
+test('accepts a plain skill dir name, rejects the flat installName escapes', () => {
+  assert.ok(isValidSkillDirSegment('gstack'));
+  assert.ok(isValidSkillDirSegment('my-skill.v2'));
+  assert.ok(!isValidSkillDirSegment('hypo'));
+  assert.ok(!isValidSkillDirSegment('Hypo-x'));
+  assert.ok(!isValidSkillDirSegment('con'));
+  assert.ok(!isValidSkillDirSegment('COM1'));
+  assert.ok(!isValidSkillDirSegment('a/b'));
+  assert.ok(!isValidSkillDirSegment('a..b'));
+  assert.ok(!isValidSkillDirSegment('.hidden'));
+});
+test('rejects a trailing dot (Windows strips it, so foo. aliases foo)', () => {
+  assert.ok(!isValidSkillDirSegment('foo.'));
+  assert.ok(isValidSkillDirSegment('foo.bar'));
+});
+
+suite('skills-dir: parseSkillKey (recorded pkg-json key)');
+
+test('accepts skills/<safe-dir> only', () => {
+  assert.deepEqual(parseSkillKey('skills/foo'), { type: 'skills', installDir: 'foo' });
+  assert.equal(parseSkillKey('commands/foo.md'), null); // flat key is not a skill key
+  assert.equal(parseSkillKey('skills/foo/SKILL.md'), null); // sub-path never a top-level key
+  assert.equal(parseSkillKey('skills/../evil'), null);
+  assert.equal(parseSkillKey('skills/hypo-x'), null);
+  assert.equal(parseSkillKey('skills/'), null);
+  assert.equal(parseSkillKey('skills'), null);
+  assert.equal(parseSkillKey(42), null);
+});
+test('a skill key must not survive parseExtKey (the no-slash rule stays shut)', () => {
+  // The regression this guards: routing skills/foo through parseExtKey silently
+  // drops the record in uninstall, stranding installed files we own.
+  assert.equal(parseExtKey('skills/foo', ['skills']), null);
+});
+
+suite('skills-dir: normalizeSkillRelPath');
+
+test('accepts canonical subtree paths', () => {
+  assert.equal(normalizeSkillRelPath('SKILL.md'), 'SKILL.md');
+  assert.equal(normalizeSkillRelPath('references/x.md'), 'references/x.md');
+  assert.equal(normalizeSkillRelPath('a/b/c/d.txt'), 'a/b/c/d.txt');
+});
+test('rejects traversal, absolute, backslash, Windows drive/UNC, NUL', () => {
+  assert.equal(normalizeSkillRelPath('../x.md'), null);
+  assert.equal(normalizeSkillRelPath('references/../../x.md'), null);
+  assert.equal(normalizeSkillRelPath('/etc/passwd'), null);
+  assert.equal(normalizeSkillRelPath('refs\\x.md'), null);
+  assert.equal(normalizeSkillRelPath('C:/x.md'), null);
+  assert.equal(normalizeSkillRelPath('C:x.md'), null);
+  assert.equal(normalizeSkillRelPath('//host/share/x.md'), null);
+  assert.equal(normalizeSkillRelPath('a/\0b.md'), null);
+});
+test('rejects dot segments and empty segments (they alias a real destination)', () => {
+  assert.equal(normalizeSkillRelPath('references/./x.md'), null);
+  assert.equal(normalizeSkillRelPath('./x.md'), null);
+  assert.equal(normalizeSkillRelPath('a//b.md'), null);
+  assert.equal(normalizeSkillRelPath(''), null);
+});
+test('rejects a trailing-dot segment and a pathological depth/length', () => {
+  assert.equal(normalizeSkillRelPath('refs./x.md'), null);
+  assert.equal(normalizeSkillRelPath(Array(20).fill('a').join('/') + '/x.md'), null);
+  assert.equal(normalizeSkillRelPath('a/' + 'x'.repeat(500) + '.md'), null);
+});
+
+suite('skills-dir: isContainedUnder (boundary-aware, not startsWith)');
+
+test('a sibling whose name merely shares a prefix is NOT contained', () => {
+  assert.ok(isContainedUnder('/a/b', '/a/b/c.md'));
+  assert.ok(!isContainedUnder('/a/b', '/a/bc/c.md')); // raw startsWith would say yes
+  assert.ok(!isContainedUnder('/a/b', '/a/b')); // the root itself is not "under" itself
+  assert.ok(!isContainedUnder('/a/b', '/a/x.md'));
+});
+
+suite('skills-dir: parseSkillShaValue (corrupt pkg-json cannot be trusted)');
+
+test('keeps only canonical relpaths mapped to hex SHAs', () => {
+  const good = 'a'.repeat(64);
+  // The returned map is null-prototype (a relpath may legitimately be `__proto__`),
+  // so compare own entries rather than deep-equal against a plain object literal.
+  assert.deepEqual(Object.entries(parseSkillShaValue({ 'SKILL.md': good })), [['SKILL.md', good]]);
+  // dropped: non-hex, wrong length, non-string, traversal key, non-canonical key
+  assert.deepEqual(
+    Object.entries(
+      parseSkillShaValue({
+        'SKILL.md': good,
+        'bad.md': 'nothex',
+        'short.md': 'abc',
+        'obj.md': { nested: 1 },
+        '../escape.md': good,
+        'refs/./x.md': good,
+      }),
+    ),
+    [['SKILL.md', good]],
+  );
+});
+test('a shape mismatch (string SHA under a skill key) yields null, not a crash', () => {
+  assert.equal(parseSkillShaValue('a'.repeat(64)), null);
+  assert.equal(parseSkillShaValue(null), null);
+  assert.equal(parseSkillShaValue(['a']), null);
 });
 
 suite('capture: isCaptureCandidate + planCapture (ADR 0061 §6/§7)');


### PR DESCRIPTION
# English

## What changed

Forward-sync now understands **directory skills**. A skill authored as `~/hypomnema/extensions/skills/hypo-ext-<name>/SKILL.md` plus an arbitrary subtree installs to `~/.claude/skills/<name>/` with its whole tree intact, and every file in it is SHA-tracked individually.

It also removes files: when the wiki subtree drops a file, the installed copy goes too, but only when we own it and the user has not edited it.

`doctor` and `uninstall` learned to read the new record shape, so a synced skill reports clean and can be fully uninstalled.

## Why

A real Claude Code skill is a directory (`skills/<name>/SKILL.md` plus `references/`, `scripts/`, assets). Sync modeled every skill as a single flat `.md`, so a directory skill was dropped at discovery and never installed at all. Skills were the one extension type the companion sync silently did not work for.

Note that a skill's directory name is the name it is invoked by, so the wiki `hypo-ext-` storage prefix is stripped on install: `extensions/skills/hypo-ext-gstack/` becomes `~/.claude/skills/gstack/`. A sidecar manifest `installName` overrides that.

## How

The interesting constraints, since the diff does not show why:

**The SHA map keeps its shape.** A recorded key stays a single segment (`skills/<name>`); only the value widens, from one SHA string to `{ "SKILL.md": sha, "references/x.md": sha }`. Flattening subpaths into the key namespace would have reopened the no-slash rule that guards uninstall against traversal, so skill keys route through a separate `parseSkillKey` instead. Both layers are schema-validated: a corrupt `hypo-pkg.json` can now name many paths under one trusted key, so an entry that fails validation is ignored rather than trusted.

**This is the first time forward-sync deletes anything.** Deletion was previously confined to uninstall. Orphan removal is gated the same way an overwrite is: the installed file's SHA must still match what we recorded, the SHA is re-read immediately before the unlink, and a file the user edited or added themselves is preserved. A preserved orphan **keeps** its record, because dropping it would leave the file unowned and beyond the reach of `--force-extensions` forever.

**Lexical containment is not enough.** A symlinked directory in the middle of an install path (`~/.claude/skills/demo/references -> /outside`) passes every string check while the write or unlink lands somewhere else entirely. Every mutation (mkdir, copy, unlink, rmdir) re-runs an lstat walk of its ancestors first, including the boundary directory itself. The source subtree is walked with lstat too, so a symlinked directory in the wiki is never followed.

**Nested maps are null-prototype.** Relpaths come from the filesystem, and a file named `__proto__` assigned into a plain object goes through the prototype setter instead of becoming an own key, which would install the file but never record it.

Flat extensions (commands, agents, hooks, and the old flat `hypo-ext-*.md` skills) are untouched, and Codex still skips skills as before.

## Manual verification

Beyond the suite, the destructive and escape paths were reproduced by hand in a temp `HOME`:

```
# install → orphan → the outside file survives the unlink
node scripts/upgrade.mjs --hypo-dir=$W --apply
rm -rf $W/extensions/skills/hypo-ext-demo/references
ln -s $PWD/outside $H/.claude/skills/demo/references
node scripts/upgrade.mjs --hypo-dir=$W --apply
# → skills/demo/references/bar.md [skip-unsafe-path — left untouched], outside/ empty
```

Each regression test was also verified to FAIL with its fix disabled, so none of them pass vacuously. The stale-record test, for one, deletes the user's own file and dies with ENOENT when the fix is removed.

## Migration notes

None for existing installs. Flat extensions keep their exact install paths and record shape, and no directory skill can exist on disk today because sync never installed one.

---

# 한국어

## 변경 내용

forward-sync가 이제 **디렉터리 skill**을 다룹니다. `~/hypomnema/extensions/skills/hypo-ext-<name>/SKILL.md`와 그 아래 서브트리로 작성한 skill이 `~/.claude/skills/<name>/`에 트리 그대로 설치되고, 안의 모든 파일이 개별 SHA로 추적됩니다.

파일 삭제도 합니다. 위키 서브트리에서 파일이 빠지면 설치본에서도 지우되, 우리가 소유하고 사용자가 수정하지 않은 파일만 지웁니다.

`doctor`와 `uninstall`도 새 레코드 형태를 읽습니다. 그래서 동기화된 skill이 정상으로 보고되고 완전히 제거됩니다.

## 이유

실제 Claude Code skill은 디렉터리입니다(`skills/<name>/SKILL.md` + `references/`·`scripts/`·assets). 그런데 sync는 모든 skill을 flat `.md` 하나로 모델링해서, 디렉터리 skill은 discovery 단계에서 걸러져 아예 설치되지 않았습니다. 확장 동기화가 조용히 작동하지 않던 유일한 타입이었습니다.

skill의 디렉터리 이름이 곧 호출되는 이름이라, 설치 시 위키 저장 접두어 `hypo-ext-`를 벗깁니다. `extensions/skills/hypo-ext-gstack/`은 `~/.claude/skills/gstack/`이 됩니다. sidecar manifest의 `installName`이 있으면 그쪽이 우선합니다.

## 방법

diff만으로는 이유가 안 드러나는 제약들입니다.

**SHA 맵의 형태는 유지합니다.** 기록되는 키는 여전히 단일 세그먼트(`skills/<name>`)이고, 값만 SHA 문자열 하나에서 `{ "SKILL.md": sha, "references/x.md": sha }`로 넓어집니다. 서브경로를 키 네임스페이스에 펼쳤다면 uninstall의 traversal을 막는 no-slash 규칙을 다시 여는 셈이라, skill 키는 별도 `parseSkillKey`로 분기시켰습니다. 두 계층 모두 스키마 검증을 거칩니다. 손상된 `hypo-pkg.json`이 이제 신뢰되는 키 하나 아래에 여러 경로를 적을 수 있으므로, 검증에 실패한 항목은 신뢰하지 않고 무시합니다.

**forward-sync가 파일을 지우는 것은 이번이 처음입니다.** 그전까지 삭제는 uninstall에만 있었습니다. orphan 삭제는 덮어쓰기와 같은 방식으로 가둡니다. 설치본의 SHA가 기록된 값과 여전히 같아야 하고, unlink 직전에 SHA를 다시 읽어 확인하며, 사용자가 수정했거나 직접 추가한 파일은 보존합니다. 보존한 orphan은 레코드를 **남깁니다**. 레코드를 지우면 그 파일이 미소유가 되어 `--force-extensions`로도 영원히 손댈 수 없기 때문입니다.

**문자열 기반 containment만으로는 부족합니다.** 설치 경로 중간의 심링크 디렉터리(`~/.claude/skills/demo/references -> /outside`)는 모든 문자열 검사를 통과하지만 쓰기나 삭제는 엉뚱한 곳에 떨어집니다. 그래서 mkdir·copy·unlink·rmdir 각 mutation 직전마다 조상 경로를 lstat로 훑고, 경계 디렉터리 자신도 검사합니다. 소스 서브트리도 lstat로 순회해서 위키 안의 심링크 디렉터리는 따라가지 않습니다.

**중첩 맵은 null-prototype입니다.** relpath는 파일시스템에서 오는데, `__proto__`라는 이름의 파일을 plain object에 넣으면 own 키가 되는 대신 프로토타입 setter를 타서, 파일은 설치되지만 레코드에는 안 남습니다.

flat 확장(commands·agents·hooks와 기존 flat `hypo-ext-*.md` skill)은 그대로이고, Codex는 전과 같이 skill을 건너뜁니다.

## 수동 검증

테스트 스위트 외에, 파괴적 경로와 탈출 경로를 임시 `HOME`에서 직접 재현했습니다.

```
# 설치 → orphan → 밖의 파일이 unlink에서 살아남음
node scripts/upgrade.mjs --hypo-dir=$W --apply
rm -rf $W/extensions/skills/hypo-ext-demo/references
ln -s $PWD/outside $H/.claude/skills/demo/references
node scripts/upgrade.mjs --hypo-dir=$W --apply
# → skills/demo/references/bar.md [skip-unsafe-path — left untouched], outside/ 비어 있음
```

각 회귀 테스트가 해당 수정을 껐을 때 실제로 실패하는지도 확인했습니다. 통과가 공허하지 않다는 뜻입니다. 예를 들어 stale-record 테스트는 수정을 끄면 사용자의 파일을 지워서 ENOENT로 죽습니다.

## 마이그레이션 노트

기존 설치에는 없습니다. flat 확장은 설치 경로와 레코드 형태가 그대로이고, 디스크에 디렉터리 skill이 있을 수 없습니다(sync가 한 번도 설치한 적이 없으므로).

---

## Changelog

- EN: Directory skills (`skills/<name>/SKILL.md` plus a subtree) now sync to `~/.claude/skills/`, with per-file ownership, SHA-gated removal of files the wiki drops, and symlink-escape guards on every write and delete. ([#187](https://github.com/sk-lim19f/Hypomnema/pull/187))
- KO: 디렉터리 skill(`skills/<name>/SKILL.md` + 서브트리)이 `~/.claude/skills/`로 동기화됩니다. 파일 단위 소유 추적, 위키에서 빠진 파일의 SHA 기반 삭제, 모든 쓰기·삭제에 대한 심링크 탈출 방어를 포함합니다. ([#187](https://github.com/sk-lim19f/Hypomnema/pull/187))

## Checklist

- [x] `npm test` passes locally (1355 passed, 0 failed)
- [x] `npm run lint` passes locally (the 9 reported errors are pre-existing wiki-content issues on `main`, none in the touched files)
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed (README version narrative is reconciled in the release PR, per this repo's accumulate-then-release model)
- [x] Filled the `## Changelog` block above (EN + KO line)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
