### PR TITLE
feat(capture): reverse-capture directory skills into the wiki

### DIFF
--- a/commands/capture.md
+++ b/commands/capture.md
@@ -1,10 +1,12 @@
 ---
-description: Pull extensions you made the normal way under ~/.claude/{commands,agents}, or a canonical hook registered in ~/.claude/settings.json, into the wiki so they sync to your other machines. Use when the user wants to capture, adopt, or back up a locally-authored slash command, agent, or hook into Hypomnema.
+description: Pull extensions you made the normal way under ~/.claude/{commands,agents,skills}, or a canonical hook registered in ~/.claude/settings.json, into the wiki so they sync to your other machines. Use when the user wants to capture, adopt, or back up a locally-authored slash command, agent, skill, or hook into Hypomnema.
 ---
 
-You are running `/hypo:capture`. Bring a command or agent that the user created the normal way (directly under `~/.claude/commands/` or `~/.claude/agents/`), or a hook they registered in `~/.claude/settings.json`, into the wiki `extensions/` tree so the existing forward-sync propagates it to their other machines under its original name.
+You are running `/hypo:capture`. Bring a command, agent, or skill that the user created the normal way (directly under `~/.claude/commands/`, `~/.claude/agents/`, or `~/.claude/skills/`), or a hook they registered in `~/.claude/settings.json`, into the wiki `extensions/` tree so the existing forward-sync propagates it to their other machines under its original name.
 
-Scope: commands, agents, and hooks. Commands and agents are enumerated from `~/.claude/{commands,agents}/`; hooks are read from the `~/.claude/settings.json` registration. A hook is captured only when its command is the canonical `node $HOME/.claude/hooks/<name>.mjs` form and it round-trips losslessly (original event, matcher, and timeout preserved); non-canonical or lossy registrations are skipped with a reason instead of being rewritten. Skills are not captured yet.
+Scope: commands, agents, skills, and hooks. Commands and agents are enumerated from `~/.claude/{commands,agents}/`; a skill is a whole directory (`~/.claude/skills/<name>/SKILL.md` plus its subtree); hooks are read from the `~/.claude/settings.json` registration.
+
+Hooks and skills are captured only when they round-trip losslessly, because what lands in the wiki is exactly what the far machine installs. A hook qualifies when its command is the canonical `node $HOME/.claude/hooks/<name>.mjs` form and its event, matcher, and timeout are preserved. A skill is refused whole (never captured as a partial subset) when its subtree holds anything that cannot survive the trip: a symlink, a hardlink, an empty directory (git cannot carry one), a VCS control directory, or more than 500 files / 5 MiB. That ceiling is what keeps a vendored skill with its own `node_modules` out of the vault. Content is reproduced byte for byte; the executable bit is not carried by sync yet, so a captured skill holding executable scripts prints a warning.
 
 ## Step 1: Resolve the package root
 
@@ -18,7 +20,7 @@ If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. O
 node ${CLAUDE_PLUGIN_ROOT}/scripts/capture.mjs [--hypo-dir="<path>"]
 ```
 
-With no names and no `--all`, the script lists capturable candidates and stops. Candidates come from two sources: commands and agents are the unowned regular `.md` files under `~/.claude/{commands,agents}/`, and hooks are the canonical `node $HOME/.claude/hooks/<name>.mjs` entries registered in `~/.claude/settings.json`. It excludes anything already managed by the wiki, the reserved `hypo-*` namespace, symlinks and other non-regular files, core hooks, and any hook whose registration would not round-trip losslessly. Skipped hook registrations are printed with the reason; unowned commands and agents that fail these filters are simply omitted from the list, without a per-item reason.
+With no names and no `--all`, the script lists capturable candidates and stops. Candidates come from three sources: commands and agents are the unowned regular `.md` files under `~/.claude/{commands,agents}/`; skills are the unowned directories under `~/.claude/skills/` that hold a real `SKILL.md`; hooks are the canonical `node $HOME/.claude/hooks/<name>.mjs` entries registered in `~/.claude/settings.json`. It excludes anything already managed by the wiki, the reserved `hypo-*` namespace, symlinks and other non-regular files, core hooks, and anything that would not round-trip losslessly. Skipped hooks and skills are printed with the reason; unowned commands and agents that fail these filters are simply omitted from the list, without a per-item reason.
 
 Show the list. Note that these are unowned candidates, not a provenance check: explicit selection is the trust boundary. A third-party tool's command, agent, or hook could appear here, so let the user pick deliberately.
 
@@ -31,9 +33,9 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/capture.mjs [--hypo-dir="<path>"] <name> [<na
 node ${CLAUDE_PLUGIN_ROOT}/scripts/capture.mjs [--hypo-dir="<path>"] --all
 ```
 
-A name is the filename (`mycmd.md`, or `myhook.mjs` for a hook), its stem (`mycmd`), or the `type/file` form (`commands/mycmd.md`, `hooks/myhook.mjs`). Add `--dry-run` to preview without writing.
+A name is the filename (`mycmd.md`, or `myhook.mjs` for a hook), its stem (`mycmd`, and for a skill the directory name), or the `type/file` form (`commands/mycmd.md`, `skills/myskill`). When a bare name matches more than one candidate (a `mine` command and a `mine` skill), the script refuses it and asks for the type-qualified form. Add `--dry-run` to preview without writing, or `--type=skills` to narrow the scan.
 
-Each capture stores the file in the wiki as `extensions/<type>/hypo-ext-<name>.<ext>` (`.md` for commands and agents, `.mjs` for hooks) with a sidecar `hypo-ext-<name>.manifest.json` that records the original install name (and, for a hook, its event, matcher, and timeout), then adopts it so the currently-installed copy is left in place and tracked. A wiki file that already exists with different content (or a mismatched manifest) is refused, not overwritten.
+A flat capture stores the file in the wiki as `extensions/<type>/hypo-ext-<name>.<ext>` (`.md` for commands and agents, `.mjs` for hooks). A skill is stored as a directory, `extensions/skills/hypo-ext-<name>/`, with its subtree intact. Either way a sidecar `hypo-ext-<name>.manifest.json` records the original install name (and, for a hook, its event, matcher, and timeout), and the capture is then adopted so the currently-installed copy is left in place and tracked. A wiki entry that already exists with different content (or a mismatched manifest) is refused, not overwritten.
 
 ## Step 4: Commit the wiki, then sync elsewhere
 

--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -8,9 +8,16 @@
  * so they propagate to other machines via the existing forward-sync ("register on
  * A → sync on B").
  *
- * Scope: commands + agents (pure file copy, no settings.json) and hooks (settings
- * reverse-capture, lossless round-trip only). skills (directory support) are
- * deferred to a separate PR.
+ * Scope: commands + agents (pure file copy, no settings.json), hooks (settings
+ * reverse-capture, lossless round-trip only), and skills (a DIRECTORY: SKILL.md
+ * plus an arbitrary subtree, stored as `extensions/skills/hypo-ext-<name>/`).
+ *
+ * Skills (skills-capture design): the same subtree walker forward-sync uses is run
+ * in `strict` mode here, so anything that cannot round-trip through the wiki
+ * (symlink, hardlink, empty directory, VCS control dir, reserved manifest name)
+ * refuses the WHOLE skill rather than capturing a lossy subset — what lands in the
+ * wiki is exactly what the far machine installs. Cumulative ceilings abort the walk
+ * early so a vendored skill (14k files, 1.1GB) never gets enumerated in full.
  *
  * Naming (capture design §3): the wiki STORAGE name is `hypo-ext-<name>.<ext>` (keeps
  * the discovery whitelist), and a sidecar `hypo-ext-<name>.manifest.json` records
@@ -31,11 +38,16 @@ import {
   readdirSync,
   writeFileSync,
   mkdirSync,
+  rmdirSync,
   unlinkSync,
   renameSync,
   realpathSync,
+  lstatSync,
+  openSync,
+  closeSync,
 } from 'fs';
-import { join, dirname } from 'path';
+import { randomBytes } from 'crypto';
+import { join, dirname, relative, sep } from 'path';
 import { homedir } from 'os';
 import { pathToFileURL, fileURLToPath } from 'url';
 import {
@@ -50,9 +62,18 @@ import {
   syncExtensions,
   readExtensionPkgStateNoMutate,
   isValidInstallStem,
+  isValidSkillDirSegment,
+  parseSkillKey,
+  parseSkillShaValue,
+  walkSkillSubtree,
+  emptyShaMap,
+  isRealDir,
+  isContainedUnder,
+  hasSymlinkAncestor,
   scanSettingsHooks,
   parseCapturableHookCommand,
   HOOK_EVENT_ALLOWLIST,
+  SKILL_ROOT_FILE,
   EXT_PREFIX,
 } from './lib/extensions.mjs';
 import { readCoreHooksConfig, deriveCoreHookBasenames } from './lib/core-hooks.mjs';
@@ -66,10 +87,26 @@ const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Captured types and their singular manifest `type` value. commands/agents install
 // as top-level `.md` files; hooks install as `.mjs` and additionally register a
-// settings.json entry (reverse of forward-sync).
-const CAPTURE_TYPES = ['commands', 'agents', 'hooks'];
-const TYPE_SINGULAR = { commands: 'command', agents: 'agent', hooks: 'hook' };
+// settings.json entry (reverse of forward-sync); skills install as a DIRECTORY.
+const CAPTURE_TYPES = ['commands', 'agents', 'hooks', 'skills'];
+// The flat, single-file types. `TYPE_EXT` has no `skills` entry on purpose: a skill
+// has no install extension, and letting it through a flat helper would silently
+// build paths with an `undefined` suffix. Every flat helper keys off this list.
+const FLAT_TYPES = ['commands', 'agents', 'hooks'];
+// The flat types enumerated by readdir. hooks are enumerated from the settings.json
+// registration instead, and skills have their own directory scanner.
+const READDIR_TYPES = ['commands', 'agents'];
+const TYPE_SINGULAR = { commands: 'command', agents: 'agent', hooks: 'hook', skills: 'skill' };
 const TYPE_EXT = { commands: '.md', agents: '.md', hooks: '.mjs' };
+
+// Ceilings for a captured skill subtree (skills-capture design §3). A hand-authored
+// skill is a handful of files; a vendored one (gstack: 14,311 files / 1.1GB, mostly
+// node_modules) must be refused, not copied into a git-tracked vault. Enforced as
+// cumulative counters DURING the walk, from lstat sizes, so the verdict lands before
+// anything is read and the candidate listing never enumerates a vendored tree.
+const SKILL_MAX_FILES = 500;
+const SKILL_MAX_BYTES = 5 * 1024 * 1024;
+const SKILL_LIMITS = { strict: true, maxFiles: SKILL_MAX_FILES, maxBytes: SKILL_MAX_BYTES };
 
 function pkgJsonPath() {
   return join(HOME, '.claude', 'hypo-pkg.json');
@@ -169,6 +206,90 @@ export function planCapture({ wantManifest, srcSha, existingFileSha, existingMan
 }
 
 /**
+ * The set of install directories the wiki VALIDLY owns as directory skills.
+ *
+ * Ownership must be read through the same schema the rest of the module trusts, not
+ * raw property truthiness (skills-capture design §8). A corrupt hypo-pkg.json that
+ * parks a string under `skills/mine` would otherwise read as "already managed" and
+ * lock that skill out of capture forever, and it would also poison the "keys this
+ * run newly recorded" bookkeeping the failed-adopt purge depends on.
+ */
+export function ownedSkillDirs(recorded) {
+  const out = new Set();
+  for (const [key, value] of Object.entries(recorded)) {
+    const parsed = parseSkillKey(key);
+    if (!parsed) continue;
+    const nested = parseSkillShaValue(value);
+    if (nested === null || Object.keys(nested).length === 0) continue;
+    out.add(parsed.installDir);
+  }
+  return out;
+}
+
+/**
+ * Plan the capture of one directory skill. Same three outcomes as the flat planner,
+ * but `ready` is deliberately narrow: it means the wiki skill directory is WHOLLY
+ * ABSENT (skills-capture design §4). That narrowness is what makes the rollback safe
+ * — every path the rollback removes is a path this run created.
+ *
+ * `wikiShas` is null when the wiki directory does not exist, and a rel→sha map when
+ * it does. A wiki path that exists but cannot be read as a clean skill (a file, a
+ * symlink, a crash-truncated directory with no SKILL.md) arrives here as
+ * `wikiPresent: true, wikiShas: null` and is a conflict — never a crash, never a
+ * silent overwrite.
+ */
+export function planSkillCapture({
+  wantManifest,
+  srcShas,
+  wikiPresent,
+  wikiShas,
+  existingManifestRaw,
+}) {
+  if (!isValidSkillDirSegment(wantManifest.installName)) {
+    return { status: 'invalid', reason: `invalid installName "${wantManifest.installName}"` };
+  }
+
+  if (wikiPresent) {
+    if (wikiShas === null) {
+      return {
+        status: 'conflict',
+        reason: 'wiki target exists but is not a readable skill directory',
+      };
+    }
+    if (!deepEqual(wikiShas, srcShas)) {
+      return { status: 'conflict', reason: 'wiki skill directory exists with different content' };
+    }
+    if (existingManifestRaw == null) {
+      return { status: 'conflict', reason: 'wiki skill exists without its installName manifest' };
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(existingManifestRaw);
+    } catch {
+      return { status: 'conflict', reason: 'wiki manifest is not valid JSON' };
+    }
+    if (!deepEqual(parsed, wantManifest)) {
+      return { status: 'conflict', reason: 'wiki manifest declares a different mapping' };
+    }
+    return { status: 'already', manifest: wantManifest };
+  }
+
+  // No wiki directory yet. A stray sidecar with a different mapping is still a conflict.
+  if (existingManifestRaw != null) {
+    let parsed;
+    try {
+      parsed = JSON.parse(existingManifestRaw);
+    } catch {
+      return { status: 'conflict', reason: 'stray wiki manifest is not valid JSON' };
+    }
+    if (!deepEqual(parsed, wantManifest)) {
+      return { status: 'conflict', reason: 'stray wiki manifest declares a different mapping' };
+    }
+  }
+  return { status: 'ready', manifest: wantManifest };
+}
+
+/**
  * Reverse-generate the sidecar manifest for a capture candidate. commands/agents
  * carry only `{ type, installName }`; hooks additionally carry the settings
  * registration fields `{ event, matcher?, timeout? }`. matcher/timeout are omitted
@@ -188,9 +309,69 @@ function buildWantManifest(c) {
 
 // ── filesystem orchestration ─────────────────────────────────────────────────
 
+/**
+ * Enumerate capturable DIRECTORY skills under `~/.claude/skills/`.
+ *
+ * Every rejected entry gets a visible reason (never a silent drop): the strict walker
+ * refuses the whole skill for anything that cannot round-trip, and the ceilings abort
+ * the walk as soon as they are crossed. Returns `{ candidates, skipped }`.
+ *
+ * A flat `.md` under `skills/` is not a candidate: the directory is the real Claude
+ * Code layout, and the flat form only exists as a backward-compatible wiki storage
+ * shape. A symlinked directory is not a candidate either (never followed).
+ */
+export function scanSkillCandidates(claudeHome, ownedDirs) {
+  const candidates = [];
+  const skipped = [];
+  const dir = join(claudeHome, 'skills');
+  if (!existsSync(dir)) return { candidates, skipped };
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return { candidates, skipped };
+  }
+  for (const name of entries) {
+    const srcPath = join(dir, name);
+    if (!isRealDir(srcPath)) continue; // flat .md, symlinked dir, or junk: not a skill dir
+    const lower = name.toLowerCase();
+    if (lower === 'hypo' || lower.startsWith('hypo-')) continue; // reserved namespace
+    if (ownedDirs.has(name)) continue; // already managed by the wiki
+    const label = `skills/${name}`;
+    if (!isValidSkillDirSegment(name)) {
+      skipped.push({ type: 'skills', file: name, reason: `unsafe skill directory name "${name}"` });
+      continue;
+    }
+    // hypoignore is not in play for a source under ~/.claude, so pass an empty pattern
+    // list. The dir argument still has to be a string: isIgnored() calls relative() on
+    // it before it ever looks at the (empty) patterns.
+    const walked = walkSkillSubtree(srcPath, label, dir, [], SKILL_LIMITS);
+    if (walked.skip) {
+      skipped.push({
+        type: 'skills',
+        file: name,
+        reason: walked.fatal || `no regular ${SKILL_ROOT_FILE} at the skill root`,
+      });
+      continue;
+    }
+    candidates.push({
+      type: 'skills',
+      file: name,
+      stem: name,
+      srcPath,
+      isDir: true,
+      files: walked.files,
+    });
+  }
+  return { candidates, skipped };
+}
+
 function scanCandidates(claudeHome, recorded, types) {
   const out = [];
   for (const type of types) {
+    // hooks come from the settings registration, skills from their own directory
+    // scanner. Letting either through here would double-enumerate them.
+    if (!READDIR_TYPES.includes(type)) continue;
     const dir = join(claudeHome, type);
     if (!existsSync(dir)) continue;
     let entries;
@@ -373,9 +554,19 @@ function log(msg) {
 
 // Write via a sibling temp + rename so the final replace is atomic and, crucially,
 // never follows a symlink already sitting at `dest` (rename swaps the link itself).
+//
+// The temp path is randomized and opened with `wx` (O_CREAT|O_EXCL). The old
+// `${dest}.tmp.${pid}` name was predictable, and writeFileSync on a path someone had
+// already planted a symlink at would follow it straight out of the wiki. O_EXCL fails
+// on an existing path of any kind, symlink included.
 function writeAtomic(dest, buf) {
-  const tmp = `${dest}.tmp.${process.pid}`;
-  writeFileSync(tmp, buf);
+  const tmp = `${dest}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
+  const fd = openSync(tmp, 'wx');
+  try {
+    writeFileSync(fd, buf);
+  } finally {
+    closeSync(fd);
+  }
   try {
     renameSync(tmp, dest);
   } catch (err) {
@@ -386,11 +577,41 @@ function writeAtomic(dest, buf) {
   }
 }
 
-// Undo one capture's wiki writes: drop the storage file (.md or .mjs), and either
-// restore the manifest bytes we overwrote (a pre-existing same-mapping sidecar) or
-// remove the manifest we created. Used on a failed/aborted adopt so a capture never
-// half-lands.
+// Undo one capture's wiki writes: drop the storage file(s), and either restore the
+// manifest bytes we overwrote (a pre-existing same-mapping sidecar) or remove the
+// manifest we created. Used on a failed/aborted adopt so a capture never half-lands.
+//
+// A skill's rollback walks the ledger of paths this run actually created, newest
+// first: files, then the directories that held them. It never removes a tree
+// wholesale. The plan only says `ready` when the wiki directory was absent, and the
+// root is claimed with an exclusive mkdir, so everything in the ledger is ours — but
+// deleting only what we recorded is what makes that true by construction rather than
+// by trusting a check made earlier in time.
 function rollbackRec(rec) {
+  // A skill ledger is AUTHORITATIVE: only paths this run actually created are removed,
+  // and the manifest is touched only if we actually wrote it. The flat branch below
+  // unlinks `manifestPath` unconditionally, which is wrong for a skill whose write
+  // failed BEFORE the manifest was written — a dangling sidecar symlink is invisible to
+  // existsSync, so the guard refuses the write and the rollback would then delete a
+  // path the run never touched (codex pre-commit BLOCKER, with a repro).
+  if (rec.createdFiles) {
+    for (const p of [...rec.createdFiles].reverse()) {
+      try {
+        unlinkSync(p);
+      } catch {}
+    }
+    for (const d of [...(rec.createdDirs || [])].reverse()) {
+      try {
+        rmdirSync(d); // fails on a non-empty dir, which is the point: never a tree wipe
+      } catch {}
+    }
+    if (rec.manifestOverwritten && rec.manifestPrevBuf != null) {
+      try {
+        writeFileSync(rec.manifestPath, rec.manifestPrevBuf);
+      } catch {}
+    }
+    return;
+  }
   try {
     unlinkSync(rec.filePath);
   } catch {}
@@ -402,6 +623,81 @@ function rollbackRec(rec) {
     try {
       unlinkSync(rec.manifestPath);
     } catch {}
+  }
+}
+
+/**
+ * Write one directory skill into the wiki, recording every path created so a failed
+ * adopt can be undone exactly (skills-capture design §5/§7).
+ *
+ * Order: the sidecar manifest first, then the subtree with SKILL.md LAST. A crash at
+ * any point therefore leaves a directory with no SKILL.md, which discovery skips —
+ * never a half-skill that the far machine would partially install.
+ *
+ * `guard` re-checks the destination against the wiki boundary immediately before each
+ * mutation. Lexical containment cannot see a symlinked ancestor, and the boundary has
+ * to be the wiki root itself: rooting the walk at `extensions/skills` would lstat
+ * straight through a symlinked `extensions/`.
+ */
+function writeSkill({ rec, skillRoot, manifestPath, manifest, files, guard, wikiRoot }) {
+  const prev = readFileIfRegular(manifestPath);
+  rec.manifestExisted = prev != null;
+  rec.manifestPrevBuf = prev;
+
+  if (!guard(manifestPath) || !guard(skillRoot)) {
+    throw new Error('wiki path is not inside the vault or crosses a symlinked directory');
+  }
+  // Build the chain down to the type directory segment by segment, so a directory this
+  // run creates (a fresh `extensions/skills/`) lands in the ledger and can be undone.
+  // A recursive mkdir would create them silently and leak them on rollback.
+  const typeDir = dirname(skillRoot);
+  const chain = relative(wikiRoot, typeDir).split(sep).filter(Boolean);
+  let cur = wikiRoot;
+  for (const seg of chain) {
+    cur = join(cur, seg);
+    if (existsSync(cur)) continue;
+    if (!guard(cur)) throw new Error('wiki path crosses a symlinked directory');
+    mkdirSync(cur);
+    rec.createdDirs.push(cur);
+  }
+  // Exclusive: EEXIST here means the "absent" verdict the plan made is already stale,
+  // and the rollback must not be handed a directory it did not create.
+  mkdirSync(skillRoot);
+  rec.createdDirs.push(skillRoot);
+
+  writeAtomic(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  // Record what the write actually did, not what we predicted it would do: the rollback
+  // must never remove or restore a manifest it did not touch.
+  if (rec.manifestExisted) rec.manifestOverwritten = true;
+  else rec.createdFiles.push(manifestPath);
+
+  // SKILL.md last: it is the file that makes the directory discoverable.
+  const ordered = [
+    ...files.filter((f) => f.rel !== SKILL_ROOT_FILE),
+    ...files.filter((f) => f.rel === SKILL_ROOT_FILE),
+  ];
+  const madeDirs = new Set([skillRoot]);
+  for (const f of ordered) {
+    const destPath = join(skillRoot, ...f.rel.split('/'));
+    if (!guard(destPath)) {
+      throw new Error(`unsafe wiki destination for ${f.rel}`);
+    }
+    const parent = dirname(destPath);
+    if (!madeDirs.has(parent)) {
+      // Build the chain segment by segment so every new directory lands in the ledger.
+      const segs = f.rel.split('/').slice(0, -1);
+      let cur = skillRoot;
+      for (const s of segs) {
+        cur = join(cur, s);
+        if (madeDirs.has(cur)) continue;
+        if (!guard(cur)) throw new Error(`unsafe wiki destination for ${f.rel}`);
+        mkdirSync(cur);
+        rec.createdDirs.push(cur);
+        madeDirs.add(cur);
+      }
+    }
+    writeAtomic(destPath, readFileSync(f.srcPath));
+    rec.createdFiles.push(destPath);
   }
 }
 
@@ -429,19 +725,152 @@ function purgeOwnedKeys(pkgPath, target, keys) {
   if (changed) writePkgJsonAtomic(pkgPath, pkg);
 }
 
+/**
+ * Plan + write one directory skill. Pushes into the caller's captured/skipped/created
+ * lists so the shared adopt + rollback machinery downstream treats it like any other
+ * capture.
+ *
+ * The wiki side is read with the SAME strict walker as the source, so a wiki directory
+ * that is unreadable, symlink-poisoned, or crash-truncated (no SKILL.md) surfaces as
+ * `wikiShas: null` and lands on the conflict branch instead of being silently treated
+ * as absent and then blown away by a rollback.
+ */
+function captureOneSkill({ c, extDir, guard, wikiRoot, args, captured, skipped, created }) {
+  const wikiStem = `${EXT_PREFIX}${c.stem}`;
+  const typeDir = join(extDir, 'skills');
+  const skillRoot = join(typeDir, wikiStem);
+  const manifestPath = join(typeDir, `${wikiStem}.manifest.json`);
+  const label = `skills/${c.file}`;
+
+  // Null-prototype: a skill file legitimately named `__proto__` would otherwise assign
+  // through the prototype setter instead of creating an own key, so it would vanish from
+  // the comparison and from the adopt check (forward-sync keeps its SHA maps this way for
+  // the same reason). codex pre-commit CONCERN.
+  const srcShas = emptyShaMap();
+  for (const f of c.files) srcShas[f.rel] = sha256(readFileSync(f.srcPath));
+
+  const wikiPresent = existsSync(skillRoot);
+  let wikiShas = null;
+  if (wikiPresent && isRealDir(skillRoot)) {
+    const walked = walkSkillSubtree(skillRoot, label, args.hypoDir, [], SKILL_LIMITS);
+    if (!walked.skip) {
+      wikiShas = emptyShaMap();
+      for (const f of walked.files) wikiShas[f.rel] = sha256(readFileSync(f.srcPath));
+    }
+  }
+  if (existsSync(manifestPath) && !isRegularFile(manifestPath)) {
+    const reason = 'wiki manifest exists but is not a regular file';
+    log(`⊘ ${label}: ${reason} — skipped`);
+    skipped.push({ ...c, reason, status: 'conflict' });
+    return;
+  }
+  const existingManifestBuf = readFileIfRegular(manifestPath);
+  const existingManifestRaw = existingManifestBuf ? existingManifestBuf.toString('utf-8') : null;
+
+  const wantManifest = { type: TYPE_SINGULAR.skills, installName: c.stem };
+  const plan = planSkillCapture({
+    wantManifest,
+    srcShas,
+    wikiPresent,
+    wikiShas,
+    existingManifestRaw,
+  });
+
+  // The install key is the whole directory; forward-sync records one nested map under
+  // it, one entry per relpath (skills-dir design).
+  const rec = { ...c, installKey: `skills/${c.stem}`, srcShas };
+
+  if (plan.status === 'invalid' || plan.status === 'conflict') {
+    log(`⊘ ${label}: ${plan.reason} — skipped`);
+    skipped.push({ ...rec, reason: plan.reason, status: plan.status });
+    return;
+  }
+  if (plan.status === 'already') {
+    log(`= ${label}: already captured`);
+    captured.push({ ...rec, status: 'already' });
+    return;
+  }
+
+  // Content round-trips; the executable bit does not (forward-sync writes with the
+  // default mode). Say so rather than let a captured `scripts/run.sh` arrive
+  // non-executable on the far machine without a word.
+  const execFiles = c.files.filter((f) => {
+    try {
+      return (lstatSync(f.srcPath).mode & 0o111) !== 0;
+    } catch {
+      return false;
+    }
+  });
+  if (execFiles.length > 0) {
+    log(
+      `! ${label}: ${execFiles.length} executable file(s) — content is captured, but the executable bit is not carried by sync`,
+    );
+  }
+
+  if (!args.dryRun) {
+    // The ledger is owned by the caller so a throw MID-write is still recoverable: the
+    // paths created before the failure are already recorded in it.
+    const ledger = {
+      type: 'skills',
+      stem: c.stem,
+      manifestPath,
+      manifestExisted: false,
+      manifestOverwritten: false,
+      manifestPrevBuf: null,
+      createdFiles: [],
+      createdDirs: [],
+    };
+    try {
+      writeSkill({
+        rec: ledger,
+        skillRoot,
+        manifestPath,
+        manifest: plan.manifest,
+        files: c.files,
+        guard,
+        wikiRoot,
+      });
+    } catch (err) {
+      rollbackRec(ledger);
+      const reason = `wiki write failed (${err.message})`;
+      log(`⊘ ${label}: ${reason} — skipped`);
+      skipped.push({ ...rec, reason, status: 'conflict' });
+      return;
+    }
+    created.push(ledger);
+  }
+  captured.push({ ...rec, status: 'ready' });
+}
+
 function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
-  const extDir = join(args.hypoDir, 'extensions');
+  // Resolve the vault root through realpath. Every wiki mutation below is boundary-
+  // checked against it, and a symlinked ancestor INSIDE the vault must be caught while
+  // a vault root that is itself a symlink (a perfectly normal setup) still works. Doing
+  // it here means extDir and the sync call see the same real root.
+  let wikiRoot = args.hypoDir;
+  try {
+    wikiRoot = realpathSync(args.hypoDir);
+  } catch {
+    // Not created yet: fall back to the lexical path; the guard below still applies.
+  }
+  const extDir = join(wikiRoot, 'extensions');
   const settingsPath = join(claudeHome, 'settings.json');
   const recorded = readExtensionPkgStateNoMutate(pkgJsonPath(), 'claude');
-  // commands/agents enumerate by readdir; hooks enumerate from settings.json.
-  const dirTypes = args.types.filter((t) => t !== 'hooks');
-  const candidates = scanCandidates(claudeHome, recorded, dirTypes);
+  // commands/agents enumerate by readdir; hooks enumerate from settings.json; skills
+  // enumerate as directories under ~/.claude/skills.
+  const candidates = scanCandidates(claudeHome, recorded, args.types);
+
+  const scanSkipped = [];
+  if (args.types.includes('skills')) {
+    const skillScan = scanSkillCandidates(claudeHome, ownedSkillDirs(recorded));
+    candidates.push(...skillScan.candidates);
+    scanSkipped.push(...skillScan.skipped);
+  }
 
   // Hooks are captured from the settings registration. Reserve the core hook
   // basenames deterministically from hooks.json; if that load is not ok (read,
   // parse, or shape failure) skip the whole hooks type rather than risk capturing
   // a core hook (T1 fail-closed contract: gate on ok, not on cfg presence).
-  const scanSkipped = [];
   if (args.types.includes('hooks')) {
     const core = readCoreHooksConfig(PKG_ROOT);
     if (!core.ok) {
@@ -457,7 +886,10 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
   // Surface every scan-time skip with its reason (never a silent drop, F4). Printed
   // before any early return so observability holds even when nothing is capturable.
   for (const s of scanSkipped) {
-    const label = s.basename ? `hooks/${s.basename}` : `hooks (${s.command})`;
+    let label;
+    if (s.type === 'skills') label = `skills/${s.file}`;
+    else if (s.basename) label = `hooks/${s.basename}`;
+    else label = `hooks (${s.command})`;
     log(`⊘ ${label}: ${s.reason} — skipped`);
   }
 
@@ -481,22 +913,37 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
     };
   }
 
-  // Resolve the selection.
+  // Resolve the selection. A bare name can now be ambiguous (`commands/mine.md` and
+  // `skills/mine/` can both exist), and the old map silently let the last candidate
+  // win. Collect every match per name and refuse when there is more than one: the
+  // caller must say which by qualifying with the type.
   let selected;
   if (args.all) {
     selected = candidates;
   } else {
     const byName = new Map();
+    const add = (key, c) => {
+      if (!byName.has(key)) byName.set(key, []);
+      byName.get(key).push(c);
+    };
     for (const c of candidates) {
-      byName.set(c.file, c);
-      byName.set(c.stem, c);
-      byName.set(`${c.type}/${c.file}`, c);
+      add(c.file, c);
+      if (c.stem !== c.file) add(c.stem, c);
+      add(`${c.type}/${c.file}`, c);
     }
     selected = [];
     for (const name of args.names) {
-      const c = byName.get(name);
-      if (c) selected.push(c);
-      else log(`⊘ ${name}: no capturable candidate by that name — skipped`);
+      const matches = byName.get(name) || [];
+      if (matches.length === 0) {
+        log(`⊘ ${name}: no capturable candidate by that name — skipped`);
+        continue;
+      }
+      if (matches.length > 1) {
+        const qualified = matches.map((c) => `${c.type}/${c.file}`).join(', ');
+        log(`⊘ ${name}: ambiguous (matches ${qualified}) — qualify with the type — skipped`);
+        continue;
+      }
+      selected.push(matches[0]);
     }
   }
 
@@ -505,7 +952,15 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
   const failed = [];
   const created = []; // files written THIS run, for rollback on adopt failure
 
+  // Every wiki mutation is checked against the vault root, not the type directory: a
+  // symlinked `extensions/` would otherwise be walked straight through.
+  const guard = (dest) => isContainedUnder(wikiRoot, dest) && !hasSymlinkAncestor(wikiRoot, dest);
+
   for (const c of selected) {
+    if (c.type === 'skills') {
+      captureOneSkill({ c, extDir, guard, wikiRoot, args, captured, skipped, created });
+      continue;
+    }
     const fileExt = TYPE_EXT[c.type];
     const wikiStem = `${EXT_PREFIX}${c.stem}`;
     const typeDir = join(extDir, c.type);
@@ -594,7 +1049,7 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
   try {
     sync = syncExtensions({
       extDir,
-      hypoDir: args.hypoDir,
+      hypoDir: wikiRoot,
       target: 'claude',
       settingsPath: join(claudeHome, 'settings.json'),
       pkgPath: pkgJsonPath(),
@@ -623,14 +1078,17 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
   // this run is preserved (never touched here).
   const strayOwnedKeys = new Set();
   for (const c of toAdopt) {
-    if (c.requiredKeys.every((k) => newSHAs[k])) {
+    const ok =
+      c.type === 'skills' ? skillAdopted(c, sync) : c.requiredKeys.every((k) => newSHAs[k]);
+    if (ok) {
       c.status = 'captured';
     } else {
       c.status = 'failed';
       failed.push(c);
       const rec = created.find((r) => r.type === c.type && r.stem === c.stem);
       if (rec) rollbackRec(rec);
-      for (const k of c.requiredKeys) {
+      const keys = c.type === 'skills' ? [c.installKey] : c.requiredKeys;
+      for (const k of keys) {
         if (recorded[k] === undefined && newSHAs[k] !== undefined) strayOwnedKeys.add(k);
       }
     }
@@ -639,7 +1097,8 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
   // stems make this impossible in practice, but the guard keeps the rollback
   // strictly scoped to failed captures).
   for (const c of toAdopt) {
-    if (c.status === 'captured') for (const k of c.requiredKeys) strayOwnedKeys.delete(k);
+    if (c.status !== 'captured') continue;
+    for (const k of c.type === 'skills' ? [c.installKey] : c.requiredKeys) strayOwnedKeys.delete(k);
   }
   purgeOwnedKeys(pkgJsonPath(), 'claude', strayOwnedKeys);
   const okCaptured = captured.filter((c) => c.status === 'captured' || c.status === 'already');
@@ -648,12 +1107,43 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
   return { selected, captured, skipped, failed, sync };
 }
 
+/**
+ * Did forward-sync actually adopt this skill, file for file?
+ *
+ * Presence of the key is not enough. A skill's recorded value is a NESTED map, so the
+ * `newSHAs[key]` truthiness test the flat types use passes as soon as a single relpath
+ * lands — a skill missing half its files would count as adopted and the wiki would own
+ * a lossy install. Worse, copyOne hands back the previously recorded SHA on its drift
+ * and skip paths, so even a per-relpath presence check can be satisfied by a file sync
+ * refused to touch.
+ *
+ * So: every captured relpath must be recorded with EXACTLY the SHA we captured, the
+ * recorded map must hold nothing else, and sync must not have reported drift or a
+ * conflict against this skill. A first capture is source == install target, so every
+ * file is expected to land on the up-to-date branch.
+ */
+function skillAdopted(c, sync) {
+  const nested = (sync.newSHAs || {})[c.installKey];
+  if (!nested || typeof nested !== 'object' || Array.isArray(nested)) return false;
+  const wikiName = `${EXT_PREFIX}${c.stem}`;
+  const touched = (list) => (list || []).some((e) => e.name === wikiName);
+  if (touched(sync.drifts) || touched(sync.conflicts)) return false;
+  const relpaths = Object.keys(c.srcShas);
+  if (Object.keys(nested).length !== relpaths.length) return false;
+  return relpaths.every((rel) => nested[rel] === c.srcShas[rel]);
+}
+
 function report(captured, skipped, failed, dryRun) {
   log('');
   if (captured.length > 0) {
     log(`${dryRun ? 'Would capture' : 'Captured'} ${captured.length} extension(s):`);
-    for (const c of captured)
-      log(`  ${c.type}/${c.file} → extensions/${c.type}/${EXT_PREFIX}${c.stem}${TYPE_EXT[c.type]}`);
+    for (const c of captured) {
+      const dest =
+        c.type === 'skills'
+          ? `extensions/skills/${EXT_PREFIX}${c.stem}/`
+          : `extensions/${c.type}/${EXT_PREFIX}${c.stem}${TYPE_EXT[c.type]}`;
+      log(`  ${c.type}/${c.file} → ${dest}`);
+    }
   }
   if (skipped.length > 0) log(`Skipped ${skipped.length} (conflict/invalid — see above).`);
   if (failed.length > 0)
@@ -667,11 +1157,14 @@ function report(captured, skipped, failed, dryRun) {
 function main() {
   const args = parseArgs(process.argv);
   if (args.help) {
-    log('Usage: hypomnema capture [names…] [--all] [--type=commands,agents,hooks] [--dry-run]');
-    log('  Pull ~/.claude/{commands,agents} extensions and canonical settings.json');
-    log('  hooks into the wiki for cross-machine sync. Hooks are captured only when');
-    log('  they round-trip losslessly to the canonical form; others are skipped with');
-    log('  a reason.');
+    log(
+      'Usage: hypomnema capture [names…] [--all] [--type=commands,agents,hooks,skills] [--dry-run]',
+    );
+    log('  Pull ~/.claude/{commands,agents,skills} extensions and canonical');
+    log('  settings.json hooks into the wiki for cross-machine sync. Hooks and skills');
+    log('  are captured only when they round-trip losslessly; others are skipped with');
+    log('  a reason. A skill is a directory (SKILL.md + subtree); one holding symlinks,');
+    log(`  hardlinks, empty dirs, or more than ${SKILL_MAX_FILES} files is refused.`);
     return 0;
   }
   const res = run(args);

--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -58,6 +58,7 @@ import {
   writePkgJsonAtomic,
 } from './lib/pkg-json.mjs';
 import { resolveHypoRoot } from './lib/hypo-root.mjs';
+import { loadHypoIgnore, isIgnored } from './lib/hypo-ignore.mjs';
 import {
   syncExtensions,
   readExtensionPkgStateNoMutate,
@@ -319,8 +320,15 @@ function buildWantManifest(c) {
  * A flat `.md` under `skills/` is not a candidate: the directory is the real Claude
  * Code layout, and the flat form only exists as a backward-compatible wiki storage
  * shape. A symlinked directory is not a candidate either (never followed).
+ *
+ * `vault` is `{ hypoDir, patterns }` — the vault's `.hypoignore`. Capture must judge a
+ * source file by the rule that will apply to it AFTER it lands in the wiki: forward-sync
+ * discovers the wiki subtree through that filter, so a file the vault ignores (a `.pdf`
+ * reference, a `.cache/` directory) would be written here and then dropped from
+ * discovery, leaving the adopt check short one relpath and failing with no reason a user
+ * could act on. Refuse it up front instead, with the pattern named.
  */
-export function scanSkillCandidates(claudeHome, ownedDirs) {
+export function scanSkillCandidates(claudeHome, ownedDirs, vault = null) {
   const candidates = [];
   const skipped = [];
   const dir = join(claudeHome, 'skills');
@@ -342,9 +350,9 @@ export function scanSkillCandidates(claudeHome, ownedDirs) {
       skipped.push({ type: 'skills', file: name, reason: `unsafe skill directory name "${name}"` });
       continue;
     }
-    // hypoignore is not in play for a source under ~/.claude, so pass an empty pattern
-    // list. The dir argument still has to be a string: isIgnored() calls relative() on
-    // it before it ever looks at the (empty) patterns.
+    // The SOURCE walk applies no ignore filter (the patterns are the vault's, and the
+    // source lives under ~/.claude). The dir argument still has to be a string: isIgnored()
+    // calls relative() on it before it ever looks at the (empty) patterns.
     const walked = walkSkillSubtree(srcPath, label, dir, [], SKILL_LIMITS);
     if (walked.skip) {
       skipped.push({
@@ -353,6 +361,21 @@ export function scanSkillCandidates(claudeHome, ownedDirs) {
         reason: walked.fatal || `no regular ${SKILL_ROOT_FILE} at the skill root`,
       });
       continue;
+    }
+    // Would any of these files be invisible to forward-sync once they are in the wiki?
+    if (vault && vault.patterns.length > 0) {
+      const wikiRootForSkill = join(vault.hypoDir, 'extensions', 'skills', `${EXT_PREFIX}${name}`);
+      const ignored = walked.files.find((f) =>
+        isIgnored(join(wikiRootForSkill, ...f.rel.split('/')), vault.hypoDir, vault.patterns),
+      );
+      if (ignored) {
+        skipped.push({
+          type: 'skills',
+          file: name,
+          reason: `${ignored.rel} matches the vault .hypoignore and would not sync back`,
+        });
+        continue;
+      }
     }
     candidates.push({
       type: 'skills',
@@ -862,7 +885,10 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
 
   const scanSkipped = [];
   if (args.types.includes('skills')) {
-    const skillScan = scanSkillCandidates(claudeHome, ownedSkillDirs(recorded));
+    const skillScan = scanSkillCandidates(claudeHome, ownedSkillDirs(recorded), {
+      hypoDir: wikiRoot,
+      patterns: loadHypoIgnore(wikiRoot),
+    });
     candidates.push(...skillScan.candidates);
     scanSkipped.push(...skillScan.skipped);
   }

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -432,7 +432,7 @@ function pkgRootDir(target) {
  * the wiki subtree (`references -> /etc`) would otherwise let the walker copy
  * files from outside the vault into the install target.
  */
-function isRealDir(p) {
+export function isRealDir(p) {
   try {
     return lstatSync(p).isDirectory();
   } catch {
@@ -440,19 +440,53 @@ function isRealDir(p) {
   }
 }
 
+// Directory names that must never be captured into the wiki: the wiki is itself a
+// git repo, so a `.git` under a skill would nest one repo inside another. Strict
+// (capture) mode only.
+const VCS_DIRS = new Set(['.git', '.hg', '.svn']);
+
 /**
- * Walk a wiki skill directory and collect its owned files. lstat-based: symlinked
+ * Walk a skill directory and collect its owned files. lstat-based: symlinked
  * files and symlinked directories are skipped with a warning, never followed.
  *
- * Returns `{ files: [{ rel, srcPath }], warnings, skip }`. `skip` is set when the
- * whole skill must be dropped: no regular SKILL.md at the root, or two source
+ * Returns `{ files: [{ rel, srcPath, size }], warnings, skip }`. `skip` is set when
+ * the whole skill must be dropped: no regular SKILL.md at the root, or two source
  * paths that canonicalize to the same destination (case-fold aliasing), which
  * would make ownership order-dependent.
+ *
+ * `opts` is empty for forward-sync, which keeps its tolerant behavior verbatim.
+ * Reverse capture passes:
+ *   - `strict`: any per-file skip reason poisons the WHOLE skill instead of
+ *     dropping that one file. Capture must never write a lossy copy into the
+ *     wiki, because what lands there is what the far machine installs. It also
+ *     turns on the checks that only matter for content coming INTO the wiki:
+ *     empty directories (git cannot carry them), VCS control dirs, and hardlinks
+ *     (link identity does not round-trip).
+ *   - `maxFiles` / `maxBytes`: cumulative ceilings, checked during the walk so a
+ *     vendored skill (gstack: 14k files / 1.1GB) aborts early instead of being
+ *     enumerated in full on every candidate listing. Sizes come from lstat, so
+ *     the verdict lands before anything is read.
  */
-function walkSkillSubtree(skillDir, label, hypoDir, hypoignorePatterns) {
+export function walkSkillSubtree(skillDir, label, hypoDir, hypoignorePatterns, opts = {}) {
+  const { strict = false, maxFiles = Infinity, maxBytes = Infinity } = opts;
   const files = [];
   const warnings = [];
   const seen = new Map(); // case-folded canonical rel -> first rel that claimed it
+  let bytes = 0;
+  // Set once the whole skill is doomed; unwinds the recursion immediately.
+  let fatal = null;
+  const poison = (reason) => {
+    fatal = reason;
+    warnings.push(`${label} skipped (${reason})`);
+    files.length = 0;
+    return { fatal: true };
+  };
+  // A per-file problem: tolerated (skip the file) by forward-sync, fatal in strict.
+  const reject = (rel, reason) => {
+    if (strict) return poison(`${rel}: ${reason}`);
+    warnings.push(`${label}/${rel} skipped (${reason})`);
+    return null;
+  };
 
   const rootFile = join(skillDir, SKILL_ROOT_FILE);
   if (!isRegularFile(rootFile)) {
@@ -465,65 +499,100 @@ function walkSkillSubtree(skillDir, label, hypoDir, hypoignorePatterns) {
 
   const walk = (dir, prefix, depth) => {
     if (depth > SKILL_MAX_DEPTH) {
-      warnings.push(`${label}/${prefix} skipped (subtree deeper than ${SKILL_MAX_DEPTH})`);
-      return;
+      return reject(prefix, `subtree deeper than ${SKILL_MAX_DEPTH}`);
     }
     let entries;
     try {
       entries = readdirSync(dir);
     } catch {
-      warnings.push(`${label}/${prefix} skipped (unreadable directory)`);
-      return;
+      return reject(prefix, 'unreadable directory');
+    }
+    // git cannot carry an empty directory, so a skill that needs one cannot be
+    // reproduced through the wiki. Refuse rather than capture a subset.
+    if (strict && entries.length === 0 && depth > 1) {
+      return poison(`${prefix}: empty directory (add a .gitkeep to carry it)`);
     }
     for (const name of entries) {
       const full = join(dir, name);
       const rel = prefix ? `${prefix}/${name}` : name;
       if (isIgnored(full, hypoDir, hypoignorePatterns)) continue;
       if (isRealDir(full)) {
+        if (strict && VCS_DIRS.has(name)) {
+          return poison(`${rel}: VCS control directory cannot be nested in the wiki`);
+        }
         // Propagate a collision found further down: ignoring this return value let a
         // deep `references/A.md` vs `references/a.md` clash through while only the
         // root level was poisoned (codex pre-commit NIT).
         const sub = walk(full, rel, depth + 1);
-        if (sub && sub.collision) return sub;
+        if (sub && (sub.collision || sub.fatal)) return sub;
         continue;
       }
       if (!isRegularFile(full)) {
         // Symlink, socket, or a symlinked dir: never followed, never owned.
-        warnings.push(`${label}/${rel} skipped (not a regular file)`);
+        const r = reject(rel, 'not a regular file');
+        if (r) return r;
         continue;
       }
       // A sidecar manifest lives NEXT TO the skill dir, not inside it. Reserve the
       // name inside the subtree so skill content can never be confused for install
       // metadata later.
       if (name.endsWith('.manifest.json')) {
-        warnings.push(`${label}/${rel} skipped (reserved manifest name inside a skill)`);
+        const r = reject(rel, 'reserved manifest name inside a skill');
+        if (r) return r;
         continue;
       }
       const norm = normalizeSkillRelPath(rel);
       if (norm === null) {
-        warnings.push(`${label}/${rel} skipped (unsafe path)`);
+        const r = reject(rel, 'unsafe path');
+        if (r) return r;
         continue;
       }
       // NFD and NFC spellings of the same name are one file on macOS, so collapse
       // the unicode form before case-folding or the alias check misses them.
       const fold = norm.normalize('NFC').toLowerCase();
       if (seen.has(fold)) {
-        warnings.push(
-          `${label} skipped (${norm} and ${seen.get(fold)} collide on a case-insensitive filesystem)`,
-        );
-        // Poison the whole skill: which file wins would depend on readdir order.
+        // Poison the whole skill: which file wins would depend on readdir order. `fatal`
+        // carries the reason out so a caller (capture) reports THIS, not the fallback
+        // "no SKILL.md" (codex pre-commit CONCERN).
+        fatal = `${norm} and ${seen.get(fold)} collide on a case-insensitive filesystem`;
+        warnings.push(`${label} skipped (${fatal})`);
         files.length = 0;
         return { collision: true };
       }
+      let st = null;
+      if (strict || maxBytes !== Infinity) {
+        try {
+          st = lstatSync(full);
+        } catch {
+          const r = reject(rel, 'unreadable file');
+          if (r) return r;
+          continue;
+        }
+        // A hardlink is a regular file, so nothing above catches it, and copying it
+        // silently flattens a link the far machine cannot reconstruct.
+        if (strict && st.nlink !== 1) {
+          return poison(`${rel}: hardlink (nlink=${st.nlink}) does not round-trip`);
+        }
+      }
       seen.set(fold, norm);
-      files.push({ rel: norm, srcPath: full });
+      files.push({ rel: norm, srcPath: full, size: st ? st.size : undefined });
+      if (files.length > maxFiles) {
+        return poison(`over ${maxFiles} files (aborted while walking)`);
+      }
+      if (st) {
+        bytes += st.size;
+        if (bytes > maxBytes) {
+          const mib = (n) => `${Math.round(n / (1024 * 1024))} MiB`;
+          return poison(`over ${mib(maxBytes)} (${mib(bytes)}+ so far, aborted while walking)`);
+        }
+      }
     }
     return null;
   };
 
   const res = walk(skillDir, '', 1);
-  if (res && res.collision) return { files: [], warnings, skip: true };
-  return { files, warnings, skip: false };
+  if (res && (res.collision || res.fatal)) return { files: [], warnings, skip: true, fatal };
+  return { files, warnings, skip: false, bytes };
 }
 
 /**

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -27358,6 +27358,35 @@ test('a skill file named __proto__ is captured and owned like any other', () => 
   });
 });
 
+// Capture must judge a source file by the rule that will apply AFTER it lands in the
+// wiki. forward-sync discovers the wiki subtree through the vault's .hypoignore, so a
+// file the vault ignores would be written, then dropped from discovery, and the adopt
+// check would fail with nothing a user could act on. Refuse it up front, naming the file.
+test('a skill holding a file the vault ignores is refused up front, not at adopt time', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      writeFileSync(join(hypoDir, '.hypoignore'), '*.pdf\n');
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(join(src, 'references'), { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      writeFileSync(join(src, 'references', 'spec.pdf'), '%PDF-1.4\n');
+
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home);
+      assert.match(r.stdout, /references\/spec\.pdf matches the vault \.hypoignore/);
+      assert.ok(
+        !existsSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine')),
+        'nothing is written to the wiki',
+      );
+      assert.doesNotMatch(r.stdout, /Failed to adopt/, 'refused at scan time, not at adopt');
+    });
+  });
+});
+
 // Success criterion 10: uninstall reaches a captured skill through its SHA-map key.
 test('uninstall removes a captured skill and preserves an unowned file inside it', () => {
   withTmpHome((home) => {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -18,6 +18,7 @@ import {
   existsSync,
   symlinkSync,
   statSync,
+  lstatSync,
   unlinkSync,
   utimesSync,
   chmodSync,
@@ -27018,6 +27019,366 @@ test('adopt failure rolls back the wiki hook writes (sidecar install path blocke
         !existsSync(join(hypoDir, 'extensions', 'hooks', 'hypo-ext-failh.manifest.json')),
         'wiki manifest rolled back',
       );
+    });
+  });
+});
+
+// ── directory skills: reverse capture (skills-capture design) ────────────────
+//
+// A skill is a DIRECTORY, and capture must put into the wiki exactly what the far
+// machine will install back. These drive the real CLI end to end.
+
+const { ownedSkillDirs, planSkillCapture, scanSkillCandidates } = await import(
+  `${SCRIPTS}/capture.mjs`
+);
+
+suite('capture: directory skills (scan + plan)');
+
+test('ownedSkillDirs trusts only validly recorded skill keys', () => {
+  const owned = ownedSkillDirs({
+    'skills/good': { 'SKILL.md': 'a'.repeat(64) },
+    'skills/corrupt': 'not-a-nested-map', // shape mismatch → not ownership
+    'skills/empty': {}, // owns nothing → not ownership
+    'skills/../escape': { 'SKILL.md': 'b'.repeat(64) }, // unparseable key
+    'commands/x.md': 'c'.repeat(64), // flat key, not a skill
+  });
+  assert.deepEqual([...owned], ['good']);
+});
+
+// A corrupt pkg-json must not lock a skill out of capture forever by reading as
+// "already managed" (codex design review W2-6).
+test('a corrupt skills/<name> record does not mark the skill as already-managed', () => {
+  withTmpHome((home) => {
+    const skill = join(home, '.claude', 'skills', 'mine');
+    mkdirSync(skill, { recursive: true });
+    writeFileSync(join(skill, 'SKILL.md'), '# mine\n');
+    const owned = ownedSkillDirs({ 'skills/mine': 'not-a-nested-map' });
+    const { candidates } = scanSkillCandidates(join(home, '.claude'), owned);
+    assert.deepEqual(
+      candidates.map((c) => c.file),
+      ['mine'],
+    );
+  });
+});
+
+test('planSkillCapture: ready only when the wiki directory is wholly absent', () => {
+  const wantManifest = { type: 'skill', installName: 'mine' };
+  const srcShas = { 'SKILL.md': 'a'.repeat(64) };
+  assert.equal(
+    planSkillCapture({ wantManifest, srcShas, wikiPresent: false, wikiShas: null }).status,
+    'ready',
+  );
+  // Present + identical + matching manifest → already (no-op).
+  assert.equal(
+    planSkillCapture({
+      wantManifest,
+      srcShas,
+      wikiPresent: true,
+      wikiShas: { 'SKILL.md': 'a'.repeat(64) },
+      existingManifestRaw: JSON.stringify(wantManifest),
+    }).status,
+    'already',
+  );
+  // Present + different content → conflict, never a silent overwrite.
+  assert.equal(
+    planSkillCapture({
+      wantManifest,
+      srcShas,
+      wikiPresent: true,
+      wikiShas: { 'SKILL.md': 'b'.repeat(64) },
+      existingManifestRaw: JSON.stringify(wantManifest),
+    }).status,
+    'conflict',
+  );
+  // Present but unreadable as a skill (crash-truncated, symlinked, a plain file):
+  // conflict, so the rollback is never handed a directory it did not create.
+  assert.equal(
+    planSkillCapture({ wantManifest, srcShas, wikiPresent: true, wikiShas: null }).status,
+    'conflict',
+  );
+  // Identical content but no sidecar → conflict: install semantics would differ.
+  assert.equal(
+    planSkillCapture({
+      wantManifest,
+      srcShas,
+      wikiPresent: true,
+      wikiShas: { 'SKILL.md': 'a'.repeat(64) },
+      existingManifestRaw: null,
+    }).status,
+    'conflict',
+  );
+});
+
+// Everything that cannot round-trip through the wiki refuses the WHOLE skill: a
+// lossy wiki copy is what the far machine would install (design §2).
+test('a subtree that cannot round-trip refuses the whole skill, with a reason', () => {
+  withTmpHome((home) => {
+    const skills = join(home, '.claude', 'skills');
+    const mk = (name) => {
+      const d = join(skills, name);
+      mkdirSync(d, { recursive: true });
+      writeFileSync(join(d, 'SKILL.md'), `# ${name}\n`);
+      return d;
+    };
+    const link = mk('haslink');
+    symlinkSync('/etc/hosts', join(link, 'evil.md'));
+    const empty = mk('hasempty');
+    mkdirSync(join(empty, 'templates'));
+    const vcs = mk('hasvcs');
+    mkdirSync(join(vcs, '.git'));
+    writeFileSync(join(vcs, '.git', 'config'), '[core]\n');
+    const nosk = join(skills, 'noskill');
+    mkdirSync(nosk, { recursive: true });
+    writeFileSync(join(nosk, 'README.md'), '# not a skill\n');
+    mk('clean');
+
+    const { candidates, skipped } = scanSkillCandidates(join(home, '.claude'), new Set());
+    assert.deepEqual(
+      candidates.map((c) => c.file),
+      ['clean'],
+      'only the clean skill is capturable',
+    );
+    const reasons = Object.fromEntries(skipped.map((s) => [s.file, s.reason]));
+    assert.match(reasons.haslink, /not a regular file/);
+    assert.match(reasons.hasempty, /empty directory/);
+    assert.match(reasons.hasvcs, /VCS control directory/);
+    assert.match(reasons.noskill, /SKILL\.md/);
+  });
+});
+
+// The ceiling is what stops a vendored skill (gstack: 14k files / 1.1GB) from being
+// copied into a git vault. It must land BEFORE any file is read.
+test('a skill over the file ceiling is refused with the measured count', () => {
+  withTmpHome((home) => {
+    const d = join(home, '.claude', 'skills', 'huge');
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, 'SKILL.md'), '# huge\n');
+    for (let i = 0; i < 520; i++) writeFileSync(join(d, `f${i}.md`), 'x\n');
+    const { candidates, skipped } = scanSkillCandidates(join(home, '.claude'), new Set());
+    assert.equal(candidates.length, 0, 'an oversized skill is not a candidate');
+    assert.match(skipped[0].reason, /over 500 files/);
+  });
+});
+
+suite('capture: directory skills end-to-end (adopt + round-trip)');
+
+// Success criterion 1 + 2. The round-trip check MUST use a SECOND home: for skills the
+// capture source and the install target are the SAME directory, so re-syncing onto the
+// source only proves adopt is a no-op and would hide a broken far machine.
+test('captures a directory skill, adopts it, and reinstalls it on a second machine', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(join(src, 'references'), { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      writeFileSync(join(src, 'references', 'a.md'), 'ref a\n');
+
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home);
+      assert.equal(r.status, 0, r.stderr);
+
+      const wikiSkill = join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine');
+      assert.ok(existsSync(join(wikiSkill, 'SKILL.md')), 'SKILL.md stored in the wiki');
+      assert.ok(existsSync(join(wikiSkill, 'references', 'a.md')), 'subtree stored in the wiki');
+      const manifest = JSON.parse(
+        readFileSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine.manifest.json'), 'utf-8'),
+      );
+      assert.deepEqual(manifest, { type: 'skill', installName: 'mine' });
+
+      const owned = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'))
+        .extensions.claude['skills/mine'];
+      assert.equal(typeof owned, 'object', 'ownership is a nested per-relpath map');
+      assert.deepEqual(Object.keys(owned).sort(), ['SKILL.md', 'references/a.md']);
+
+      // Second machine: a fresh HOME pointed at the same wiki must reproduce the skill.
+      withTmpHome((home2) => {
+        const up = runWithHome('upgrade.mjs', ['--apply', `--hypo-dir=${hypoDir}`], home2);
+        assert.equal(up.status, 0, up.stderr);
+        const far = join(home2, '.claude', 'skills', 'mine');
+        assert.equal(readFileSync(join(far, 'SKILL.md'), 'utf-8'), '# mine\n');
+        assert.equal(readFileSync(join(far, 'references', 'a.md'), 'utf-8'), 'ref a\n');
+        assert.ok(
+          !existsSync(join(home2, '.claude', 'skills', 'hypo-ext-mine')),
+          'installs under the original name, not the wiki storage name',
+        );
+      });
+    });
+  });
+});
+
+test('--dry-run writes nothing to the wiki and does not adopt a skill', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all', '--dry-run'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(!existsSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine')));
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(!pkg.extensions.claude['skills/mine'], 'dry-run records no ownership');
+    });
+  });
+});
+
+// A second capture of the same skill is a no-op, not a conflict and not a rewrite.
+test('re-capturing an unchanged skill reports already, and a changed wiki copy refuses', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      assert.equal(runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home).status, 0);
+
+      // Now owned: the skill is no longer even a candidate.
+      const again = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, 'mine'], home);
+      assert.equal(again.status, 0, again.stderr);
+      assert.match(again.stdout, /no capturable candidate/);
+
+      // Drop the ownership record but leave a DIFFERENT wiki copy: capture must refuse
+      // rather than silently overwrite what the wiki already carries.
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      delete pkg.extensions.claude['skills/mine'];
+      writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+      writeFileSync(
+        join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine', 'SKILL.md'),
+        '# edited in the wiki\n',
+      );
+      const conflict = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, 'mine'], home);
+      assert.match(conflict.stdout, /different content/);
+      assert.equal(
+        readFileSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine', 'SKILL.md'), 'utf-8'),
+        '# edited in the wiki\n',
+        'the wiki copy is left alone',
+      );
+    });
+  });
+});
+
+// A bare name that matches both a command and a skill must not silently pick one
+// (codex design review W2-7).
+test('an ambiguous bare name is refused and nothing is captured', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      mkdirSync(join(home, '.claude', 'commands'), { recursive: true });
+      writeFileSync(join(home, '.claude', 'commands', 'mine.md'), '# cmd\n');
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# skill\n');
+
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, 'mine'], home);
+      assert.match(r.stdout, /ambiguous/);
+      assert.ok(!existsSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine')));
+      assert.ok(!existsSync(join(hypoDir, 'extensions', 'commands', 'hypo-ext-mine.md')));
+
+      // Qualifying by type resolves it.
+      const q = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, 'skills/mine'], home);
+      assert.equal(q.status, 0, q.stderr);
+      assert.ok(existsSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine', 'SKILL.md')));
+      assert.ok(
+        !existsSync(join(hypoDir, 'extensions', 'commands', 'hypo-ext-mine.md')),
+        'the command was not captured',
+      );
+    });
+  });
+});
+
+// The rollback ledger is authoritative. A refused write must not delete a wiki path the
+// run never touched: a DANGLING sidecar symlink is invisible to existsSync, the boundary
+// guard refuses the write, and the old rollback then unlinked the symlink anyway (codex
+// pre-commit BLOCKER, reproduced).
+test('a refused skill write never deletes a wiki path the run did not create', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      const sidecar = join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine.manifest.json');
+      symlinkSync(join(dir, 'no-such-target'), sidecar);
+
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, 'skills/mine'], home);
+      assert.match(r.stdout, /symlinked directory/);
+      assert.ok(lstatSync(sidecar).isSymbolicLink(), 'the pre-existing symlink is left alone');
+      assert.ok(
+        !existsSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine')),
+        'nothing was written',
+      );
+    });
+  });
+});
+
+// A file legitimately named `__proto__` must be tracked as an own key, not assigned
+// through the prototype setter (codex pre-commit CONCERN; forward-sync already guards
+// this, so capture must too or the two disagree about what was captured).
+test('a skill file named __proto__ is captured and owned like any other', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      writeFileSync(join(src, '__proto__'), 'polluted?\n');
+
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(existsSync(join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine', '__proto__')));
+      const owned = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'))
+        .extensions.claude['skills/mine'];
+      assert.deepEqual(Object.keys(owned).sort(), ['SKILL.md', '__proto__']);
+    });
+  });
+});
+
+// Success criterion 10: uninstall reaches a captured skill through its SHA-map key.
+test('uninstall removes a captured skill and preserves an unowned file inside it', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(join(src, 'references'), { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      writeFileSync(join(src, 'references', 'a.md'), 'ref a\n');
+      assert.equal(runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home).status, 0);
+
+      writeFileSync(join(src, 'notes.md'), 'my own notes\n'); // unowned
+      const r = runWithHome('uninstall.mjs', ['--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+      assert.ok(!existsSync(join(src, 'SKILL.md')), 'owned SKILL.md removed');
+      assert.ok(!existsSync(join(src, 'references', 'a.md')), 'owned subtree file removed');
+      assert.equal(readFileSync(join(src, 'notes.md'), 'utf-8'), 'my own notes\n', 'unowned kept');
     });
   });
 });


### PR DESCRIPTION
## Summary / 요약

**EN** — A Claude Code skill is a directory (`SKILL.md` + a subtree), not a flat file. The previous slice taught forward-sync that; this one closes the loop. `hypomnema capture` can now pull a skill authored the normal way under `~/.claude/skills/<name>/` into the wiki as `extensions/skills/hypo-ext-<name>/` plus a sidecar manifest, and forward-sync installs it on another machine under its original name.

What lands in the wiki is exactly what the far machine installs, so the gate sits at the wiki door. A subtree holding anything that cannot round-trip (a symlink, a hardlink, an empty directory, a VCS control dir, a reserved manifest name) refuses the **whole** skill rather than capturing a lossy subset. Cumulative ceilings (500 files / 5 MiB, measured from `lstat` sizes during the walk) abort early, which is what keeps a vendored skill carrying its own `node_modules` out of a git-tracked vault. Measured on the real `~/.claude/skills`: `gstack` is 14,311 files / 1.1GB and is refused in 61ms.

**KO** — Claude Code skill은 flat 파일이 아니라 디렉터리(`SKILL.md` + 서브트리)다. 앞 슬라이스가 forward-sync에 그걸 가르쳤고, 이번이 역방향을 닫는다. `~/.claude/skills/<name>/`에 보통 방식으로 만든 skill을 위키 `extensions/skills/hypo-ext-<name>/` + sidecar manifest로 끌어오고, 다른 머신에서 원래 이름으로 설치된다.

위키에 들어간 것이 곧 far machine이 설치하는 것이라, 게이트를 위키 입구에 둔다. 라운드트립 불가 파일(심링크·하드링크·빈 디렉터리·VCS 디렉터리·예약 manifest명)이 하나라도 있으면 부분 capture 대신 **skill 통째** 거절한다. ceiling(500 파일 / 5 MiB, walk 중 `lstat` 크기로 누적)은 early-abort라 벤더 skill이 git 볼트에 들어오지 못한다. 실측: `gstack`은 14,311 파일 / 1.1GB이고 61ms에 거절된다.

## Design / 설계

Spec: `specs/skills-capture/spec.md`. ADR 0064 (wiki).

- **First wiki deletion path.** Rollback removes only the paths this run actually created, deepest-first, never a tree wipe. The skill root is claimed with an exclusive `mkdir`, every mutation is re-checked against the vault root (rooting the symlink walk at the type directory would `lstat` straight through a symlinked `extensions/`), and the temp file is opened `O_EXCL` so a planted symlink cannot be written through. / **위키 안에서 지우는 첫 경로.** 롤백은 이번 실행이 만든 경로만 역순으로 지운다.
- **Adopt is verified by SHA per relpath**, not key presence: a skill's recorded value is a nested map, and `copyOne` returns the old SHA on its drift path, so a presence check would let a lossy install be owned. / **adopt 검증은 relpath별 SHA 일치**로 한다.
- **Shared walker.** `walkSkillSubtree` is now exported and takes `{strict, maxFiles, maxBytes}`; defaults are unchanged, so forward-sync behaves exactly as before. / **walker 공유.** 기본값 불변이라 forward-sync 무영향.
- **Not in this PR:** the executable bit is not carried by sync (a pre-existing forward-sync gap, tracked separately). Capture warns when a captured skill holds executable files. / **이 PR 밖:** 실행 비트 보존(선재 갭, 별도 추적). capture가 경고만 낸다.

## Verification / 검증

- 12 new tests (1367 passed, 0 failed). Each regression test was verified by **disabling the fix and confirming it fails** (strict off, ceiling lifted, ambiguity gate removed, rollback fix reverted). / 신규 테스트 12건. 각 회귀 테스트는 수정을 껐을 때 실제로 실패하는지로 검증했다.
- Live QA against the real `~/.claude/skills`: `gstack` refused (61ms), symlinked satellite skills refused, `commit` (single file) and `teams` (3-level subtree + 2 executables) captured, then reinstalled on a **second HOME** and diffed byte-for-byte against the source. / 실볼트 QA: 두 번째 HOME에 재설치해 원본과 바이트 동일 확인.
- codex review: design (2 workers, both BLOCKER → hardened) and pre-commit (2 workers, 1 BLOCKER + 3 CONCERN → all fixed). The BLOCKER: rollback could delete a dangling sidecar symlink it never wrote; the ledger is now the sole authority. / codex 2단계 검토, BLOCKER 포함 전건 수정.

## Changelog

- EN: Reverse-capture now supports directory skills: `hypomnema capture` pulls `~/.claude/skills/<name>/` into the wiki with its subtree, refusing anything that cannot round-trip and capping the size, so skills sync across machines under their original name.
- KO: 역방향 capture가 디렉터리 skill을 지원한다. `hypomnema capture`가 `~/.claude/skills/<name>/`를 서브트리째 위키로 끌어오고, 라운드트립 불가 항목은 거절하며 크기 상한을 둔다. skill이 원래 이름으로 머신 간 동기화된다.

## Checklist

- [x] Tests pass (1367 passed, 0 failed)
- [x] Lint / smoke gates pass
- [x] Docs updated (`commands/capture.md`)
- [x] codex cross-review (design + pre-commit)