### PR TITLE
fix(proposal-store): supersede only the writing session's own parked proposal

### DIFF
--- a/hooks/proposal-store.mjs
+++ b/hooks/proposal-store.mjs
@@ -22,13 +22,24 @@
 //      whole target, which for an append-only history file would drop every other
 //      entry. crystallize filters `kind: 'append'` out before it ever calls here.
 //
-//   2. One artifact per target. Each close re-derives the same drifted target, so
-//      without supersede a fresh random id would accumulate a stale artifact on
-//      every close and inflate the pending count. writeProposal writes the new
-//      artifact durably FIRST, then deletes any older same-target sibling — so a
-//      crash between the two leaves an extra artifact (harmless, superseded next
-//      time), never zero. A same-target close that is byte-identical reuses the
-//      existing id instead of writing at all (idempotent).
+//   2. One artifact per (target, SESSION). Each close re-derives the same drifted
+//      target, so without supersede a fresh random id would accumulate a stale
+//      artifact on every close and inflate the pending count. But supersede is
+//      scoped to the writing session: a LATER close only replaces that same
+//      session's own earlier attempt at the target. Two concurrent sessions that
+//      both withhold bytes for one target keep BOTH artifacts, because each holds
+//      a distinct payload and this artifact is its only durable copy (crystallize
+//      never puts withheld bytes on disk and drops them from its reported shape).
+//      Deleting across sessions would silently destroy the first session's work,
+//      which is exactly the clobber this gate exists to prevent. A session id we
+//      cannot match (null on either side) supersedes nothing: never delete a
+//      payload we cannot prove is our own earlier attempt.
+//      writeProposal writes the new artifact durably FIRST, then deletes the older
+//      same-session sibling — so a crash between the two leaves an extra artifact
+//      (harmless, superseded next time), never zero. A same-target close that is
+//      byte-identical reuses the existing id instead of writing at all (idempotent,
+//      and session-agnostic: identical bytes are one payload, so reusing another
+//      session's artifact drops nothing).
 //
 // Everything is best-effort on the read side (a malformed artifact is skipped, not
 // fatal) and atomic on the write side (tmp+rename), mirroring base-store.
@@ -261,8 +272,19 @@ export function writeProposal(hypoDir, fields) {
   atomicWrite(path, JSON.stringify(body, null, 2));
 
   const supersedeWarnings = [];
+  const mine = body.sessionId;
   for (const p of sameTarget) {
     if (p.id === id) continue; // never delete what we just wrote
+    // Same target is NOT enough: a sibling written by a DIFFERENT session holds
+    // that session's only copy of its withheld bytes (invariant 2). Supersede
+    // only our own earlier attempt, and only when both ids are known.
+    //
+    // `typeof === 'string'` before comparing, never String(p.sessionId): the body
+    // is hand-editable and listProposals validates only `id`, so a field like
+    // `["s-A"]` would coerce to a matching primitive. writeProposal always stores
+    // a string, so a non-string id belongs to no session we can identify — and an
+    // unidentifiable owner is exactly the case that must not be deleted.
+    if (mine === null || typeof p.sessionId !== 'string' || p.sessionId !== mine) continue;
     if (!deleteProposal(hypoDir, p.id)) {
       supersedeWarnings.push(`could not supersede stale proposal ${p.id} for ${target}`);
     }

--- a/scripts/proposal.mjs
+++ b/scripts/proposal.mjs
@@ -475,7 +475,30 @@ export async function applyProposal({ hypoDir, id }, { isTTY, prompt, stdout, st
   }
 
   out.write(`✓ applied proposal ${id} to ${shownTarget}\n`);
-  return { ok: true, code: 0, id, target: proposal.target, warned: decision.warned };
+
+  // (13) A target can carry one parked payload per session (plus any whose owner is
+  // unidentifiable), so applying this id may leave another proposal for the same
+  // file still pending. Say so, or the human reads "✓ applied" as done and meets the
+  // leftover only via the next pending count. Never auto-delete it: destroying a
+  // payload nobody reviewed is the clobber this store exists to prevent.
+  const siblings = listProposals(hypoDir).filter((p) => p.target === proposal.target);
+  if (siblings.length > 0) {
+    const ids = siblings.map((p) => p.id).join(', ');
+    err.write(
+      `⚠️  ${siblings.length} other proposal(s) still target ${shownTarget}: ${ids}\n` +
+        `    The write above changed that file, so each one now needs a fresh look. ` +
+        `\`hypomnema proposal apply <id>\` re-reads the file and diffs against it; discard the ones you do not want.\n`,
+    );
+  }
+
+  return {
+    ok: true,
+    code: 0,
+    id,
+    target: proposal.target,
+    warned: decision.warned,
+    siblingsPending: siblings.length,
+  };
 }
 
 /**

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -3612,6 +3612,106 @@ test('FEAT-11 T6: proposal-store round-trip, supersede-by-target, idempotent reu
   }
 });
 
+// Supersede is scoped to the writing session. Two concurrent sessions that both
+// withhold bytes for ONE target each hold a distinct payload, and the artifact is
+// its only durable copy (crystallize never puts withheld bytes on disk). Deleting
+// across sessions destroys the first session's work — the very clobber this gate
+// exists to prevent. Regression for the target-only supersede that shipped in T6.
+test('FEAT-11 T6: a concurrent session does not supersede another session proposal', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-ps-'));
+  try {
+    // Session A and session B both drift off the same base for the same target.
+    const a = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'cX',
+      proposedContent: 'A-BYTES',
+      sessionId: 's-A',
+      device: 'dev1',
+    });
+    const b = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'cX',
+      proposedContent: 'B-BYTES',
+      sessionId: 's-B',
+      device: 'dev1',
+    });
+
+    assert.notEqual(b.id, a.id, 'a different session mints its own artifact');
+    assert.equal(psListProposals(dir).length, 2, "session B must not delete session A's payload");
+    assert.equal(psReadProposal(dir, a.id)?.proposedContent, 'A-BYTES', "A's bytes survive");
+    assert.equal(psReadProposal(dir, b.id)?.proposedContent, 'B-BYTES', "B's bytes survive");
+
+    // Session A re-closes with new bytes: it replaces its OWN earlier attempt only.
+    const a2 = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'cY',
+      proposedContent: 'A-BYTES-2',
+      sessionId: 's-A',
+      device: 'dev1',
+    });
+    assert.equal(psReadProposal(dir, a.id), null, "A's own earlier attempt is superseded");
+    assert.equal(psReadProposal(dir, b.id)?.proposedContent, 'B-BYTES', "B survives A's re-close");
+    assert.equal(psListProposals(dir).length, 2, 'one artifact per (target, session)');
+    assert.equal(psReadProposal(dir, a2.id)?.proposedContent, 'A-BYTES-2');
+
+    // An unknown session id proves ownership of nothing, so it deletes nothing.
+    const anon = psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'cZ',
+      proposedContent: 'ANON',
+      sessionId: null,
+      device: 'dev1',
+    });
+    assert.equal(psListProposals(dir).length, 3, 'a null session id supersedes nothing');
+    assert.equal(psReadProposal(dir, anon.id)?.proposedContent, 'ANON');
+    assert.equal(psReadProposal(dir, a2.id)?.proposedContent, 'A-BYTES-2');
+    assert.equal(psReadProposal(dir, b.id)?.proposedContent, 'B-BYTES');
+
+    // The artifact body is hand-editable and only its `id` is validated, so a
+    // non-string owner must not coerce into a match: `["s-B"]` stringifies to
+    // "s-B" and would otherwise let session s-B delete it.
+    const spoofPath = psReadProposal(dir, b.id) && join(psProposalsDir(dir), `${b.id}.json`);
+    const spoofBody = JSON.parse(readFileSync(spoofPath, 'utf-8'));
+    spoofBody.sessionId = ['s-B'];
+    writeFileSync(spoofPath, JSON.stringify(spoofBody, null, 2));
+    psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'cW',
+      proposedContent: 'B-BYTES-3',
+      sessionId: 's-B',
+      device: 'dev1',
+    });
+    assert.equal(
+      psReadProposal(dir, b.id)?.proposedContent,
+      'B-BYTES',
+      'a non-string owner is unidentifiable, so it is never superseded',
+    );
+
+    // The reverse of the null case above: a KNOWN session writing the same target
+    // must not sweep up the anonymous artifact either. Ownership runs both ways.
+    psWriteProposal(dir, {
+      target: 'hot.md',
+      baseHash: 'b1',
+      currentAtProposalHash: 'cV',
+      proposedContent: 'A-BYTES-3',
+      sessionId: 's-A',
+      device: 'dev1',
+    });
+    assert.equal(
+      psReadProposal(dir, anon.id)?.proposedContent,
+      'ANON',
+      'a named session does not supersede an artifact with no owner',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('FEAT-11 T6: readProposal/deleteProposal reject path-traversal ids (no escape from the store)', () => {
   const dir = mkdtempSync(join(tmpdir(), 'hypo-ps-'));
   try {
@@ -4026,6 +4126,63 @@ test('FEAT-11 T7: no hook imports the apply path (no unattended auto-apply)', ()
     `hooks must never reach the apply path (fires unattended): ${importers.join(', ')}`,
   );
 });
+
+// Applying one id no longer empties the target's queue: a concurrent session's
+// proposal for the same file survives (one artifact per (target, session)), and the
+// write we just made drifted it. A silent "✓ applied" would read as done.
+await testAsync(
+  'FEAT-11 T7: apply warns that a concurrent session proposal still targets the file, and keeps it',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hypo-t7-'));
+    try {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      const target = join(dir, 'pages', 'note.md');
+      writeFileSync(target, 'ORIGINAL');
+      const rel = join('pages', 'note.md');
+      const mine = psWriteProposal(dir, {
+        target: rel,
+        baseHash: null,
+        currentAtProposalHash: bsHashContent('ORIGINAL'),
+        proposedContent: 'FROM SESSION A',
+        sessionId: 's-A',
+        device: 'd7',
+      });
+      const theirs = psWriteProposal(dir, {
+        target: rel,
+        baseHash: null,
+        currentAtProposalHash: bsHashContent('ORIGINAL'),
+        proposedContent: 'FROM SESSION B',
+        sessionId: 's-B',
+        device: 'd7',
+      });
+
+      const err = capStream();
+      const r = await applyProposal(
+        { hypoDir: dir, id: mine.id },
+        {
+          isTTY: true,
+          stdout: capStream(),
+          stderr: err,
+          prompt: async () => `apply ${mine.id}`,
+          now: () => '2026-07-12T00:00:00.000Z',
+        },
+      );
+
+      assert.equal(r.ok, true, `apply should succeed: ${JSON.stringify(r)}`);
+      assert.equal(r.siblingsPending, 1, "session B's proposal is still pending");
+      assert.equal(readFileSync(target, 'utf-8'), 'FROM SESSION A', 'the applied bytes landed');
+      assert.equal(
+        psReadProposal(dir, theirs.id)?.proposedContent,
+        'FROM SESSION B',
+        'apply never deletes another session payload',
+      );
+      assert.match(err.text(), /still target/, 'the leftover is announced, not silent');
+      assert.ok(err.text().includes(theirs.id), 'the warning names the leftover id');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
 
 await testAsync(
   'FEAT-11 T7: non-TTY apply is refused: target bytes unchanged, proposal preserved',


### PR DESCRIPTION
# English

## What changed

`writeProposal` now supersedes only the writing session's own parked proposal for a target, instead of every proposal that happens to share that target.

## Why

The write=proposal gate (unreleased, shipping in v1.7.0) destroyed the thing it exists to protect.

A parked artifact under `.cache/proposals/` is the **only** durable copy of a session's withheld overwrite bytes: crystallize deliberately does not put them on disk, and drops `proposedContent` from its reported shape (`scripts/crystallize.mjs:1502-1510`). But `writeProposal` selected supersede candidates by `target` alone and then deleted every same-target sibling. So:

1. Session A and Session B both observe base V0 for the same overwrite target.
2. The file drifts to Vx (some other writer).
3. A closes: its bytes are withheld and parked as `P_A`.
4. B closes: its bytes are withheld and parked as `P_B`.
5. `writeProposal` deletes `P_A` as an "older same-target artifact".

A's work is now gone: not on disk (withheld by design), never committed, no longer in the store. The gate whose whole selling point is "we do not clobber the other writer" was clobbering the other writer.

The store's invariant #2 ("one artifact per target") was reasoned for a single session re-closing repeatedly, to keep stale artifacts from inflating the pending count. The code never discriminated by session, so the same line also ate concurrent sessions' payloads.

## How

Supersede is scoped to the writing session. An existing same-target artifact is deleted only when its stored `sessionId` is a string equal to the incoming one.

An owner we cannot identify supersedes nothing. That covers a null id on either side, and a hand-edited non-string that would otherwise coerce into a match: the artifact body is plaintext and `listProposals` validates only `id`, so a field like `["s-A"]` would pass a `String()` comparison. Comparing with `typeof === 'string'` costs nothing (`writeProposal` always stores a primitive string) and closes that door. An unidentifiable owner is exactly the payload that must not be deleted.

Same-session re-closes still collapse, so the churn the invariant was written for is unaffected. Idempotent reuse stays session-agnostic on purpose: identical bytes against an identical base and disk state are one payload, so reusing another session's identical artifact drops nothing.

Keying on `sessionId` is not new ground. The base-store already keys each observed-base snapshot on it (`.cache/sessions/<sessionId>/base.json`), so the guard rests on the same assumption the rest of FEAT-11 already rests on.

Invariant #2 is now "one artifact per (target, session)". The pending count can therefore exceed 1 for a file, which is honest: there really are N withheld payloads nobody has reviewed. `proposal list` already prints `sessionId` and `device` per item, so they can be told apart. And since applying one id can leave another parked against a file the apply just changed, `apply` now names the leftovers on stderr instead of letting a silent `✓ applied` read as done. It never deletes them.

## Manual verification

```
$ npm test    # 1370 passed, 0 failed
```

The regression was checked the way this repo requires, by turning the fix off rather than trusting a green run: reverting the single guard line makes exactly the new test fail (`session B must not delete session A's payload`, 1368 passed / 1 failed), and restoring it returns the suite to green.

New tests pin: two sessions with different bytes for one target both survive; a session re-closing supersedes only its own earlier attempt; a null owner deletes nothing and is itself never deleted by a named session; a non-string owner does not coerce into a match; and `apply` warns about, and preserves, a concurrent session's leftover proposal.

Reviewed by codex at the design stage (endorsed session-scoped supersede over never-supersede and over content-addressed storage) and again pre-commit (verdict NIT; both nits are folded in: the apply warning no longer overclaims that leftovers come from other sessions or that they necessarily differ from disk, and the two missing test cases were added).

## Migration notes

None. Artifacts written before this change keep working; an older one whose `sessionId` matches the writing session is still superseded normally.

---

# 한국어

## 변경 내용

`writeProposal`이 이제 target이 같다고 다 지우지 않고, **그 target에 대한 자기 세션의 이전 시도만** supersede합니다.

## 이유

write=proposal 게이트(미출하, v1.7.0에 나갈 예정)가 자기가 지키려던 것을 없애고 있었습니다.

`.cache/proposals/`에 park된 아티팩트는 그 세션이 withhold한 overwrite 바이트의 **유일한** durable 사본입니다. crystallize는 그 바이트를 일부러 디스크에 쓰지 않고, 보고 shape에서도 `proposedContent`를 뺍니다(`scripts/crystallize.mjs:1502-1510`). 그런데 `writeProposal`은 supersede 대상을 `target`만으로 고른 뒤 같은 target의 형제를 전부 삭제했습니다.

1. 세션 A와 B가 같은 overwrite target에 대해 base V0를 관측
2. 다른 writer가 파일을 Vx로 드리프트
3. A가 닫히며 자기 바이트를 withhold하고 `P_A`로 park
4. B가 닫히며 자기 바이트를 withhold하고 `P_B`로 park
5. `writeProposal`이 "오래된 same-target 아티팩트"라며 `P_A`를 삭제

이 시점에 A의 작업은 사라집니다. 디스크에 없고(설계상 withheld), 커밋된 적 없고, 스토어에도 없습니다. "남의 편집을 덮지 않는다"를 내건 게이트가 남의 편집을 덮고 있었습니다.

스토어의 불변식 2번("target당 아티팩트 하나")은 *한 세션이 반복해서 닫을 때* stale 아티팩트가 대기 건수를 부풀리지 않게 하려고 쓴 것입니다. 코드가 세션을 구분하지 않는 바람에, 같은 줄이 동시 세션의 payload까지 먹었습니다.

## 방법

supersede를 쓰는 세션 범위로 좁혔습니다. 기존 same-target 아티팩트는 저장된 `sessionId`가 문자열이고 들어오는 값과 같을 때만 삭제합니다.

주인을 특정할 수 없으면 아무것도 지우지 않습니다. 어느 쪽이든 id가 null인 경우, 그리고 손으로 편집돼 `String()` 비교에서 매칭될 뻔한 비문자열 값이 여기 해당합니다. 아티팩트 본문은 평문이고 `listProposals`는 `id`만 검증하므로 `["s-A"]` 같은 필드가 통과할 수 있습니다. `writeProposal`은 늘 문자열 원시값을 저장하니 `typeof === 'string'` 검사는 잃는 것이 없고 그 구멍을 막습니다. 주인을 특정할 수 없는 payload야말로 지우면 안 되는 것입니다.

같은 세션의 재close는 여전히 합쳐지므로, 불변식이 원래 막으려던 churn은 그대로 막힙니다. 멱등 재사용은 의도적으로 세션 무관하게 두었습니다. 같은 base·같은 디스크 상태에 대한 동일 바이트는 payload가 하나이므로, 다른 세션의 동일 아티팩트를 재사용해도 잃는 것이 없습니다.

`sessionId`에 거는 것은 새로운 가정이 아닙니다. base-store가 이미 관측 base 스냅샷을 그것으로 키잉합니다(`.cache/sessions/<sessionId>/base.json`). 즉 이 가드는 FEAT-11의 나머지가 이미 딛고 선 전제 위에 섭니다.

이제 불변식 2번은 "(target, 세션)당 아티팩트 하나"입니다. 그래서 한 파일의 대기 건수가 1을 넘을 수 있는데, 이게 정직합니다. 실제로 아무도 검토하지 않은 withheld payload가 N개 있는 것이니까요. `proposal list`는 이미 항목별 `sessionId`·`device`를 찍어주므로 구분됩니다. 그리고 한 id를 apply하면 방금 바뀐 그 파일에 다른 proposal이 남아 있을 수 있으므로, `apply`는 조용한 `✓ applied`로 끝내지 않고 남은 것들의 id를 stderr에 알립니다. 지우지는 않습니다.

## 수동 검증

```
$ npm test    # 1370 passed, 0 failed
```

회귀 테스트는 green을 믿지 않고 이 레포 관행대로 **수정을 꺼서** 확인했습니다. 가드 한 줄을 되돌리면 정확히 새 테스트만 실패하고(`session B must not delete session A's payload`, 1368 passed / 1 failed), 되살리면 다시 green입니다.

새 테스트가 고정하는 것: 한 target에 서로 다른 바이트를 가진 두 세션이 모두 살아남는다, 세션의 재close는 자기 이전 시도만 supersede한다, 주인 없는 아티팩트는 아무것도 지우지 않고 이름 있는 세션에게도 지워지지 않는다, 비문자열 주인은 매칭으로 강제변환되지 않는다, `apply`가 동시 세션의 남은 proposal을 경고하고 보존한다.

codex 검토는 설계 단계(session-scoped supersede를 never-supersede·content-addressed storage보다 우선으로 지지)와 커밋 직전(판정 NIT) 두 번 받았습니다. NIT 2건은 모두 반영했습니다. apply 경고가 "다른 세션이 park했고 디스크와 다르다"고 단정하지 않도록 문구를 고쳤고, 빠졌던 테스트 2건을 추가했습니다.

## 마이그레이션 노트

None. 이 변경 전에 쓰인 아티팩트도 그대로 동작하고, 그중 `sessionId`가 쓰는 세션과 같은 것은 종전대로 supersede됩니다.

---

## Changelog

- EN: Fixed the write=proposal gate destroying a concurrent session's parked proposal: two sessions withholding an overwrite for the same page kept only the last one's bytes. Supersede is now scoped to the writing session, and `proposal apply` reports any proposal left pending against the file it just wrote (#191)
- KO: write=proposal 게이트가 동시 세션이 park한 proposal을 지우던 문제를 고쳤습니다. 같은 페이지에 대해 두 세션이 overwrite를 withhold하면 마지막 세션의 바이트만 남았습니다. 이제 supersede는 쓰는 세션 범위로 한정되고, `proposal apply`는 방금 쓴 파일에 남아 있는 proposal을 알려줍니다 (#191)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
