### PR TITLE
docs(readme): add a "For AI assistants" section in both languages

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -393,6 +393,20 @@ E. 멈춘 프로젝트 재개.
 
 ---
 
+## AI 어시스턴트에게
+
+Claude(또는 다른 코딩 에이전트)로서 Hypomnema 위키를 운영한다면 아래가 기본 규칙입니다.
+
+위키가 단일 SoT입니다. 사용자가 기억해 달라고 한 것은 전부 위키 루트 아래 마크다운으로 있고, 기억에 의존해 답하기 전에 그것부터 읽습니다. 한 프로젝트의 배경은 `projects/<name>/hot.md`에, 다음에 할 일은 `projects/<name>/session-state.md`에 있으며 `/hypo:resume`이 둘 다 불러옵니다. 위키 루트의 `hot.md`는 다른 파일입니다. 어떤 프로젝트가 활성인지 가리키는 포인터 테이블입니다.
+
+그 상태를 위키 밖에 또 두지 마세요. `MEMORY.md`와 `~/.claude/CLAUDE.md`의 `<learned_behaviors>` 블록은 당신의 메모리처럼 보이지만, Hypomnema가 `pages/feedback/`에서 뽑아내는 단방향 projection입니다. 교정은 `/hypo:feedback`으로 적고 동기화가 다시 만들게 두면 됩니다. projection을 손으로 고치면 다음 동기화가 그것을 병합하지 않고 conflict로 멈춥니다. 어느 쪽이 진실인지 판단할 근거가 없기 때문이고, 그때부터 feedback 페이지로 되돌려 정리하는 일은 당신 몫이 됩니다. 위키 사실을 당신만 보는 곳에 챙겨두면 사용자의 다른 머신에는 아예 닿지 않습니다.
+
+`sources/`는 불변입니다. 그 아래는 무엇도 고치지 않습니다. 대신 `pages/`로 합성하고 출처를 링크로 되짚습니다.
+
+운영 절차는 위키 안에 함께 깔리므로 따로 받아올 필요가 없습니다. 위키 루트의 `hypo-guide.md`가 운영 가이드이고, `SCHEMA.md`가 페이지 타입과 frontmatter를 정의하며, `hypo-help.md`가 명령어 목록입니다. 세션에서 첫 위키 작업을 할 때 `SCHEMA.md`, `hypo-guide.md` 순으로 읽습니다.
+
+---
+
 ## 문서
 
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md): 내부 구조, 컴포넌트 맵, 데이터 흐름

--- a/README.md
+++ b/README.md
@@ -393,6 +393,20 @@ No external services. No API keys. No vector databases.
 
 ---
 
+## For AI assistants
+
+If you are Claude (or another coding agent) operating a Hypomnema wiki, these are the ground rules.
+
+The wiki is the single source of truth. Everything the user asked you to remember about their work is markdown under the wiki root, and you read it before answering from recollection. `projects/<name>/hot.md` holds the background for one project, `projects/<name>/session-state.md` holds what to do next, and `/hypo:resume` loads both. The `hot.md` at the wiki root is a different file: a pointer table of which projects are active.
+
+Keep no second copy of that state. `MEMORY.md` and the `<learned_behaviors>` block inside `~/.claude/CLAUDE.md` look like your own memory, but they are one-way projections that Hypomnema derives from `pages/feedback/`. Record a correction with `/hypo:feedback` and let the sync regenerate them. Edit a projection by hand and the next sync stops on it as a conflict instead of merging it, because nothing can tell which side is now the truth; reconciling it back into the feedback page becomes your job. And a wiki fact you stash somewhere only you can see never reaches the user's other machines at all.
+
+Captured sources are immutable. Never edit anything under `sources/`. Synthesize into `pages/` instead, and link back to the source.
+
+The operating procedure ships inside the wiki, so you do not have to fetch anything. `hypo-guide.md` at the wiki root is the operations guide, `SCHEMA.md` defines the page types and frontmatter, and `hypo-help.md` lists the commands. Read `SCHEMA.md` then `hypo-guide.md` on your first wiki task of a session.
+
+---
+
 ## Docs
 
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md): internals, component map, data flows


### PR DESCRIPTION
# English

## What changed

A new `## For AI assistants` section in `README.md` and `README.ko.md`, placed just before `## Docs`.

## Why

Hypomnema is a wiki that Claude operates, but the README addresses a human reader. An agent arriving at a wiki for the first time has no stated ground rules, and the failure mode that costs the most is the quiet one: it keeps wiki state in its own memory, or hand-edits a projection, and the source of truth forks.

## How

The section states four things and routes onward:

The wiki is the source of truth, and `/hypo:resume` loads `projects/<name>/hot.md` plus `projects/<name>/session-state.md`. (Root `hot.md` is called out explicitly as a different file, the active-project pointer table, since the name invites the confusion.)

`MEMORY.md` and the `<learned_behaviors>` block in `~/.claude/CLAUDE.md` are one-way projections derived from `pages/feedback/`, not a second store to write into. The section is precise about what happens if an agent edits one anyway: `feedback-sync` detects the managed-block hash mismatch, exits 3, and refuses to merge, and reconciling the edit back into the feedback page falls to whoever made it. It does not claim the sync silently overwrites, because it does not.

`sources/` is immutable; synthesis goes to `pages/`.

The operating procedure already ships inside the wiki (`hypo-guide.md`, `SCHEMA.md`, `hypo-help.md` at the wiki root, installed by `init`), so no fetch is needed.

No `AGENTS.md` link: that file does not exist in this repo, and bundling an agent guide is a separate change. Everything the section links to was checked to resolve.

## Manual verification

Docs only. No hooks, templates, or init flow touched.

```
$ npm test                  # 1368 passed, 0 failed
$ npm run check:readme      # both READMEs mention version 1.6.2
$ npm run check:tracker-ids # no wiki-internal tracker ids found
```

Every factual claim in the section was checked against the code rather than written from memory:

- `scripts/feedback-sync.mjs`: projections derive from `pages/feedback/`; a managed-block hash mismatch is a conflict (exit 3, no auto-merge), and the import path writes the hand-edited content to a draft under `pages/feedback/_drafts/` for reconciliation.
- `scripts/resume.mjs`: `/hypo:resume` reads `projects/<name>/session-state.md` and `projects/<name>/hot.md`.
- `templates/hypo-guide.md:51`: "never edit `sources/`".
- `scripts/init.mjs:885-890`: `SCHEMA.md`, `hypo-guide.md`, `hypo-help.md` are installed at the wiki root.

## Migration notes

None.

---

# 한국어

## 변경 내용

`README.md`와 `README.ko.md`에 `## For AI assistants`(한글판 `## AI 어시스턴트에게`) 섹션을 `## Docs` 바로 앞에 추가했습니다.

## 이유

Hypomnema는 Claude가 운영하는 위키인데 README는 사람 독자를 향해 쓰여 있습니다. 위키를 처음 만난 에이전트에게는 지켜야 할 기본 규칙이 명시되어 있지 않고, 그 대가가 가장 큰 실패는 조용히 일어납니다. 위키 상태를 자기 메모리에 따로 들고 있거나 projection을 손으로 고치면 SoT가 갈라집니다.

## 방법

섹션은 네 가지를 밝히고 이어질 문서로 안내합니다.

위키가 SoT이고, `/hypo:resume`이 `projects/<name>/hot.md`와 `projects/<name>/session-state.md`를 불러옵니다. 루트 `hot.md`는 이름 때문에 헷갈리기 쉬워서, 활성 프로젝트를 가리키는 포인터 테이블이라는 점을 따로 짚었습니다.

`MEMORY.md`와 `~/.claude/CLAUDE.md`의 `<learned_behaviors>` 블록은 `pages/feedback/`에서 파생된 단방향 projection이지, 따로 써넣을 두 번째 저장소가 아닙니다. 그럼에도 에이전트가 고쳤을 때 무슨 일이 벌어지는지도 정확히 적었습니다. `feedback-sync`가 managed block 해시 불일치를 감지해 exit 3으로 멈추고 병합을 거부하며, 그 편집을 feedback 페이지로 되돌려 정리하는 일은 고친 사람 몫이 됩니다. 동기화가 조용히 덮어쓴다고 쓰지 않았습니다. 실제로 그러지 않기 때문입니다.

`sources/`는 불변이고, 합성 결과는 `pages/`로 갑니다.

운영 절차는 이미 위키 안에 함께 깔립니다(`init`이 위키 루트에 설치하는 `hypo-guide.md`, `SCHEMA.md`, `hypo-help.md`). 따로 받아올 것이 없습니다.

`AGENTS.md`는 링크하지 않았습니다. 이 레포에 없는 파일이고, 에이전트 가이드 동봉은 별개 작업입니다. 섹션이 가리키는 대상은 전부 실재하는지 확인했습니다.

## 수동 검증

문서만 변경했습니다. 훅·템플릿·init 흐름은 건드리지 않았습니다.

```
$ npm test                  # 1368 passed, 0 failed
$ npm run check:readme      # 두 README 모두 버전 1.6.2 언급
$ npm run check:tracker-ids # 위키 내부 tracker id 없음
```

섹션의 모든 사실 주장은 기억이 아니라 코드로 확인했습니다.

- `scripts/feedback-sync.mjs`: projection은 `pages/feedback/`에서 파생되고, managed block 해시 불일치는 conflict(exit 3, 자동 병합 없음)이며, import 경로가 손으로 고친 내용을 `pages/feedback/_drafts/` 아래 draft로 옮겨 사람이 정리하게 합니다.
- `scripts/resume.mjs`: `/hypo:resume`은 `projects/<name>/session-state.md`와 `projects/<name>/hot.md`를 읽습니다.
- `templates/hypo-guide.md:51`: "never edit `sources/`".
- `scripts/init.mjs:885-890`: `SCHEMA.md`, `hypo-guide.md`, `hypo-help.md`가 위키 루트에 설치됩니다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: README now has a "For AI assistants" section stating the ground rules an agent operating the wiki needs: the wiki is the source of truth, `MEMORY.md` and `<learned_behaviors>` are one-way projections of `pages/feedback/`, and `sources/` is immutable (#190)
- KO: README에 위키를 운영하는 에이전트를 위한 "For AI assistants" 섹션을 추가했습니다. 위키가 SoT이고, `MEMORY.md`와 `<learned_behaviors>`는 `pages/feedback/`의 단방향 projection이며, `sources/`는 불변이라는 기본 규칙을 명시합니다 (#190)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
