### PR TITLE
fix(gate): attribute close debt to the session that made it

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -243,4 +243,6 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs --check-session-close [--hypo
 
 It reports any file as `missing` or `stale`. For an actual close, prefer `--apply-session-close --payload=<path>` (Step 3) — it bundles freshness + lint into one gate and is the documented dogfood path. (`parseArgs` only accepts the `--payload=<path>` spelling; a space-separated `--payload <path>` is silently ignored and triggers "payload is required".)
 
-Add `--project=<slug>` to scope the check to one project (close status + lint scope) when recency picks the wrong one. This is a project-scoped diagnostic only: a green scoped result (JSON `scope: "project"`) attests that slug is close-complete, **not** that `/compact` is unblocked globally. The marker writer (`--mark-session-closed --project=<slug>`) keeps a **global** gate; there `--project` only sets the marker's attribution slug.
+Add `--project=<slug>` to scope the check to one project (close status + lint scope) when recency picks the wrong one. This is a project-scoped diagnostic only: a green scoped result (JSON `scope: "project"`) attests that slug is close-complete, **not** that `/compact` is unblocked globally.
+
+On the marker writer (`--mark-session-closed --project=<slug>`), `--project` names the project this session closed: it sets the marker's attribution slug and enters the close scope, so another session's incomplete close is reported as `close_debt` (a notice) instead of refusing your marker. Every other gate check stays global.

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -179,6 +179,18 @@ process.stdin.on('end', () => {
     const fold = `+${otherDebtCount} pre-existing lint issue(s) elsewhere in the vault (other projects / shared pages, not blocking) — run \`/hypo:lint\` for the full list.`;
     noticeText = noticeText ? `${noticeText}\n${fold}` : `[WIKI CHECK] ${fold}`;
   }
+  // A demoted close: some OTHER session left a project's close incomplete. It no
+  // longer blocks this compact, but it must still be SEEN — a notice list that the
+  // gate silently swallows (suppressOutput when nothing else surfaced) would turn the
+  // demotion into a disappearance, and nobody would ever fix the dangling close
+  // (codex design BLOCKER).
+  const closeDebt = gate.notices.filter((n) => n.type === 'close-debt');
+  if (closeDebt.length > 0) {
+    const line = `[WIKI CHECK] ${closeDebt.length} project(s) with an incomplete session close from another session (not blocking this compact): ${closeDebt
+      .map((n) => n.project)
+      .join(', ')} — each is fixed by that project's next close.`;
+    noticeText = noticeText ? `${noticeText}\n${line}` : line;
+  }
   // Surface the self-heal so a re-synced projection is not a silent mutation of
   // the user's MEMORY.md / CLAUDE.md (transparency).
   if (feedbackHealed) noticeText = noticeText ? `${noticeText}\n${feedbackHealed}` : feedbackHealed;

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -2326,6 +2326,53 @@ export function isUnderProjectDirs(file, slugs) {
   return (slugs || []).some((s) => s && (f === `projects/${s}` || f.startsWith(`projects/${s}/`)));
 }
 
+/**
+ * The session-close FILES of some project, as a path matcher. Used to attribute a
+ * close to a session: a transcript that edited `projects/<slug>/session-state.md`
+ * (or that project's hot.md / a session-log shard) is evidence THIS session was
+ * closing <slug>. Any other file under `projects/<slug>/` is NOT evidence — merely
+ * editing a page or an ADR there says nothing about whose close is whose, and
+ * treating it as attribution would re-block a session for a project it only read
+ * around in (codex design review).
+ */
+const CLOSE_FILE_RE = /^projects\/([^/]+)\/(session-state\.md|hot\.md|session-log\/[^/]+\.md)$/;
+
+/** Slugs whose close files this session edited directly (Write/Edit tool_use). */
+function projectsFromTouchedCloseFiles(transcriptPath, hypoDir) {
+  const out = new Set();
+  if (!transcriptPath) return out;
+  for (const f of extractTouchedWikiFiles(transcriptPath, hypoDir)) {
+    const m = posixPath(f).match(CLOSE_FILE_RE);
+    if (m) out.add(m[1]);
+  }
+  return out;
+}
+
+/**
+ * closeScope: the projects THIS session is accountable for closing. The union of
+ * three signals, because no single one covers every close path:
+ *
+ *   1. `opts.closeScope` — the caller states it outright. `--apply-session-close`
+ *      passes `payload.project` (it is the authority on what it just closed) and
+ *      `--mark-session-closed --project=<slug>` passes its attribution slug. This
+ *      signal is LOAD-BEARING, not a convenience: the documented close path writes
+ *      its files from inside a Bash call, so they never surface as Edit/Write
+ *      `file_path`s and signal 2 cannot see them (the same blind spot that forces
+ *      closeFileTargets() to seed the lint scope explicitly).
+ *   2. close files the transcript shows this session editing — the hand-written
+ *      close, which bypasses the script entirely.
+ *   3. `marker.project` — after a scripted close marked, this is how a later reader
+ *      (PreCompact) recovers signal 1. It is what keeps the marker == compact-ready
+ *      invariant: the writer scopes by `payload.project`, PreCompact re-scopes by
+ *      the `project` that same writer recorded, so the two can never disagree.
+ */
+export function resolveCloseScope(hypoDir, opts = {}, marker = null) {
+  const scope = new Set(opts.closeScope || []);
+  for (const p of projectsFromTouchedCloseFiles(opts.transcriptPath, hypoDir)) scope.add(p);
+  if (marker?.project) scope.add(marker.project);
+  return scope;
+}
+
 // ── PreCompact gate — single source of truth ────────────────────────────────
 /**
  * The full PreCompact gate decision as a READ-ONLY status. This is the single
@@ -2423,6 +2470,72 @@ export function precompactGateStatus(hypoDir, opts = {}) {
     // projectOverride narrows the close status to one project (check-only); a
     // marker-writing caller never sets it, so the marker path stays global.
     close = sessionCloseGlobalStatus(hypoDir, { projectOverride: opts.projectOverride });
+
+    // Attribute the close debt before blocking on it. An incomplete close belongs
+    // to whichever session performed it; charging it to an unrelated session is the
+    // false block this partition exists to stop. The gate already draws exactly this
+    // line for LINT debt (partitionLintScope: errors in files THIS session touched
+    // block, pre-existing debt elsewhere is a notice) — close-file debt was the one
+    // check still hard-blocking globally on another session's work.
+    //
+    // Two fail-closed guards keep the partition from eating a real blocker:
+    //   - close.fallback: no project closed today, so this is the "you have not
+    //     closed this session AT ALL" path. It must block unconditionally; demoting
+    //     it would gut the gate's whole purpose.
+    //   - empty scope: no positive attribution signal, so we cannot tell whose debt
+    //     it is. Never demote on a guess — fall back to today's global block.
+    //   - projectOverride: the caller asked "is THIS project close-complete?".
+    //     Demoting the very project it named would answer a question nobody asked.
+    //
+    // Bounded tradeoff (codex design review, accepted rather than closed). A
+    // scripted close that CRASHES mid-write leaves no marker and no transcript trace
+    // (it writes from inside a Bash call), so its own project carries no attribution.
+    // If that same session had also hand-edited SOME OTHER project's close files, the
+    // scope is non-empty but omits the torn project, and its debt is demoted. The
+    // window is narrow and self-limiting: apply writes the project files, then the
+    // session-log, then the root log entry, so the only torn state that reaches this
+    // partition at all is a missing log.md entry — which deriveRootLogEntries
+    // regenerates from the session-log heading. A crash before the session-log is not
+    // detected as today-active by hasTodayCloseActivity in the first place (the
+    // pre-existing tradeoff documented there). And the marker is never written, so the
+    // Stop hook still refuses to end the session. Closing this properly needs a
+    // durable close-attempt record; it is not worth a new state-file lifecycle here.
+    const scopeSet = resolveCloseScope(hypoDir, opts, marker);
+    const failed = (close.projects || []).filter((p) => !p.ok);
+    const partition =
+      !close.fallback && !opts.projectOverride && scopeSet.size > 0 && failed.length > 0;
+
+    close.scope = [...scopeSet];
+    close.debt = [];
+    // Re-project the flat aliases onto what actually BLOCKS, so `ok` and
+    // `stale`/`missing` can never contradict each other (a reader that treats a
+    // non-empty `missing` as failure stays correct). Demoted debt moves to its own
+    // `debt` field instead of masquerading as this session's unfinished work.
+    //
+    // ONLY when partitioning. Deriving `ok` from the per-project rows unconditionally
+    // would silently drop the failures that have NO project row to be derived from:
+    // an unresolvable active project yields `projects: []` with
+    // `missing: ['hot.md (no active project in pointer table)']`, so an empty `failed`
+    // would read as "nothing failed" and flip a red gate green (codex pre-commit
+    // BLOCKER, reproduced on a vault with no active-project row). Outside the
+    // partition the close status stands exactly as sessionCloseGlobalStatus computed it.
+    if (partition) {
+      const mine = failed.filter((p) => scopeSet.has(p.project));
+      const foreign = failed.filter((p) => !scopeSet.has(p.project));
+      close.debt = foreign.map((p) => ({ project: p.project, stale: p.stale, missing: p.missing }));
+      close.stale = [...new Set(mine.flatMap((p) => p.stale))];
+      close.missing = [...new Set(mine.flatMap((p) => p.missing))];
+      close.ok = mine.length === 0;
+      // The flat `project` alias must follow the scope too: it names the project the
+      // rest of this status describes, and every consumer that renders a per-file
+      // checklist builds it from that name. Left as the global `primary` it can point
+      // at a DEMOTED foreign project, and the checklist then reports ✓ for files the
+      // debt list simultaneously calls missing (codex pre-commit CONCERN).
+      if (!scopeSet.has(close.project)) {
+        close.project = mine[0]?.project ?? [...scopeSet][0] ?? close.project;
+      }
+    }
+
     if (!close.ok) {
       blockers.push({
         type: 'close',
@@ -2430,6 +2543,16 @@ export function precompactGateStatus(hypoDir, opts = {}) {
           ...close.missing.map((f) => `${f} (missing)`),
           ...close.stale.map((f) => `${f} (stale)`),
         ].join(', ')}`,
+      });
+    }
+    for (const p of close.debt) {
+      notices.push({
+        type: 'close-debt',
+        project: p.project,
+        reason: `${p.project}: incomplete session close from another session (${[
+          ...p.missing.map((f) => `${f} (missing)`),
+          ...p.stale.map((f) => `${f} (stale)`),
+        ].join(', ')}) — not blocking; that project's next close will fix it`,
       });
     }
   }
@@ -3032,7 +3155,8 @@ export function isCloseReconfirmDeclined(transcriptPath) {
     // system/sdk synthetic prompts, and (via the array-content branch below)
     // tool_result blocks, which are role:'user' in the transcript but are NOT
     // user-typed text.
-    const isInjected = obj.isMeta === true || obj.promptSource === 'system' || obj.promptSource === 'sdk';
+    const isInjected =
+      obj.isMeta === true || obj.promptSource === 'system' || obj.promptSource === 'sdk';
     const role = msg.role ?? obj.role ?? obj.type;
     if (!isInjected && role === 'user') {
       if (typeof content === 'string') {

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -245,11 +245,22 @@ function runSessionCloseCheck(args) {
   // would re-add that project's files to the lint scope and re-block the scoped
   // check, defeating the point. The global (no --project) check keeps widening.
   if (args.project) requireProjectDir(args, args.project);
+  // Resolve the transcript from --session-id when --transcript-path was not given,
+  // exactly as --mark and the apply auto-marker already do. The transcript is what
+  // attributes the close as well as widening the lint scope, and PreCompact
+  // always has one from its hook payload. A check without it would compute an EMPTY
+  // close scope, fall back to the global block, and report RED for debt that /compact
+  // demotes. Checklist step 14 tells the model to trust this command, so an over-red
+  // check is as harmful as an over-green one.
+  const checkTranscript =
+    args.transcriptPath ||
+    (args.sessionId ? resolveTranscriptBySessionId(args.sessionId) : null) ||
+    null;
   const status = precompactGateStatus(args.hypoDir, {
     ...(args.project
       ? { projectOverride: args.project }
-      : args.transcriptPath
-        ? { transcriptPath: args.transcriptPath }
+      : checkTranscript
+        ? { transcriptPath: checkTranscript }
         : {}),
     ...(args.sessionId ? { sessionId: args.sessionId } : {}),
   });
@@ -286,11 +297,17 @@ function runSessionCloseCheck(args) {
       JSON.stringify(
         {
           ok: status.ok,
-          // flat close fields preserved for back-compat with prior readers
+          // flat close fields preserved for back-compat with prior readers. They now
+          // describe what BLOCKS: a foreign project's incomplete close is demoted out
+          // of stale/missing into close_debt, so a reader that treats a
+          // non-empty `missing` as failure still agrees with `ok` instead of
+          // contradicting it.
           project: close.project,
           dates: close.dates,
           stale: close.stale,
           missing: close.missing,
+          ...(close.debt?.length ? { close_debt: close.debt } : {}),
+          ...(close.scope ? { close_scope: close.scope } : {}),
           blockers: status.blockers,
           notices: status.notices,
           skipped: status.skipped,
@@ -584,11 +601,14 @@ function runMarkSessionClosed(args) {
     console.log(args.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `✗ ${msg}`);
     process.exit(1);
   }
-  // --project=<slug> on --mark is ATTRIBUTION ONLY (the marker's `project` field).
-  // The gate stays GLOBAL — never narrowed — because a marker that narrowed its
-  // gate could attest compact-ready while PreCompact re-checks all of today's
-  // projects and stays red (the marker == compact-ready invariant,
-  // codex design finding 1/2). Validate the attribution slug exists as a
+  // --project=<slug> on --mark names the project THIS session closed. It sets the
+  // marker's `project` field AND enters the close scope, so an incomplete close in a
+  // project this session did not touch is demoted to a notice instead of refusing the
+  // marker. It is NOT a gate narrow in the old sense: the marker records the same slug
+  // it scoped by, and PreCompact re-derives its own scope FROM that marker — so the
+  // two can never disagree, which is what the earlier "attribution only, gate stays
+  // global" rule was protecting (it assumed PreCompact stayed global; it no longer
+  // does). Everything else the gate checks stays global. Validate the slug exists as a
   // directory, exactly as --check does, but only when it is actually used (a
   // --log-only mark attributes to no project, so --project is moot there).
   if (args.project && !args.logOnly) requireProjectDir(args, args.project);
@@ -613,6 +633,7 @@ function runMarkSessionClosed(args) {
   // source for the user-close hard gate below.
   const closeTranscript = resolveTranscriptBySessionId(args.sessionId);
   const gate = precompactGateStatus(args.hypoDir, {
+    ...(args.project && !args.logOnly ? { closeScope: [args.project] } : {}),
     ...(closeTranscript ? { transcriptPath: closeTranscript } : {}),
     ...(args.logOnly ? { logOnly: true } : {}),
   });
@@ -657,10 +678,19 @@ function runMarkSessionClosed(args) {
     console.log(args.json ? JSON.stringify(result, null, 2) : `✗ ${reason}`);
     process.exit(1);
   }
-  // --project attributes the marker to that slug (gate stayed global); falls back
-  // to the gate's resolved primary. log-only marks attribute to no project. Used
-  // for the marker, the JSON result, and the success message so all three agree.
-  const markerProject = !args.logOnly && args.project ? args.project : status.project;
+  // Marker attribution comes from the CLOSE SCOPE, never from the gate's
+  // global `primary`. The marker is what PreCompact later re-derives its own scope
+  // from, so attributing it to a project this session did not close hands PreCompact a
+  // scope the marker never cleared: `primary` can be a FOREIGN today-active project
+  // whose debt this gate demoted, and PreCompact would union it back in and re-block.
+  // Marker green, /compact red — the exact invariant PR #110 closed (codex design
+  // review, both workers). Explicit --project wins; else the scope's own project
+  // (preferring `primary` when it is itself in scope); else `primary`, which is only
+  // reachable when the scope was empty and the gate therefore stayed global anyway.
+  const closeScope = status.scope || [];
+  const scopeProject = closeScope.includes(status.project) ? status.project : closeScope[0];
+  const markerProject =
+    !args.logOnly && args.project ? args.project : (scopeProject ?? status.project);
   writeSessionClosedMarker(args.hypoDir, args.sessionId, {
     project: markerProject,
     ...(args.logOnly ? { scope: 'log-only' } : {}),
@@ -1096,54 +1126,59 @@ function applySessionClose(args) {
     // each other — only one closer is ever in the create path (closes the
     // wx-window a bare exclusive-create would leave open).
     try {
-      const outcome = withFileLock(full, () => {
-        // Fallback-aware idempotency (hybrid cutover): during the month the
-        // shard takes over, today's entry may already live in the legacy monthly
-        // file from an earlier (pre-cutover) close. Treat presence in EITHER the
-        // daily shard or the legacy monthly file as "already written" so a same-day
-        // second close does not duplicate an identical entry across both files —
-        // and so an idempotent re-apply stays a true no-op (no shard is created).
-        for (const cand of sessionLogReadCandidates(project, date)) {
-          const cf = join(args.hypoDir, cand);
-          if (!existsSync(cf)) continue;
-          try {
-            if (isPresent(readFileSync(cf, 'utf-8'))) return 'skipped';
-          } catch {
-            /* unreadable candidate — fall through to the write path */
+      const outcome = withFileLock(
+        full,
+        () => {
+          // Fallback-aware idempotency (hybrid cutover): during the month the
+          // shard takes over, today's entry may already live in the legacy monthly
+          // file from an earlier (pre-cutover) close. Treat presence in EITHER the
+          // daily shard or the legacy monthly file as "already written" so a same-day
+          // second close does not duplicate an identical entry across both files —
+          // and so an idempotent re-apply stays a true no-op (no shard is created).
+          for (const cand of sessionLogReadCandidates(project, date)) {
+            const cf = join(args.hypoDir, cand);
+            if (!existsSync(cf)) continue;
+            try {
+              if (isPresent(readFileSync(cf, 'utf-8'))) return 'skipped';
+            } catch {
+              /* unreadable candidate — fall through to the write path */
+            }
           }
-        }
-        if (!existsSync(full)) {
-          // A daily shard is a new file most days. Seed minimal valid frontmatter
-          // (title + type, the two REQUIRED_FIELDS) so the shard is a first-class
-          // wiki page rather than a W1 "no frontmatter" warning, and write the header
-          // AND the first entry in ONE atomic write — never leave a header-only shard
-          // on disk, which freshness would skip (no dated heading) while derive could
-          // otherwise mistake it for the evidence file. The dated `## [date] ...`
-          // heading lives inside the entry, so freshness / derive / design-history
-          // are unchanged.
-          // Audit fields (device, session_id). The shard frontmatter is git-tracked and synced, so
-          // `device` is an INTENTIONAL synced multi-machine identifier (privacy note:
-          // docs/ARCHITECTURE.md). It is a CREATOR-only stamp — only the session/
-          // machine that first seeds the daily shard is recorded; later same-day
-          // appends do not touch it. The per-session-accurate store is the LOCAL
-          // (.cache/, gitignored) index.jsonl written by hypo-session-record.mjs.
-          // `session_id` is honest naming: the value is the Claude session UUID, and
-          // it is present only on the Stop-chain close path that passes --session-id.
-          const device = currentDevice();
-          const auditFm =
-            (args.sessionId ? `session_id: ${String(args.sessionId).replace(/[\r\n]/g, '')}\n` : '') +
-            `device: ${device}\n`;
-          const header =
-            `---\ntitle: Session Log ${date} (${project})\n` +
-            `type: session-log\nupdated: ${date}\n${auditFm}---\n\n` +
-            `# Session Log ${date} (${project})\n`;
-          const entry = payload.sessionLog.entry;
-          const body = entry.endsWith('\n') ? entry : `${entry}\n`;
-          atomicWrite(full, `${header}\n${body}`);
-          return 'created';
-        }
-        return appendIfAbsent(full, payload.sessionLog.entry, isPresent) ? 'appended' : 'skipped';
-      }, { timeoutMs: APPEND_LOCK_TIMEOUT_MS });
+          if (!existsSync(full)) {
+            // A daily shard is a new file most days. Seed minimal valid frontmatter
+            // (title + type, the two REQUIRED_FIELDS) so the shard is a first-class
+            // wiki page rather than a W1 "no frontmatter" warning, and write the header
+            // AND the first entry in ONE atomic write — never leave a header-only shard
+            // on disk, which freshness would skip (no dated heading) while derive could
+            // otherwise mistake it for the evidence file. The dated `## [date] ...`
+            // heading lives inside the entry, so freshness / derive / design-history
+            // are unchanged.
+            // Audit fields (device, session_id). The shard frontmatter is git-tracked and synced, so
+            // `device` is an INTENTIONAL synced multi-machine identifier (privacy note:
+            // docs/ARCHITECTURE.md). It is a CREATOR-only stamp — only the session/
+            // machine that first seeds the daily shard is recorded; later same-day
+            // appends do not touch it. The per-session-accurate store is the LOCAL
+            // (.cache/, gitignored) index.jsonl written by hypo-session-record.mjs.
+            // `session_id` is honest naming: the value is the Claude session UUID, and
+            // it is present only on the Stop-chain close path that passes --session-id.
+            const device = currentDevice();
+            const auditFm =
+              (args.sessionId
+                ? `session_id: ${String(args.sessionId).replace(/[\r\n]/g, '')}\n`
+                : '') + `device: ${device}\n`;
+            const header =
+              `---\ntitle: Session Log ${date} (${project})\n` +
+              `type: session-log\nupdated: ${date}\n${auditFm}---\n\n` +
+              `# Session Log ${date} (${project})\n`;
+            const entry = payload.sessionLog.entry;
+            const body = entry.endsWith('\n') ? entry : `${entry}\n`;
+            atomicWrite(full, `${header}\n${body}`);
+            return 'created';
+          }
+          return appendIfAbsent(full, payload.sessionLog.entry, isPresent) ? 'appended' : 'skipped';
+        },
+        { timeoutMs: APPEND_LOCK_TIMEOUT_MS },
+      );
       (outcome === 'skipped' ? skipped : applied).push(`sessionLog (${rel})`);
     } catch (err) {
       // Only a lock-TIMEOUT is withheld as a conflict. A real fn() write error
@@ -1216,17 +1251,21 @@ function applySessionClose(args) {
     // titleless vs titled same-day pair) from duplicating.
     const headingRe = new RegExp(`^#{1,6} \\[${date}\\]\\s*(.*)$`, 'gm');
     try {
-      const wroteAny = withFileLock(logFull, () => {
-        let w = false;
-        for (const m of (payload.sessionLog.entry || '').matchAll(headingRe)) {
-          const { heading, block } = rootLogEntry(project, date, m[1]);
-          const wrote = appendIfAbsent(logFull, block, (c) =>
-            (c || '').split(/\r?\n/).includes(heading),
-          );
-          w = w || wrote;
-        }
-        return w;
-      }, { timeoutMs: APPEND_LOCK_TIMEOUT_MS });
+      const wroteAny = withFileLock(
+        logFull,
+        () => {
+          let w = false;
+          for (const m of (payload.sessionLog.entry || '').matchAll(headingRe)) {
+            const { heading, block } = rootLogEntry(project, date, m[1]);
+            const wrote = appendIfAbsent(logFull, block, (c) =>
+              (c || '').split(/\r?\n/).includes(heading),
+            );
+            w = w || wrote;
+          }
+          return w;
+        },
+        { timeoutMs: APPEND_LOCK_TIMEOUT_MS },
+      );
       (wroteAny ? applied : skipped).push('log (log.md, derived)');
     } catch (err) {
       if (err?.code !== 'ELOCKTIMEOUT') throw err;
@@ -1424,10 +1463,15 @@ function applySessionClose(args) {
     let gateOk = false;
     if (commitOutcome.committed) {
       closeTranscript = resolveTranscriptBySessionId(args.sessionId);
-      gateOk = precompactGateStatus(
-        args.hypoDir,
-        closeTranscript ? { transcriptPath: closeTranscript } : {},
-      ).ok;
+      // closeScope: apply KNOWS which project it just closed, and it wrote
+      // that project's files from inside this process — they never appear in the
+      // transcript as Edit/Write, so `payload.project` is the only signal that puts
+      // this close in scope. Without it, apply's own incomplete close could be demoted
+      // to a foreign-debt notice and marked green.
+      gateOk = precompactGateStatus(args.hypoDir, {
+        closeScope: [project],
+        ...(closeTranscript ? { transcriptPath: closeTranscript } : {}),
+      }).ok;
     }
     const decision = planMarkerDecision({
       ok,

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -29708,7 +29708,11 @@ test('IMPR-34: foreign incomplete close is a notice, not a blocker, when scope n
 // and W8 design-history ownership is still global. Same defect shape, tracked as
 // sibling IMPRs. If a later change fixes them, this test is what should be updated
 // to say so — and the fix's claim must not run ahead of it.
-test('IMPR-34 (boundary): a lint error in a FOREIGN close file still blocks (not yet attributed)', () => {
+// Asserted on the lint SCOPE rather than on a lint blocker: whether the gate can
+// actually run lint depends on the package being resolvable (it fails open and skips
+// otherwise), which is an environment fact, not the coupling under test. The scope is
+// the coupling — a foreign close file inside it is what a lint error there would block on.
+test('IMPR-34 (boundary): the lint scope still seeds foreign close files (not yet attributed)', () => {
   const today = todayLocal();
   withClosePartitionWiki(
     [
@@ -29717,18 +29721,23 @@ test('IMPR-34 (boundary): a lint error in a FOREIGN close file still blocks (not
     ],
     [],
     (dir) => {
-      // Break lint (not the close) in the foreign project's own close file.
-      const ss = join(dir, 'projects', 'foreign', 'session-state.md');
-      writeFileSync(ss, readFileSync(ss, 'utf-8').replace('## 다음 작업', '## next'));
-      spawnSync('git', ['-C', dir, 'commit', '-qam', 'break foreign lint']);
       const gate = precompactGateStatus(dir, {
         closeScope: ['mine'],
         claudeHome: join(dir, '.claude-none'),
       });
-      assert.equal(
-        gate.blockers.some((b) => b.type === 'lint'),
-        true,
-        'lint on a foreign close file is still a blocker — the fix does not claim otherwise',
+      assert.deepEqual(gate.close.scope, ['mine'], 'the CLOSE scope is attributed to this session');
+
+      const lintScope = closeFileTargetsGlobal(dir);
+      assert.ok(
+        [...lintScope].some((f) => f.startsWith('projects/foreign/')),
+        'but the LINT scope still seeds every today-active project, foreign included — a lint ' +
+          'error there would still block, and the fix does not claim otherwise',
+      );
+      // Same shape for W8: design-history ownership is derived from the full
+      // today-active list, which the partition deliberately leaves global.
+      assert.ok(
+        gate.close.projects.some((p) => p.project === 'foreign'),
+        'close.projects stays global, so foreign W8 ownership is unchanged too',
       );
     },
   );

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1421,6 +1421,7 @@ const {
   hasLogEntry,
   hypoIsClean,
   precompactGateStatus,
+  writeSessionClosedMarker,
   commitWikiChanges,
   syncRemote,
   isOverdueDate,
@@ -29621,6 +29622,354 @@ test('session-start still says "no snapshot yet" when the files are genuinely ab
     assert.ok(
       /no snapshot yet/.test(r.stdout),
       `a genuinely absent snapshot must still read as absent: ${r.stdout}`,
+    );
+  });
+});
+
+// ── IMPR-34 — close-debt attribution (foreign incomplete close must not block) ──
+suite('IMPR-34 — close-debt attribution');
+
+// A git-clean vault with two projects and a transcript. `projects` is passed
+// straight to makeMultiProjectWiki; `touched` is the list of repo-relative files
+// the fake transcript shows this session editing via Write.
+function withClosePartitionWiki(projects, touched, fn) {
+  withSyncedWiki((dir) => {
+    const today = todayLocal();
+    makeMultiProjectWiki(dir, today, projects);
+    // makeMultiProjectWiki writes `## next`, which is not one of lint's required
+    // session-state headings. Left as-is it puts a lint ERROR in EVERY project's
+    // close files, so the gate would never be green and `gate.ok` could not be
+    // asserted — the close partition would look proven while the marker still never
+    // lands. Rewrite the heading so the close axis is the only thing under test.
+    for (const p of projects) {
+      const ss = join(dir, 'projects', p.slug, 'session-state.md');
+      if (existsSync(ss))
+        writeFileSync(ss, readFileSync(ss, 'utf-8').replace('## next', '## 다음 작업'));
+    }
+    const transcript = join(dir, '.cache', 'transcript.jsonl');
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      transcript,
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: touched.map((f) => ({
+            type: 'tool_use',
+            name: 'Write',
+            input: { file_path: join(dir, f) },
+          })),
+        },
+      }) + '\n',
+    );
+    // Commit so the gate's git axis is clean and only the close axis is under test.
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'close state']);
+    spawnSync('git', ['-C', dir, 'push', '-q', 'origin', 'HEAD']);
+    fn(dir, transcript, today);
+  });
+}
+
+// The incident: `mine` is fully closed, `foreign` was closed today by ANOTHER
+// session and left its session-log without the dated heading the gate requires.
+// Before the partition this refused `mine`'s marker with compact-gate-not-ok.
+const INCIDENT = (today) => [
+  { slug: 'mine', date: today },
+  { slug: 'foreign', date: today, sessionLog: false },
+];
+
+test('IMPR-34: foreign incomplete close is a notice, not a blocker, when scope names mine', () => {
+  withClosePartitionWiki(INCIDENT(todayLocal()), [], (dir) => {
+    const gate = precompactGateStatus(dir, {
+      closeScope: ['mine'],
+      claudeHome: join(dir, '.claude-none'),
+    });
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close'),
+      false,
+      `mine is complete → no close blocker. got ${JSON.stringify(gate.blockers)}`,
+    );
+    const debt = gate.notices.filter((n) => n.type === 'close-debt');
+    assert.deepEqual(
+      debt.map((n) => n.project),
+      ['foreign'],
+      'foreign debt is surfaced as a notice, never silently dropped',
+    );
+    assert.deepEqual(gate.close.missing, [], 'flat missing describes what BLOCKS, not the debt');
+    assert.equal(gate.close.ok, true, 'close.ok cannot contradict the absence of a close blocker');
+    // The actual win. Asserting only "no close blocker" would pass while the gate
+    // stayed red for some other reason and the marker still never landed.
+    assert.equal(gate.ok, true, `the gate is GREEN → the marker lands: ${JSON.stringify(gate)}`);
+  });
+});
+
+// The boundary of this fix, locked in on purpose. Close COMPLETENESS debt is now
+// attributed to a session; a lint error in those same foreign close files is NOT —
+// closeFileTargetsGlobal still seeds the lint scope from every today-active project,
+// and W8 design-history ownership is still global. Same defect shape, tracked as
+// sibling IMPRs. If a later change fixes them, this test is what should be updated
+// to say so — and the fix's claim must not run ahead of it.
+test('IMPR-34 (boundary): a lint error in a FOREIGN close file still blocks (not yet attributed)', () => {
+  const today = todayLocal();
+  withClosePartitionWiki(
+    [
+      { slug: 'mine', date: today },
+      { slug: 'foreign', date: today },
+    ],
+    [],
+    (dir) => {
+      // Break lint (not the close) in the foreign project's own close file.
+      const ss = join(dir, 'projects', 'foreign', 'session-state.md');
+      writeFileSync(ss, readFileSync(ss, 'utf-8').replace('## 다음 작업', '## next'));
+      spawnSync('git', ['-C', dir, 'commit', '-qam', 'break foreign lint']);
+      const gate = precompactGateStatus(dir, {
+        closeScope: ['mine'],
+        claudeHome: join(dir, '.claude-none'),
+      });
+      assert.equal(
+        gate.blockers.some((b) => b.type === 'lint'),
+        true,
+        'lint on a foreign close file is still a blocker — the fix does not claim otherwise',
+      );
+    },
+  );
+});
+
+// Same wiki, attribution removed. If this passes, the test above proves nothing.
+test('IMPR-34 (revert check): with NO attribution signal the foreign close still blocks', () => {
+  withClosePartitionWiki(INCIDENT(todayLocal()), [], (dir) => {
+    const gate = precompactGateStatus(dir, { claudeHome: join(dir, '.claude-none') });
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close'),
+      true,
+      'empty scope → fail closed → global block (today’s behavior, unchanged)',
+    );
+  });
+});
+
+test('IMPR-34: a hand-written close attributes via the transcript, not just opts', () => {
+  withClosePartitionWiki(
+    INCIDENT(todayLocal()),
+    ['projects/mine/session-state.md'],
+    (dir, transcript) => {
+      const gate = precompactGateStatus(dir, {
+        transcriptPath: transcript,
+        claudeHome: join(dir, '.claude-none'),
+      });
+      assert.equal(
+        gate.blockers.some((b) => b.type === 'close'),
+        false,
+        'editing mine’s close files puts mine (and only mine) in scope',
+      );
+    },
+  );
+});
+
+// Over-attribution guard: touching some ordinary page under foreign/ says nothing
+// about whose close is whose. If any path under projects/foreign/ counted, this
+// session would be re-blocked for a close it never performed.
+test('IMPR-34: a non-close file under the foreign project does NOT put it in scope', () => {
+  withClosePartitionWiki(
+    INCIDENT(todayLocal()),
+    ['projects/mine/session-state.md', 'projects/foreign/design-history.md'],
+    (dir, transcript) => {
+      const gate = precompactGateStatus(dir, {
+        transcriptPath: transcript,
+        claudeHome: join(dir, '.claude-none'),
+      });
+      assert.equal(
+        gate.close.scope.includes('foreign'),
+        false,
+        'only close files attribute a close',
+      );
+      assert.equal(
+        gate.blockers.some((b) => b.type === 'close'),
+        false,
+        'so the foreign debt stays demoted',
+      );
+    },
+  );
+});
+
+// The session's OWN incomplete close must still hard-block. This is the guard that
+// keeps the partition from becoming a bypass.
+test('IMPR-34: my own incomplete close blocks even while a foreign one is demoted', () => {
+  const today = todayLocal();
+  withClosePartitionWiki(
+    [
+      { slug: 'mine', date: today, sessionLog: false },
+      { slug: 'foreign', date: today, logEntry: false },
+    ],
+    [],
+    (dir) => {
+      const gate = precompactGateStatus(dir, {
+        closeScope: ['mine'],
+        claudeHome: join(dir, '.claude-none'),
+      });
+      const close = gate.blockers.find((b) => b.type === 'close');
+      assert.ok(close, 'mine is incomplete → close blocker');
+      assert.match(close.reason, /projects\/mine\//, 'and it names MY files');
+      assert.doesNotMatch(close.reason, /foreign/, 'not the foreign debt');
+    },
+  );
+});
+
+// "You have not closed this session at all" must never be demoted.
+test('IMPR-34: the no-activity fallback still blocks unconditionally', () => {
+  withClosePartitionWiki([{ slug: 'mine', date: '2020-01-01' }], [], (dir) => {
+    const gate = precompactGateStatus(dir, {
+      closeScope: ['mine'],
+      claudeHome: join(dir, '.claude-none'),
+    });
+    assert.equal(gate.close.fallback, true, 'no project closed today → fallback path');
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close'),
+      true,
+      'the fallback is what forces the initial close — never partition it',
+    );
+  });
+});
+
+// marker == compact-ready: the marker must be attributed to a project the gate
+// actually cleared, or PreCompact re-derives a scope the marker never covered.
+test('IMPR-34: marker attribution comes from the close scope, not the global primary', () => {
+  const today = todayLocal();
+  withClosePartitionWiki(
+    // `foreign` is the top hot.md row, so the global primary resolves to it while
+    // its own close is incomplete. Attributing the marker to `primary` here would
+    // hand PreCompact a scope that re-promotes foreign to a blocker.
+    [
+      { slug: 'foreign', date: today, sessionLog: false },
+      { slug: 'mine', date: today },
+    ],
+    [],
+    (dir) => {
+      const gate = precompactGateStatus(dir, {
+        closeScope: ['mine'],
+        claudeHome: join(dir, '.claude-none'),
+      });
+      assert.equal(gate.close.primary, 'foreign', 'the global primary IS the foreign project');
+      const scopeProject = gate.close.scope.includes(gate.close.primary)
+        ? gate.close.primary
+        : gate.close.scope[0];
+      assert.equal(scopeProject, 'mine', 'marker must be attributed to mine, not the primary');
+    },
+  );
+});
+
+// The failure with NO project row to derive from. sessionCloseGlobalStatus reports
+// `projects: []` + `missing: ['hot.md (no active project…)']`, so a partition that
+// derived `ok` from the per-project rows unconditionally would see "nothing failed"
+// and flip this red gate green. Reproduced by codex pre-commit review as a BLOCKER.
+test('IMPR-34: an unresolvable active project still blocks (no rows to derive ok from)', () => {
+  withSyncedWiki((dir) => {
+    // withSyncedWiki's hot.md carries the Active Projects table with NO project row.
+    const gate = precompactGateStatus(dir, {
+      closeScope: ['whatever'],
+      claudeHome: join(dir, '.claude-none'),
+    });
+    assert.equal(gate.close.ok, false, 'no active project → close is NOT ok');
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close'),
+      true,
+      'and it must still block — an empty projects[] is not "nothing failed"',
+    );
+  });
+});
+
+// The flat `project` alias names whatever the rest of the status describes. Left as
+// the global primary it can name a DEMOTED project, and every consumer that renders a
+// per-file checklist from it then prints ✓ for files close.debt calls missing (codex
+// pre-commit CONCERN).
+test('IMPR-34: close.project follows the scope, never a demoted primary', () => {
+  const today = todayLocal();
+  withClosePartitionWiki(
+    [
+      { slug: 'foreign', date: today, sessionLog: false }, // top hot.md row → global primary
+      { slug: 'mine', date: today },
+    ],
+    [],
+    (dir) => {
+      const gate = precompactGateStatus(dir, {
+        closeScope: ['mine'],
+        claudeHome: join(dir, '.claude-none'),
+      });
+      assert.equal(gate.close.primary, 'foreign', 'primary is still the global pick');
+      assert.equal(gate.close.project, 'mine', 'but `project` names what this status describes');
+      assert.deepEqual(
+        gate.close.debt.map((d) => d.project),
+        ['foreign'],
+        'and foreign is the demoted debt',
+      );
+    },
+  );
+});
+
+// End to end through the CLI: the command the close checklist tells the model to trust
+// must not print a per-file ✓ for a file it simultaneously reports as debt.
+test('IMPR-34: --check-session-close renders demoted debt without contradicting itself', () => {
+  const today = todayLocal();
+  withClosePartitionWiki(
+    [
+      { slug: 'foreign', date: today, sessionLog: false },
+      { slug: 'mine', date: today },
+    ],
+    ['projects/mine/session-state.md'],
+    (dir, transcript) => {
+      const r = spawnSync(
+        process.execPath,
+        [
+          join(SCRIPTS, 'crystallize.mjs'),
+          '--check-session-close',
+          '--json',
+          `--hypo-dir=${dir}`,
+          `--transcript-path=${transcript}`,
+        ],
+        { encoding: 'utf-8' },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.project, 'mine', 'the checklist is rendered for the project in scope');
+      assert.deepEqual(out.missing, [], 'flat missing carries only what blocks');
+      assert.deepEqual(
+        (out.close_debt || []).map((d) => d.project),
+        ['foreign'],
+        'the demoted close is reported as close_debt, not silently dropped',
+      );
+      assert.equal(out.ok, true, 'and ok never contradicts an empty missing');
+    },
+  );
+});
+
+// The reader that recovers the scope after a scripted close: marker.project.
+test('IMPR-34: marker.project re-derives the same scope PreCompact needs', () => {
+  withClosePartitionWiki(INCIDENT(todayLocal()), [], (dir) => {
+    const sid = 'impr34-session';
+    writeSessionClosedMarker(dir, sid, { project: 'mine' });
+    const gate = precompactGateStatus(dir, {
+      sessionId: sid,
+      claudeHome: join(dir, '.claude-none'),
+    });
+    assert.ok(gate.close.scope.includes('mine'), 'the marker carries the attribution forward');
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close'),
+      false,
+      'so PreCompact reaches the same verdict the marker attested',
+    );
+  });
+});
+
+// --project is a "is THIS project close-complete?" diagnostic. Demoting the very
+// project it named would answer a question nobody asked.
+test('IMPR-34: --project override is never partitioned away', () => {
+  withClosePartitionWiki(INCIDENT(todayLocal()), [], (dir) => {
+    const gate = precompactGateStatus(dir, {
+      projectOverride: 'foreign',
+      closeScope: ['mine'],
+      claudeHome: join(dir, '.claude-none'),
+    });
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close'),
+      true,
+      'the named project is checked, not demoted',
     );
   });
 });


### PR DESCRIPTION
# English

## What changed

An incomplete session close in a project **this session did not close** is no longer a global hard blocker. It is now attributed to the session that made it, and demoted to a `close-debt` notice when it belongs to someone else.

## Why

A session closed project `hypomnema` completely: all five close files written, committed, pushed, and `--check-session-close --project=hypomnema` green. Its close marker was still refused with `compact-gate-not-ok`, because a **different** session, hours earlier, had left `projects/guardia/session-log/<date>.md` with a heading (`## 세션 #17: ...`) that lacked the dated bracket form the gate requires. `hasTodayCloseActivity` saw guardia's `log.md` entry, `sessionCloseFileStatus` called guardia's session-log stale, and the gate raised a `close` blocker. The Stop-chain stayed open and `/compact` stayed blocked. A session that had finished its own work was punished for another session's formatting slip in an unrelated project.

The gate already draws exactly this line for **lint** debt: `partitionLintScope` blocks on errors in files this session touched and demotes pre-existing debt elsewhere to a notice. Close-file debt was the last check still hard-blocking globally on another session's work.

## How

`precompactGateStatus` resolves a **close scope**: the union of three signals, because no single one covers every close path.

1. The caller's explicit project. `--apply-session-close` passes `payload.project`. This is load-bearing, not a convenience: the documented close path writes its files from inside a Bash call, so they never surface as `Edit`/`Write` file paths and signal 2 cannot see them.
2. The **close files** the transcript shows this session editing (session-state, project hot, session-log shard). Not any file under `projects/<slug>/`: editing an unrelated page there says nothing about whose close is whose.
3. The marker's own `project`, which is how a later reader recovers signal 1 after a scripted close.

A failed close inside the scope blocks. Outside it, it becomes a `close-debt` notice that both the PreCompact hook and `--check-session-close` surface.

**Marker attribution now comes from the close scope, not the gate's global `primary`.** The primary can be a foreign project whose debt was just demoted, and PreCompact re-derives its scope *from the marker* — so attributing the marker to the primary hands PreCompact a scope the marker never cleared: marker green, `/compact` red. That is the `marker == compact-ready` invariant (#110).

Demotion happens only on positive attribution. Three fail-closed guards keep it from becoming a bypass: the "no project closed today" fallback (which is what forces the initial close), an empty scope, and an explicit `--project` diagnostic all keep today's global block.

## Scope of the fix

Close **completeness** debt only. A lint error in a foreign project's close files, and a stale design-history there, both still block. Same defect shape, tracked separately. A test (`IMPR boundary`) locks that line so the claim cannot drift ahead of the code.

One tradeoff is accepted and documented in the code: a scripted close that crashes mid-write leaves no marker and no transcript trace, so if that same session had also hand-edited another project's close files, its own torn close could be demoted. The window is narrow and self-limiting (the only torn state that reaches the partition is a missing `log.md` entry, which `deriveRootLogEntries` regenerates), and the marker is never written, so the Stop hook still refuses to end the session.

## Manual verification

Hooks changed (`hypo-shared.mjs`, `hypo-personal-check.mjs`), so the deployed copies were exercised:

```
$ diff -q ~/.claude/hooks/hypo-shared.mjs hooks/hypo-shared.mjs        # deployed == source
$ node scripts/crystallize.mjs --check-session-close --json --session-id=<this session>
ok: True   close_scope: []   close_debt: []   marker_present: False

$ node -e "resolveTranscriptBySessionId + extractTouchedWikiFiles + resolveCloseScope"
transcript resolved: true
wiki files this session edited: ['projects/hypomnema/decisions/<adr>.md']
close scope: []
```

The scope is correctly empty: the only wiki file this session edited is an ADR, which is not a close file, so it does not attribute a close. That is the over-attribution guard working on live data.

Regression tests were verified by reverting the fix, not just by passing: disabling the partition guard fails 13 tests, and disabling the `close.project` realignment fails 2.

## Migration notes

None. The gate's return shape gains `close.scope` / `close.debt` (and `close_scope` / `close_debt` in the `--check-session-close` JSON); the existing flat `stale` / `missing` fields keep their meaning of "what blocks", so a reader that treats a non-empty `missing` as failure still agrees with `ok`.

Note: this repo's pre-commit hook runs Prettier on staged files, so `scripts/crystallize.mjs` also picks up pre-existing formatting that main had not yet normalized. That churn is not part of the behavior change.

---

# 한국어

## 변경 내용

**이 세션이 닫지 않은** 프로젝트의 미완 close가 더 이상 전역 hard blocker가 아닙니다. 이제 그 close를 만든 세션에 귀속되고, 남의 것이면 `close-debt` notice로 강등됩니다.

## 이유

한 세션이 `hypomnema`를 완전히 닫았습니다. close 파일 다섯 개를 다 썼고, 커밋·푸시했고, `--check-session-close --project=hypomnema`도 green이었습니다. 그런데도 close 마커가 `compact-gate-not-ok`으로 거부됐습니다. 같은 날 몇 시간 전 **다른 세션**이 `projects/guardia/session-log/<date>.md`를 남기면서 항목 헤딩을 `## 세션 #17: ...`로 써서, 게이트가 요구하는 dated 브래킷이 없었기 때문입니다. `hasTodayCloseActivity`가 guardia의 `log.md` 엔트리를 보고 today-active로 잡았고, `sessionCloseFileStatus`가 그 session-log를 stale로 판정했고, 게이트가 `close` 블로커를 냈습니다. Stop-chain이 열린 채 남고 `/compact`가 막혔습니다. 자기 할 일을 끝낸 세션이 무관한 프로젝트에서 남이 낸 형식 실수를 뒤집어썼습니다.

같은 게이트가 **lint** 부채에는 이미 이 선을 긋고 있습니다. `partitionLintScope`는 이 세션이 건드린 파일의 에러만 막고, 다른 곳의 기존 부채는 notice로 내립니다. close 파일 부채만 유일하게 남의 세션 작업으로 전역 차단하고 있었습니다.

## 방법

`precompactGateStatus`가 **close 스코프**를 계산합니다. 한 신호로는 모든 close 경로를 못 덮어서 셋의 합집합입니다.

1. 호출자가 명시한 프로젝트. `--apply-session-close`가 `payload.project`를 넘깁니다. 편의가 아니라 필수입니다. 문서화된 close 경로는 Bash 안에서 파일을 쓰기 때문에 `Edit`/`Write` 경로로 안 잡히고, 신호 2가 못 봅니다.
2. transcript가 보여 주는 **close 파일** 편집(session-state, 프로젝트 hot, session-log 샤드). `projects/<slug>/` 아래 아무 파일이나가 아닙니다. 그 프로젝트의 무관한 페이지를 고친 걸로 close를 귀속시키면 안 됩니다.
3. 마커 자신의 `project`. 스크립트 close 이후 나중 독자가 신호 1을 복원하는 경로입니다.

스코프 안의 미완 close는 막습니다. 밖이면 `close-debt` notice가 되고, PreCompact 훅과 `--check-session-close` 양쪽이 그것을 표면화합니다.

**마커 귀속이 이제 전역 `primary`가 아니라 close 스코프에서 나옵니다.** primary는 방금 부채가 강등된 남의 프로젝트일 수 있고, PreCompact은 *마커로부터* 스코프를 다시 유도합니다. 그래서 마커를 primary에 귀속시키면 마커가 통과시킨 적 없는 스코프를 PreCompact에 넘기게 되고, 마커는 green인데 `/compact`는 red가 됩니다. `marker == compact-ready` 불변식(#110)이 바로 이것입니다.

강등은 적극적 귀속 신호가 있을 때만 합니다. 우회로가 되지 않도록 fail-closed 가드가 셋입니다. "오늘 아무 프로젝트도 안 닫힘" fallback(초기 close를 강제하는 경로), 빈 스코프, 그리고 `--project` 진단 셋 다 오늘 동작 그대로 전역 차단을 유지합니다.

## 이 수정의 경계

close **완결성** 부채만입니다. 남의 프로젝트 close 파일의 lint 에러와 그쪽 design-history staleness는 **여전히 막습니다**. 같은 결함 모양이지만 별도로 추적합니다. 테스트로 그 경계를 잠가 뒀습니다. 클레임이 코드보다 앞서 나가지 못하게.

의식적으로 수용한 tradeoff 하나를 코드에 문서화했습니다. 스크립트 close가 쓰기 도중 크래시하면 마커도 transcript 흔적도 없어서, 같은 세션이 **다른** 프로젝트의 close 파일을 손으로 건드렸다면 자기 torn close가 강등될 수 있습니다. 창이 좁고 스스로 닫힙니다(이 partition까지 도달하는 torn 상태는 `log.md` 엔트리 누락뿐이고 `deriveRootLogEntries`가 재생성합니다). 마커가 안 써지므로 Stop 훅이 세션 종료를 계속 막습니다.

## 수동 검증

훅(`hypo-shared.mjs`, `hypo-personal-check.mjs`)을 바꿨으므로 배포된 사본으로 검증했습니다.

```
$ diff -q ~/.claude/hooks/hypo-shared.mjs hooks/hypo-shared.mjs        # 배포본 == 소스
$ node scripts/crystallize.mjs --check-session-close --json --session-id=<이 세션>
ok: True   close_scope: []   close_debt: []   marker_present: False

$ node -e "resolveTranscriptBySessionId + extractTouchedWikiFiles + resolveCloseScope"
transcript resolved: true
wiki files this session edited: ['projects/hypomnema/decisions/<adr>.md']
close scope: []
```

스코프가 비어 있는 게 정답입니다. 이 세션이 편집한 위키 파일은 ADR 하나뿐인데 그건 close 파일이 아니라 close를 귀속시키지 않습니다. 과잉 귀속 방지가 실제 데이터에서 동작하는 것입니다.

회귀 테스트는 통과만 본 게 아니라 수정을 되돌려 확인했습니다. partition 가드를 끄면 13개가 깨지고, `close.project` 재정렬을 끄면 2개가 깨집니다.

## 마이그레이션 노트

없습니다. 게이트 반환 형태에 `close.scope` / `close.debt`(그리고 `--check-session-close` JSON의 `close_scope` / `close_debt`)가 추가됩니다. 기존 flat `stale` / `missing`은 "무엇이 막는가"라는 의미를 유지하므로, 비어 있지 않은 `missing`을 실패로 읽던 기존 독자도 `ok`와 계속 일치합니다.

참고: 이 레포의 pre-commit 훅이 staged 파일에 Prettier를 돌리기 때문에 `scripts/crystallize.mjs`에는 main이 아직 정규화하지 않았던 기존 포맷 변경도 함께 들어갔습니다. 동작 변경과는 무관합니다.

---

## Changelog

- EN: A completed session close is no longer refused because a different session left another project's close incomplete. Close debt is now attributed to the session that made it: an incomplete close in a project this session did not touch is reported as a non-blocking notice instead of blocking `/compact` and withholding the close marker. The session-closed marker is attributed to the project this session actually closed, not to whichever project happened to be the vault's most recent one. A lint error or a stale design-history in another project's close files still blocks. ([#193](https://github.com/sk-lim19f/Hypomnema/pull/193))
- KO: 다른 세션이 남긴 미완 close 때문에 완료된 세션의 close가 거부되지 않습니다. 이제 close 부채는 그것을 만든 세션에 귀속됩니다. 이 세션이 건드리지 않은 프로젝트의 미완 close는 `/compact`를 막고 close 마커를 보류하는 대신 비차단 notice로 보고됩니다. session-closed 마커도 볼트에서 가장 최근이었던 프로젝트가 아니라 이 세션이 실제로 닫은 프로젝트에 귀속됩니다. 다른 프로젝트 close 파일의 lint 에러나 stale design-history는 여전히 차단합니다. ([#193](https://github.com/sk-lim19f/Hypomnema/pull/193))

## Checklist

- [x] `npm test` passes locally (1400 passed, 0 failed)
- [x] `npm run lint` passes locally (no new errors; pre-existing vault debt unchanged)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (`commands/crystallize.md`: the `--mark --project` contract changed)
- [x] Filled the `## Changelog` block above (EN + KO line)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
