### PR TITLE
ci(workflows): default every workflow to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege by default. A job that needs more must declare its own
+# `permissions:` block, which REPLACES this default rather than merging with it.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+# Least privilege by default. A job that needs more must declare its own
+# `permissions:` block, which REPLACES this default rather than merging with it.
+permissions:
+  contents: read
+
 jobs:
   verify-pages:
     # Checks verify_by / verify_by_date frontmatter fields only.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ on:
   # BEFORE a real tag depends on it. Use it after rotating NPM_TOKEN.
   workflow_dispatch:
 
+# Least privilege by default. Both jobs below declare their own `permissions:`
+# block, which REPLACES this default rather than merging with it; this line only
+# governs any job added later that forgets to.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to npm


### PR DESCRIPTION
# English

## What changed

Every workflow now declares a top-level `permissions: contents: read`.

- `ci.yml` and `nightly.yml` had no `permissions:` block at all, so their `GITHUB_TOKEN` fell back to whatever the repository default grants.
- `release.yml` already scoped both of its jobs, so its new top-level default is purely defensive.

## Why

Least privilege for the automatic `GITHUB_TOKEN`. A workflow with no declared permissions inherits the repository-wide default, which can be read/write depending on the org or repo setting. If a future job (or a compromised action pulled in as a dependency) runs under one of these workflows, it should not be able to push to the repo, open a release, or comment on a PR just because nobody thought to restrict it.

## How

Neither `ci.yml` (9 jobs) nor `nightly.yml` (2 jobs) touches the token: no `gh` CLI, no `git push`, no `secrets.*`, no artifact upload, no cache action, no dependency submission. `contents: read` is enough for `actions/checkout` and the npm scripts they run.

`release.yml` is the one workflow that needs more, and it already asks for it per job: `publish` declares `contents: write` (for `gh release create`) plus `id-token: write` (for `npm publish --provenance`), and `publish-precheck` declares `contents: read`. A job-level `permissions:` block *replaces* the workflow-level default rather than merging with it, so adding the restrictive default cannot silently downgrade the publish job. The top-level line only governs a job someone adds later and forgets to scope. Each file carries a short comment stating that replace-not-merge rule, since assuming the opposite is the easy way to get this wrong.

## Manual verification

No hooks, templates, or init flow touched. Verified locally:

```
$ npx js-yaml .github/workflows/ci.yml       # YAML OK
$ npx js-yaml .github/workflows/nightly.yml  # YAML OK
$ npx js-yaml .github/workflows/release.yml  # YAML OK
$ grep -nE "GITHUB_TOKEN|GH_TOKEN|secrets\.|gh [a-z]|git push|actions/(cache|upload|download)" \
    .github/workflows/ci.yml .github/workflows/nightly.yml
(no matches)
$ npm test    # 1368 passed, 0 failed
```

The release path itself is only exercisable on a `v*` tag push; it is unchanged by construction, since both of its jobs keep their existing per-job blocks.

## Migration notes

None.

---

# 한국어

## 변경 내용

모든 워크플로가 최상단에 `permissions: contents: read`를 선언합니다.

- `ci.yml`과 `nightly.yml`에는 `permissions:` 블록이 아예 없어서 `GITHUB_TOKEN`이 레포 기본값을 그대로 받고 있었습니다.
- `release.yml`은 이미 두 잡 모두 권한을 명시하고 있어, 새로 붙는 최상단 기본값은 방어적 의미입니다.

## 이유

자동 발급되는 `GITHUB_TOKEN`에 최소 권한을 주기 위해서입니다. 권한을 선언하지 않은 워크플로는 레포 전역 기본값을 물려받는데, 이 값은 조직·레포 설정에 따라 read/write일 수 있습니다. 나중에 잡이 추가되거나 의존성으로 딸려온 액션이 손상됐을 때, 아무도 제한을 걸어두지 않았다는 이유만으로 레포에 push하거나 릴리스를 만들거나 PR에 코멘트를 달 수 있어서는 안 됩니다.

## 방법

`ci.yml`(9잡)과 `nightly.yml`(2잡)은 토큰을 전혀 쓰지 않습니다. `gh` CLI도, `git push`도, `secrets.*`도, artifact 업로드도, cache 액션도, dependency submission도 없습니다. `actions/checkout`과 npm 스크립트 실행에는 `contents: read`면 충분합니다.

더 큰 권한이 필요한 워크플로는 `release.yml` 하나뿐이고, 이미 잡별로 요청하고 있습니다. `publish` 잡은 `contents: write`(`gh release create`용)와 `id-token: write`(`npm publish --provenance`용)를, `publish-precheck` 잡은 `contents: read`를 선언합니다. 잡 레벨 `permissions:` 블록은 워크플로 레벨 기본값과 병합되는 게 아니라 **대체**하므로, 제한적인 기본값을 추가해도 publish 잡의 권한이 조용히 깎이지 않습니다. 최상단 선언은 나중에 누군가 잡을 추가하면서 권한 지정을 잊었을 때만 작동합니다. 이 대체 규칙을 반대로 짐작하는 게 흔한 실수라, 파일마다 짧은 주석으로 명시했습니다.

## 수동 검증

훅·템플릿·init 흐름은 건드리지 않았습니다. 로컬 확인 결과입니다.

```
$ npx js-yaml .github/workflows/ci.yml       # YAML OK
$ npx js-yaml .github/workflows/nightly.yml  # YAML OK
$ npx js-yaml .github/workflows/release.yml  # YAML OK
$ grep -nE "GITHUB_TOKEN|GH_TOKEN|secrets\.|gh [a-z]|git push|actions/(cache|upload|download)" \
    .github/workflows/ci.yml .github/workflows/nightly.yml
(매치 없음)
$ npm test    # 1368 passed, 0 failed
```

릴리스 경로 자체는 `v*` 태그 push에서만 실행됩니다. 두 잡 모두 기존 잡별 권한 블록을 그대로 유지하므로 구조상 변화가 없습니다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: None (CI plumbing only, no user-visible behavior change)
- KO: None (CI 설정 변경, 사용자에게 보이는 동작 변화 없음)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (N/A)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible (N/A, internal)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
