### PR TITLE
fix(scope): filter machine-scoped pages from session-resume injection paths

### DIFF
--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -24,6 +24,9 @@ import {
   pickProjectByCwd,
   collectProjectWorkingDirs,
   buildVaultOrientation,
+  currentDevice,
+  scopeVisible,
+  readVisibilityScope,
 } from './hypo-shared.mjs';
 
 const PROJECTS_DIR = join(HYPO_DIR, 'projects');
@@ -32,10 +35,32 @@ const MAX_CHARS = 3000;
 
 // Privacy guard: a .hypoignore-matched hot.md must not be
 // re-emitted into additionalContext on cwd change.
+//
+// Visibility guard: same contract as hypo-file-watch and hypo-session-start. A
+// machine-scoped hot.md stays off every machine but its owner. Scope is read
+// from the RAW content before the MAX_CHARS slice, since slicing first could cut
+// the frontmatter off and fail open. The root hot.md carries no frontmatter, so
+// it reads as '' and passes as shared.
 function readIfNotIgnored(path, patterns) {
   if (!path) return null;
   if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return null;
-  return readFileSync(path, 'utf-8').slice(0, MAX_CHARS);
+  const raw = readFileSync(path, 'utf-8');
+  if (!scopeVisible(readVisibilityScope(raw), currentDevice())) return null;
+  return raw.slice(0, MAX_CHARS);
+}
+
+// Scoped-out is not absent. Both make readIfNotIgnored return null, but the
+// absent-case placeholder tells the model the file "will be created at session
+// close". On a foreign machine that invites it to author over a hot.md that
+// exists and belongs elsewhere. Report the fact, never the withheld body.
+function isScopedOut(path, patterns) {
+  try {
+    if (!path || !existsSync(path)) return false;
+    if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return false;
+    return !scopeVisible(readVisibilityScope(readFileSync(path, 'utf-8')), currentDevice());
+  } catch {
+    return false;
+  }
 }
 
 function findProjectHot(cwd) {
@@ -87,7 +112,11 @@ process.stdin.on('end', () => {
 
     if (newHit) {
       const fromFile = readIfNotIgnored(newHit.hotPath, ignorePatterns);
-      const content = fromFile ?? '(no hot.md yet — will be created at session close)';
+      const content =
+        fromFile ??
+        (isScopedOut(newHit.hotPath, ignorePatterns)
+          ? '(hot.md for this project is scoped to another machine and is not visible here)'
+          : '(no hot.md yet — will be created at session close)');
       // arm the first-prompt marker so the NEXT user prompt re-triggers
       // hypo-first-prompt, which forces a "Resuming <project>" summary line.
       // Only arm when real hot content was actually injected — if hot.md is

--- a/hooks/hypo-first-prompt.mjs
+++ b/hooks/hypo-first-prompt.mjs
@@ -48,7 +48,17 @@ process.stdin.on('end', () => {
     }
 
     const hasSnapshot = marker.hasSnapshot ?? (marker.hotPath && existsSync(marker.hotPath));
-    const snapshotNote = hasSnapshot ? '' : ' (no snapshot yet — first session)';
+    // A snapshot withheld by visibility_scope is NOT an absent one. session-start
+    // stamps the marker so this hook can tell them apart: without it, a project
+    // resumed on a foreign machine is announced as a first session, and the model
+    // then has every reason to author a fresh hot.md over the one that exists on
+    // the owning machine. Never name the withheld contents, only the fact.
+    const scopedOut = marker.scopedOut === true;
+    const snapshotNote = hasSnapshot
+      ? ''
+      : scopedOut
+        ? ' (snapshot scoped to another machine)'
+        : ' (no snapshot yet — first session)';
     // a cwd-change re-trigger says "Resuming"; a fresh session start
     // (default source) says "Previously working on".
     const verb = marker.source === 'cwd-change' ? 'Resuming' : 'Previously working on';
@@ -63,11 +73,17 @@ process.stdin.on('end', () => {
     // first-ever session (codex v2 review 2026-05-26).
     const exampleLine = hasSnapshot
       ? `${verb} ${projSafe}: [one-line summary]. Continue with [next task]?`
-      : `${verb} ${projSafe}: no prior snapshot yet — first session. What would you like to start with?`;
+      : scopedOut
+        ? `${projSafe}: this project has a prior snapshot, but it is scoped to another machine and is not visible here. What would you like to work on?`
+        : `${verb} ${projSafe}: no prior snapshot yet — first session. What would you like to start with?`;
     const fillNote = hasSnapshot
       ? `Replace the bracketed placeholders using the [HOT] / [SESSION STATE] ` +
         `context already injected this session — do NOT emit the literal brackets.`
-      : `Use the line above verbatim — there is no prior snapshot to summarize.`;
+      : scopedOut
+        ? `Use the line above verbatim. The project has prior work; its snapshot ` +
+          `simply belongs to another machine, so treat it as an existing project ` +
+          `whose history you cannot see from here.`
+        : `Use the line above verbatim — there is no prior snapshot to summarize.`;
 
     console.log(
       JSON.stringify(

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -32,6 +32,9 @@ import {
   collectProjectWorkingDirs,
   buildVaultOrientation,
   staleMarkerFor,
+  currentDevice,
+  scopeVisible,
+  readVisibilityScope,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -53,10 +56,38 @@ import { listProposals } from './proposal-store.mjs';
 // wiki files into additionalContext. Without this, a user who lists
 // `projects/private/hot.md` in .hypoignore would still see SECRET emit because
 // session-start reads hot/state paths directly.
+//
+// Visibility guard: a machine-scoped page (visibility_scope: machine:<owner>)
+// must not be injected on a machine other than its owner. hypo-file-watch
+// already filters these very files, so leaving session start unfiltered made the
+// SAME file behave differently depending on which path opened it: the user sets
+// the field, sees it honored on edit, and never learns that session start still
+// ships the body. Read the scope from the RAW content before the maxChars slice:
+// slicing first could cut the frontmatter off and silently fail open.
+// The root hot.md is a frontmatter-less pointer table, so it reads as '' and
+// passes (shared) unchanged.
 function readIfNotIgnored(path, maxChars, patterns) {
   if (!path) return null;
   if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return null;
-  return readFileSync(path, 'utf-8').slice(0, maxChars);
+  const raw = readFileSync(path, 'utf-8');
+  if (!scopeVisible(readVisibilityScope(raw), currentDevice())) return null;
+  return raw.slice(0, maxChars);
+}
+
+// Scoped-out is not the same as absent. Both make readIfNotIgnored return null,
+// but telling the model "no snapshot yet / first session" when the snapshot merely
+// belongs to another machine is a lie it will act on. Returns false for an ignored
+// or missing file so only a real machine-scope hide reports true.
+// The caller may name the project and the fact, never the withheld body: a message
+// explaining the hide must not re-leak what it hid.
+function isScopedOut(path, patterns) {
+  try {
+    if (!path || !existsSync(path)) return false;
+    if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return false;
+    return !scopeVisible(readVisibilityScope(readFileSync(path, 'utf-8')), currentDevice());
+  } catch {
+    return false;
+  }
 }
 
 // Compute the STALE marker for a hot/state file from its RAW content (readIfNotIgnored
@@ -464,17 +495,29 @@ process.stdin.on('end', () => {
           ),
         );
       } else {
+        // A snapshot that exists but is scoped to another machine must not be
+        // reported as "no snapshot yet": the model would treat a resumed project
+        // as a first session. Say which it is, and say nothing of the contents.
+        const scopedOut =
+          isScopedOut(hit.hotPath, ignorePatterns) || isScopedOut(hit.statePath, ignorePatterns);
+        const reason = scopedOut ? 'snapshot scoped to another machine' : 'no snapshot yet';
         process.stderr.write(
-          `\n\x1b[36m[Hypomnema]\x1b[0m project: \x1b[1m${hit.proj}\x1b[0m (no snapshot yet)\n\n`,
+          `\n\x1b[36m[Hypomnema]\x1b[0m project: \x1b[1m${hit.proj}\x1b[0m (${reason})\n\n`,
         );
+        // Carry the reason into the marker, not just this hook's output.
+        // hypo-first-prompt derives its resume line from the marker alone, so a
+        // marker that says only `hotPath: null` makes the NEXT prompt announce
+        // "first session" for a project that merely belongs to another machine.
+        // That lie is what invites the model to author a fresh hot.md over one
+        // that already exists elsewhere.
         writeFileSync(
           MARKER_FILE,
-          JSON.stringify({ proj: hit.proj, hotPath: null, ts: Date.now() }),
+          JSON.stringify({ proj: hit.proj, hotPath: null, scopedOut, ts: Date.now() }),
         );
         console.log(
           JSON.stringify(
             buildOutput(
-              `${noticePrefix}${hitPrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}, no snapshot yet]`,
+              `${noticePrefix}${hitPrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}, ${reason}]`,
               outExtra,
             ),
           ),

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -30,6 +30,7 @@ import { existsSync, readFileSync, readdirSync, statSync, realpathSync } from 'f
 import { join } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { pickProjectByCwd, collectProjectWorkingDirs } from './lib/wd-match.mjs';
+import { currentDevice, scopeVisible, readVisibilityScope } from '../hooks/hypo-shared.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -189,16 +190,27 @@ function resolveActiveProject(hypoDir, cwd = null) {
 
 // ── read session state ────────────────────────────────────────────────────────
 
-function readSessionState(hypoDir, project) {
-  const ssPath = join(hypoDir, 'projects', project, 'session-state.md');
-  if (!existsSync(ssPath)) return null;
-  return readFileSync(ssPath, 'utf-8');
+// Visibility guard: same contract as hypo-file-watch / hypo-session-start /
+// hypo-cwd-change. A machine-scoped page (visibility_scope: machine:<owner>) is
+// not surfaced on any machine but its owner, and /hypo:resume feeds its stdout
+// straight into the model, so it is one of those injection paths.
+//
+// `hidden` is kept distinct from "file absent" on purpose: reporting a scoped-out
+// state file as "no session-state.md found" would read as a broken vault. The
+// caller says which one it was.
+function readVisible(path, device) {
+  if (!existsSync(path)) return { content: null, hidden: false };
+  const raw = readFileSync(path, 'utf-8');
+  if (!scopeVisible(readVisibilityScope(raw), device)) return { content: null, hidden: true };
+  return { content: raw, hidden: false };
 }
 
-function readHot(hypoDir, project) {
-  const hotPath = join(hypoDir, 'projects', project, 'hot.md');
-  if (!existsSync(hotPath)) return null;
-  return readFileSync(hotPath, 'utf-8');
+function readSessionState(hypoDir, project, device) {
+  return readVisible(join(hypoDir, 'projects', project, 'session-state.md'), device);
+}
+
+function readHot(hypoDir, project, device) {
+  return readVisible(join(hypoDir, 'projects', project, 'hot.md'), device);
 }
 
 // ── main ─────────────────────────────────────────────────────────────────────
@@ -212,13 +224,23 @@ if (!project) {
   process.exit(1);
 }
 
-const sessionState = readSessionState(args.hypoDir, project);
-if (!sessionState) {
-  console.error(`Error: no session-state.md found for project "${project}"`);
+const device = currentDevice();
+
+const state = readSessionState(args.hypoDir, project, device);
+if (!state.content) {
+  if (state.hidden) {
+    console.error(
+      `Error: session-state.md for "${project}" is scoped to another machine ` +
+        `(visibility_scope). Nothing to resume on this machine (${device}).`,
+    );
+  } else {
+    console.error(`Error: no session-state.md found for project "${project}"`);
+  }
   process.exit(1);
 }
+const sessionState = state.content;
 
-const hotContent = readHot(args.hypoDir, project);
+const hotContent = readHot(args.hypoDir, project, device).content;
 
 if (args.json) {
   console.log(JSON.stringify({ project, sessionState, hot: hotContent }, null, 2));

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -29230,6 +29230,401 @@ test('FEAT-11 T8: session-start emits no proposal line when none are parked', ()
   });
 });
 
+// ── FEAT-5 T11: visibility_scope on the session-resume paths ─────────────────
+// T4-T8 wired the five content-injection consumers. The session-resume paths
+// (session-start, cwd-change, resume.mjs) read the SAME projects/<p>/hot.md and
+// session-state.md that hypo-file-watch already filters, so leaving them
+// unfiltered made one file behave differently depending on which path opened it:
+// the user sets visibility_scope, watches file-watch honor it, and never learns
+// session start still ships the body. That is a false guarantee, not a fail-open.
+suite('FEAT-5 T11 — session-resume paths honor visibility_scope');
+
+// Same shape as withPrivateProject, but hot/state carry a scope line. The body
+// markers are exactly what must not reach a foreign device.
+function withScopedProject(scopeLine, fn) {
+  withGrowthWiki((dir) => {
+    const work = mkdtempSync(join(tmpdir(), 'hypo-scope-work-'));
+    const projDir = join(dir, 'projects', 'scoped');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'index.md'),
+      `---\ntitle: scoped\ntype: project-index\nupdated: 2026-07-12\nworking_dir: "${work}"\n---\n# Scoped\n`,
+    );
+    const fm = scopeLine ? `---\n${scopeLine}\n---\n` : '';
+    writeFileSync(join(projDir, 'hot.md'), `${fm}# hot\nSCOPED_HOT_BODY\n`);
+    writeFileSync(join(projDir, 'session-state.md'), `${fm}# state\nSCOPED_STATE_BODY\n`);
+    try {
+      fn(dir, work);
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+}
+
+const SCOPED_BODIES = /SCOPED_HOT_BODY|SCOPED_STATE_BODY/;
+
+test('session-start hides a machine-scoped project hot/state on a foreign device', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'test-t11-ss-foreign' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !SCOPED_BODIES.test(r.stdout),
+      `machine:devA body leaked into session-start on devB: ${r.stdout}`,
+    );
+  });
+});
+
+test('session-start still injects a machine-scoped project hot/state on its own device', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'test-t11-ss-own' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      /SCOPED_HOT_BODY/.test(r.stdout) && /SCOPED_STATE_BODY/.test(r.stdout),
+      `expected hot+state injection on the owning device: ${r.stdout}`,
+    );
+  });
+});
+
+test('session-start leaves an unscoped project unchanged on every device', () => {
+  for (const device of ['devA', 'devB']) {
+    withScopedProject('', (dir, work) => {
+      const r = runHook(
+        'hypo-session-start.mjs',
+        { cwd: work, session_id: `test-t11-ss-plain-${device}` },
+        { HYPO_DIR: dir, HYPO_DEVICE: device },
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.ok(
+        /SCOPED_HOT_BODY/.test(r.stdout) && /SCOPED_STATE_BODY/.test(r.stdout),
+        `a field-less project must inject on ${device}: ${r.stdout}`,
+      );
+    });
+  }
+});
+
+test('cwd-change hides a machine-scoped project hot on a foreign device', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = runHook(
+      'hypo-cwd-change.mjs',
+      { new_cwd: work, old_cwd: '/tmp', session_id: 'test-t11-cwd-foreign' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !SCOPED_BODIES.test(r.stdout),
+      `machine:devA hot leaked into cwd-change on devB: ${r.stdout}`,
+    );
+  });
+});
+
+test('cwd-change still injects a machine-scoped project hot on its own device', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = runHook(
+      'hypo-cwd-change.mjs',
+      { new_cwd: work, old_cwd: '/tmp', session_id: 'test-t11-cwd-own' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      /SCOPED_HOT_BODY/.test(r.stdout),
+      `expected hot injection on the owning device: ${r.stdout}`,
+    );
+  });
+});
+
+test('resume.mjs hides a machine-scoped session-state on a foreign device and says why', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped'],
+      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devB' } },
+    );
+    assert.ok(
+      !SCOPED_BODIES.test(r.stdout),
+      `machine:devA body leaked through resume stdout on devB: ${r.stdout}`,
+    );
+    // A scoped-out state file is not a missing one. Reporting "no session-state.md
+    // found" would read as a broken vault, so the reason must be explicit.
+    assert.ok(
+      /scoped to another machine/.test(r.stderr),
+      `expected an explicit scoped-out reason, got: ${r.stderr}`,
+    );
+  });
+});
+
+test('resume.mjs still returns a machine-scoped session-state on its own device', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped'],
+      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devA' } },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      /SCOPED_STATE_BODY/.test(r.stdout) && /SCOPED_HOT_BODY/.test(r.stdout),
+      `expected state+hot on the owning device: ${r.stdout}`,
+    );
+  });
+});
+
+// --json serializes the bodies through a different branch than the text output,
+// so it needs its own foreign-device assertion.
+test('resume.mjs --json does not serialize a machine-scoped body on a foreign device', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped', '--json'],
+      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devB' } },
+    );
+    assert.ok(
+      !SCOPED_BODIES.test(r.stdout),
+      `machine:devA body leaked through the --json branch on devB: ${r.stdout}`,
+    );
+  });
+});
+
+// The two files are scoped independently, so a visible state must still come
+// through when only hot.md is scoped out (and hot's body must not).
+test('resume.mjs returns a visible session-state while hiding a scoped-out hot.md', () => {
+  withScopedProject('', (dir, work) => {
+    writeFileSync(
+      join(dir, 'projects', 'scoped', 'hot.md'),
+      '---\nvisibility_scope: machine:devA\n---\n# hot\nSCOPED_HOT_BODY\n',
+    );
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped'],
+      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devB' } },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      /SCOPED_STATE_BODY/.test(r.stdout),
+      `the unscoped session-state must still surface: ${r.stdout}`,
+    );
+    assert.ok(
+      !/SCOPED_HOT_BODY/.test(r.stdout),
+      `the scoped-out hot body must not surface: ${r.stdout}`,
+    );
+  });
+});
+
+// Scoped-out must not be reported as absent. "no snapshot yet" would make the
+// model treat a resumed project as a first session. The fix says which it is,
+// while naming nothing from the withheld body.
+test('session-start reports a scoped-out snapshot as scoped, not as "no snapshot yet"', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'test-t11-ss-reason' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      /scoped to another machine/.test(r.stdout),
+      `expected the scoped-out reason in additionalContext: ${r.stdout}`,
+    );
+    assert.ok(
+      !/no snapshot yet/.test(r.stdout),
+      `a scoped-out snapshot must not be reported as absent: ${r.stdout}`,
+    );
+    assert.ok(
+      !SCOPED_BODIES.test(r.stdout),
+      `the explanation must not re-leak the body: ${r.stdout}`,
+    );
+  });
+});
+
+test('cwd-change reports a scoped-out hot as scoped, not as "will be created"', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const r = runHook(
+      'hypo-cwd-change.mjs',
+      { new_cwd: work, old_cwd: '/tmp', session_id: 'test-t11-cwd-reason' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      /scoped to another machine/.test(r.stdout),
+      `expected the scoped-out placeholder: ${r.stdout}`,
+    );
+    assert.ok(
+      !/will be created at session close/.test(r.stdout),
+      `an existing scoped hot.md must not be advertised as creatable: ${r.stdout}`,
+    );
+    assert.ok(
+      !SCOPED_BODIES.test(r.stdout),
+      `the placeholder must not re-leak the body: ${r.stdout}`,
+    );
+  });
+});
+
+// The lie also travels through the marker: hypo-first-prompt builds its resume
+// line from the marker alone, so fixing only session-start's own output would
+// still let the NEXT prompt announce "first session" for a project that merely
+// lives on another machine. That is the announcement that invites the model to
+// author a fresh hot.md over the owning machine's copy.
+test('first-prompt does not call a scoped-out project a first session', () => {
+  const sid = `fp-scoped-${process.pid}-${Date.now()}`;
+  writeMarker(sid, { proj: 'demo', hotPath: null, scopedOut: true });
+  try {
+    const r = runFirstPrompt(sid);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout).additionalContext || '';
+    assert.match(out, /scoped to another machine/, 'must name the scope as the reason');
+    assert.doesNotMatch(out, /first session/, 'a scoped-out project is not a first session');
+  } finally {
+    if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+  }
+});
+
+test('first-prompt still calls a genuinely snapshot-less project a first session', () => {
+  const sid = `fp-absent-${process.pid}-${Date.now()}`;
+  writeMarker(sid, { proj: 'demo', hotPath: null });
+  try {
+    const r = runFirstPrompt(sid);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const out = JSON.parse(r.stdout).additionalContext || '';
+    assert.match(
+      out,
+      /first session/,
+      'a genuinely absent snapshot must still read as first session',
+    );
+    assert.doesNotMatch(out, /scoped to another machine/, 'must not claim a scope that is not set');
+  } finally {
+    if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+  }
+});
+
+// The two files are scoped independently. When hot is hidden but state is shared,
+// session-start must take the CONTENT branch: inject the state, withhold the hot
+// body, and report hasSnapshot truthfully (a snapshot really was injected). The
+// marker then carries a hotPath pointing at a hidden file, so nothing downstream
+// may read that path for content. first-prompt only existsSync's it.
+test('session-start injects a shared state while withholding a scoped-out hot, and stays truthful', () => {
+  withScopedProject('', (dir, work) => {
+    writeFileSync(
+      join(dir, 'projects', 'scoped', 'hot.md'),
+      '---\nvisibility_scope: machine:devA\n---\n# hot\nSCOPED_HOT_BODY\n',
+    );
+    const sid = `t11-mixed-${process.pid}-${Date.now()}`;
+    try {
+      const r = runHook(
+        'hypo-session-start.mjs',
+        { cwd: work, session_id: sid },
+        { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.ok(
+        !/SCOPED_HOT_BODY/.test(r.stdout),
+        `the hidden hot body must not surface: ${r.stdout}`,
+      );
+      assert.ok(
+        /SCOPED_STATE_BODY/.test(r.stdout),
+        `the shared state must still surface: ${r.stdout}`,
+      );
+
+      // hasSnapshot: true is the honest answer here, a snapshot WAS injected.
+      const marker = JSON.parse(readFileSync(markerPath(sid), 'utf-8'));
+      assert.equal(marker.hasSnapshot, true, 'a partially visible snapshot is still a snapshot');
+
+      const fp = runFirstPrompt(sid);
+      const out = JSON.parse(fp.stdout).additionalContext || '';
+      assert.ok(
+        !/SCOPED_HOT_BODY/.test(out),
+        `first-prompt must not read the hidden hotPath for content: ${out}`,
+      );
+    } finally {
+      if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+    }
+  });
+});
+
+// cwd-change deliberately arms the first-prompt marker only when real content was
+// injected (a forced "Resuming" line with nothing to summarize is empty noise).
+// A scoped-out hot takes that same path, which is correct precisely because the
+// additionalContext placeholder already states the fact: the model is not left
+// silent, it is told the snapshot lives elsewhere.
+test('cwd-change does not arm the resume marker for a scoped-out hot', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const sid = `t11-cc-marker-${process.pid}-${Date.now()}`;
+    try {
+      const r = runHook(
+        'hypo-cwd-change.mjs',
+        { new_cwd: work, old_cwd: '/tmp', session_id: sid },
+        { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.ok(
+        /scoped to another machine/.test(r.stdout),
+        `the placeholder must state the fact: ${r.stdout}`,
+      );
+      assert.ok(
+        !existsSync(markerPath(sid)),
+        'no forced resume line when there is nothing visible to summarize',
+      );
+    } finally {
+      if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+    }
+  });
+});
+
+// End to end: the marker session-start actually writes must carry the fact.
+test('session-start stamps scopedOut on the marker it hands to first-prompt', () => {
+  withScopedProject('visibility_scope: machine:devA', (dir, work) => {
+    const sid = `t11-e2e-${process.pid}-${Date.now()}`;
+    try {
+      const r = runHook(
+        'hypo-session-start.mjs',
+        { cwd: work, session_id: sid },
+        { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      const marker = JSON.parse(readFileSync(markerPath(sid), 'utf-8'));
+      assert.equal(
+        marker.scopedOut,
+        true,
+        `marker must record the scope hide: ${JSON.stringify(marker)}`,
+      );
+
+      const fp = runFirstPrompt(sid);
+      const out = JSON.parse(fp.stdout).additionalContext || '';
+      assert.doesNotMatch(
+        out,
+        /first session/,
+        'the hand-off must not degrade into "first session"',
+      );
+      assert.ok(!SCOPED_BODIES.test(out), `first-prompt must not surface the body either: ${out}`);
+    } finally {
+      if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
+    }
+  });
+});
+
+// The scoped-out branch must not swallow the genuine first-session signal.
+test('session-start still says "no snapshot yet" when the files are genuinely absent', () => {
+  withScopedProject('', (dir, work) => {
+    rmSync(join(dir, 'projects', 'scoped', 'hot.md'));
+    rmSync(join(dir, 'projects', 'scoped', 'session-state.md'));
+    const r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'test-t11-ss-absent' },
+      { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      /no snapshot yet/.test(r.stdout),
+      `a genuinely absent snapshot must still read as absent: ${r.stdout}`,
+    );
+  });
+});
+
 // ── summary ──────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
# English

## What changed

`visibility_scope` shipped wired into the five content-injection consumers: `hypo-lookup`, `hypo:query`, `hypo-file-watch`, the crystallize candidate scan, and the page-usage cold aggregation. The session-resume paths read the same `projects/<p>/hot.md` and `session-state.md` and injected their bodies **without** the predicate.

This wires the shared predicate into the remaining paths and makes every consumer of the resulting "empty" state tell *hidden* apart from *absent*.

| Path | What was leaking |
|---|---|
| `hooks/hypo-session-start.mjs` | project `hot.md` + `session-state.md` |
| `hooks/hypo-cwd-change.mjs` | project `hot.md` |
| `scripts/resume.mjs` | `hot.md` + `session-state.md` |

## Why

`hypo-file-watch` already filtered those very files. So the same file behaved differently depending on which path opened it: edit it and the scope was honored, start a session and the body shipped anyway.

A user who sets `visibility_scope: machine:laptop-A` on a project note believes it is hidden elsewhere. It was not. That is a false guarantee, not a fail-open, and it is the worst failure mode a privacy field can have.

## How

The guard goes inside `readIfNotIgnored()` in both hooks, which is already the `.hypoignore` privacy chokepoint, so every caller is covered at one point. Scope is read from the **raw** content before the `maxChars` slice, mirroring `hypo-file-watch`: slicing first could cut the frontmatter off and silently pass.

Hiding a file manufactures an "empty" state, and every consumer of that state has to distinguish hidden from absent:

- `hypo-session-start` says "snapshot scoped to another machine" instead of "no snapshot yet", and stamps `scopedOut` on the marker it hands to `hypo-first-prompt`.
- `hypo-first-prompt` reads that flag. Without it, the next prompt announces a *first session* for a project that merely lives on another machine, and that is precisely the announcement that invites the model to author a fresh `hot.md` over the owning machine's copy.
- `hypo-cwd-change` replaces its `(no hot.md yet, will be created at session close)` placeholder, which on a foreign machine advertised an existing file as creatable.
- `scripts/resume.mjs` distinguishes a scoped-out state file from a missing one. Reporting the former as "not found" would read as a broken vault.

None of these messages names any part of the withheld body. An explanation of a hide must not re-leak what it hid.

Mixed visibility stays truthful: when `hot.md` is scoped out but `session-state.md` is shared, session-start injects the state and reports `hasSnapshot: true` honestly, because a snapshot really was injected.

**Not in scope:** `crystallize` does not honor `visibility_scope` on its *write* path (`session-state.md` / `hot.md` overwrite). That is pre-existing, untouched here, and blocked on a design question this PR should not answer: these are single-path files, so if a foreign machine refuses to write a scoped file, its own handoff has nowhere to go. Tracked separately.

## Manual verification

Ran the real hooks against a temp vault holding a `machine:laptop-A` project.

```
### On the owning machine (laptop-A):
[WIKI HOT CACHE: project=manualtest]
[HOT] ... MANUAL_SECRET_HOT
[SESSION STATE] ... MANUAL_SECRET_STATE

### On a foreign machine (laptop-B):
[Hypomnema] project: manualtest (snapshot scoped to another machine)
[WIKI HOT CACHE: project=manualtest, snapshot scoped to another machine]
(no body)

### resume.mjs on laptop-B:
Error: session-state.md for "manualtest" is scoped to another machine
(visibility_scope). Nothing to resume on this machine (laptop-B).
exit=1
```

Mixed case (hot scoped to devA, state shared, opened on devB): the hidden hot body is absent, the shared state surfaces, and `hypo-first-prompt` does not read the hidden `hotPath` for content.

`npm test` → 1387 passing (17 new). Verified by negative control three times, because a regression test that passes for the wrong reason is worthless:

- removing the three guards fails exactly the three "hides" tests, with the real leak payload in the failure output;
- making `isScopedOut` always return false fails exactly the two "reason" tests, with the false signals in the output;
- dropping `scopedOut` from the marker fails the first-prompt hand-off test.

## Migration notes

None. The field is additive and every pre-existing page reads as `shared`.

---

# 한국어

## 변경 내용

`visibility_scope`는 콘텐츠 주입 소비자 5개(`hypo-lookup`, `hypo:query`, `hypo-file-watch`, crystallize 후보 스캔, page-usage cold 집계)에만 배선돼 있었다. 세션 재개 경로는 같은 `projects/<p>/hot.md`와 `session-state.md`를 읽으면서 predicate **없이** 본문을 주입했다.

남은 경로에 공유 predicate를 배선하고, 그 결과로 생기는 "비어 있음" 상태의 모든 소비자가 *가려짐*과 *없음*을 구분하게 했다.

| 경로 | 새던 파일 |
|---|---|
| `hooks/hypo-session-start.mjs` | 프로젝트 `hot.md` + `session-state.md` |
| `hooks/hypo-cwd-change.mjs` | 프로젝트 `hot.md` |
| `scripts/resume.mjs` | `hot.md` + `session-state.md` |

## 이유

`hypo-file-watch`는 바로 그 파일들을 이미 필터하고 있었다. 그래서 같은 파일이 열리는 경로에 따라 다르게 취급됐다. 편집하면 스코프가 지켜지고, 세션을 시작하면 본문이 그대로 나갔다.

프로젝트 노트에 `visibility_scope: machine:laptop-A`를 건 사용자는 그게 다른 곳에서 가려진다고 믿는다. 안 가려졌다. 이건 fail-open이 아니라 거짓 보증이고, 프라이버시 필드가 가질 수 있는 최악의 실패 모드다.

## 방법

guard는 두 훅의 `readIfNotIgnored()` 안에 넣었다. 이미 `.hypoignore` 프라이버시 관문이라 한 지점에서 모든 호출부가 덮인다. 스코프는 `maxChars` slice **전의 raw**에서 읽는다(`hypo-file-watch`와 동일). 먼저 자르면 frontmatter가 잘려 조용히 통과한다.

파일을 가리면 "비어 있음" 상태가 만들어지고, 그 상태의 모든 소비자가 가려짐과 없음을 구분해야 한다.

- `hypo-session-start`는 "no snapshot yet" 대신 "snapshot scoped to another machine"이라 말하고, `hypo-first-prompt`에 넘기는 marker에 `scopedOut`을 찍는다.
- `hypo-first-prompt`가 그 플래그를 읽는다. 없으면 다음 프롬프트가 다른 머신의 프로젝트를 *첫 세션*이라 선언하고, 그 선언이야말로 model에게 소유 머신의 `hot.md` 위에 새 파일을 쓰라고 부추긴다.
- `hypo-cwd-change`는 `(no hot.md yet, will be created at session close)` placeholder를 교체한다. 외부 머신에서 이 문구는 존재하는 파일을 만들어도 된다고 광고한 셈이었다.
- `scripts/resume.mjs`는 스코프로 가려진 상태 파일과 없는 파일을 구분한다. 전자를 "not found"로 보고하면 사용자가 볼트가 깨진 줄 안다.

이 메시지들 중 어느 것도 withhold한 본문을 언급하지 않는다. 가림을 설명하다 가린 것을 다시 흘리면 안 된다.

혼합 가시성도 정직하다. `hot.md`는 가려지고 `session-state.md`는 공유일 때, session-start는 상태를 주입하고 `hasSnapshot: true`를 그대로 보고한다. 실제로 스냅샷이 주입됐기 때문이다.

**범위 밖**: `crystallize`의 *쓰기* 경로(`session-state.md`·`hot.md` overwrite)는 `visibility_scope`를 보지 않는다. 이건 기존 동작이고 이번에 건드리지 않았으며, 이 PR이 답할 일이 아닌 설계 질문에 걸려 있다. 두 파일은 프로젝트당 경로가 하나라, 외부 머신이 scoped 파일 쓰기를 거부하면 자기 핸드오프를 쓸 곳이 없다. 별건으로 추적한다.

## 수동 검증

`machine:laptop-A` 프로젝트를 담은 임시 볼트에 실제 훅을 돌렸다.

```
### 소유 머신(laptop-A):
[WIKI HOT CACHE: project=manualtest]
[HOT] ... MANUAL_SECRET_HOT
[SESSION STATE] ... MANUAL_SECRET_STATE

### 외부 머신(laptop-B):
[Hypomnema] project: manualtest (snapshot scoped to another machine)
[WIKI HOT CACHE: project=manualtest, snapshot scoped to another machine)
(본문 없음)

### laptop-B의 resume.mjs:
Error: session-state.md for "manualtest" is scoped to another machine
(visibility_scope). Nothing to resume on this machine (laptop-B).
exit=1
```

혼합 케이스(hot은 devA scoped, state는 공유, devB에서 열기): 가려진 hot 본문은 안 나오고, 공유 state는 나오고, `hypo-first-prompt`는 가려진 `hotPath`로 내용을 읽지 않는다.

`npm test` → 1387 passing(신규 17). 잘못된 이유로 통과하는 회귀 테스트는 쓸모가 없으므로 negative control을 세 번 돌렸다.

- guard 3개를 빼면 정확히 3건의 "hides" 테스트가 실제 누수 payload와 함께 실패한다.
- `isScopedOut`이 항상 false를 반환하게 하면 정확히 2건의 "reason" 테스트가 거짓 신호와 함께 실패한다.
- marker에서 `scopedOut`을 빼면 first-prompt 인계 테스트가 실패한다.

## 마이그레이션 노트

없음. 필드는 additive이고 기존 모든 페이지는 `shared`로 읽힌다.

---

## Changelog

- EN: Machine-scoped pages (`visibility_scope: machine:<device>`) no longer surface on other machines through session start, cwd change, or `/hypo:resume` (#192).
- KO: 머신 전용 페이지(`visibility_scope: machine:<device>`)가 세션 시작, 작업 디렉터리 변경, `/hypo:resume` 경로로 다른 머신에 노출되지 않는다 (#192).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
