### PR TITLE
fix(gate): enforce the ship-surface rules on the PR and commit surface

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ PR title: Conventional Commits plus a scope, e.g.
 Body language: write the full body TWICE, once under `# English` and once
 under `# 한국어` (this repo ships bilingual docs). The `## Changelog` and
 `## Checklist` blocks are language-neutral, so they appear once, after both
-blocks. Do NOT add any "Generated with ..." / tool-attribution footer.
+blocks. Do NOT add a tool-attribution footer or a session URL of any kind.
 -->
 
 # English

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `edited` is NOT in the default type set ([opened, synchronize, reopened]).
+    # Without it, the pr-surface gate below would only ever see the body a PR was
+    # OPENED with: open clean, then edit in an attribution footer or a tracker id,
+    # and nothing re-runs. The gate would be bypassable by a two-step edit.
+    types: [opened, edited, reopened, synchronize]
 
 # Least privilege by default. A job that needs more must declare its own
 # `permissions:` block, which REPLACES this default rather than merging with it.
@@ -47,6 +52,77 @@ jobs:
           node-version: 20
       - name: No wiki-internal tracker ids in public artifacts
         run: npm run check:tracker-ids
+
+  push-commit-messages:
+    name: Commit message gate (push)
+    # The hole the pr-surface job below cannot see. That job scans
+    # `base.sha..head.sha` — the PR BRANCH's commits. This repo merges with
+    # SQUASH: the message that actually lands on `main` is composed in the merge
+    # dialog, never existed on the branch, and was never in that range. An
+    # attribution trailer typed there ships to a public `main` with every check
+    # green. Nothing else looks at it — the push workflow only ran file scanners.
+    #
+    # LIMITATION, on purpose and out loud: this runs on `push`, i.e. AFTER the
+    # merge. It DETECTS, it does not PREVENT. The remedy when it goes red is the
+    # one CLAUDE.md already prescribes — `git commit --amend`, strip the trailer,
+    # `git push --force-with-lease`. A red build a minute after the merge beats a
+    # leak nobody ever looks for.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # `before..after` must resolve locally; the default shallow clone does
+          # not have `before`.
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - name: No tracker ids or tool attribution in the commit messages this push added
+        # --push-range (not --commit-range) because `before` is all-zeros on a
+        # first push and points into discarded history after a force-push; the
+        # script resolves that and falls back to the tip commit rather than
+        # failing for the wrong reason. Same judgeMessage() the commit-msg hook
+        # and the PR range scan use — one judgment, several entry points.
+        run: |
+          node scripts/check-tracker-ids.mjs --push-range \
+            "${{ github.event.before }}..${{ github.event.after }}"
+
+  pr-surface:
+    name: PR surface gate
+    # The PR title/body is a public artifact that is NOT a file in the repo, so
+    # the tracker-ids job above (which scans the checkout) cannot see it. This job
+    # is the only thing that reads it. Skipped on push events, where there is no
+    # PR to check.
+    #
+    # The title and body arrive in the event payload, so the default
+    # `permissions: contents: read` is enough — no token scope, no API call, and
+    # deliberately NOT `pull_request_target` (that would run fork code with write
+    # scope for zero benefit here).
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history, not the default shallow clone: the commit-range step
+          # below needs `base.sha..head.sha` to resolve, and a shallow checkout
+          # would not have the base commit locally.
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - name: No tracker ids or tool attribution in the PR title/body; template filled
+        run: node scripts/check-pr-surface.mjs --github-event="$GITHUB_EVENT_PATH"
+      - name: No tracker ids or tool attribution in the PR's commit messages
+        # The commit-msg hook (scripts/install-git-hooks.mjs) is local-only,
+        # fails open on tooling problems, and is bypassable with --no-verify — an
+        # attribution trailer landed on `main` on 8 commits this way while the PR
+        # body itself stayed clean. This is the CI backstop: it scans every
+        # commit in the PR's range with the SAME judgment check-tracker-ids.mjs
+        # uses locally (judgeMessage(), reused, not reimplemented).
+        run: |
+          node scripts/check-tracker-ids.mjs --commit-range \
+            "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
 
   plugin-channel:
     name: Plugin channel (versions + smoke)

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ specs/
 # live in the maintainer's own ~/.claude/commands/, not here.
 .claude/
 
+# CLAUDE.md is the maintainer's agent guide, not product documentation. It names
+# the wiki, the tracker, and the maintainer's own review workflow, which is the
+# same reason .claude/ and specs/ are excluded: this repo carries user-facing
+# docs only. It is carried across machines by the wiki, not by this repo.
+CLAUDE.md
+
 # Append-lock files (transient <target>.lock around session-log / log.md writes)
 *.lock
 

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -122,9 +122,11 @@ process.stdin.on('end', () => {
   // turn the (otherwise non-blocking) drift into a blocker, since real drift is
   // confirmed and silently passing it would defeat the gate. --write only applies
   // when no target conflicts/over-caps (code===0 across ALL targets), so a late
-  // race exits non-zero and blocks here. It is semantic-preflight atomic but not
-  // filesystem-atomic (concurrent edit / mid-write I/O fault is best-effort) —
-  // pre-existing engine behavior, not introduced by the self-heal.
+  // race exits non-zero and blocks here. Each FILE it writes is atomic (tmp+
+  // rename, see feedback-sync's atomicWrite), so a mid-write fault can no longer
+  // truncate a target; what is still not atomic is the write ACROSS targets (one
+  // file can land before another fails), which the preflight narrows to genuine
+  // fs errors and no further.
   let feedbackHealed = '';
   if (gate.ok && gate.driftTargets.length > 0) {
     const feedbackPath = PKG_ROOT ? join(PKG_ROOT, 'scripts', 'feedback-sync.mjs') : null;

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -2704,8 +2704,55 @@ export function precompactGateStatus(hypoDir, opts = {}) {
           .map(([n]) => n);
         const overCapT = entries.filter(([, t]) => t.overCap).map(([n]) => n);
         const driftedT = entries.filter(([, t]) => t.dirty).map(([n]) => n);
-        if (!report || !(conflictedT.length || overCapT.length || driftedT.length)) {
-          skipped.feedback = true; // buildError / unparseable / non-actionable → fail-open
+        // A target whose file EXISTS but cannot be projected into (its
+        // <learned_behaviors> container is gone) reports dirty:false with no
+        // conflict flag — it cannot be built, so nothing "would change". That
+        // shape used to fall into the non-actionable branch below and fail OPEN,
+        // the worst possible reading: a projection that loads ZERO rules on this
+        // machine was classified as "nothing to do" and waved through. It is a
+        // blocker, not a shrug.
+        //
+        // ONLY kind 'build-failed'. A 'target-missing' buildError (no ~/.claude/
+        // CLAUDE.md yet) is the ordinary first-run state and must keep failing
+        // OPEN, or the gate blocks every new user on their first /compact.
+        const buildErrT = entries
+          .filter(([, t]) => t.buildError && t.buildErrorKind === 'build-failed')
+          .map(([n]) => n);
+        // Side-file I/O trouble (an unreadable feedback_<slug>.md under the
+        // project memory dir) is a NOTICE, never a blocker: the primary
+        // projection still loads every rule, and the only fix is a permission
+        // bit on that path — `--ensure-container` cannot touch it. A gate that
+        // blocks on a condition its own named remedy cannot clear is a gate that
+        // gets bypassed.
+        const sideWarnT = entries.filter(([, t]) => (t.sideWarnings || []).length);
+        if (
+          !report ||
+          !(
+            conflictedT.length ||
+            overCapT.length ||
+            driftedT.length ||
+            buildErrT.length ||
+            sideWarnT.length
+          )
+        ) {
+          skipped.feedback = true; // unparseable / non-actionable → fail-open
+        } else if (buildErrT.length) {
+          // Name the EXACT target file and the remedy for THIS cause. "Restore
+          // the managed container" with no path is a dead end, and so is naming
+          // `--ensure-container` for a permission error or a dangling symlink,
+          // which it cannot fix — a blocker with no way through gets bypassed
+          // rather than obeyed. t.buildError carries the target's absolute path
+          // and t.buildErrorRemedy the cause-specific way out; feedback-sync
+          // makes that judgment once, at the branch that detects the cause.
+          const failed = entries.filter(([n]) => buildErrT.includes(n));
+          const details = failed.map(([n, t]) => `${n}: ${t.buildError}`).join('; ');
+          const remedies = [
+            ...new Set(failed.map(([, t]) => t.buildErrorRemedy).filter(Boolean)),
+          ].join(' ');
+          blockers.push({
+            type: 'feedback',
+            reason: `feedback projection cannot be built — ${details} — no rules are loaded from it. ${remedies}`,
+          });
         } else if (conflictedT.length) {
           blockers.push({
             type: 'feedback',
@@ -2716,11 +2763,21 @@ export function precompactGateStatus(hypoDir, opts = {}) {
             type: 'feedback',
             reason: `feedback projection over cap (${overCapT.join(', ')}) — demote/archive feedback pages`,
           });
-        } else {
+        } else if (driftedT.length) {
           driftTargets.push(...driftedT); // pure drift → self-healable, not a blocker
           notices.push({
             type: 'feedback',
             reason: `feedback projection drift (${driftedT.join(', ')}) — will self-heal at /compact`,
+          });
+        }
+        // Additive, and deliberately outside the chain above: a side-file I/O
+        // problem is orthogonal to the primary target's health, so it is a notice
+        // whatever else is (or is not) going on. It names the path and the
+        // permission fix, because that — not a command — is the way out.
+        for (const [n, t] of sideWarnT) {
+          notices.push({
+            type: 'feedback',
+            reason: `feedback projection side file unreadable (${n}): ${t.sideWarnings.join('; ')} — fix the permissions on that path; the primary projection still loads every rule (\`--ensure-container\` does not fix this)`,
           });
         }
       }

--- a/scripts/check-pr-surface.mjs
+++ b/scripts/check-pr-surface.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * check-pr-surface.mjs — CI gate: the PR title and body are a public surface.
+ *
+ * The repo's other gates all read files. A PR title/body is not a file in the
+ * repo, so `check:tracker-ids` has never seen one — an `ISSUE-N` in a PR title
+ * sails past a green `Tracker-id gate`. This closes that hole, plus the two other
+ * PR-surface rules that had no enforcement at all: tool attribution (the harness
+ * prompt actively instructs the agent to add what this repo bans) and the PR
+ * template (`gh pr create --body` REPLACES the body, so
+ * .github/PULL_REQUEST_TEMPLATE.md never loads on the path agents use).
+ *
+ * All judgment lives in scripts/lib/check-pr-surface.mjs (pure, unit-tested).
+ * This wrapper only does I/O.
+ *
+ * Modes:
+ *   --title=<str> --body-file=<path>   Check an explicit title/body (local
+ *                                      pre-flight before `gh pr create`).
+ *   --github-event=<path>              Read pull_request.title / .body from a
+ *                                      GitHub event payload. Defaults to
+ *                                      $GITHUB_EVENT_PATH when neither --title
+ *                                      nor --body-file is given, so CI needs no
+ *                                      extra permissions: the title and body are
+ *                                      already in the payload.
+ *   --json                             Machine-readable output.
+ *
+ * Exit: 0 clean · 1 violations · 2 usage / unreadable input.
+ *
+ * NOTE the CI workflow must list `edited` in `on.pull_request.types`. The default
+ * type set is [opened, synchronize, reopened] — WITHOUT `edited` a contributor
+ * opens a clean PR, then edits the body to add an attribution footer, and no job
+ * ever re-runs.
+ */
+
+import { readFileSync } from 'node:fs';
+import { checkPrSurface } from './lib/check-pr-surface.mjs';
+
+function usage(code) {
+  process.stdout.write(
+    'Usage:\n' +
+      '  node scripts/check-pr-surface.mjs --title=<str> --body-file=<path> [--json]\n' +
+      '  node scripts/check-pr-surface.mjs --github-event=<path> [--json]\n' +
+      '  node scripts/check-pr-surface.mjs [--json]   (reads $GITHUB_EVENT_PATH)\n',
+  );
+  process.exit(code);
+}
+
+function die(msg) {
+  process.stderr.write(`[check-pr-surface] ${msg}\n`);
+  process.exit(2);
+}
+
+function readText(path, what) {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch (err) {
+    die(`cannot read ${what} ${path}: ${err.message}`);
+  }
+}
+
+const argv = process.argv.slice(2);
+if (argv.includes('--help') || argv.includes('-h')) usage(0);
+const json = argv.includes('--json');
+
+function flag(name) {
+  const hit = argv.find((a) => a.startsWith(`--${name}=`));
+  return hit === undefined ? null : hit.slice(name.length + 3);
+}
+
+const titleArg = flag('title');
+const bodyFile = flag('body-file');
+const eventArg = flag('github-event');
+
+let title;
+let body;
+
+if (titleArg !== null || bodyFile !== null) {
+  // Explicit mode. An empty body is a legitimate input here (and a violation),
+  // so only a missing --body-file falls back to an empty string.
+  title = titleArg ?? '';
+  body = bodyFile !== null ? readText(bodyFile, 'body file') : '';
+} else {
+  const eventPath = eventArg ?? process.env.GITHUB_EVENT_PATH ?? null;
+  if (!eventPath) {
+    process.stderr.write(
+      '[check-pr-surface] no --title/--body-file and no --github-event / $GITHUB_EVENT_PATH\n',
+    );
+    usage(2);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(readText(eventPath, 'event payload'));
+  } catch (err) {
+    die(`event payload ${eventPath} is not valid JSON: ${err.message}`);
+  }
+  const pr = payload && payload.pull_request;
+  if (!pr) {
+    // Not a pull_request event (push, workflow_dispatch, ...). Nothing to gate;
+    // the job's own `if:` should have prevented this, so say so and pass.
+    process.stdout.write('[check-pr-surface] event carries no pull_request — nothing to check.\n');
+    process.exit(0);
+  }
+  // GitHub sends `body: null` for an empty PR body.
+  title = typeof pr.title === 'string' ? pr.title : '';
+  body = typeof pr.body === 'string' ? pr.body : '';
+}
+
+const { ok, violations } = checkPrSurface({ title, body });
+
+if (json) {
+  process.stdout.write(
+    JSON.stringify({ ok, count: violations.length, violations }, null, 2) + '\n',
+  );
+  process.exit(ok ? 0 : 1);
+}
+
+if (ok) {
+  process.stdout.write('[check-pr-surface] OK: PR title and body are clean.\n');
+  process.exit(0);
+}
+
+process.stderr.write(
+  `[check-pr-surface] FAIL: ${violations.length} violation(s) on the PR surface:\n\n`,
+);
+for (const v of violations) {
+  process.stderr.write(`  [${v.rule}] ${v.surface}: ${v.detail}\n`);
+  // The fix is the point of the gate: a blocked agent that cannot see the way
+  // through works around the gate instead of obeying the rule.
+  process.stderr.write(`      fix: ${v.fix}\n\n`);
+}
+process.stderr.write(
+  'The PR title and body are a public surface: no wiki-internal tracker ids, no tool\n' +
+    'attribution, and the body follows .github/PULL_REQUEST_TEMPLATE.md (both language\n' +
+    'blocks + Changelog + Checklist). Re-run this check locally before pushing:\n' +
+    '  node scripts/check-pr-surface.mjs --title="$(gh pr view <N> --json title -q .title)" \\\n' +
+    '    --body-file=<file>\n',
+);
+process.exit(1);

--- a/scripts/check-tracker-ids.mjs
+++ b/scripts/check-tracker-ids.mjs
@@ -18,12 +18,42 @@
  *                          formatter's name-status/-z/diff-filter plumbing so
  *                          deletes, type-changes, symlinks and submodules are
  *                          skipped. Used by the pre-commit hook.
- *   --commit-msg <file>    Scan a commit message. Drops the --verbose scissors
- *                          diff, then strips comment lines ONLY when git added
- *                          its template (editor/strip mode); for `commit -m` /
- *                          whitespace / verbatim (no template) it scans comment
- *                          lines too, since git keeps them. Used by the
- *                          commit-msg hook.
+ *   --commit-msg <file>    Scan a commit message for tracker ids AND for tool-
+ *                          attribution trailers (ATTRIBUTION_PATTERNS: the
+ *                          harness system prompt instructs the agent to append a
+ *                          `Co-Authored-By:` / `Claude-Session:` trailer that
+ *                          this repo bans, and 8 of 47 post-ban commits carried
+ *                          one to main). Drops the --verbose scissors diff, then
+ *                          strips comment lines ONLY when git added its template
+ *                          (editor/strip mode); for `commit -m` / whitespace /
+ *                          verbatim (no template) it scans comment lines too,
+ *                          since git keeps them. Used by the commit-msg hook,
+ *                          which is FAST FEEDBACK, not a guarantee: the hook
+ *                          installer fails open at every guard (and --no-verify
+ *                          skips it outright), so CI is the real gate.
+ *   --commit-range <a..b>  CI backstop for the exact gap above: the commit-msg
+ *                          hook fails open on tooling problems and is bypassable
+ *                          with --no-verify, so a trailer can reach `main` on a
+ *                          commit while the PR body itself stays clean (this
+ *                          shipped 8 times). Scans every commit message in range
+ *                          `a..b` (`git log --format=%B`) with judgeMessage() —
+ *                          the SAME function --commit-msg uses on a single
+ *                          message — so the two entry points can never disagree
+ *                          about what counts as a violation (one judgment, not
+ *                          two — a duplicated judgment drifts). Wired into the
+ *                          pr-surface CI job, which checks out with
+ *                          fetch-depth:0 so `a..b` resolves against the PR's
+ *                          base/head SHAs.
+ *   --push-range <a..b>    The gap --commit-range still leaves open: this repo
+ *                          SQUASH-merges, so the message that actually lands on
+ *                          `main` is written in the merge dialog and never
+ *                          existed on the PR branch — it was never inside
+ *                          base.sha..head.sha, and every check stayed green. Runs
+ *                          on the `push` to main over
+ *                          github.event.before..github.event.after, tolerating an
+ *                          all-zero / force-pushed `before` (resolvePushRange).
+ *                          Post-merge detection, not prevention — see that
+ *                          function's comment.
  *   --json                 Machine-readable output.
  *
  * Exit: 0 clean · 1 violations · 2 usage error.
@@ -55,6 +85,7 @@ import {
   BLOCKED_PATTERNS,
   DECISION_PATTERNS,
   TAG_BODY_PATTERNS,
+  ATTRIBUTION_PATTERNS,
 } from './lib/check-tracker-ids.mjs';
 import {
   parseNameStatus,
@@ -76,6 +107,16 @@ const RULE_REF =
   'OSS-public artifacts must not reference the private wiki tracker ' +
   '(ISSUE-N / fix #N / FEAT-N / IMPR-N / PRAC-N). ' +
   'Use a GitHub ref (#N / PR #N) or drop the reference.';
+
+// Printed only when a --commit-msg scan trips ATTRIBUTION_PATTERNS. It names the
+// exact way out, because the agent that hit this was TOLD by its harness to write
+// the trailer and needs to know that here it must not comply.
+const ATTRIBUTION_REF =
+  'Rule: CLAUDE.md ship-surface (no attribution, anywhere). This repo ships no ' +
+  'tool-attribution trailer, whatever the harness default asks for. ' +
+  'Fix: delete the trailer line(s) from the commit message and commit again ' +
+  '(already committed? `git commit --amend`, strip it, then ' +
+  '`git push --force-with-lease`). Do NOT use `--no-verify`.';
 
 // Top-level public-artifact entry points. Files are scanned directly; dirs are
 // walked recursively. Anything outside this set is out of scope. package.json is
@@ -221,9 +262,9 @@ function report(violations, json) {
   } else if (violations.length === 0) {
     process.stdout.write('[check-tracker-ids] OK: no wiki-internal tracker ids found.\n');
   } else {
-    process.stderr.write(
-      `[check-tracker-ids] FAIL: ${violations.length} tracker-id reference(s):\n`,
-    );
+    // "blocked reference(s)", not "tracker-id reference(s)": --commit-msg also
+    // reports attribution trailers through this same reporter.
+    process.stderr.write(`[check-tracker-ids] FAIL: ${violations.length} blocked reference(s):\n`);
     for (const v of violations) {
       process.stderr.write(
         `  ${v.file}:${v.line}:${v.col}  ${v.match}  (${v.label})\n` +
@@ -294,6 +335,22 @@ function runStaged(json) {
   process.exit(report(violations, json));
 }
 
+// The ONE judgment function for a commit message TEXT: tracker-id scan +
+// attribution scan, both via scanText. --commit-msg (local hook, a single
+// COMMIT_EDITMSG file) and --commit-range (CI backstop, every already-recorded
+// message in a range) both call this and NOTHING ELSE decides the verdict —
+// this repo's rule against implementing the same judgment in two places (a
+// duplicated judgment drifts) applies here, and this is exactly the kind of
+// judgment that drifted before: a local-only check with no CI backstop let an
+// attribution trailer land on `main` on 8 separate commits while the PR body
+// itself stayed clean.
+function judgeMessage(text) {
+  return [
+    ...scanText(text).map((h) => ({ ...h })),
+    ...scanText(text, ATTRIBUTION_PATTERNS).map((h) => ({ ...h, attribution: true })),
+  ];
+}
+
 function runCommitMsg(file, json) {
   let raw;
   try {
@@ -323,7 +380,7 @@ function runCommitMsg(file, json) {
   // `#` lines, so a tracker id sitting in a comment line there is not caught.
   // This needs a non-default flag AND a `#`-prefixed id; the prose path (the real
   // risk) is always caught, and the file gate (--all/--staged/CI) is the hard
-  // guarantee. commit-msg is best-effort.
+  // guarantee. commit-msg is best-effort — --commit-range below is the real one.
   let text;
   if (messageHasGitTemplate(raw)) {
     const noScissors = stripScissors(raw);
@@ -332,8 +389,114 @@ function runCommitMsg(file, json) {
   } else {
     text = raw;
   }
-  const violations = scanText(text).map((h) => ({ file: relative(REPO_ROOT, file) || file, ...h }));
-  process.exit(report(violations, json));
+  const rel = relative(REPO_ROOT, file) || file;
+  // The commit message is where the harness/repo conflict actually bites: the
+  // system prompt tells the agent to append `Co-Authored-By:` / `Claude-Session:`
+  // on every commit, and 8 of the 47 commits that reached main after the ban did.
+  //
+  // Reminder on how much this is worth: install-git-hooks.mjs fails OPEN at every
+  // identity guard (CI, no .git, symlinked hook, missing script) and --no-verify
+  // skips it outright, so this hook is FAST LOCAL FEEDBACK, never the guarantee.
+  // The guarantee is CI — the tracker-id job for files, the pr-surface job for the
+  // PR title/body, and --commit-range below for the commit messages themselves.
+  const violations = judgeMessage(text).map((h) => ({ file: rel, ...h }));
+  const code = report(violations, json);
+  if (code !== 0 && !json && violations.some((v) => v.attribution)) {
+    process.stderr.write(`${ATTRIBUTION_REF}\n`);
+  }
+  process.exit(code);
+}
+
+// CI backstop for the gap above: --commit-msg only ever runs locally (fails
+// open on tooling problems, skippable with --no-verify), so a commit with an
+// attribution trailer can reach `main` while the PR body itself is clean — this
+// happened 8 times. Scans every commit message in `range` (`a..b`, resolved by
+// `git log`) with the SAME judgeMessage() --commit-msg uses.
+//
+// Commit messages read via `git log --format=%B` are already-recorded: git
+// itself stripped any editor template / --verbose scissors diff at commit time,
+// so unlike --commit-msg (which reads a live COMMIT_EDITMSG file) no
+// messageHasGitTemplate/stripScissors preprocessing applies or is needed here.
+function runCommitRange(range, json) {
+  const listRes = git(['log', '--format=%H', range, '--']);
+  if (listRes.status !== 0) {
+    process.stderr.write(
+      `[check-tracker-ids] --commit-range: git log failed for "${range}": ${(listRes.stderr || '').trim()}\n`,
+    );
+    process.exit(2);
+  }
+  const shas = (listRes.stdout || '')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const violations = [];
+  for (const sha of shas) {
+    const msgRes = git(['log', '-1', '--format=%B', sha]);
+    if (msgRes.status !== 0) continue; // sha came from the same git log call above
+    const short = sha.slice(0, 7);
+    violations.push(
+      ...judgeMessage(msgRes.stdout || '').map((h) => ({ file: `commit:${short}`, ...h })),
+    );
+  }
+  const code = report(violations, json);
+  if (code !== 0 && !json && violations.some((v) => v.attribution)) {
+    process.stderr.write(`${ATTRIBUTION_REF}\n`);
+  }
+  process.exit(code);
+}
+
+// The all-zero SHA GitHub sends as `github.event.before` for a branch's first push.
+const ZERO_SHA_RE = /^0{40}$/;
+
+/**
+ * Resolve the commit range a `push` event actually ADDED to the branch.
+ *
+ * Why a push scan exists at all: this repo merges with SQUASH. The message that
+ * lands on `main` is composed in the merge dialog, so it never existed on the PR
+ * branch and was never inside the pr-surface job's `base.sha..head.sha` range —
+ * every check could be green while the public commit on `main` carries an
+ * attribution trailer. That is not theoretical; it is the only path left open.
+ *
+ * KNOWN LIMITATION, stated plainly: this runs on `push`, i.e. AFTER the merge. It
+ * DETECTS, it cannot PREVENT. The commit is already on `main` when the job goes
+ * red — the remedy is `git commit --amend` + `git push --force-with-lease`, which
+ * is exactly what CLAUDE.md prescribes. A red build a minute after the merge beats
+ * a leak nobody ever looks for.
+ *
+ * `before` cannot be trusted blindly: it is all-zeros on a first push and points
+ * into discarded history after a force-push, so `before..after` would fail to
+ * resolve (exit 2, a red build for the wrong reason) or silently scan nothing.
+ *   before resolvable          → before..after  (exactly the commits this push added)
+ *   otherwise, after has a parent → after^1..after (the tip alone — less, never nothing)
+ *   after is a root commit     → after (that single commit)
+ */
+function resolvePushRange(before, after) {
+  const usable =
+    before &&
+    !ZERO_SHA_RE.test(before) &&
+    git(['cat-file', '-e', `${before}^{commit}`]).status === 0;
+  if (usable) return `${before}..${after}`;
+  if (git(['rev-parse', '-q', '--verify', `${after}^1`]).status === 0)
+    return `${after}^1..${after}`;
+  return after;
+}
+
+function runPushRange(spec, json) {
+  const idx = String(spec).indexOf('..');
+  if (idx < 0) {
+    process.stderr.write(
+      '[check-tracker-ids] --push-range requires a "<before>..<after>" argument\n',
+    );
+    usage(2);
+  }
+  const before = String(spec).slice(0, idx);
+  const after = String(spec).slice(idx + 2);
+  if (!after) {
+    process.stderr.write('[check-tracker-ids] --push-range: the <after> sha is required\n');
+    usage(2);
+  }
+  // Same judgment as every other entry point: runCommitRange → judgeMessage.
+  runCommitRange(resolvePushRange(before, after), json);
 }
 
 // Scan an annotated tag's body for ALL wiki tracker prefixes (TAG_BODY_PATTERNS:
@@ -390,6 +553,12 @@ function usage(code) {
       '  node scripts/check-tracker-ids.mjs [--all] [--json]\n' +
       '  node scripts/check-tracker-ids.mjs --staged [--json]\n' +
       '  node scripts/check-tracker-ids.mjs --commit-msg <file> [--json]\n' +
+      '  node scripts/check-tracker-ids.mjs --commit-range <base>..<head> [--json]\n' +
+      '      CI backstop: scan every commit message in the range for tracker ids\n' +
+      '      and attribution trailers (the local commit-msg hook is bypassable).\n' +
+      '  node scripts/check-tracker-ids.mjs --push-range <before>..<after> [--json]\n' +
+      '      Same scan for a `push` event, tolerating an all-zero / force-pushed\n' +
+      '      <before>. This is the ONLY thing that sees a squash-merge message.\n' +
       '  node scripts/check-tracker-ids.mjs --tag <ref|-> [--json]\n' +
       '      Scan an annotated tag body (or stdin via "-") for ALL tracker\n' +
       '      prefixes; the public release surface must be tracker-ID-0.\n',
@@ -409,6 +578,26 @@ if (argv.includes('--commit-msg')) {
     usage(2);
   }
   runCommitMsg(file, json);
+} else if (argv.includes('--commit-range')) {
+  const i = argv.indexOf('--commit-range');
+  const range = argv[i + 1];
+  if (!range || range.startsWith('--')) {
+    process.stderr.write(
+      '[check-tracker-ids] --commit-range requires a "<base>..<head>" argument\n',
+    );
+    usage(2);
+  }
+  runCommitRange(range, json);
+} else if (argv.includes('--push-range')) {
+  const i = argv.indexOf('--push-range');
+  const spec = argv[i + 1];
+  if (!spec || spec.startsWith('--')) {
+    process.stderr.write(
+      '[check-tracker-ids] --push-range requires a "<before>..<after>" argument\n',
+    );
+    usage(2);
+  }
+  runPushRange(spec, json);
 } else if (argv.includes('--tag')) {
   const i = argv.indexOf('--tag');
   const ref = argv[i + 1];

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1203,9 +1203,44 @@ function checkFeedbackProjection(hypoDir, claudeHome, projectId) {
       `${name}: ${reason} — run \`hypomnema feedback-sync --import-target-change\` to reconcile`,
     );
   } else {
-    // 2) build error → WARN
-    const buildErr = targets.find(([, t]) => t.buildError);
-    if (buildErr) {
+    // 2) build error. Split by kind:
+    //
+    //    'build-failed' → FAIL. The target file EXISTS but its
+    //      <learned_behaviors> container is gone, so the projection cannot be
+    //      built: NOT ONE L1 rule is loaded on that machine and every later sync
+    //      is a silent no-op. This was a warn, which made a structurally broken
+    //      projection near-invisible — nothing else reported it either (the
+    //      PreCompact gate classified it as "nothing to do" and failed open), and
+    //      it went unnoticed on a real machine. A projection that cannot be built
+    //      is a failure, not a note.
+    //
+    //    'target-missing' → WARN, as before. No ~/.claude/CLAUDE.md yet is the
+    //      ordinary first-run state, not a broken one; failing here would fail
+    //      every new user's doctor run.
+    //
+    // Select the build-failed target SPECIFICALLY rather than taking the first
+    // buildError of any kind: with more than one container target, a
+    // 'target-missing' one earlier in iteration order would otherwise mask a
+    // structurally broken one behind a warn — the exact invisibility this check
+    // exists to end. Only `claude` carries a container today, so that masking is
+    // latent, not live; the precompact gate filters the same way.
+    const failedErr = targets.find(([, t]) => t.buildErrorKind === 'build-failed');
+    const buildErr = failedErr || targets.find(([, t]) => t.buildError);
+    if (failedErr) {
+      const [name, t] = failedErr;
+      // Name the remedy for THIS cause, not a fixed one. `--ensure-container`
+      // restores a MISSING container; it cannot chmod an unreadable file, cannot
+      // repoint a dangling symlink, and refuses a corrupt container outright — so
+      // printing it for those causes hands the reader a command that does nothing
+      // and teaches them to ignore the next failure too. feedback-sync decides the
+      // remedy where it detects the cause and ships it as `buildErrorRemedy`; this
+      // just prints it (one judgment, several consumers).
+      fail(
+        'Feedback projection',
+        `${name}: ${t.buildError} — the projection cannot be built, so NO rules are loaded from it ` +
+          `and every sync is a silent no-op. ${t.buildErrorRemedy || ''}`.trimEnd(),
+      );
+    } else if (buildErr) {
       warn('Feedback projection', buildErr[1].buildError);
     } else if (targets.find(([, t]) => t.overCap)) {
       warn('Feedback projection', 'projection over cap — demote/archive feedback pages');
@@ -1218,7 +1253,23 @@ function checkFeedbackProjection(hypoDir, claudeHome, projectId) {
     }
   }
 
-  // 3) unresolved project-id is a separate, non-fatal concern (MEMORY skipped)
+  // 3) side-file I/O problems: a WARN, and additive rather than part of the
+  //    if/else chain above — an unreadable feedback_<slug>.md copy is orthogonal
+  //    to the primary target's health. It must not fail: the index line still
+  //    projects, every rule still loads, and the remedy is a permission bit on a
+  //    named path — nothing `--ensure-container` (the build-failed remedy) can
+  //    touch. feedback-sync already put the path in the message.
+  for (const [name, t] of targets) {
+    for (const w of t.sideWarnings || []) {
+      warn(
+        'Feedback projection side file',
+        `${name}: ${w} — fix the permissions on that path; the primary projection still loads ` +
+          `(\`--ensure-container\` does not fix this)`,
+      );
+    }
+  }
+
+  // 4) unresolved project-id is a separate, non-fatal concern (MEMORY skipped)
   if (report.projectIdResolved === false) {
     warn(
       'Feedback projection',

--- a/scripts/feedback-sync.mjs
+++ b/scripts/feedback-sync.mjs
@@ -12,13 +12,17 @@
  * --check / --write engine: per-slug managed blocks + sha256 idempotency +
  * conflict (exit 3) + over-cap (exit 2) [Phase A]. --bootstrap / --import-target-
  * change: reverse one-time helpers that scaffold pages/feedback/_drafts/ for human
- * review — never write pages/feedback/<slug>.md directly [Phase D].
+ * review — never write pages/feedback/<slug>.md directly [Phase D]. --ensure-
+ * container: provisions the ONE thing --write can never create on its own — the
+ * `<learned_behaviors>` container itself is a precondition for --write, not
+ * something it can bootstrap into existence (that would mean guessing WHERE in
+ * an arbitrary, possibly hand-authored CLAUDE.md to insert it).
  *
  * Contract: projects/hypomnema/fix-37-contract.md (per-slug managed block model,
  * sha256 over normalized inner content, sort key, exit matrix, project-id rule).
  *
  * Usage:
- *   node scripts/feedback-sync.mjs [--check|--write|--bootstrap|--import-target-change --from=<memory|claude>]
+ *   node scripts/feedback-sync.mjs [--check|--write|--bootstrap|--import-target-change --from=<memory|claude>|--ensure-container]
  *     --hypo-dir=<path>      Hypomnema root (default: HYPO_DIR / hypo-config.md / ~/hypomnema)
  *     --claude-home=<path>   Claude Code home (default: ~/.claude)
  *     --project-id=<id>      Override derived project-id (§5; always wins, no prompt)
@@ -26,6 +30,23 @@
  *     --strict               Promote warnings to failures (PreCompact gate)
  *     --json                 Machine-readable output
  *     --dry-run              (bootstrap/import) report planned drafts, write nothing
+ *
+ * --ensure-container: the remedy for a 'build-failed' target (its
+ * `<learned_behaviors>` container is gone, so NOT ONE L1 rule loads and every
+ * --write is a silent no-op — see doctor's "Feedback projection" fail and the
+ * PreCompact gate's "feedback projection cannot be built" blocker). If
+ * `<claude-home>/CLAUDE.md` EXISTS and has no container, appends a short
+ * guidance comment plus an empty `<learned_behaviors></learned_behaviors>`
+ * pair to the end of the file — the existing bytes are re-written verbatim ahead
+ * of the addition, through an ATOMIC tmp+rename (see atomicWrite), so a crash or
+ * a full disk mid-write leaves the user's file exactly as it was. If the
+ * container is already there, it is a no-op (idempotent, safe to re-run). If
+ * the file does not exist at all, it is ALSO a no-op ('target-missing' is the
+ * ordinary first-run state, not something to provision here). If the file
+ * carries a CORRUPT container (inverted / duplicated / unpaired tags), it
+ * REFUSES and says what is wrong: appending a valid pair on top of a broken one
+ * produces a file this tool can never repair (the predicate keeps reading "no
+ * container", every re-run appends another pair, --write keeps failing).
  *
  * Project-id fallback (§5 step 4): when the derived project-id directory does not
  * exist AND stdin is an interactive TTY AND --no-input is not set, prompt the user
@@ -49,8 +70,12 @@ import {
   mkdirSync,
   rmSync,
   realpathSync,
+  lstatSync,
+  statSync,
+  chmodSync,
+  renameSync,
 } from 'node:fs';
-import { join, basename, resolve, sep } from 'node:path';
+import { join, basename, dirname, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
@@ -63,7 +88,7 @@ const HOME = homedir();
 
 function parseArgs(argv) {
   const args = {
-    mode: 'check', // check | write | bootstrap | import
+    mode: 'check', // check | write | bootstrap | import | ensure-container
     from: null,
     hypoDir: null,
     claudeHome: null,
@@ -80,6 +105,7 @@ function parseArgs(argv) {
     else if (arg === '--write') args.mode = 'write';
     else if (arg === '--bootstrap') args.mode = 'bootstrap';
     else if (arg === '--import-target-change') args.mode = 'import';
+    else if (arg === '--ensure-container') args.mode = 'ensure-container';
     else if (arg.startsWith('--from=')) args.from = arg.slice(7);
     else if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg.startsWith('--claude-home=')) args.claudeHome = expandHome(arg.slice(14));
@@ -94,6 +120,72 @@ function parseArgs(argv) {
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   if (!args.claudeHome) args.claudeHome = join(HOME, '.claude');
   return args;
+}
+
+// ── atomic write (tmp + rename) ──────────────────────────────────────────────
+//
+// `writeFileSync(file, content)` truncates first and writes second: a crash, a
+// full disk, or a kill between the two leaves the file cut in half. Every file
+// this tool touches is a file it does NOT own — `~/.claude/CLAUDE.md` is
+// hand-authored global config, and --ensure-container advertises "existing
+// content is never touched" while doing a whole-file overwrite. So writes go
+// through tmp+rename: rename(2) is atomic within a filesystem, so the target
+// holds either every old byte or every new byte, never a truncated mix. Same
+// shape as hooks/base-store.mjs and hooks/proposal-store.mjs (kept local rather
+// than imported: those live behind the hooks/ boundary and this file owns its
+// own fs layer).
+//
+// A SYMLINKED target (a dotfile repo that links ~/.claude/CLAUDE.md into a git
+// checkout is a common setup) is resolved with realpathSync FIRST, so the tmp
+// file lands beside the REAL file — same directory, therefore same filesystem,
+// therefore an atomic rename — and the rename replaces the real file instead of
+// clobbering the link itself with a regular file.
+function atomicWrite(file, content) {
+  let real = file;
+  try {
+    real = realpathSync(file);
+  } catch {
+    // not there yet (a first-write side-file): write it where it was requested
+  }
+  const dir = dirname(real);
+  mkdirSync(dir, { recursive: true });
+  // Carry the existing mode across: a bare rename would silently relax a 0600
+  // CLAUDE.md to whatever the process umask hands the tmp file.
+  let mode = null;
+  try {
+    mode = statSync(real).mode & 0o777;
+  } catch {
+    /* new file → default mode */
+  }
+  const tmp = join(
+    dir,
+    `.${basename(real)}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`,
+  );
+  try {
+    writeFileSync(tmp, content);
+    if (mode !== null) chmodSync(tmp, mode);
+    renameSync(tmp, real);
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      /* best-effort: an orphan tmp is inert, the original file is intact either way */
+    }
+    throw err;
+  }
+}
+
+// Is `file` a symlink whose target does not exist? existsSync FOLLOWS the link,
+// so a dangling one reads as "no file at all" — the ordinary, benign first-run
+// state — and a target that is configured but broken would be waved through with
+// zero rules loaded. lstat sees the link itself.
+function isDanglingSymlink(file) {
+  if (existsSync(file)) return false;
+  try {
+    return lstatSync(file).isSymbolicLink();
+  } catch {
+    return false; // genuinely absent
+  }
 }
 
 // ── frontmatter helpers ──────────────────────────────────────────────────────
@@ -287,33 +379,165 @@ function buildRegion(desired) {
   return desired.map((d) => renderBlock(d.slug, d.inner)).join('\n');
 }
 
+// ── the <learned_behaviors> container: ONE judgment, one view ────────────────
+
+const LB_OPEN = '<learned_behaviors>';
+const LB_CLOSE = '</learned_behaviors>';
+
+// Replace every character of `match` with a space, newlines excepted.
+function blank(match) {
+  return match.replace(/[^\n]/g, ' ');
+}
+
+// Mask the spans a markdown reader does NOT read as live text — HTML comments,
+// fenced code blocks, inline code spans — so a tag inside one of them cannot be
+// mistaken for the container. Masked characters become spaces and newlines are
+// kept, so the masked view has EXACTLY the same length and line structure as the
+// input: an index found here is a valid index into the original content, which
+// is what lets placement splice on it.
+//
+// Why this exists: a plain indexOf() said "container present" for
+// `<!-- <learned_behaviors></learned_behaviors> -->` and for a pair inside a code
+// fence. --ensure-container then no-op'd while placement wrote the managed region
+// INSIDE the comment/fence, where it is inert — and the hook read that as ordinary
+// drift and kept rewriting it. Inline code matters just as much: a CLAUDE.md that
+// merely MENTIONS `<learned_behaviors>` in prose (this repo's own does) would
+// otherwise read as an unpaired open tag.
+function maskInertSpans(content) {
+  const lines = content.replace(/<!--[\s\S]*?-->/g, blank).split('\n');
+  let fence = null;
+  return lines
+    .map((line) => {
+      const delim = /^[ \t]*(`{3,}|~{3,})/.exec(line);
+      if (fence) {
+        if (delim && delim[1][0] === fence.char && delim[1].length >= fence.len) fence = null;
+        return blank(line); // every line inside the fence, close delimiter included
+      }
+      if (delim) {
+        fence = { char: delim[1][0], len: delim[1].length };
+        return blank(line);
+      }
+      return line.replace(/`[^`\n]*`/g, blank);
+    })
+    .join('\n');
+}
+
+function indicesOf(text, needle) {
+  const out = [];
+  for (let i = text.indexOf(needle); i !== -1; i = text.indexOf(needle, i + needle.length)) {
+    out.push(i);
+  }
+  return out;
+}
+
+/**
+ * The ONE definition of "the container is there", over the masked view above:
+ *
+ *   { state: 'present', open, close }  exactly one pair, open BEFORE close
+ *   { state: 'absent',  ... }          no tag at all → --ensure-container provisions it
+ *   { state: 'corrupt', reason, ... }  inverted / duplicated / unpaired tags
+ *
+ * 'corrupt' is its own state because the alternative — folding it into "absent" —
+ * built a trap: with `</learned_behaviors>` sitting before `<learned_behaviors>`,
+ * a first-occurrence predicate reads false forever, so --ensure-container appends
+ * a fresh pair, the inverted tags stay, the predicate STILL reads false, and every
+ * --write keeps failing. The tool manufactured a state it could not repair. A
+ * corrupt container is damage a human fixes; the tool says so and stops.
+ *
+ * buildNextContent's placement, --ensure-container's idempotency check and
+ * evaluateTarget's out-of-container check all call this, so they cannot drift
+ * apart on what counts as a container — and they are wrong together or right
+ * together, never half of each.
+ */
+function classifyContainer(content) {
+  const view = maskInertSpans(content);
+  const opens = indicesOf(view, LB_OPEN);
+  const closes = indicesOf(view, LB_CLOSE);
+  if (!opens.length && !closes.length) return { state: 'absent', open: -1, close: -1 };
+  if (opens.length === 1 && closes.length === 1 && opens[0] < closes[0]) {
+    return { state: 'present', open: opens[0], close: closes[0] };
+  }
+  let reason;
+  if (!opens.length) reason = `a closing ${LB_CLOSE} with no opening ${LB_OPEN}`;
+  else if (!closes.length) reason = `an opening ${LB_OPEN} with no closing ${LB_CLOSE}`;
+  else if (opens.length > 1 || closes.length > 1)
+    reason = `${opens.length} opening and ${closes.length} closing tags (exactly one pair is required)`;
+  else reason = `the closing ${LB_CLOSE} appears BEFORE the opening ${LB_OPEN}`;
+  return {
+    state: 'corrupt',
+    reason,
+    open: opens.length ? opens[0] : -1,
+    close: closes.length ? closes[0] : -1,
+  };
+}
+
+// ── remedies (one way out per CAUSE) ─────────────────────────────────────────
+//
+// A blocker that names a command which cannot possibly fix the condition it
+// reports teaches the reader to ignore blockers. `--ensure-container` only ever
+// touches CLAUDE.md's container: it cannot chmod an unreadable file, cannot
+// repoint a dangling symlink, and must not append onto a corrupt container. The
+// remedy is decided ONCE, here, next to the branch that detects the cause, and
+// rides along in the JSON report (`buildErrorRemedy`) so doctor and the PreCompact
+// gate print the same way out instead of each guessing one.
+const REMEDY = {
+  containerMissing: (file) =>
+    'Run `hypomnema feedback-sync --ensure-container` to add the missing ' +
+    `<learned_behaviors></learned_behaviors> pair to ${file} (existing content is untouched), ` +
+    'then `hypomnema feedback-sync --write`.',
+  containerCorrupt: (file, reason) =>
+    `Repair ${file} BY HAND so it holds exactly one <learned_behaviors></learned_behaviors> pair ` +
+    `with the opening tag first — found ${reason}. \`--ensure-container\` refuses to append here: ` +
+    'a second pair stacked on a broken one leaves the file unprojectable forever.',
+  io: (file) =>
+    `Fix the permissions on ${file} so this user can read and write it (e.g. \`chmod u+rw\`), then ` +
+    're-run `hypomnema feedback-sync --write`. `--ensure-container` cannot fix a permission bit.',
+  danglingSymlink: (file) =>
+    `${file} is a symlink whose target does not exist (\`ls -l\` it). Repoint or remove the link, ` +
+    'then re-run `hypomnema feedback-sync --write`.',
+};
+
 // Compute the next file content for a target. Returns { content } on success or
-// { error } when the region cannot be placed (e.g. missing container). Pure — no
-// disk writes — so run() can preflight every target before any write (atomicity).
+// { error, remedy } when the region cannot be placed (missing / corrupt
+// container). Pure — no disk writes — so run() can preflight every target before
+// any write (atomicity).
 function buildNextContent(content, region, target) {
   const { firstStart, lastEnd } = findBlocks(content);
-  if (firstStart >= 0) {
-    // replace the contiguous managed span (region may be '' to clear it)
-    return { content: content.slice(0, firstStart) + region + content.slice(lastEnd) };
-  }
-  // no existing blocks
-  if (region === '') return { content }; // nothing to place → no-op (idempotent)
+  // replace the contiguous managed span (region may be '' to clear it)
+  const replaceSpan = () => ({
+    content: content.slice(0, firstStart) + region + content.slice(lastEnd),
+  });
   if (target.container === 'learned_behaviors') {
-    const open = content.indexOf('<learned_behaviors>');
-    const close = content.indexOf('</learned_behaviors>');
-    if (open < 0 || close < 0 || close < open) {
-      return { error: `<learned_behaviors> container not found in ${target.file}` };
+    const c = classifyContainer(content);
+    // Checked BEFORE the existing-blocks fast path: rewriting a managed span
+    // inside a file whose container tags are broken just re-lands the region in a
+    // structure nothing reads.
+    if (c.state === 'corrupt') {
+      return {
+        error: `<learned_behaviors> container in ${target.file} is corrupt: ${c.reason}`,
+        remedy: REMEDY.containerCorrupt(target.file, c.reason),
+      };
+    }
+    if (firstStart >= 0) return replaceSpan();
+    if (region === '') return { content }; // nothing to place → no-op (idempotent)
+    if (c.state === 'absent') {
+      return {
+        error: `<learned_behaviors></learned_behaviors> container not found in ${target.file}`,
+        remedy: REMEDY.containerMissing(target.file),
+      };
     }
     // an anchor is honored ONLY when it sits inside the container span
     const anchorIdx = content.indexOf(MARK_ANCHOR);
-    if (anchorIdx > open && anchorIdx < close) {
+    if (anchorIdx > c.open && anchorIdx < c.close) {
       return {
         content:
           content.slice(0, anchorIdx) + region + content.slice(anchorIdx + MARK_ANCHOR.length),
       };
     }
-    return { content: content.slice(0, close) + region + '\n' + content.slice(close) };
+    return { content: content.slice(0, c.close) + region + '\n' + content.slice(c.close) };
   }
+  if (firstStart >= 0) return replaceSpan();
+  if (region === '') return { content };
   // memory index: anchor (anywhere) or append
   const anchorIdx = content.indexOf(MARK_ANCHOR);
   if (anchorIdx >= 0) {
@@ -327,6 +551,10 @@ function buildNextContent(content, region, target) {
 
 // sync-owned full-copy files (feedback_<slug>.md) no longer backed by an active
 // candidate → must be removed so deletions/demotions propagate (MEDIUM-1).
+// readdirSync MAY THROW (e.g. EACCES on target.dir) — deliberately NOT caught
+// here. The caller (evaluateTarget) catches it and classifies it exactly like a
+// primary-target read failure ('build-failed'), so a directory permission
+// problem cannot silently masquerade as "no stale side-files to clean up".
 function staleSideFiles(target, desired) {
   if (!target.dir || !existsSync(target.dir)) return [];
   const keep = new Set(desired.map((d) => `feedback_${d.slug}.md`));
@@ -335,7 +563,11 @@ function staleSideFiles(target, desired) {
     .map((f) => join(target.dir, f))
     .filter((p) => {
       // only delete files THIS tool generated (provenance header on line 1) —
-      // never a user's hand-written feedback_*.md memory file
+      // never a user's hand-written feedback_*.md memory file. Unreadable here
+      // just means "don't delete it" (a safe, non-destructive default) — this
+      // per-file check was already caught before this fix and stays that way;
+      // it is the DIRECTORY listing and the PRIMARY target read that used to
+      // throw uncaught, not this narrow provenance probe.
       try {
         return readFileSync(p, 'utf-8').startsWith(SIDE_MARKER_PREFIX);
       } catch {
@@ -349,7 +581,24 @@ function staleSideFiles(target, desired) {
 function evaluateTarget(pages, target) {
   const desired = computeDesired(pages, target);
   const fileExists = existsSync(target.file);
-  const content = fileExists ? readFileSync(target.file, 'utf-8') : '';
+  const dangling = isDanglingSymlink(target.file);
+  // The FILE existing does not mean it is READABLE. A permission error here
+  // (mode 000, an ACL change mid-session, ...) used to throw uncaught: the
+  // whole --check/--write run crashed, no JSON report was produced, and every
+  // downstream consumer (doctor's "no JSON" branch, the PreCompact gate's
+  // unparseable-stdout branch) reads "no report" as "nothing to project" and
+  // fails OPEN — reproducing, via an ordinary filesystem error, the exact
+  // failure mode ("rules not loaded, gate stays green") this whole projection
+  // system exists to prevent. Caught and classified as 'build-failed' instead.
+  let content = '';
+  let ioError = null;
+  if (fileExists) {
+    try {
+      content = readFileSync(target.file, 'utf-8');
+    } catch (err) {
+      ioError = `cannot read target file ${target.file}: ${err.message}`;
+    }
+  }
   const { blocks } = findBlocks(content);
   const { starts, ends } = countMarkers(content);
 
@@ -361,12 +610,16 @@ function evaluateTarget(pages, target) {
   const intruder = regionHasIntruders(content);
   // out-of-container: an existing managed block sitting outside <learned_behaviors>
   // (drifted/hand-moved) — replacing it in place would leave it outside the
-  // required region, so refuse and require import.
+  // required region, so refuse and require import. A CORRUPT container is
+  // deliberately NOT reported here: it is a build failure with its own remedy
+  // (repair by hand), and routing it through the conflict path would print
+  // "run --import-target-change", which reconciles nothing.
   let outOfContainer = false;
-  if (target.container === 'learned_behaviors' && blocks.length) {
-    const open = content.indexOf('<learned_behaviors>');
-    const close = content.indexOf('</learned_behaviors>');
-    outOfContainer = open < 0 || close < 0 || blocks.some((b) => b.start < open || b.end > close);
+  const container = target.container === 'learned_behaviors' ? classifyContainer(content) : null;
+  if (container && container.state !== 'corrupt' && blocks.length) {
+    outOfContainer =
+      container.state !== 'present' ||
+      blocks.some((b) => b.start < container.open || b.end > container.close);
   }
 
   const region = buildRegion(desired);
@@ -378,28 +631,97 @@ function evaluateTarget(pages, target) {
     overCap = desired.reduce((n, d) => n + d.inner.split('\n').length, 0) > target.cap;
 
   // build the next content (validation happens here, before any write)
+  //
+  // buildErrorKind splits the two very different reasons a build fails, because
+  // consumers must treat them differently and the string alone does not say which
+  // is which:
+  //
+  //   'target-missing'   The target FILE is not there at all (no ~/.claude/
+  //                      CLAUDE.md yet). That is the ordinary first-run state, so
+  //                      the PreCompact gate and doctor must NOT block on it — a
+  //                      block here would hit every new user (same reasoning that
+  //                      keeps this out of strictWarnings below).
+  //   'build-failed'     The file EXISTS but cannot be projected into — e.g. its
+  //                      <learned_behaviors> container is gone. Nothing is broken
+  //                      about the user's setup EXCEPT that not one L1 rule loads
+  //                      on this machine, and every sync is a silent no-op. That
+  //                      is a hard failure and must be surfaced as one.
   let nextContent = null;
   let buildError = null;
-  if (!fileExists && target.container) {
+  let buildErrorKind = null;
+  let buildErrorRemedy = null;
+  if (ioError) {
+    // The target file exists but could not be read (permissions, a mid-session
+    // ACL change, ...). Structurally identical to a missing container: nothing
+    // is projected, and the difference from a fresh install matters, so this
+    // gets the SAME 'build-failed' kind as a missing container, not
+    // 'target-missing' (the file is right there, just unreadable).
+    buildError = ioError;
+    buildErrorKind = 'build-failed';
+    buildErrorRemedy = REMEDY.io(target.file);
+  } else if (dangling) {
+    // A dangling symlink is NOT 'target-missing'. existsSync follows the link and
+    // sees nothing, so this used to be classified as the benign first-run state:
+    // the gate stayed green while the configured target was broken and zero rules
+    // loaded — and a --write would have replaced the link with a regular file,
+    // silently detaching it from whatever it was meant to point at.
+    buildError = `target file ${target.file} is a dangling symlink (its link target does not exist)`;
+    buildErrorKind = 'build-failed';
+    buildErrorRemedy = REMEDY.danglingSymlink(target.file);
+  } else if (!fileExists && target.container) {
     buildError = `target file missing: ${target.file}`;
+    buildErrorKind = 'target-missing';
   } else {
     const r = buildNextContent(fileExists ? content : '', region, target);
-    if (r.error) buildError = r.error;
-    else nextContent = r.content;
+    if (r.error) {
+      buildError = r.error;
+      buildErrorKind = 'build-failed';
+      buildErrorRemedy = r.remedy;
+    } else nextContent = r.content;
   }
 
-  // side-files: writes (current candidates) + deletes (stale sync-owned copies)
+  // side-files: writes (current candidates) + deletes (stale sync-owned copies).
+  // An I/O error on a SIDE file (the directory listing, or one feedback_<slug>.md
+  // copy) is a WARNING, not a build failure — the split matters:
+  //
+  //   PRIMARY target (CLAUDE.md's container, MEMORY.md's index) unreadable ⇒ the
+  //     projection cannot be built at all, no rule loads, hard-fail ('build-failed').
+  //   SIDE file unreadable ⇒ the index line still projects and every rule still
+  //     loads; one full-copy convenience file is stale. Blocking /compact on that
+  //     — with a message naming `--ensure-container`, which only ever touches
+  //     CLAUDE.md and could not chmod a file if it tried — is a gate whose own
+  //     named remedy cannot open it. Warn, name the path, name the permission fix.
+  //
+  // They are NOT swallowed (that was the original bug: a silent "nothing to clean
+  // up" default) — they ride out in the report as `sideWarnings` and reach the
+  // human through doctor and the PreCompact gate's notices.
+  const sideWarnings = [];
   const sideWrites = [];
   for (const d of desired) {
     for (const sf of target.sideFiles(d.page)) sideWrites.push(sf);
   }
-  const sideDeletes = staleSideFiles(target, desired);
+  let sideDeletes = [];
+  if (!buildError) {
+    try {
+      sideDeletes = staleSideFiles(target, desired);
+    } catch (err) {
+      sideWarnings.push(`cannot read side-file directory ${target.dir}: ${err.message}`);
+    }
+  }
 
   // dirty: main content would change OR any side-file would change/be removed
   let dirty = nextContent !== null && nextContent !== (fileExists ? content : '');
   if (sideDeletes.length) dirty = true;
   for (const sf of sideWrites) {
-    const cur = existsSync(sf.path) ? readFileSync(sf.path, 'utf-8') : null;
+    let cur = null;
+    if (existsSync(sf.path)) {
+      try {
+        cur = readFileSync(sf.path, 'utf-8');
+      } catch (err) {
+        sideWarnings.push(`cannot read side file ${sf.path}: ${err.message}`);
+        cur = null; // unreadable → treat as needing a (re)write, the safe default
+      }
+    }
     if (cur !== sf.content) dirty = true;
   }
 
@@ -415,28 +737,40 @@ function evaluateTarget(pages, target) {
     fileExists,
     nextContent,
     buildError,
+    buildErrorKind,
+    buildErrorRemedy,
     sideWrites,
     sideDeletes,
+    sideWarnings,
   };
 }
 
-// Pure writer: applies a fully-validated plan. No validation here.
+// Writer: applies a fully-validated plan. No validation here. Every write is
+// atomic (tmp+rename), so an interrupted run leaves each file at its previous
+// content rather than truncated. Returns the (non-fatal) side-file warnings it
+// collected; a PRIMARY-target write failure is NOT swallowed — it throws, and
+// run() turns it into a reported error with the permission remedy.
 function applyTarget(target, res) {
+  const warnings = [];
   if (target.dir) mkdirSync(target.dir, { recursive: true });
   for (const sf of res.sideWrites) {
-    mkdirSync(join(sf.path, '..'), { recursive: true });
-    writeFileSync(sf.path, sf.content);
+    try {
+      atomicWrite(sf.path, sf.content);
+    } catch (err) {
+      warnings.push(`cannot write side file ${sf.path}: ${err.message}`);
+    }
   }
   for (const p of res.sideDeletes) {
     try {
       rmSync(p);
-    } catch {
-      /* best-effort */
+    } catch (err) {
+      warnings.push(`cannot remove stale side file ${p}: ${err.message}`);
     }
   }
   if (res.nextContent !== null && res.nextContent !== (res.fileExists ? res.content : '')) {
-    writeFileSync(target.file, res.nextContent);
+    atomicWrite(target.file, res.nextContent);
   }
+  return warnings;
 }
 
 // ── project-id derivation ─────────────────────────────────────────────────────
@@ -563,10 +897,12 @@ function oneLineSummary(text, max = 100) {
 // HYPO:FEEDBACK-SYNC managed block are skipped — those already have a wiki SoT
 // and are not legacy entries to migrate.
 function parseLearnedBehaviors(content) {
-  const open = content.indexOf('<learned_behaviors>');
-  const close = content.indexOf('</learned_behaviors>');
-  if (open < 0 || close < 0 || close < open) return [];
-  const inner = content.slice(open + '<learned_behaviors>'.length, close);
+  // Same container judgment placement uses (classifyContainer): a pair quoted in
+  // an HTML comment / a code fence / inline code is not a container to read
+  // legacy rules out of, and a corrupt one has no unambiguous inner span at all.
+  const c = classifyContainer(content);
+  if (c.state !== 'present') return [];
+  const inner = content.slice(c.open + LB_OPEN.length, c.close);
   const scrubbed = inner.replace(BLOCK_RE, ''); // blank out already-projected blocks
   const out = [];
   for (const line of scrubbed.split('\n')) {
@@ -813,12 +1149,89 @@ function runImport(args) {
   return { code: 0, report, warnings };
 }
 
+// The provisioning step --write can never do on its own: --write only ever
+// PLACES a region INSIDE an existing `<learned_behaviors>` container (it has
+// no way to guess where in an arbitrary, possibly hand-authored CLAUDE.md a
+// container belongs — that would risk corrupting content it does not own).
+// When the container is simply gone (deleted by hand, a bad merge, ...),
+// --write's only recourse is the 'build-failed' error, and a gate that reports
+// a failure with no way through gets bypassed rather than obeyed — this is the
+// way through.
+//
+//   file MISSING entirely → no-op ('target-missing' is the ordinary first-run
+//     state; --ensure-container repairs an EXISTING file, it does not create
+//     one out of nothing).
+//   file is a DANGLING symlink → fail. It is not missing, it is broken, and the
+//     fix is on the link, not here.
+//   file exists, container ALREADY present → no-op (idempotent: safe to run
+//     from a blocker message without checking state first).
+//   file exists, container CORRUPT → fail, and say what is wrong. A blind append
+//     onto inverted/duplicated tags is how this command would manufacture a state
+//     it can never repair: the pair it adds does not fix the broken one, the
+//     predicate still reads "no container", the next run appends ANOTHER pair, and
+//     --write fails forever. Refusing is the only honest move.
+//   file exists, no container → append a short guidance comment plus an empty
+//     `<learned_behaviors></learned_behaviors>` pair to the END of the file. The
+//     existing bytes are re-written verbatim ahead of the addition through
+//     atomicWrite (tmp+rename), so a crash or a full disk mid-write cannot leave
+//     the user's global config truncated — the file is either wholly old or
+//     wholly new. (The previous writeFileSync(file, content + addition) truncated
+//     first and wrote second: the one command that promises "existing content is
+//     never touched" was the one that could shred it.)
+function runEnsureContainer(args) {
+  const target = claudeTarget(args);
+  const file = target.file;
+  if (!existsSync(file)) {
+    if (isDanglingSymlink(file)) {
+      return {
+        code: 1,
+        error:
+          `${file} is a dangling symlink (its link target does not exist) — nothing to provision. ` +
+          REMEDY.danglingSymlink(file),
+      };
+    }
+    return { code: 0, report: { mode: 'ensure-container', file, action: 'target-missing' } };
+  }
+  let content;
+  try {
+    content = readFileSync(file, 'utf-8');
+  } catch (err) {
+    return { code: 1, error: `cannot read ${file}: ${err.message} — ${REMEDY.io(file)}` };
+  }
+  const c = classifyContainer(content);
+  if (c.state === 'present') {
+    return { code: 0, report: { mode: 'ensure-container', file, action: 'noop-already-present' } };
+  }
+  if (c.state === 'corrupt') {
+    return {
+      code: 1,
+      error:
+        `refusing to append to ${file}: it already carries a corrupt <learned_behaviors> ` +
+        `container — ${c.reason}. ${REMEDY.containerCorrupt(file, c.reason)}`,
+    };
+  }
+  const sep = content.endsWith('\n') ? '' : '\n';
+  const addition =
+    `${sep}\n` +
+    '<!-- Added by `hypomnema feedback-sync --ensure-container`: this pair is the managed\n' +
+    'region feedback-sync projects wiki-sourced learned behaviors into. Do not hand-edit its\n' +
+    'contents — a hand-edit becomes a sync conflict. -->\n' +
+    '<learned_behaviors>\n</learned_behaviors>\n';
+  try {
+    atomicWrite(file, content + addition);
+  } catch (err) {
+    return { code: 1, error: `cannot write ${file}: ${err.message} — ${REMEDY.io(file)}` };
+  }
+  return { code: 0, report: { mode: 'ensure-container', file, action: 'created' } };
+}
+
 // ── modes ─────────────────────────────────────────────────────────────────────
 
 function run(args, resolvedPid = null) {
   if (!existsSync(args.hypoDir)) {
     return { code: 1, error: `wiki not found: ${args.hypoDir}` };
   }
+  if (args.mode === 'ensure-container') return runEnsureContainer(args);
   if (args.mode === 'bootstrap') return runBootstrap(args);
   if (args.mode === 'import') return runImport(args);
 
@@ -888,8 +1301,25 @@ function run(args, resolvedPid = null) {
       outOfContainer: res.outOfContainer,
       overCap: res.overCap,
       dirty: res.dirty,
-      ...(res.buildError ? { buildError: res.buildError } : {}),
+      // buildErrorKind rides along with buildError so a consumer (doctor, the
+      // PreCompact gate) can tell a first-run missing file from a structurally
+      // broken one WITHOUT re-deriving that judgment by string-matching the
+      // message. The judgment is made once, here, where the branch is taken —
+      // and buildErrorRemedy carries the way OUT for that exact cause, so no
+      // consumer has to guess one (a permission error advised to run
+      // `--ensure-container` is a blocker its own remedy cannot open).
+      ...(res.buildError
+        ? {
+            buildError: res.buildError,
+            buildErrorKind: res.buildErrorKind,
+            ...(res.buildErrorRemedy ? { buildErrorRemedy: res.buildErrorRemedy } : {}),
+          }
+        : {}),
+      // Non-fatal: a side-file I/O problem degrades the projection, it does not
+      // break it. Reported (never swallowed), but it must not block /compact.
+      ...(res.sideWarnings.length ? { sideWarnings: res.sideWarnings } : {}),
     };
+    for (const w of res.sideWarnings) warnings.push(`${target.name}: ${w}`);
     if (res.conflicts.length || res.intruder || res.unpaired || res.outOfContainer)
       code = Math.max(code, 3);
     else if (res.overCap) code = Math.max(code, 2);
@@ -906,7 +1336,26 @@ function run(args, resolvedPid = null) {
   // so writes stay byte-idempotent.
   if (args.mode === 'write' && code === 0 && !strictFail) {
     for (const { target, res } of evals) {
-      if (res.dirty) applyTarget(target, res);
+      if (!res.dirty) continue;
+      try {
+        warnings.push(...applyTarget(target, res).map((w) => `${target.name}: ${w}`));
+      } catch (err) {
+        // A PRIMARY-target write failure (ENOSPC, EACCES, a read-only mount).
+        // Reported, not thrown: an uncaught throw prints no JSON, and every
+        // consumer reads "no report" as "nothing to project" and fails OPEN —
+        // the exact silent-green failure this projection system exists to stop.
+        // The preflight already ruled out every failure it CAN see; an fs error
+        // at write time is the one thing it cannot, so the cross-target atomicity
+        // contract holds up to that point and no further (documented, not fixed
+        // here: a two-phase commit across two independent files is a different
+        // change).
+        return {
+          code: 1,
+          error: `cannot write ${target.file}: ${err.message} — ${REMEDY.io(target.file)}`,
+          report,
+          warnings,
+        };
+      }
     }
   }
 
@@ -922,7 +1371,12 @@ async function main() {
   // exactly once. resolveProjectId only touches stdin when stdin.isTTY is truthy
   // and --no-input is unset → hooks/CI/pipes never block here.
   let resolvedPid = null;
-  if (existsSync(args.hypoDir) && args.mode !== 'bootstrap' && args.mode !== 'import') {
+  if (
+    existsSync(args.hypoDir) &&
+    args.mode !== 'bootstrap' &&
+    args.mode !== 'import' &&
+    args.mode !== 'ensure-container' // no MEMORY/project-id involvement at all
+  ) {
     resolvedPid = await resolveProjectId(args);
   }
   const out = run(args, resolvedPid);
@@ -931,6 +1385,23 @@ async function main() {
     console.log(JSON.stringify(out.error ? { error: out.error } : out.report, null, 2));
   } else if (out.error) {
     console.error(`[feedback-sync] ${out.error}`);
+  } else if (out.report.mode === 'ensure-container') {
+    const { action, file } = out.report;
+    if (action === 'target-missing') {
+      console.error(
+        `[feedback-sync] ensure-container: ${file} does not exist yet — nothing to provision ` +
+          `(this is the ordinary first-run state, not something --ensure-container creates).`,
+      );
+    } else if (action === 'noop-already-present') {
+      console.error(
+        `[feedback-sync] ensure-container: ${file} already has a <learned_behaviors> container — no changes made.`,
+      );
+    } else {
+      console.error(
+        `[feedback-sync] ensure-container: appended an empty <learned_behaviors></learned_behaviors> ` +
+          `container to ${file} (existing content untouched). Run \`hypomnema feedback-sync --write\` next.`,
+      );
+    }
   } else if (out.report.mode === 'bootstrap') {
     for (const w of out.warnings || []) console.error(`[feedback-sync] warn: ${w}`);
     const verb = out.report.dryRun ? 'would create' : 'created';

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -100,7 +100,15 @@ TRK="$HYPOMNEMA_ROOT/scripts/check-tracker-ids.mjs"
 [ -f "$TRK" ] && { node "$TRK" --staged || exit 1; }
 exit 0`;
   }
-  // commit-msg: scan the message file (passed as $1) for wiki tracker ids.
+  // commit-msg: scan the message file (passed as $1) for wiki tracker ids AND
+  // tool-attribution trailers. No shim change was needed to add the second check
+  // — check-tracker-ids.mjs --commit-msg scans both — so the deployed v2 shim in
+  // an existing checkout picks it up with no reinstall.
+  //
+  // This hook is FAST LOCAL FEEDBACK, not the guarantee. Every guard above fails
+  // OPEN (CI, no .git, foreign toplevel, symlinked hook, missing script), and
+  // `--no-verify` skips it outright. The real gates are in CI: the tracker-id job
+  // for files, the pr-surface job for the PR title/body.
   return `${unsetSeam}
 TRK="$HYPOMNEMA_ROOT/scripts/check-tracker-ids.mjs"
 [ -f "$TRK" ] || exit 0
@@ -278,8 +286,9 @@ async function main() {
     }
 
     // (7) Install both hooks: pre-commit (format + tracker-id gate on staged
-    //     blobs) and commit-msg (tracker-id gate on the message). Each is
-    //     independently marker-detected so a user's own hook is never clobbered.
+    //     blobs) and commit-msg (tracker-id + tool-attribution gate on the
+    //     message). Each is independently marker-detected so a user's own hook is
+    //     never clobbered.
     const results = [
       installHook('pre-commit', absHooksDir, expectedRoot, absGitDir),
       installHook('commit-msg', absHooksDir, expectedRoot, absGitDir),

--- a/scripts/lib/check-pr-surface.mjs
+++ b/scripts/lib/check-pr-surface.mjs
@@ -1,0 +1,570 @@
+/**
+ * lib/check-pr-surface.mjs — pure scanner for the PR title/body public surface.
+ *
+ * The PR title and body are a public artifact that lives OUTSIDE the repo, so no
+ * file-based gate can see them. Two rules leak through that hole today:
+ *
+ *   1. Tool attribution. The harness system prompt instructs the agent to append
+ *      a `Co-Authored-By:` / `Generated with ...` footer; this repo forbids it.
+ *      Conflicting instructions do not resolve in the gate's favor on their own.
+ *   2. Wiki-internal tracker ids. `check-tracker-ids.mjs` gates files, staged
+ *      blobs, commit messages and tag bodies — not a PR title. An `ISSUE-N` in a
+ *      PR title has already shipped past a green `Tracker-id gate`.
+ *
+ * A third rule is structural: `gh pr create --body` REPLACES the body outright,
+ * so `.github/PULL_REQUEST_TEMPLATE.md` never loads on the path an agent actually
+ * uses. The template's bilingual blocks, `## Changelog` and `## Checklist` are
+ * therefore silently skipped every time. The release collector assembles
+ * CHANGELOG.md from the `## Changelog` block of merged PR bodies, so a missing
+ * block is not cosmetic: the change vanishes from the next release notes.
+ *
+ * This module is PURE (no fs, no git, no process) so it is unit-testable; the CLI
+ * wrapper (scripts/check-pr-surface.mjs) does the file / GitHub-event I/O.
+ *
+ * Every violation carries a `fix`: a gate that reports a violation without a way
+ * out gets bypassed rather than obeyed, so each `fix` names the concrete command
+ * that makes the PR pass (`gh pr edit <N> --title ...` / `--body-file <file>`).
+ */
+
+import {
+  scanText,
+  BLOCKED_PATTERNS,
+  DECISION_PATTERNS,
+  ATTRIBUTION_PATTERNS,
+} from './check-tracker-ids.mjs';
+
+// Wiki tracker ids (`ISSUE-N`, `fix #N`, `FEAT-N`, ...): blocked on the whole
+// title and the whole body, no exemption.
+const PR_TRACKER_PATTERNS = BLOCKED_PATTERNS;
+
+// Wiki ADR pointers (`ADR NNNN`, `decisions/NNNN`) are blocked here too — CLAUDE.md
+// names them as forbidden on a public surface, and a PR title/body is as public as
+// it gets. They were left out of this gate entirely, which meant the ONE rule that
+// spells out `decisions/NNNN` had no enforcement on the ONE surface an agent
+// authors by hand.
+//
+// With ONE exemption, and it is not a hedge: the `## Changelog` block of a merged
+// PR body is collected VERBATIM into CHANGELOG.md, and CHANGELOG.md is itself
+// ADR-exempt in the file gate (a version-history line may cite the decision behind
+// a release). Blocking an ADR ref inside that block would make a line the file gate
+// explicitly allows unwritable through the only path that writes it. So the ADR
+// scan reads a body with exactly that section blanked (maskChangelogSection) — the
+// same carve-out the file gate already makes, in the same place, for the same
+// reason.
+//
+// The COMMIT-MESSAGE gate keeps letting `ADR NNNN` through (judgeMessage scans
+// BLOCKED_PATTERNS only); that is existing, tested behavior and this change does
+// not touch it.
+const PR_DECISION_PATTERNS = DECISION_PATTERNS;
+
+// Tracker ids AND attribution are BOTH scanned on the RAW body (no comment
+// stripping). A body written from the template used to keep an HTML comment
+// that quoted the very phrase this scan blocks ("Generated with ..."), so an
+// earlier version of this gate stripped HTML comments before the attribution
+// scan to avoid tripping on that quote. That created a real hole: an
+// `<!-- Co-Authored-By: ... -->` trailer, invisible on GitHub's rendered view
+// but still present in the body text `gh pr create --body-file` actually
+// submits, sailed through untouched. The rule is "no attribution ANYWHERE in
+// the body", comments included — a comment does not render, but it still ships.
+//
+// The fix on the template side: `.github/PULL_REQUEST_TEMPLATE.md`'s
+// instructional comment no longer quotes any banned literal (reworded to "Do
+// NOT add a tool-attribution footer or a session URL of any kind."), so the RAW
+// scan no longer self-trips on a compliant, template-derived body.
+//
+// Structural checks (bilingual headings, required subheadings, `## Changelog`,
+// `## Checklist`) still read a STRIPPED view — see `structuralBody` below — but
+// that stripping now removes comments AND fenced code / inline code, because a
+// heading that only exists inside a code fence (```# English```) is example
+// text, not a real section, and must not satisfy the template-compliance check.
+
+// Newlines inside the comment are preserved so any position-sensitive caller
+// downstream keeps consistent line counts even though this module no longer
+// scans this view for attribution.
+function stripHtmlComments(text) {
+  return text.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ''));
+}
+
+// Remove fenced code blocks (``` or ~~~, 3+ chars, matching the same char at
+// the close) from a STRUCTURAL view. A heading-like line inside a fence
+// (```# English```) is example text, not a real section boundary, so the whole
+// fenced span — delimiters included — is dropped entirely. An unterminated
+// fence drops everything to the end of the text (fail toward MORE stripping,
+// i.e. toward a violation being reported, never toward silently accepting
+// content that never left the fence).
+function stripCodeBlocks(text) {
+  const lines = text.split('\n');
+  const out = [];
+  let fenceChar = null;
+  let fenceLen = 0;
+  for (const line of lines) {
+    if (fenceChar) {
+      const close = /^[ \t]*(`{3,}|~{3,})[ \t]*$/.exec(line);
+      if (close && close[1][0] === fenceChar && close[1].length >= fenceLen) {
+        fenceChar = null;
+        fenceLen = 0;
+      }
+      continue; // drop every line inside the fence, including this close line
+    }
+    const open = /^[ \t]*(`{3,}|~{3,})/.exec(line);
+    if (open) {
+      fenceChar = open[1][0];
+      fenceLen = open[1].length;
+      continue; // drop the opening fence line itself
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+// Remove inline code spans (`...`) from a STRUCTURAL view, so a heading-shaped
+// inline example (`` `# English` ``, used in this file's own fix text and in
+// the template's guidance prose) is not mistaken for a real heading and so
+// prose that is ENTIRELY inline code does not count as "content" for the
+// language-block emptiness check. Single-backtick spans only (the template
+// never uses double-backtick code spans); does not cross a newline.
+function stripInlineCode(text) {
+  return text.replace(/`[^`\n]*`/g, '');
+}
+
+// Raw HTML BLOCKS. Inside one, GFM parses NO markdown: a `#` line inside
+// `<pre> ... </pre>` is preformatted text, not a heading. The structural view was
+// blind to this, so a body of `<pre>` + a perfectly-shaped template + `</pre>`
+// passed every heading, subheading, changelog and checklist check while GitHub
+// rendered not one of those headings — the whole template check satisfied by text
+// that is, to a reader, a code listing.
+//
+// Two of GFM's seven block kinds cover this:
+//   type 1   <pre|script|style|textarea ...> → runs to the matching CLOSE TAG
+//            line. A blank line does NOT end it.
+//   type 6/7 a known block tag (<div>, <table>, <details>, ...) or any complete
+//            standalone tag on its own line (<code>) → runs to the next BLANK line.
+// An unterminated block eats the rest of the text — the same fail-toward-more-
+// stripping direction stripCodeBlocks takes (toward reporting a violation, never
+// toward accepting content that never rendered).
+const HTML_BLOCK_1_OPEN = /^ {0,3}<(?:pre|script|style|textarea)\b/i;
+const HTML_BLOCK_1_CLOSE = /<\/(?:pre|script|style|textarea)>/i;
+const HTML_BLOCK_TAGS =
+  'address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|' +
+  'dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|' +
+  'head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|' +
+  'p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul';
+const HTML_BLOCK_6_OPEN = new RegExp(`^ {0,3}</?(?:${HTML_BLOCK_TAGS})(?:[ \\t/>]|$)`, 'i');
+// A complete open/close tag alone on its line (GFM type 7) — this is what makes
+// `<code>` / `<span>` / any custom element behave as a block opener.
+const HTML_BLOCK_7_OPEN = /^ {0,3}<\/?[a-zA-Z][a-zA-Z0-9-]*(?:[ \t][^<>]*)?\/?>[ \t]*$/;
+
+function stripHtmlBlocks(text) {
+  const lines = text.split('\n');
+  const out = [];
+  let until = null; // 'close-tag' | 'blank'
+  for (const line of lines) {
+    if (until === 'close-tag') {
+      if (HTML_BLOCK_1_CLOSE.test(line)) until = null;
+      continue;
+    }
+    if (until === 'blank') {
+      if (line.trim() === '') {
+        until = null;
+        out.push(line);
+      }
+      continue;
+    }
+    if (HTML_BLOCK_1_OPEN.test(line)) {
+      until = HTML_BLOCK_1_CLOSE.test(line) ? null : 'close-tag'; // may open and close on one line
+      continue;
+    }
+    if (HTML_BLOCK_6_OPEN.test(line) || HTML_BLOCK_7_OPEN.test(line)) {
+      until = 'blank';
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+// 4-space (or tab) indented code blocks: `    # English` is preformatted text,
+// not a heading, for the same reason a fenced one is not. A block can only START
+// where a paragraph could not be continued (top of the text, or after a blank
+// line) — an indented line INSIDE a paragraph is a lazy continuation, not code,
+// so the `prevBlank` guard is load-bearing rather than defensive.
+function stripIndentedCode(text) {
+  const lines = text.split('\n');
+  const out = [];
+  let prevBlank = true;
+  let inCode = false;
+  for (const line of lines) {
+    const blank = line.trim() === '';
+    const indented = /^(?: {4}|\t)/.test(line);
+    if (inCode) {
+      if (indented || blank) continue; // a blank line does not close an indented block
+      inCode = false;
+    } else if (indented && prevBlank) {
+      inCode = true;
+      continue;
+    }
+    out.push(line);
+    prevBlank = blank;
+  }
+  return out.join('\n');
+}
+
+// The full STRUCTURAL view: everything GFM does not render as live markdown is
+// gone. Order matters — comments first (they can wrap anything), then fences,
+// then HTML blocks, then indented code, then inline code spans.
+function structuralView(rawBody) {
+  return stripInlineCode(
+    stripIndentedCode(stripHtmlBlocks(stripCodeBlocks(stripHtmlComments(rawBody)))),
+  );
+}
+
+// A `## Changelog` / `## Checklist` heading, exactly two hashes (`### Changelog`
+// is not the section the release collector reads).
+function hasHeading(text, re) {
+  return re.test(text);
+}
+
+// Non-global on purpose: a /g regex carries lastIndex across .test() calls and
+// would alternate true/false on repeated use.
+const H1_ENGLISH = /^#[ \t]+English[ \t]*$/im;
+const H1_KOREAN = /^#[ \t]+한국어[ \t]*$/m;
+const H2_CHANGELOG = /^##[ \t]+Changelog[ \t]*$/im;
+const H2_CHECKLIST = /^##[ \t]+Checklist[ \t]*$/im;
+
+// The line index (0-based) of the first line matching `re` in `text`, or -1.
+// Reuses the SAME heading regex as `hasHeading` (single-line `.test()` on an
+// embedded-newline-free string is unaffected by the regex's /m flag), so the
+// "is it present" check and the "where is it" check can never disagree about
+// what counts as a heading.
+function headingLineIndex(text, re) {
+  const lines = text.split(/\r?\n/);
+  return lines.findIndex((l) => re.test(l));
+}
+
+// The body of the section starting at the first line matching `startRe`:
+// everything from the line AFTER that heading up to (not including) the first
+// line matching `isBoundary`, or end of text. Returns null when the start
+// heading is absent, so a caller can distinguish "missing" (reported
+// elsewhere) from "present but empty" (reported here).
+function sectionBody(text, startRe, isBoundary) {
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((l) => startRe.test(l));
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (isBoundary(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start + 1, end).join('\n');
+}
+
+// Any ATX heading of any level (`#` through `######`) ends a section that has
+// no nested structure of its own — used for `## Changelog`, whose body is a
+// flat two-line list with no subheadings.
+const ANY_HEADING = (line) => /^#{1,6}[ \t]+\S/.test(line);
+
+// A language block (`# English` / `# 한국어`) DOES have nested structure — its
+// own required `##` subheadings — so those must NOT end the section (that was
+// the bug: treating "any heading" as the boundary truncated every language
+// block down to its first blank line, before its first subheading). Only the
+// NEXT top-level heading, or the language-neutral `## Changelog` / `##
+// Checklist` that follow both language blocks, closes it.
+const ANY_H1 = /^#[ \t]+\S/;
+const isLanguageBlockBoundary = (line) =>
+  ANY_H1.test(line) || H2_CHANGELOG.test(line) || H2_CHECKLIST.test(line);
+
+// The `## Changelog` section body: everything from its heading to the next ATX
+// heading of any level (in the template, `## Checklist`) or end of text.
+function changelogSection(text) {
+  return sectionBody(text, H2_CHANGELOG, ANY_HEADING);
+}
+
+// A LINE-PRESERVING structural view: HTML comments and fenced code blocks are
+// blanked IN PLACE (the line stays, its content is emptied) instead of removed,
+// so line index i here is line index i in the RAW body. `structuralView` above
+// drops lines, which is fine where only relative ORDER matters (heading checks)
+// and useless where raw positions do (the changelog carve-out below).
+function maskedLines(rawBody) {
+  const lines = stripHtmlComments(rawBody).split('\n');
+  let fence = null;
+  return lines.map((line) => {
+    const delim = /^[ \t]*(`{3,}|~{3,})[ \t]*/.exec(line);
+    if (fence) {
+      if (delim && delim[1][0] === fence.char && delim[1].length >= fence.len) fence = null;
+      return '';
+    }
+    if (/^[ \t]*(`{3,}|~{3,})/.test(line)) {
+      const open = /^[ \t]*(`{3,}|~{3,})/.exec(line);
+      fence = { char: open[1][0], len: open[1].length };
+      return '';
+    }
+    return line;
+  });
+}
+
+// Blank out the BODY of the `## Changelog` section (the heading line stays, its
+// content lines become empty) so the ADR scan can read everything ELSE in the PR
+// body. Line count is preserved, so a violation's reported line number still
+// points at the line the author wrote.
+//
+// This is the ADR carve-out, and it is exactly the file gate's: CHANGELOG.md is
+// ADR-exempt there, and this block IS CHANGELOG.md's source text. A `## Changelog`
+// heading that only exists inside a code fence is not the real section, so the
+// heading is located on the masked view, not the raw one.
+function maskChangelogSection(rawBody) {
+  const view = maskedLines(rawBody);
+  const start = view.findIndex((l) => H2_CHANGELOG.test(l));
+  if (start === -1) return rawBody;
+  let end = view.length;
+  for (let i = start + 1; i < view.length; i++) {
+    if (ANY_HEADING(view[i])) {
+      end = i;
+      break;
+    }
+  }
+  const raw = rawBody.split('\n');
+  for (let i = start + 1; i < end; i++) raw[i] = '';
+  return raw.join('\n');
+}
+
+// `- EN: <something>` with actual content after the colon. The unfilled template
+// ships a bare `- EN:` line, which must NOT count as filled.
+const EN_LINE = /^[ \t]*-[ \t]*EN:[ \t]*(\S.*)$/im;
+const KO_LINE = /^[ \t]*-[ \t]*KO:[ \t]*(\S.*)$/im;
+// "None" on its own line (optionally as a list item) = an explicit, deliberate
+// "this change is not user-visible", which the template blesses.
+const NONE_LINE = /^[ \t]*(?:[-*][ \t]*)?None[.!]?[ \t]*$/im;
+
+// The required `##` subheadings inside each language block, per
+// .github/PULL_REQUEST_TEMPLATE.md. A body that carries the H1 but skips a
+// subheading (or fills none of them) has not actually followed the template —
+// the prior version of this gate only checked for the H1, which a body with
+// TWO bare headings and no content would still pass.
+const EN_SUBHEADINGS = ['What changed', 'Why', 'How', 'Manual verification', 'Migration notes'];
+const KO_SUBHEADINGS = ['변경 내용', '이유', '방법', '수동 검증', '마이그레이션 노트'];
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Does `sectionText` (a language block's body, already structural-stripped)
+// carry any content besides its own `##` subheading lines and blank lines? A
+// block that is nothing but empty subheadings (the unfilled template shape) is
+// template-compliant in STRUCTURE only, not in substance — it never actually
+// says anything.
+function blockHasContent(sectionText) {
+  return sectionText
+    .split(/\r?\n/)
+    .filter((l) => !/^#{1,6}[ \t]+\S/.test(l))
+    .some((l) => l.trim().length > 0);
+}
+
+const BODY_FIX =
+  'Write the corrected body to a file and re-upload it: `gh pr edit <N> --body-file <file>`.';
+const TITLE_FIX = 'Re-set the title: `gh pr edit <N> --title "<corrected title>"`.';
+
+// Check one language block: subheadings all present, block not empty. Called
+// only when the block's H1 heading itself is present (a missing H1 is already
+// reported as a `bilingual` violation — this would just be a confusing
+// duplicate of the same underlying problem).
+function checkLanguageBlock(structuralBody, h1Re, h1Label, requiredSubs, violations) {
+  const sec = sectionBody(structuralBody, h1Re, isLanguageBlockBoundary);
+  if (sec === null) return;
+  const missingSubs = requiredSubs.filter(
+    (name) => !new RegExp(`^##[ \\t]+${escapeRegExp(name)}[ \\t]*$`, 'm').test(sec),
+  );
+  const empty = !blockHasContent(sec);
+  if (missingSubs.length === 0 && !empty) return;
+  const parts = [];
+  if (missingSubs.length) {
+    parts.push(`missing subheading(s): ${missingSubs.map((s) => `\`## ${s}\``).join(', ')}`);
+  }
+  if (empty) parts.push('the block has no content beyond its headings');
+  violations.push({
+    rule: 'template-sections',
+    surface: 'body',
+    detail: `\`# ${h1Label}\` block: ${parts.join('; ')}`,
+    fix:
+      `Fill the \`# ${h1Label}\` block using EVERY subheading from .github/PULL_REQUEST_TEMPLATE.md ` +
+      `(${requiredSubs.map((s) => `\`## ${s}\``).join(', ')}), each with real content underneath — ` +
+      `headings alone do not count. ` +
+      BODY_FIX,
+  });
+}
+
+/**
+ * Check a PR's public surface.
+ *
+ *   checkPrSurface({ title, body }) -> { ok, violations }
+ *   Violation = { rule, surface: 'title'|'body', detail, fix }
+ *
+ * `rule` is one of: tracker-ids, attribution, bilingual, order, template-sections,
+ * changelog, checklist.
+ * A missing/non-string title or body is treated as empty (a PR can genuinely have
+ * an empty body — that is a structural violation, not a crash).
+ */
+export function checkPrSurface({ title, body } = {}) {
+  // Normalize CRLF first. A body edited in the GitHub web UI comes back CRLF, and
+  // the `edited` trigger this gate depends on is exactly that path — so CRLF is
+  // the COMMON input here, not an edge case. The `/m` anchors below already
+  // tolerate it (JS `$` matches before CR as well as LF, so a compliant CRLF body
+  // does pass today), but that is a subtlety no future edit should have to know:
+  // one `.*$`-style pattern added later would silently capture a trailing `\r`.
+  // Dropping the CR changes no line count, so reported line numbers still match
+  // the body the author submitted.
+  const rawTitle = (typeof title === 'string' ? title : '').replace(/\r/g, '');
+  const rawBody = (typeof body === 'string' ? body : '').replace(/\r\n/g, '\n');
+  // Structural view ONLY (headings, subheadings, changelog, checklist): drop
+  // everything GFM does not render as live markdown — HTML comments, fenced code,
+  // raw HTML blocks, indented code, inline code. Tracker-ids and attribution scan
+  // the RAW body/title — see the comment above `PR_TRACKER_PATTERNS` and the block
+  // comment before `stripHtmlComments`.
+  const structuralBody = structuralView(rawBody);
+  const violations = [];
+
+  // ── tracker ids + ADR pointers ─────────────────────────────────────────────
+  // Reuses the file gate's scanner and pattern sets, so the two surfaces can never
+  // disagree about what a tracker id is. Three passes, because the ADR set has one
+  // carve-out the tracker set does not: the `## Changelog` block (see
+  // PR_DECISION_PATTERNS / maskChangelogSection).
+  for (const [surface, text, patterns] of [
+    ['title', rawTitle, [...PR_TRACKER_PATTERNS, ...PR_DECISION_PATTERNS]],
+    ['body', rawBody, PR_TRACKER_PATTERNS],
+    ['body', maskChangelogSection(rawBody), PR_DECISION_PATTERNS],
+  ]) {
+    for (const h of scanText(text, patterns)) {
+      violations.push({
+        rule: 'tracker-ids',
+        surface,
+        detail: `${h.match} (${h.label}) at line ${h.line}: ${h.lineText.trim()}`,
+        fix:
+          `Delete "${h.match}" — it is a pointer into the maintainer's private wiki and resolves to ` +
+          `nothing for anyone else. Say what changed in plain prose, or cite the public PR number (e.g. #123). ` +
+          (surface === 'title' ? TITLE_FIX : BODY_FIX),
+      });
+    }
+  }
+
+  // ── attribution: raw title + RAW body (no comment-stripping exemption) ─────
+  for (const [surface, text] of [
+    ['title', rawTitle],
+    ['body', rawBody],
+  ]) {
+    for (const h of scanText(text, ATTRIBUTION_PATTERNS)) {
+      violations.push({
+        rule: 'attribution',
+        surface,
+        detail: `${h.match} (${h.label}) at line ${h.line}: ${h.lineText.trim()}`,
+        fix:
+          `Remove the "${h.match}" ${surface === 'title' ? 'text' : 'line and the whole attribution footer'} ` +
+          `(even if it is inside an HTML comment — a comment does not render, but it still ships in the body ` +
+          `text) — this repo ships no tool attribution, whatever the harness default says. ` +
+          (surface === 'title' ? TITLE_FIX : BODY_FIX),
+      });
+    }
+  }
+
+  // ── bilingual body ─────────────────────────────────────────────────────────
+  const hasEnglish = hasHeading(structuralBody, H1_ENGLISH);
+  const hasKorean = hasHeading(structuralBody, H1_KOREAN);
+  if (!hasEnglish || !hasKorean) {
+    const missing = [!hasEnglish && '`# English`', !hasKorean && '`# 한국어`'].filter(Boolean);
+    violations.push({
+      rule: 'bilingual',
+      surface: 'body',
+      detail: `missing top-level heading: ${missing.join(' and ')}`,
+      fix:
+        `This repo ships bilingual docs, so the PR body carries the FULL body twice: once under a ` +
+        `\`# English\` heading, once under \`# 한국어\`. Copy the section layout from ` +
+        `.github/PULL_REQUEST_TEMPLATE.md (\`gh pr create --body\` bypasses that template, which is why ` +
+        `it is missing here — and a heading inside a code fence does not count, either). ` +
+        BODY_FIX,
+    });
+  }
+
+  // ── language-block sections: every required subheading present, non-empty ──
+  if (hasEnglish)
+    checkLanguageBlock(structuralBody, H1_ENGLISH, 'English', EN_SUBHEADINGS, violations);
+  if (hasKorean)
+    checkLanguageBlock(structuralBody, H1_KOREAN, '한국어', KO_SUBHEADINGS, violations);
+
+  // ── section order: # English → # 한국어 → ## Changelog → ## Checklist ──────
+  // Only compared pairwise when BOTH headings of a pair are present — a missing
+  // heading is already reported above (bilingual/changelog/checklist), and
+  // reporting it again here as "out of order" would just be confusing noise.
+  const engIdx = headingLineIndex(structuralBody, H1_ENGLISH);
+  const korIdx = headingLineIndex(structuralBody, H1_KOREAN);
+  const chgIdx = headingLineIndex(structuralBody, H2_CHANGELOG);
+  const chkIdx = headingLineIndex(structuralBody, H2_CHECKLIST);
+  const ORDER_FIX =
+    `Reorder the body to match .github/PULL_REQUEST_TEMPLATE.md: \`# English\`, then \`# 한국어\`, then the ` +
+    `language-neutral \`## Changelog\`, then \`## Checklist\`. ` +
+    BODY_FIX;
+  for (const [aLabel, aIdx, bLabel, bIdx] of [
+    ['# English', engIdx, '# 한국어', korIdx],
+    ['# 한국어', korIdx, '## Changelog', chgIdx],
+    ['## Changelog', chgIdx, '## Checklist', chkIdx],
+  ]) {
+    if (aIdx !== -1 && bIdx !== -1 && aIdx > bIdx) {
+      violations.push({
+        rule: 'order',
+        surface: 'body',
+        detail: `\`${bLabel}\` appears before \`${aLabel}\` — expected order: # English → # 한국어 → ## Changelog → ## Checklist`,
+        fix: ORDER_FIX,
+      });
+    }
+  }
+
+  // ── changelog block ────────────────────────────────────────────────────────
+  const section = changelogSection(structuralBody);
+  if (section === null) {
+    violations.push({
+      rule: 'changelog',
+      surface: 'body',
+      detail: 'missing `## Changelog` section',
+      fix:
+        `Add a language-neutral \`## Changelog\` section after both language blocks, holding one \`- EN:\` ` +
+        `line and one \`- KO:\` line describing the user-visible change (or the single word \`None\` if the ` +
+        `change is internal only). The release collector builds CHANGELOG.md from this block, so without it ` +
+        `the change is missing from the next release notes. Never edit CHANGELOG.md directly in a feature PR. ` +
+        BODY_FIX,
+    });
+  } else if (!NONE_LINE.test(section)) {
+    const hasEn = EN_LINE.test(section);
+    const hasKo = KO_LINE.test(section);
+    if (!hasEn || !hasKo) {
+      const missing = [!hasEn && '`- EN:`', !hasKo && '`- KO:`'].filter(Boolean);
+      violations.push({
+        rule: 'changelog',
+        surface: 'body',
+        detail: `\`## Changelog\` present but ${missing.join(' and ')} ${
+          missing.length > 1 ? 'lines are' : 'line is'
+        } missing or empty`,
+        fix:
+          `Fill both lines under \`## Changelog\` with real text, e.g. "- EN: Add a PR surface gate." and ` +
+          `"- KO: PR 표면 게이트를 추가한다." (an empty \`- EN:\` from the template does not count). If the ` +
+          `change is internal only (refactor, test, CI plumbing), replace both lines with the single word ` +
+          `\`None\`. No em dashes, and cite PRs by number only (e.g. #123). ` +
+          BODY_FIX,
+      });
+    }
+  }
+
+  // ── checklist block ────────────────────────────────────────────────────────
+  if (!hasHeading(structuralBody, H2_CHECKLIST)) {
+    violations.push({
+      rule: 'checklist',
+      surface: 'body',
+      detail: 'missing `## Checklist` section',
+      fix:
+        `Add the \`## Checklist\` section from .github/PULL_REQUEST_TEMPLATE.md after \`## Changelog\` and ` +
+        `tick the boxes you actually did (npm test, npm run lint, docs updated, both language blocks written, ` +
+        `no attribution footer). ` +
+        BODY_FIX,
+    });
+  }
+
+  return { ok: violations.length === 0, violations };
+}

--- a/scripts/lib/check-pr-surface.mjs
+++ b/scripts/lib/check-pr-surface.mjs
@@ -32,6 +32,16 @@ import {
   DECISION_PATTERNS,
   ATTRIBUTION_PATTERNS,
 } from './check-tracker-ids.mjs';
+import {
+  heading,
+  stripHtmlComments,
+  changelogSection,
+  parseChangelogBody,
+  H1_ENGLISH,
+  H1_KOREAN,
+  H2_CHANGELOG,
+  H2_CHECKLIST,
+} from './pr-body.mjs';
 
 // Wiki tracker ids (`ISSUE-N`, `fix #N`, `FEAT-N`, ...): blocked on the whole
 // title and the whole body, no exemption.
@@ -78,13 +88,6 @@ const PR_DECISION_PATTERNS = DECISION_PATTERNS;
 // heading that only exists inside a code fence (```# English```) is example
 // text, not a real section, and must not satisfy the template-compliance check.
 
-// Newlines inside the comment are preserved so any position-sensitive caller
-// downstream keeps consistent line counts even though this module no longer
-// scans this view for attribution.
-function stripHtmlComments(text) {
-  return text.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ''));
-}
-
 // Remove fenced code blocks (``` or ~~~, 3+ chars, matching the same char at
 // the close) from a STRUCTURAL view. A heading-like line inside a fence
 // (```# English```) is example text, not a real section boundary, so the whole
@@ -127,95 +130,34 @@ function stripInlineCode(text) {
   return text.replace(/`[^`\n]*`/g, '');
 }
 
-// Raw HTML BLOCKS. Inside one, GFM parses NO markdown: a `#` line inside
-// `<pre> ... </pre>` is preformatted text, not a heading. The structural view was
-// blind to this, so a body of `<pre>` + a perfectly-shaped template + `</pre>`
-// passed every heading, subheading, changelog and checklist check while GitHub
-// rendered not one of those headings — the whole template check satisfied by text
-// that is, to a reader, a code listing.
+// The STRUCTURAL view: HTML comments, fenced code, and inline code spans are
+// gone. Order matters: comments first (they can wrap anything), then fences,
+// then inline spans.
 //
-// Two of GFM's seven block kinds cover this:
-//   type 1   <pre|script|style|textarea ...> → runs to the matching CLOSE TAG
-//            line. A blank line does NOT end it.
-//   type 6/7 a known block tag (<div>, <table>, <details>, ...) or any complete
-//            standalone tag on its own line (<code>) → runs to the next BLANK line.
-// An unterminated block eats the rest of the text — the same fail-toward-more-
-// stripping direction stripCodeBlocks takes (toward reporting a violation, never
-// toward accepting content that never rendered).
-const HTML_BLOCK_1_OPEN = /^ {0,3}<(?:pre|script|style|textarea)\b/i;
-const HTML_BLOCK_1_CLOSE = /<\/(?:pre|script|style|textarea)>/i;
-const HTML_BLOCK_TAGS =
-  'address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|' +
-  'dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|' +
-  'head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|' +
-  'p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul';
-const HTML_BLOCK_6_OPEN = new RegExp(`^ {0,3}</?(?:${HTML_BLOCK_TAGS})(?:[ \\t/>]|$)`, 'i');
-// A complete open/close tag alone on its line (GFM type 7) — this is what makes
-// `<code>` / `<span>` / any custom element behave as a block opener.
-const HTML_BLOCK_7_OPEN = /^ {0,3}<\/?[a-zA-Z][a-zA-Z0-9-]*(?:[ \t][^<>]*)?\/?>[ \t]*$/;
-
-function stripHtmlBlocks(text) {
-  const lines = text.split('\n');
-  const out = [];
-  let until = null; // 'close-tag' | 'blank'
-  for (const line of lines) {
-    if (until === 'close-tag') {
-      if (HTML_BLOCK_1_CLOSE.test(line)) until = null;
-      continue;
-    }
-    if (until === 'blank') {
-      if (line.trim() === '') {
-        until = null;
-        out.push(line);
-      }
-      continue;
-    }
-    if (HTML_BLOCK_1_OPEN.test(line)) {
-      until = HTML_BLOCK_1_CLOSE.test(line) ? null : 'close-tag'; // may open and close on one line
-      continue;
-    }
-    if (HTML_BLOCK_6_OPEN.test(line) || HTML_BLOCK_7_OPEN.test(line)) {
-      until = 'blank';
-      continue;
-    }
-    out.push(line);
-  }
-  return out.join('\n');
-}
-
-// 4-space (or tab) indented code blocks: `    # English` is preformatted text,
-// not a heading, for the same reason a fenced one is not. A block can only START
-// where a paragraph could not be continued (top of the text, or after a blank
-// line) — an indented line INSIDE a paragraph is a lazy continuation, not code,
-// so the `prevBlank` guard is load-bearing rather than defensive.
-function stripIndentedCode(text) {
-  const lines = text.split('\n');
-  const out = [];
-  let prevBlank = true;
-  let inCode = false;
-  for (const line of lines) {
-    const blank = line.trim() === '';
-    const indented = /^(?: {4}|\t)/.test(line);
-    if (inCode) {
-      if (indented || blank) continue; // a blank line does not close an indented block
-      inCode = false;
-    } else if (indented && prevBlank) {
-      inCode = true;
-      continue;
-    }
-    out.push(line);
-    prevBlank = blank;
-  }
-  return out.join('\n');
-}
-
-// The full STRUCTURAL view: everything GFM does not render as live markdown is
-// gone. Order matters — comments first (they can wrap anything), then fences,
-// then HTML blocks, then indented code, then inline code spans.
+// This view deliberately does NOT model raw HTML blocks or 4-space indented code
+// blocks, and that is a reversal. Earlier rounds grew a GFM block parser here (a
+// 60-tag list, HTML block types 1/6/7, an indented-code state machine with a
+// lazy-continuation guard) chasing rendering fidelity: a body wrapped in `<pre>`
+// renders as a code listing, so its `#` lines are not really headings, so the
+// template check should not count them. Every round of that produced a new edge
+// case (block types 3-5, `&Tab;`, entity-encoded tags) and no round ended.
+//
+// It was aimed at the wrong actor. This gate is maintainer-only tooling (it does
+// not ship — see package.json `files`), and it runs on trusted input: this repo's
+// CI and the maintainer's local hooks. The thing it exists to stop is an agent
+// obeying its harness and appending an attribution trailer, or pasting a private
+// wiki tracker id. Nobody is trying to evade it. A PR body wrapped in `<div>`
+// therefore now SATISFIES the template check, and that is fine: it is self-harm,
+// not a failure mode, and no agent does it by accident. The banned-string scan is
+// unaffected, because it reads the RAW body — an attribution trailer inside
+// `<pre>` is still rejected.
+//
+// What replaced the indented-code machine is the ` {0,3}` bound on every heading
+// matcher below, which is where GFM actually draws the line: 0-3 spaces is an ATX
+// heading, 4+ is code. That bound is load-bearing in the OTHER direction too. See
+// the note on H1_ENGLISH.
 function structuralView(rawBody) {
-  return stripInlineCode(
-    stripIndentedCode(stripHtmlBlocks(stripCodeBlocks(stripHtmlComments(rawBody)))),
-  );
+  return stripInlineCode(stripCodeBlocks(stripHtmlComments(rawBody)));
 }
 
 // A `## Changelog` / `## Checklist` heading, exactly two hashes (`### Changelog`
@@ -224,12 +166,12 @@ function hasHeading(text, re) {
   return re.test(text);
 }
 
-// Non-global on purpose: a /g regex carries lastIndex across .test() calls and
-// would alternate true/false on repeated use.
-const H1_ENGLISH = /^#[ \t]+English[ \t]*$/im;
-const H1_KOREAN = /^#[ \t]+한국어[ \t]*$/m;
-const H2_CHANGELOG = /^##[ \t]+Changelog[ \t]*$/im;
-const H2_CHECKLIST = /^##[ \t]+Checklist[ \t]*$/im;
+// The heading matchers, the live-line view, and the changelog parse all come from
+// lib/pr-body.mjs, because the release collector asks the same questions of the
+// same text and its answers must be THESE answers. When the two had their own
+// copies they drifted, and the drift was silent: the gate went green on a body
+// whose changelog block the collector then failed to find (or found in a code
+// fence, and shipped the example). See that module's header.
 
 // The line index (0-based) of the first line matching `re` in `text`, or -1.
 // Reuses the SAME heading regex as `hasHeading` (single-line `.test()` on an
@@ -260,49 +202,15 @@ function sectionBody(text, startRe, isBoundary) {
   return lines.slice(start + 1, end).join('\n');
 }
 
-// Any ATX heading of any level (`#` through `######`) ends a section that has
-// no nested structure of its own — used for `## Changelog`, whose body is a
-// flat two-line list with no subheadings.
-const ANY_HEADING = (line) => /^#{1,6}[ \t]+\S/.test(line);
-
 // A language block (`# English` / `# 한국어`) DOES have nested structure — its
 // own required `##` subheadings — so those must NOT end the section (that was
 // the bug: treating "any heading" as the boundary truncated every language
 // block down to its first blank line, before its first subheading). Only the
 // NEXT top-level heading, or the language-neutral `## Changelog` / `##
 // Checklist` that follow both language blocks, closes it.
-const ANY_H1 = /^#[ \t]+\S/;
+const ANY_H1 = /^ {0,3}#[ \t]+\S/;
 const isLanguageBlockBoundary = (line) =>
   ANY_H1.test(line) || H2_CHANGELOG.test(line) || H2_CHECKLIST.test(line);
-
-// The `## Changelog` section body: everything from its heading to the next ATX
-// heading of any level (in the template, `## Checklist`) or end of text.
-function changelogSection(text) {
-  return sectionBody(text, H2_CHANGELOG, ANY_HEADING);
-}
-
-// A LINE-PRESERVING structural view: HTML comments and fenced code blocks are
-// blanked IN PLACE (the line stays, its content is emptied) instead of removed,
-// so line index i here is line index i in the RAW body. `structuralView` above
-// drops lines, which is fine where only relative ORDER matters (heading checks)
-// and useless where raw positions do (the changelog carve-out below).
-function maskedLines(rawBody) {
-  const lines = stripHtmlComments(rawBody).split('\n');
-  let fence = null;
-  return lines.map((line) => {
-    const delim = /^[ \t]*(`{3,}|~{3,})[ \t]*/.exec(line);
-    if (fence) {
-      if (delim && delim[1][0] === fence.char && delim[1].length >= fence.len) fence = null;
-      return '';
-    }
-    if (/^[ \t]*(`{3,}|~{3,})/.test(line)) {
-      const open = /^[ \t]*(`{3,}|~{3,})/.exec(line);
-      fence = { char: open[1][0], len: open[1].length };
-      return '';
-    }
-    return line;
-  });
-}
 
 // Blank out the BODY of the `## Changelog` section (the heading line stays, its
 // content lines become empty) so the ADR scan can read everything ELSE in the PR
@@ -310,32 +218,17 @@ function maskedLines(rawBody) {
 // points at the line the author wrote.
 //
 // This is the ADR carve-out, and it is exactly the file gate's: CHANGELOG.md is
-// ADR-exempt there, and this block IS CHANGELOG.md's source text. A `## Changelog`
-// heading that only exists inside a code fence is not the real section, so the
-// heading is located on the masked view, not the raw one.
+// ADR-exempt there, and this block IS CHANGELOG.md's source text. Its boundaries
+// come from the shared reader, so the span exempted here is EXACTLY the span the
+// collector will publish — no more (an ADR pointer outside the block would escape
+// the scan) and no less.
 function maskChangelogSection(rawBody) {
-  const view = maskedLines(rawBody);
-  const start = view.findIndex((l) => H2_CHANGELOG.test(l));
-  if (start === -1) return rawBody;
-  let end = view.length;
-  for (let i = start + 1; i < view.length; i++) {
-    if (ANY_HEADING(view[i])) {
-      end = i;
-      break;
-    }
-  }
+  const sec = changelogSection(rawBody);
+  if (sec === null) return rawBody;
   const raw = rawBody.split('\n');
-  for (let i = start + 1; i < end; i++) raw[i] = '';
+  for (let i = sec.start + 1; i < sec.end; i++) raw[i] = '';
   return raw.join('\n');
 }
-
-// `- EN: <something>` with actual content after the colon. The unfilled template
-// ships a bare `- EN:` line, which must NOT count as filled.
-const EN_LINE = /^[ \t]*-[ \t]*EN:[ \t]*(\S.*)$/im;
-const KO_LINE = /^[ \t]*-[ \t]*KO:[ \t]*(\S.*)$/im;
-// "None" on its own line (optionally as a list item) = an explicit, deliberate
-// "this change is not user-visible", which the template blesses.
-const NONE_LINE = /^[ \t]*(?:[-*][ \t]*)?None[.!]?[ \t]*$/im;
 
 // The required `##` subheadings inside each language block, per
 // .github/PULL_REQUEST_TEMPLATE.md. A body that carries the H1 but skips a
@@ -357,7 +250,7 @@ function escapeRegExp(s) {
 function blockHasContent(sectionText) {
   return sectionText
     .split(/\r?\n/)
-    .filter((l) => !/^#{1,6}[ \t]+\S/.test(l))
+    .filter((l) => !/^ {0,3}#{1,6}[ \t]+\S/.test(l))
     .some((l) => l.trim().length > 0);
 }
 
@@ -372,9 +265,7 @@ const TITLE_FIX = 'Re-set the title: `gh pr edit <N> --title "<corrected title>"
 function checkLanguageBlock(structuralBody, h1Re, h1Label, requiredSubs, violations) {
   const sec = sectionBody(structuralBody, h1Re, isLanguageBlockBoundary);
   if (sec === null) return;
-  const missingSubs = requiredSubs.filter(
-    (name) => !new RegExp(`^##[ \\t]+${escapeRegExp(name)}[ \\t]*$`, 'm').test(sec),
-  );
+  const missingSubs = requiredSubs.filter((name) => !heading('##', escapeRegExp(name)).test(sec));
   const empty = !blockHasContent(sec);
   if (missingSubs.length === 0 && !empty) return;
   const parts = [];
@@ -416,11 +307,12 @@ export function checkPrSurface({ title, body } = {}) {
   // the body the author submitted.
   const rawTitle = (typeof title === 'string' ? title : '').replace(/\r/g, '');
   const rawBody = (typeof body === 'string' ? body : '').replace(/\r\n/g, '\n');
-  // Structural view ONLY (headings, subheadings, changelog, checklist): drop
-  // everything GFM does not render as live markdown — HTML comments, fenced code,
-  // raw HTML blocks, indented code, inline code. Tracker-ids and attribution scan
-  // the RAW body/title — see the comment above `PR_TRACKER_PATTERNS` and the block
-  // comment before `stripHtmlComments`.
+  // Structural view ONLY (headings, subheadings, changelog, checklist): HTML
+  // comments, fenced code and inline code spans dropped, so a heading that only
+  // exists as an EXAMPLE is not mistaken for a real section. Raw HTML blocks and
+  // indented code are deliberately NOT modeled — see the note on `structuralView`.
+  // Tracker-ids and attribution scan the RAW body/title instead, so nothing hidden
+  // in a comment or a code block escapes them.
   const structuralBody = structuralView(rawBody);
   const violations = [];
 
@@ -518,8 +410,14 @@ export function checkPrSurface({ title, body } = {}) {
   }
 
   // ── changelog block ────────────────────────────────────────────────────────
-  const section = changelogSection(structuralBody);
-  if (section === null) {
+  // Judged with the release collector's OWN parse, on the RAW body, so a green
+  // gate means exactly "the collector will publish this". The gate used to apply
+  // its own, looser rules here, and the two disagreed: `None.` with a period, a
+  // duplicated `- EN:` line — the gate waved them through and the collector then
+  // called them malformed, at release time, when the PR could no longer be edited.
+  // The author is told now, while it is still one `gh pr edit` away.
+  const changelog = parseChangelogBody(rawBody);
+  if (changelog === null) {
     violations.push({
       rule: 'changelog',
       surface: 'body',
@@ -531,25 +429,20 @@ export function checkPrSurface({ title, body } = {}) {
         `the change is missing from the next release notes. Never edit CHANGELOG.md directly in a feature PR. ` +
         BODY_FIX,
     });
-  } else if (!NONE_LINE.test(section)) {
-    const hasEn = EN_LINE.test(section);
-    const hasKo = KO_LINE.test(section);
-    if (!hasEn || !hasKo) {
-      const missing = [!hasEn && '`- EN:`', !hasKo && '`- KO:`'].filter(Boolean);
-      violations.push({
-        rule: 'changelog',
-        surface: 'body',
-        detail: `\`## Changelog\` present but ${missing.join(' and ')} ${
-          missing.length > 1 ? 'lines are' : 'line is'
-        } missing or empty`,
-        fix:
-          `Fill both lines under \`## Changelog\` with real text, e.g. "- EN: Add a PR surface gate." and ` +
-          `"- KO: PR 표면 게이트를 추가한다." (an empty \`- EN:\` from the template does not count). If the ` +
-          `change is internal only (refactor, test, CI plumbing), replace both lines with the single word ` +
-          `\`None\`. No em dashes, and cite PRs by number only (e.g. #123). ` +
-          BODY_FIX,
-      });
-    }
+  } else if (changelog.malformed) {
+    violations.push({
+      rule: 'changelog',
+      surface: 'body',
+      detail: `\`## Changelog\` is present but the release collector cannot read it: ${changelog.reason}`,
+      fix:
+        `Fix the block so it holds exactly one \`- EN:\` line and one \`- KO:\` line, each with real text — ` +
+        `e.g. "- EN: Add a PR surface gate." and "- KO: PR 표면 게이트를 추가한다." (an empty \`- EN:\` from ` +
+        `the template does not count). If the change is internal only (refactor, test, CI plumbing), the whole ` +
+        `block is the single word \`None\` instead, with no EN/KO lines beside it. This is the same parse the ` +
+        `release collector runs, so what passes here is what lands in CHANGELOG.md. No em dashes, and cite PRs ` +
+        `by number only (e.g. #123). ` +
+        BODY_FIX,
+    });
   }
 
   // ── checklist block ────────────────────────────────────────────────────────

--- a/scripts/lib/check-tracker-ids.mjs
+++ b/scripts/lib/check-tracker-ids.mjs
@@ -79,6 +79,54 @@ export const BLOCKED_PATTERNS = [
   { name: 'PRAC-N', label: 'wiki practice-tracker id', re: /\bPRAC-\d+\b/gi },
 ];
 
+// Tool-attribution markers. A SEPARATE export, deliberately NOT folded into
+// BLOCKED_PATTERNS: BLOCKED_PATTERNS is applied by `--all` to the whole shipped
+// tree, where a doc may legitimately QUOTE an attribution trailer while telling
+// you not to write one (CLAUDE.md and the PR template both do exactly that).
+// These patterns apply only to authored public surfaces: the commit message and
+// the PR title/body.
+//
+// Why this gate exists at all: the harness system prompt instructs the agent to
+// append these on every commit and every PR, which directly contradicts this
+// repo's ship-surface rule. Two conflicting instructions cannot be resolved by a
+// third instruction — 8 of the 47 commits that landed on main after the ban took
+// effect carried a trailer anyway. Only a deterministic gate holds.
+//
+// The set mirrors the canonical grep documented in CLAUDE.md
+// (`grep -icE 'co-authored-by|claude-session|generated with'`) so the doc and the
+// gate cannot drift apart, plus the session URL and the robot-emoji footer that
+// open the harness's default footer block.
+export const ATTRIBUTION_PATTERNS = [
+  {
+    name: 'Co-Authored-By:',
+    label: 'tool-attribution trailer',
+    re: /co-authored-by:/gi,
+  },
+  {
+    name: 'Claude-Session:',
+    label: 'agent session trailer',
+    re: /claude-session:/gi,
+  },
+  // Intentionally broad (matches the documented grep): prose like "generated
+  // with the init script" trips it too. Reword to "produced by" — the cost of a
+  // reworded sentence is far below the cost of a leaked attribution footer.
+  {
+    name: 'Generated with',
+    label: 'tool-attribution footer',
+    re: /generated with/gi,
+  },
+  {
+    name: 'session URL',
+    label: 'agent session URL',
+    re: /claude\.ai\/code\/session/gi,
+  },
+  {
+    name: 'robot-emoji footer',
+    label: 'tool-attribution footer marker',
+    re: /\u{1F916}/gu,
+  },
+];
+
 // The full tracker-ID set for a no-code public surface (the annotated tag body,
 // republished verbatim by `gh release create --notes-from-tag`). It equals
 // BLOCKED_PATTERNS now that FEAT-/IMPR-/PRAC- live there; ADR/decisions anchors
@@ -91,12 +139,179 @@ export const TAG_BODY_PATTERNS = [...BLOCKED_PATTERNS];
 // comment line can be re-joined to its predecessor as flowing text.
 const COMMENT_CONT_RE = /^[ \t]*(?:\*|\/\/|#+)[ \t]?/;
 
+// Zero-width characters: ZERO WIDTH SPACE/NON-JOINER/JOINER (U+200B-U+200D)
+// and the BYTE ORDER MARK used as ZERO WIDTH NO-BREAK SPACE (U+FEFF). A
+// pattern like `co-authored-by:` still reads as "Co-Authored-By:" to a human
+// with one of these wedged inside it, but the raw regex never sees a
+// contiguous match. Stripped before matching. Written as explicit \u escapes,
+// never as literal invisible bytes in this source file, on purpose.
+const ZERO_WIDTH_RE = /[\u200B\u200C\u200D\uFEFF]/g;
+
+// ── markdown-rendering bypasses ─────────────────────────────────────────────
+//
+// Every surface this scanner gates (a commit message on GitHub, a PR title, a PR
+// body) is RENDERED as GitHub-Flavored Markdown before a human reads it. The
+// question a pattern must answer is therefore not "do these bytes match" but
+// "does this RENDER as the banned string". Four encodings answer yes to the
+// second and no to the first, and all four were demonstrated slipping a live
+// trailer past this gate:
+//
+//   Co-Authored-By&#58;        HTML entity (numeric, or named: &colon;)
+//   Co-Authored-By\:          markdown backslash escape
+//   Co<!--x-->-Authored-By:   an inline HTML comment splitting the token
+//   &#x1F916; Generated with  a numeric reference to the robot-emoji footer
+//
+// The scan copy decodes entities, drops markdown backslash escapes and folds
+// NFKC — and scanText additionally scans a SECOND view with inline HTML removed.
+// Two views, not one, because the two needs conflict: a trailer hidden INSIDE
+// `<!-- ... -->` must still be caught (a comment does not render, but it does
+// ship in the body text `gh pr create --body-file` submits), while a trailer
+// SPLIT BY a comment is only visible once the comment is gone. Keeping the
+// comment catches the first, removing it catches the second, the union catches
+// both.
+//
+// This is not a markdown renderer and does not try to be. It covers the
+// encodings that reconstruct a banned literal, and it errs toward catching.
+
+// The HTML named entities that could rebuild a banned literal. CommonMark accepts
+// the whole HTML5 name list; only names that decode to a character appearing in a
+// pattern (or that could glue one back together) are worth carrying.
+const NAMED_ENTITIES = {
+  amp: '&',
+  apos: "'",
+  ast: '*',
+  colon: ':',
+  comma: ',',
+  commat: '@',
+  dash: '-',
+  dollar: '$',
+  equals: '=',
+  excl: '!',
+  grave: '`',
+  gt: '>',
+  hyphen: '-',
+  lowbar: '_',
+  lpar: '(',
+  lsqb: '[',
+  lt: '<',
+  minus: '-',
+  nbsp: ' ',
+  num: '#',
+  period: '.',
+  plus: '+',
+  quest: '?',
+  quot: '"',
+  rpar: ')',
+  rsqb: ']',
+  semi: ';',
+  sol: '/',
+  sp: ' ',
+  Tab: '\t',
+  verbar: '|',
+};
+
+const ENTITY_RE = /&(#[0-9]{1,7}|#[xX][0-9a-fA-F]{1,6}|[a-zA-Z][a-zA-Z0-9]{1,31});/g;
+
+function decodeEntities(text) {
+  return text.replace(ENTITY_RE, (m, body) => {
+    if (body[0] === '#') {
+      const hex = body[1] === 'x' || body[1] === 'X';
+      const code = Number.parseInt(hex ? body.slice(2) : body.slice(1), hex ? 16 : 10);
+      if (!Number.isInteger(code) || code <= 0 || code > 0x10ffff) return m;
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return m; // lone surrogate / invalid code point → leave the source text
+      }
+    }
+    const named = NAMED_ENTITIES[body];
+    return named === undefined ? m : named;
+  });
+}
+
+// Inline HTML: a comment, or a single tag. GFM renders NEITHER as text, so
+// `Co<!--x-->-Authored-By:` reads to a human as exactly the banned trailer.
+// REMOVED (not blanked) in the second scan view, so the neighbours join up.
+const INLINE_HTML_RE = /<!--[\s\S]*?-->|<\/?[a-zA-Z][^<>]*>/g;
+
+// Markdown backslash escapes: `\:` renders as `:`. Only ASCII punctuation is
+// escapable in CommonMark, so restricting the class to it leaves `\d` / `\b`
+// inside a regex literal (this repo's own sources are in scope for --all) alone.
+const MD_ESCAPE_RE = /\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~\\])/g;
+
+// Normalize a copy of `line` for MATCHING ONLY: strip zero-width characters,
+// optionally remove inline HTML, decode HTML entities, drop markdown backslash
+// escapes, then NFKC-fold confusable/compatibility forms (e.g. the full-width
+// colon "：" U+FF1A folds to the ASCII ":" a pattern like `co-authored-by:`
+// requires). This is the scan's own internal copy — the caller's original
+// text is never touched, and `report()` output for a file/commit-msg gate
+// always names the FILE and the matched TOKEN, not this function's line
+// indexing, so a normalization-shifted column is a cosmetic, not a
+// correctness, concern (documented rather than chased further).
+//
+// A decoded `&#10;` would inject a newline into a line and desync every line
+// number below it, so any newline the decode produces collapses to a space:
+// normalization never adds or removes a LINE.
+function normalizeForScan(line, { stripHtml = false } = {}) {
+  let s = line.replace(ZERO_WIDTH_RE, '');
+  if (stripHtml) s = s.replace(INLINE_HTML_RE, '');
+  s = decodeEntities(s).replace(/[\r\n]/g, ' ');
+  s = s.replace(MD_ESCAPE_RE, '$1');
+  return s.normalize('NFKC');
+}
+
+// Every match of `patterns` in one ALREADY-normalized line. `lineNo` is 1-based.
+function scanLine(lineText, patterns, lineNo) {
+  const hits = [];
+  for (const { name, label, re } of patterns) {
+    re.lastIndex = 0; // reset shared /g regex between lines
+    let m;
+    while ((m = re.exec(lineText)) !== null) {
+      hits.push({ pattern: name, label, match: m[0], line: lineNo, col: m.index + 1, lineText });
+      if (m.index === re.lastIndex) re.lastIndex++; // never-zero-width guard
+    }
+  }
+  return hits;
+}
+
+// The hits from the second (HTML-removed) view that the first view did not
+// already find. Keyed by pattern + matched text and COUNTED, not set-deduped, so
+// a line carrying the same token twice keeps both hits while a token found in
+// both views is still reported once.
+function extraHits(primary, secondary) {
+  const key = (h) => `${h.pattern}|${h.match}`;
+  const budget = new Map();
+  for (const h of primary) budget.set(key(h), (budget.get(key(h)) || 0) + 1);
+  const out = [];
+  for (const h of secondary) {
+    const k = key(h);
+    const left = budget.get(k) || 0;
+    if (left > 0) budget.set(k, left - 1);
+    else out.push(h);
+  }
+  return out;
+}
+
 /**
  * Scan a blob of text against `patterns` (default BLOCKED_PATTERNS). Returns hits:
  *   { pattern, label, match, line, col, lineText }
  * `line`/`col` are 1-based. Empty array => clean. The CLI passes the broader
  * [...BLOCKED_PATTERNS, ...DECISION_PATTERNS] set for every in-scope file but the
  * CHANGELOG.
+ *
+ * Both the per-line scan and the line-wrap join below run over a NORMALIZED
+ * copy of the text (see `normalizeForScan`): zero-width characters removed,
+ * HTML entities decoded, markdown backslash escapes dropped, NFKC-folded. Every
+ * one of those hides `Co-Authored-By:` from a raw regex while still RENDERING as
+ * the banned trailer to a human on GitHub — the rendered string is what ships, so
+ * the rendered string is what is gated. Each line is scanned twice: once in that
+ * view, and once more with inline HTML removed (which reconstructs a token split
+ * by `Co<!--x-->-Authored-By:`); only the second view's EXTRA hits are kept, so a
+ * trailer hidden inside a comment is still caught and nothing is double-reported.
+ * `line` numbers stay accurate (normalization never adds or removes a line);
+ * `lineText` reflects the NORMALIZED line, which is intentional — reporting the
+ * obfuscated bytes back verbatim would be less legible, not more, to whoever
+ * reads the violation.
  *
  * Tracker tokens also line-wrap inside comments (`... continuing (ADR\n * 0045)`).
  * A pure per-line scan misses those, so each line is ALSO scanned joined to the
@@ -108,23 +323,19 @@ const COMMENT_CONT_RE = /^[ \t]*(?:\*|\/\/|#+)[ \t]?/;
 export function scanText(text, patterns = BLOCKED_PATTERNS) {
   if (typeof text !== 'string' || text.length === 0) return [];
   const hits = [];
-  const lines = text.split(/\r?\n/);
+  const rawLines = text.split(/\r?\n/);
+  const lines = rawLines.map((l) => normalizeForScan(l));
+  // Second view, inline HTML removed. Only its EXTRA hits are kept (extraHits),
+  // so a token the primary view already found is not double-reported, and a
+  // trailer hiding inside an HTML comment — which this view deletes — is still
+  // caught by the primary view, which keeps it.
+  const noHtml = rawLines.map((l) => normalizeForScan(l, { stripHtml: true }));
   for (let i = 0; i < lines.length; i++) {
     const lineText = lines[i];
-    for (const { name, label, re } of patterns) {
-      re.lastIndex = 0; // reset shared /g regex between lines
-      let m;
-      while ((m = re.exec(lineText)) !== null) {
-        hits.push({
-          pattern: name,
-          label,
-          match: m[0],
-          line: i + 1,
-          col: m.index + 1,
-          lineText,
-        });
-        if (m.index === re.lastIndex) re.lastIndex++; // never-zero-width guard
-      }
+    const lineHits = scanLine(lineText, patterns, i + 1);
+    hits.push(...lineHits);
+    if (noHtml[i] !== lineText) {
+      hits.push(...extraHits(lineHits, scanLine(noHtml[i], patterns, i + 1)));
     }
     // Wrapped-token guard: a token can line-wrap at two points — between its
     // prefix WORD and its number (`ADR\n0045`, where the break stands in for a

--- a/scripts/lib/collect-changelog.mjs
+++ b/scripts/lib/collect-changelog.mjs
@@ -18,6 +18,8 @@ import {
   SECTION,
   SECTION_TITLE,
 } from './changelog-classify.mjs';
+// One reading of a PR body, shared with the PR gate — see lib/pr-body.mjs.
+import { parseChangelogBody } from './pr-body.mjs';
 
 // Derive the `…/pull` base URL for inline PR links from a package.json
 // repository URL (`https://github.com/owner/repo.git`, `git+https://…`, or the
@@ -84,64 +86,14 @@ export function normalizeIndexTitle(subject) {
 //   null                    the `## Changelog` heading is absent
 //   { malformed, reason }   present but invalid (missing EN/KO, empty value,
 //                           duplicate line, or None mixed with EN/KO)
-// HTML comments (the template's instructions) are stripped before parsing.
-export function parseChangelogBlock(body) {
-  const text = String(body ?? '').replace(/\r\n/g, '\n');
-  const lines = text.split('\n');
-  let start = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (/^##\s+Changelog\s*$/i.test(lines[i])) {
-      start = i + 1;
-      break;
-    }
-  }
-  if (start === -1) return null; // heading absent
-
-  // Collect the section body until the next `## ` heading or EOF, with HTML
-  // comments removed (they may span multiple lines).
-  const body_lines = [];
-  for (let i = start; i < lines.length; i++) {
-    if (/^##\s+\S/.test(lines[i])) break;
-    body_lines.push(lines[i]);
-  }
-  const cleaned = body_lines.join('\n').replace(/<!--[\s\S]*?-->/g, '');
-
-  const enLines = [];
-  const koLines = [];
-  let noneSeen = false;
-  for (const raw of cleaned.split('\n')) {
-    const line = raw.trim();
-    if (!line) continue;
-    const en = /^-?\s*EN\s*:\s*(.*)$/i.exec(line);
-    const ko = /^-?\s*KO\s*:\s*(.*)$/i.exec(line);
-    if (en) {
-      enLines.push(en[1].trim());
-    } else if (ko) {
-      koLines.push(ko[1].trim());
-    } else if (/^-?\s*None\s*$/i.test(line)) {
-      noneSeen = true;
-    }
-    // other prose lines are tolerated and ignored
-  }
-
-  if (noneSeen && (enLines.length || koLines.length)) {
-    return { malformed: true, reason: 'None mixed with EN/KO lines' };
-  }
-  if (noneSeen) return 'none';
-  if (enLines.length > 1 || koLines.length > 1) {
-    return { malformed: true, reason: 'duplicate EN or KO line' };
-  }
-  if (enLines.length === 0 && koLines.length === 0) {
-    return { malformed: true, reason: 'empty Changelog block (no EN/KO/None)' };
-  }
-  if (enLines.length === 0 || !enLines[0]) {
-    return { malformed: true, reason: 'missing or empty EN line' };
-  }
-  if (koLines.length === 0 || !koLines[0]) {
-    return { malformed: true, reason: 'missing or empty KO line' };
-  }
-  return { en: enLines[0], ko: koLines[0] };
-}
+//
+// The reading itself lives in lib/pr-body.mjs, shared with the PR gate. It used
+// to live here, and drifted from the gate's: this parser read the RAW body, so a
+// PR whose body DEMONSTRATED a changelog block inside a code fence handed it the
+// example, and the example shipped in CHANGELOG.md while the real note was never
+// seen. The gate passed that PR, because the gate masks fences and found the real
+// heading further down. A green gate has to mean the entry will be found here.
+export const parseChangelogBlock = parseChangelogBody;
 
 // Assemble classified, API-enriched entries into a structured draft. Pure: takes
 // the already-collected entry list, returns sections + index + contributors +

--- a/scripts/lib/pr-body.mjs
+++ b/scripts/lib/pr-body.mjs
@@ -1,0 +1,161 @@
+// pr-body.mjs — the one reading of a PR body's markdown, shared by the PR gate
+// (check-pr-surface) and the release collector (collect-changelog).
+//
+// These two modules ask the same questions of the same text: where is the
+// `## Changelog` heading, where does its section end, and is what is inside it a
+// usable release note. They used to answer separately, and the answers drifted:
+//
+//   - The collector read the RAW body, so a PR that DEMONSTRATES a changelog
+//     block inside a code fence (a PR about the template, or about this
+//     collector) handed it the example. The example shipped in CHANGELOG.md and
+//     the real note was never seen. The gate passed the PR, because the gate
+//     masks fences and found the real heading further down.
+//   - The gate had its own idea of a valid EN/KO block, looser than the
+//     collector's, so shapes the gate called fine (`None.`, a duplicated `- EN:`)
+//     came out of the collector as `malformed`.
+//
+// A green gate is a PROMISE that the entry below it will reach the changelog.
+// Two parsers cannot keep that promise, so there is one, and it lives here.
+//
+// Maintainer-only, like both of its consumers: nothing here is in package.json
+// `files`.
+
+// ── headings ────────────────────────────────────────────────────────────────
+//
+// GFM's ATX heading, both halves of its shape:
+//   - 0-3 spaces of leading indent still render as a heading; 4+ is an indented
+//     code block. A gate anchored at column 0 rejects a body that renders
+//     perfectly, which is the worst thing a gate can do.
+//   - a closing run of `#` is optional and means nothing (`## Changelog ##` is
+//     the same H2 as `## Changelog`), so demanding end-of-line right after the
+//     text is the same false positive in a different disguise.
+const ATX_TAIL = '[ \\t]*(?:#+[ \\t]*)?$';
+
+/** An ATX heading matcher for `hashes` + `text` (a regex source fragment). */
+export function heading(hashes, text, flags = 'm') {
+  return new RegExp(`^ {0,3}${hashes}[ \\t]+${text}${ATX_TAIL}`, flags);
+}
+
+/** Any ATX heading, `#` through `######`. Ends a section. */
+export const isAnyHeading = (line) => /^ {0,3}#{1,6}[ \t]+\S/.test(String(line ?? ''));
+
+export const H1_ENGLISH = heading('#', 'English', 'im');
+export const H1_KOREAN = heading('#', '한국어');
+export const H2_CHANGELOG = heading('##', 'Changelog', 'im');
+export const H2_CHECKLIST = heading('##', 'Checklist', 'im');
+
+// ── the live view ───────────────────────────────────────────────────────────
+
+/** HTML comments blanked in place (line count preserved). */
+export function stripHtmlComments(text) {
+  return String(text ?? '').replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ''));
+}
+
+/**
+ * The body as an array of LIVE lines: HTML comments and fenced code blocks
+ * blanked (emptied, not removed, so index i here is line i of the raw body).
+ *
+ * This is what "the text GFM actually renders as markdown" means for every
+ * structural question either consumer asks. A heading inside a fence is an
+ * example, not a section.
+ *
+ * An unterminated fence blanks everything after it — failing toward reporting a
+ * missing section rather than toward silently accepting text that never rendered.
+ */
+export function maskedLines(rawBody) {
+  const lines = stripHtmlComments(String(rawBody ?? '').replace(/\r\n/g, '\n')).split('\n');
+  let fence = null;
+  return lines.map((line) => {
+    const delim = /^[ \t]*(`{3,}|~{3,})[ \t]*/.exec(line);
+    if (fence) {
+      if (delim && delim[1][0] === fence.char && delim[1].length >= fence.len) fence = null;
+      return '';
+    }
+    const open = /^[ \t]*(`{3,}|~{3,})/.exec(line);
+    if (open) {
+      fence = { char: open[1][0], len: open[1].length };
+      return '';
+    }
+    return line;
+  });
+}
+
+// ── the changelog section ───────────────────────────────────────────────────
+
+/**
+ * The `## Changelog` section: its boundaries found on the LIVE view, its content
+ * taken from the RAW lines between them.
+ *
+ * Returns { start, end, lines } (0-based, `end` exclusive, `lines` the raw content
+ * lines), or null when the heading is absent. `start` is the heading's own line.
+ */
+export function changelogSection(rawBody) {
+  const raw = String(rawBody ?? '')
+    .replace(/\r\n/g, '\n')
+    .split('\n');
+  const view = maskedLines(rawBody);
+  const start = view.findIndex((l) => H2_CHANGELOG.test(l));
+  if (start === -1) return null;
+  let end = view.length;
+  for (let i = start + 1; i < view.length; i++) {
+    if (isAnyHeading(view[i])) {
+      end = i;
+      break;
+    }
+  }
+  return { start, end, lines: raw.slice(start + 1, end) };
+}
+
+/**
+ * Parse the content lines of a `## Changelog` section.
+ *
+ *   { en, ko }              both present and non-empty
+ *   'none'                  a literal `None` (no changelog entry; still indexed)
+ *   { malformed, reason }   present but unusable
+ *
+ * This is the ONE judgment of whether a changelog block is usable. The gate
+ * reports its `reason` to the author while the PR can still be edited; the
+ * collector relies on the gate having done so. They cannot disagree, because
+ * this is the only place the question is answered.
+ */
+export function parseChangelogLines(contentLines) {
+  const cleaned = (contentLines || []).join('\n').replace(/<!--[\s\S]*?-->/g, '');
+  const enLines = [];
+  const koLines = [];
+  let noneSeen = false;
+  for (const rawLine of cleaned.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const en = /^-?\s*EN\s*:\s*(.*)$/i.exec(line);
+    const ko = /^-?\s*KO\s*:\s*(.*)$/i.exec(line);
+    if (en) enLines.push(en[1].trim());
+    else if (ko) koLines.push(ko[1].trim());
+    else if (/^[-*]?\s*None\s*$/i.test(line)) noneSeen = true;
+    // other prose lines are tolerated and ignored
+  }
+
+  if (noneSeen && (enLines.length || koLines.length)) {
+    return { malformed: true, reason: 'None mixed with EN/KO lines' };
+  }
+  if (noneSeen) return 'none';
+  if (enLines.length > 1 || koLines.length > 1) {
+    return { malformed: true, reason: 'duplicate EN or KO line' };
+  }
+  if (enLines.length === 0 && koLines.length === 0) {
+    return { malformed: true, reason: 'empty Changelog block (no EN/KO/None)' };
+  }
+  if (enLines.length === 0 || !enLines[0]) {
+    return { malformed: true, reason: 'missing or empty EN line' };
+  }
+  if (koLines.length === 0 || !koLines[0]) {
+    return { malformed: true, reason: 'missing or empty KO line' };
+  }
+  return { en: enLines[0], ko: koLines[0] };
+}
+
+/** parseChangelogLines applied to a whole PR body. null = the heading is absent. */
+export function parseChangelogBody(rawBody) {
+  const sec = changelogSection(rawBody);
+  if (sec === null) return null;
+  return parseChangelogLines(sec.lines);
+}

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -30679,7 +30679,28 @@ function withClosePartitionWiki(projects, touched, fn) {
     spawnSync('git', ['-C', dir, 'add', '-A']);
     spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'close state']);
     spawnSync('git', ['-C', dir, 'push', '-q', 'origin', 'HEAD']);
-    fn(dir, transcript, today);
+    // A controlled HOME for the children these tests spawn. crystallize runs the
+    // full gate, which resolves PKG_ROOT from <home>/.claude/hypo-pkg.json and the
+    // feedback projection from <home>/.claude. Left ambient, the child reads the
+    // DEVELOPER's real ~/.claude, and a close assertion then turns on whatever state
+    // that happens to be in: an unreadable CLAUDE.md there is a feedback blocker, so
+    // `ok` goes false while `missing` stays empty, which is the exact contradiction
+    // the CLI test below exists to rule out. CI never catches it (no hypo-pkg.json
+    // there, so PKG_ROOT is null and both axes skip), so it can only ever fail on a
+    // maintainer's machine.
+    //
+    // hypo-pkg.json is present so lint still runs against the wiki under test;
+    // CLAUDE.md is absent so the feedback axis fails open on target-missing. Same
+    // neutralization the in-process tests take from `claudeHome: '.claude-none'`,
+    // which a spawned child cannot be handed.
+    const home = mkdtempSync(join(tmpdir(), 'hypo-close-home-'));
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+    try {
+      fn(dir, transcript, home, today);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 }
 
@@ -30937,17 +30958,11 @@ test('IMPR-34: --check-session-close renders demoted debt without contradicting 
       { slug: 'mine', date: today },
     ],
     ['projects/mine/session-state.md'],
-    (dir, transcript) => {
-      const r = spawnSync(
-        process.execPath,
-        [
-          join(SCRIPTS, 'crystallize.mjs'),
-          '--check-session-close',
-          '--json',
-          `--hypo-dir=${dir}`,
-          `--transcript-path=${transcript}`,
-        ],
-        { encoding: 'utf-8' },
+    (dir, transcript, home) => {
+      const r = runWithHome(
+        'crystallize.mjs',
+        ['--check-session-close', '--json', `--hypo-dir=${dir}`, `--transcript-path=${transcript}`],
+        home,
       );
       const out = JSON.parse(r.stdout);
       assert.equal(out.project, 'mine', 'the checklist is rendered for the project in scope');
@@ -31662,6 +31677,24 @@ test('package.json files: every listed scripts/ path exists on disk', () => {
   }
 });
 
+test('package.json files: no shipped script imports a script that is not shipped', () => {
+  const root = new URL('../', import.meta.url);
+  const pkg = JSON.parse(readFileSync(new URL('package.json', root), 'utf-8'));
+  // hooks/ ships as a whole directory and reaches into scripts/lib, so it counts
+  // as an importer even though it is not enumerated file-by-file.
+  const hookFiles = readdirSync(new URL('hooks/', root))
+    .filter((f) => f.endsWith('.mjs'))
+    .map((f) => `hooks/${f}`);
+  const shipped = [...pkg.files.filter((f) => f.endsWith('.mjs')), ...hookFiles];
+  const v = closureViolations(shipped, (p) => readFileSync(new URL(p, root), 'utf-8'));
+  assert.deepEqual(
+    v,
+    [],
+    `shipped modules import unshipped files (they would crash on npm install):\n` +
+      v.map((x) => `  ${x.from} → ${x.resolved}`).join('\n'),
+  );
+});
+
 // ── PR surface gate ──────────────────────────────────────────────────────────
 // The PR title/body is a public artifact that is not a file in the repo, so no
 // file-scanning gate ever saw it: a tracker id shipped in a PR title past a green
@@ -31859,24 +31892,6 @@ test('PR surface: tracker ids in the body are caught (all wiki prefixes)', () =>
       `${id} should be a body tracker-id violation`,
     );
   }
-});
-
-test('package.json files: no shipped script imports a script that is not shipped', () => {
-  const root = new URL('../', import.meta.url);
-  const pkg = JSON.parse(readFileSync(new URL('package.json', root), 'utf-8'));
-  // hooks/ ships as a whole directory and reaches into scripts/lib, so it counts
-  // as an importer even though it is not enumerated file-by-file.
-  const hookFiles = readdirSync(new URL('hooks/', root))
-    .filter((f) => f.endsWith('.mjs'))
-    .map((f) => `hooks/${f}`);
-  const shipped = [...pkg.files.filter((f) => f.endsWith('.mjs')), ...hookFiles];
-  const v = closureViolations(shipped, (p) => readFileSync(new URL(p, root), 'utf-8'));
-  assert.deepEqual(
-    v,
-    [],
-    `shipped modules import unshipped files (they would crash on npm install):\n` +
-      v.map((x) => `  ${x.from} → ${x.resolved}`).join('\n'),
-  );
 });
 
 test('PR surface: a legitimate GitHub ref (#123 / PR #50) is NOT flagged', () => {

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -104,7 +104,9 @@ import {
   BLOCKED_PATTERNS,
   DECISION_PATTERNS,
   TAG_BODY_PATTERNS,
+  ATTRIBUTION_PATTERNS,
 } from '../scripts/lib/check-tracker-ids.mjs';
+import { checkPrSurface } from '../scripts/lib/check-pr-surface.mjs';
 import {
   collectPagesLint,
   collectPagesGraph,
@@ -17282,6 +17284,131 @@ test('feedback projection over cap → still blocks, never auto-writes (ADR 0045
   );
 });
 
+test('feedback gate: CLAUDE.md present but WITHOUT its container → BLOCKS (was a silent fail-open)', () => {
+  // The projection cannot be built, so NOT ONE L1 rule is loaded on this machine
+  // and every sync is a silent no-op. The buildError shape is dirty:false with no
+  // conflict flag, so the gate used to classify it as "nothing to do" and fail
+  // OPEN — structurally broken, and nothing anywhere said so. It must block.
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'feedback', 'rule-a.md'), fbPage(FB_GLOBAL_L1));
+    },
+    (dir) => {
+      const home = mkdtempSync(join(tmpdir(), 'hypo-fbhook-nocontainer-'));
+      try {
+        mkdirSync(join(home, '.claude'), { recursive: true });
+        writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+        // The file EXISTS (so this is NOT the benign first-run case) but the
+        // managed <learned_behaviors> container is gone.
+        writeFileSync(join(home, '.claude', 'CLAUDE.md'), '# Global\n\nNo container here.\n');
+        const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+        const out = JSON.parse(r.stdout);
+        assert.equal(out.decision, 'block', `unbuildable projection must block: ${r.stdout}`);
+        assert.ok(
+          /cannot be built/.test(out.reason || ''),
+          `block reason must name the build failure: ${r.stdout}`,
+        );
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+test('feedback gate: CLAUDE.md exists but is UNREADABLE → BLOCKS, not fail-open (BLOCKER 5)', () => {
+  // BLOCKER 5: existsSync sees the file, readFileSync throws (mode 000), and an
+  // uncaught throw used to crash feedback-sync entirely — no JSON report at all.
+  // The PreCompact gate's "unparseable stdout" branch then read that as
+  // "nothing to project" and failed OPEN: an ordinary filesystem error
+  // reproduced the exact failure mode (rules not loaded, gate stays green) this
+  // whole system exists to prevent. It must block, the same as a missing
+  // container.
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'feedback', 'rule-a.md'), fbPage(FB_GLOBAL_L1));
+    },
+    (dir) => {
+      const home = mkdtempSync(join(tmpdir(), 'hypo-fbhook-unreadable-'));
+      try {
+        mkdirSync(join(home, '.claude'), { recursive: true });
+        writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+        const claudeMdPath = join(home, '.claude', 'CLAUDE.md');
+        writeFileSync(claudeMdPath, '# Global\n<learned_behaviors>\n</learned_behaviors>\n');
+        chmodSync(claudeMdPath, 0o000);
+        try {
+          const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+          const out = JSON.parse(r.stdout);
+          assert.equal(
+            out.decision,
+            'block',
+            `unreadable target must block, not fail-open: ${r.stdout}`,
+          );
+          assert.ok(
+            /cannot be built/.test(out.reason || ''),
+            `block reason must name the build failure: ${r.stdout}`,
+          );
+        } finally {
+          chmodSync(claudeMdPath, 0o644); // restore so cleanup (rmSync) can remove the tree
+        }
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+test('feedback gate: CLAUDE.md file absent entirely → still fail-open (first-run, not a break)', () => {
+  // Counterpart of the unreadable-target test above: a file that does not
+  // exist AT ALL is the ordinary first-run state, not a broken one, and must
+  // keep failing open — 'target-missing' stays distinct from 'build-failed'.
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'feedback', 'rule-a.md'), fbPage(FB_GLOBAL_L1));
+    },
+    (dir) => {
+      const home = mkdtempSync(join(tmpdir(), 'hypo-fbhook-missing-'));
+      try {
+        mkdirSync(join(home, '.claude'), { recursive: true });
+        writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+        // No CLAUDE.md at all.
+        const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+        const out = JSON.parse(r.stdout);
+        assert.equal(
+          out.continue,
+          true,
+          `a missing (not unreadable) target must still fail-open: ${r.stdout}`,
+        );
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+test('feedback gate: no container AND no feedback pages → still fail-open (nothing to project)', () => {
+  // The other side of the promotion above: a user whose CLAUDE.md has no managed
+  // container and who has no feedback pages yet has NOTHING to project, so there
+  // is no build error and nothing to block on. A gate that blocked here would hit
+  // every user who keeps a plain global CLAUDE.md.
+  withWiki(null, (dir) => {
+    const home = mkdtempSync(join(tmpdir(), 'hypo-fbhook-nocontainer-empty-'));
+    try {
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+      writeFileSync(join(home, '.claude', 'CLAUDE.md'), '# Global\n\nNo container here.\n');
+      const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.continue, true, `no candidates must not block: ${r.stdout}`);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 test('feedback gate: memory clean + missing CLAUDE.md → fail-open (no false block)', () => {
   // Regression: the prior `every(buildError)` predicate blocked
   // when the memory target was clean but the claude target only had a buildError
@@ -18061,6 +18188,45 @@ test('feedback-sync-project-id-unknown-skips-memory: derived dir missing → no 
   });
 });
 
+test('feedback-sync --check --json: an UNREADABLE target file reports build-failed, no crash (BLOCKER 5)', () => {
+  // existsSync sees the file; readFileSync throws (mode 000). This used to be
+  // an UNCAUGHT exception: the process crashed before writing any JSON to
+  // stdout, so every downstream consumer (doctor, the PreCompact gate) saw "no
+  // report" and treated it as "nothing to project" — fail OPEN on an ordinary
+  // filesystem error. Caught now and reported like any other structural
+  // failure: valid JSON, buildErrorKind 'build-failed'.
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runFb }) => {
+    const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+    chmodSync(claudeMdPath, 0o000);
+    try {
+      const r = runFb(['--check', '--json']);
+      const rep = JSON.parse(r.stdout); // must not throw: a report must still come out
+      assert.equal(
+        rep.targets.claude.buildErrorKind,
+        'build-failed',
+        `an unreadable (not missing) target must be 'build-failed': ${r.stdout}`,
+      );
+      assert.match(rep.targets.claude.buildError, /cannot read target file/);
+      assert.notEqual(r.status, 0, 'an unreadable target must not exit clean');
+    } finally {
+      chmodSync(claudeMdPath, 0o644); // restore so withFeedbackEnv cleanup can remove it
+    }
+  });
+});
+
+test('feedback-sync --check --json: a target file that is simply MISSING stays target-missing', () => {
+  // The counterpart of the unreadable case above: no file at all is the
+  // ordinary first-run state and must keep its own distinct classification, not
+  // collapse into 'build-failed'.
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runFb }) => {
+    rmSync(join(claudeHome, 'CLAUDE.md'), { force: true });
+    const r = runFb(['--check', '--json']);
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.targets.claude.buildErrorKind, 'target-missing');
+  });
+});
+
 // ── feedback-sync hardening regressions ──────────────────────────────────────
 
 test('feedback-sync-crlf-block-idempotent: CRLF managed block is recognized, no duplicate region', () => {
@@ -18353,6 +18519,88 @@ test('tampered managed block (conflict) → fail Feedback projection integrity',
       `conflict must fail: ${JSON.stringify(fb)}`,
     );
     assert.equal(r.status, 1, 'doctor exits 1 when any check fails');
+  });
+});
+
+test('CLAUDE.md without its <learned_behaviors> container → FAIL, not warn (no rules load)', () => {
+  // Was a warn. A target that cannot be built loads ZERO L1 rules on that machine
+  // and every sync is a silent no-op — nothing else in the system reports it, and
+  // it went unnoticed on a real machine. doctor must fail, not murmur.
+  withDoctorFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runDoctor }) => {
+      const { r, fb } = runDoctor();
+      assert.ok(
+        fb.some((c) => c.status === 'fail' && /container not found/.test(c.detail)),
+        `unbuildable projection must fail: ${JSON.stringify(fb)}`,
+      );
+      assert.ok(
+        fb.some((c) => c.status === 'fail' && /feedback-sync --write/.test(c.detail)),
+        `the fail must name the way out: ${JSON.stringify(fb)}`,
+      );
+      assert.equal(r.status, 1, 'doctor exits 1 when any check fails');
+    },
+    { claudeMd: '# Global\n\nSomeone deleted the managed container.\n' },
+  );
+});
+
+test('a build-failed target is never masked by a target-missing one (fail wins over warn)', () => {
+  // doctor used to take the FIRST buildError of any kind. With more than one
+  // container target, a benign 'target-missing' earlier in iteration order would
+  // downgrade a structurally broken target to a warn — re-hiding exactly what this
+  // check exists to surface. Latent today (only `claude` has a container), so this
+  // pins the selection rule before a second container target makes it live.
+  withDoctorFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runDoctor }) => {
+      const { fb } = runDoctor();
+      assert.ok(
+        fb.some((c) => c.status === 'fail' && /container not found/.test(c.detail)),
+        `a build-failed target must fail even alongside other buildErrors: ${JSON.stringify(fb)}`,
+      );
+    },
+    { claudeMd: '# Global\n\nNo container.\n' },
+  );
+});
+
+test('CLAUDE.md file absent entirely → still a WARN (first-run state, not a break)', () => {
+  // The counterpart of the promotion above: no ~/.claude/CLAUDE.md yet is the
+  // ordinary first-run state. Failing here would fail every new user's doctor run,
+  // so buildErrorKind splits it from the structural 'build-failed' case.
+  withDoctorFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runDoctor }) => {
+    rmSync(join(claudeHome, 'CLAUDE.md'), { force: true });
+    const { fb } = runDoctor();
+    assert.ok(
+      fb.every((c) => c.status !== 'fail'),
+      `a missing target file must not fail doctor: ${JSON.stringify(fb)}`,
+    );
+    assert.ok(
+      fb.some((c) => c.status === 'warn' && /target file missing/.test(c.detail)),
+      `expected a target-missing warn: ${JSON.stringify(fb)}`,
+    );
+  });
+});
+
+test('CLAUDE.md exists but is UNREADABLE (mode 000) → doctor FAILS as build-failed (BLOCKER 5)', () => {
+  // existsSync sees the file; readFileSync throws. That used to be an uncaught
+  // exception inside feedback-sync.mjs, so `--check --json` produced NO stdout
+  // at all — doctor's "feedback-sync produced no JSON report" branch then only
+  // warned. An unreadable target must be treated exactly like a missing
+  // container: a hard doctor failure, not a shrug.
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withDoctorFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runDoctor }) => {
+    const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+    chmodSync(claudeMdPath, 0o000);
+    try {
+      const { r, fb } = runDoctor();
+      assert.ok(
+        fb.some((c) => c.status === 'fail' && /cannot read target file/.test(c.detail)),
+        `unreadable target must fail as build-failed: ${JSON.stringify(fb)}`,
+      );
+      assert.equal(r.status, 1, 'doctor exits 1 when any check fails');
+    } finally {
+      chmodSync(claudeMdPath, 0o644); // restore so withDoctorFeedbackEnv cleanup can remove it
+    }
   });
 });
 
@@ -18984,6 +19232,578 @@ imported_from: claude
 
 - [2026-05-20] HAND EDITED — 근거: [[rule-a]]
 `;
+
+// ── CONCERN 6: --ensure-container — the provisioning path a blocker can
+// actually name. A gate that detects a missing container but names no way to
+// create one gets bypassed, not obeyed; --ensure-container is that way.
+suite('feedback-sync.mjs — --ensure-container (CONCERN 6 provisioning path)');
+
+test('--ensure-container: file exists WITHOUT a container → appends an empty pair, preserves content', () => {
+  withFeedbackEnv(
+    {},
+    ({ claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      const before = '# Global\n\nSome hand-written prose the user cares about.\n';
+      writeFileSync(claudeMdPath, before);
+      const r = runFb(['--ensure-container', '--json']);
+      assert.equal(r.status, 0, r.stderr);
+      const rep = JSON.parse(r.stdout);
+      assert.equal(rep.action, 'created');
+      const after = readFileSync(claudeMdPath, 'utf-8');
+      assert.ok(after.startsWith(before), 'existing content must be preserved verbatim, untouched');
+      assert.ok(after.includes('<learned_behaviors>'));
+      assert.ok(after.includes('</learned_behaviors>'));
+      assert.ok(
+        after.indexOf('<learned_behaviors>') < after.indexOf('</learned_behaviors>'),
+        'open tag must precede close tag',
+      );
+    },
+    { claudeMd: '# placeholder' }, // overwritten before --ensure-container runs
+  );
+});
+
+test('--ensure-container: a container the file ALREADY has → no-op (idempotent, byte-identical)', () => {
+  withFeedbackEnv({}, ({ claudeHome, runFb }) => {
+    const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+    const before = readFileSync(claudeMdPath, 'utf-8'); // withFeedbackEnv default already has a container
+    const r = runFb(['--ensure-container', '--json']);
+    assert.equal(r.status, 0, r.stderr);
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.action, 'noop-already-present');
+    assert.equal(readFileSync(claudeMdPath, 'utf-8'), before, 'no bytes must change');
+  });
+});
+
+test('--ensure-container: file does not exist at all → no-op, no file created (first-run stays first-run)', () => {
+  withFeedbackEnv({}, ({ claudeHome, runFb }) => {
+    const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+    rmSync(claudeMdPath, { force: true });
+    const r = runFb(['--ensure-container', '--json']);
+    assert.equal(r.status, 0, r.stderr);
+    const rep = JSON.parse(r.stdout);
+    assert.equal(rep.action, 'target-missing');
+    assert.ok(
+      !existsSync(claudeMdPath),
+      '--ensure-container must not create the file from nothing',
+    );
+  });
+});
+
+test('--ensure-container is idempotent across TWO real runs (created, then no-op, same bytes)', () => {
+  withFeedbackEnv(
+    {},
+    ({ claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      writeFileSync(claudeMdPath, '# Global\n\nprose\n');
+      assert.equal(runFb(['--ensure-container']).status, 0);
+      const afterFirst = readFileSync(claudeMdPath, 'utf-8');
+      assert.equal(runFb(['--ensure-container']).status, 0);
+      assert.equal(
+        readFileSync(claudeMdPath, 'utf-8'),
+        afterFirst,
+        'a second run must change nothing',
+      );
+    },
+    { claudeMd: '# placeholder' },
+  );
+});
+
+test('--ensure-container then --write succeeds (the container it created is a valid placement target)', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      writeFileSync(claudeMdPath, '# Global\n\nprose\n');
+      assert.equal(runFb(['--ensure-container']).status, 0);
+      assert.equal(
+        runFb(['--write']).status,
+        0,
+        'write must succeed into the just-created container',
+      );
+      const content = readFileSync(claudeMdPath, 'utf-8');
+      assert.ok(content.includes('HYPO:FEEDBACK-SYNC:START'));
+      assert.ok(
+        content.includes('prose'),
+        'original content must survive the whole ensure+write flow',
+      );
+    },
+    { claudeMd: '# placeholder' },
+  );
+});
+
+test('the hook blocker for a build-failed target names --ensure-container and the exact path/tag', () => {
+  // CONCERN 6: "restore the managed container in the target file" alone names
+  // neither WHICH file nor WHAT tag — this pins that the reason string a real
+  // session sees carries both, plus the executable remedy command.
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'feedback', 'rule-a.md'), fbPage(FB_GLOBAL_L1));
+    },
+    (dir) => {
+      const home = mkdtempSync(join(tmpdir(), 'hypo-fbhook-ensure-msg-'));
+      try {
+        mkdirSync(join(home, '.claude'), { recursive: true });
+        writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+        const claudeMdPath = join(home, '.claude', 'CLAUDE.md');
+        writeFileSync(claudeMdPath, '# Global\n\nNo container here.\n');
+        const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+        const out = JSON.parse(r.stdout);
+        assert.equal(out.decision, 'block');
+        assert.ok(
+          out.reason.includes(claudeMdPath),
+          `blocker reason must name the exact target path: ${out.reason}`,
+        );
+        assert.ok(
+          out.reason.includes('<learned_behaviors></learned_behaviors>'),
+          `blocker reason must name the literal container tag pair: ${out.reason}`,
+        );
+        assert.match(
+          out.reason,
+          /--ensure-container/,
+          'blocker reason must name the remedy command',
+        );
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+test('doctor names --ensure-container and the exact path for a build-failed target', () => {
+  withDoctorFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ claudeHome, runDoctor }) => {
+      const { fb } = runDoctor();
+      const hit = fb.find((c) => c.status === 'fail' && /container not found/.test(c.detail));
+      assert.ok(hit, `expected a build-failed fail entry: ${JSON.stringify(fb)}`);
+      assert.ok(
+        hit.detail.includes(join(claudeHome, 'CLAUDE.md')),
+        `doctor detail must name the exact target path: ${hit.detail}`,
+      );
+      assert.match(hit.detail, /--ensure-container/, 'doctor remedy must name the command');
+    },
+    { claudeMd: '# Global\n\nNo container.\n' },
+  );
+});
+
+// ── BLOCKER 1: --ensure-container overwrote the user's global config with a
+// truncating writeFileSync. The ONE command that promises "existing content is
+// never touched" was the one that could shred it: a crash / a full disk between
+// the truncate and the write leaves ~/.claude/CLAUDE.md cut in half. Every write
+// goes through tmp+rename now.
+suite('feedback-sync.mjs — atomic writes + symlink safety (BLOCKER 1)');
+
+test('--ensure-container writes via tmp+rename (the target inode CHANGES, no tmp left behind)', () => {
+  // The direct, unfakeable signature of tmp+rename: rename(2) swaps a NEW inode
+  // into the path. An in-place writeFileSync keeps the old inode. Turn atomicWrite
+  // back into writeFileSync and this assertion goes red immediately.
+  if (process.platform === 'win32') return;
+  withFeedbackEnv(
+    {},
+    ({ claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      const before = '# Global\n\nProse the user cares about.\n';
+      writeFileSync(claudeMdPath, before);
+      const inoBefore = statSync(claudeMdPath).ino;
+      assert.equal(runFb(['--ensure-container']).status, 0);
+      const after = readFileSync(claudeMdPath, 'utf-8');
+      assert.ok(after.startsWith(before), 'every existing byte must survive verbatim');
+      assert.notEqual(
+        statSync(claudeMdPath).ino,
+        inoBefore,
+        'a tmp+rename write replaces the inode; an in-place overwrite would keep it',
+      );
+      assert.deepEqual(
+        readdirSync(claudeHome).filter((f) => f.endsWith('.tmp')),
+        [],
+        'no tmp file may be left behind',
+      );
+    },
+    { claudeMd: '# placeholder' },
+  );
+});
+
+test('--write writes the projection via tmp+rename too (inode changes, content correct)', () => {
+  if (process.platform === 'win32') return;
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, memDir, runFb }) => {
+    const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+    const inoBefore = statSync(claudeMdPath).ino;
+    assert.equal(runFb(['--write']).status, 0);
+    assert.notEqual(statSync(claudeMdPath).ino, inoBefore, 'projection write must be atomic too');
+    assert.ok(readFileSync(claudeMdPath, 'utf-8').includes('HYPO:FEEDBACK-SYNC:START'));
+    assert.deepEqual(
+      readdirSync(claudeHome).filter((f) => f.endsWith('.tmp')),
+      [],
+      'no tmp file left in the claude home',
+    );
+    assert.deepEqual(
+      readdirSync(memDir).filter((f) => f.endsWith('.tmp')),
+      [],
+      'no tmp file left in the memory dir',
+    );
+  });
+});
+
+test('--ensure-container: a FAILED write leaves the original file byte-identical', () => {
+  // The whole point of tmp+rename. The tmp write fails (read-only directory), so
+  // the rename never runs and the target keeps every byte it had. The old
+  // writeFileSync path would have opened the EXISTING file for writing (the
+  // directory mode does not gate that), truncated it, and written the new content.
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withFeedbackEnv(
+    {},
+    ({ claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      const before = '# Global\n\nIrreplaceable hand-written prose.\n';
+      writeFileSync(claudeMdPath, before);
+      chmodSync(claudeHome, 0o500); // dir not writable → the tmp file cannot be created
+      try {
+        const r = runFb(['--ensure-container']);
+        assert.notEqual(r.status, 0, 'a write that cannot complete must fail loudly');
+        assert.equal(
+          readFileSync(claudeMdPath, 'utf-8'),
+          before,
+          'a failed atomic write must not have touched the original file',
+        );
+      } finally {
+        chmodSync(claudeHome, 0o700);
+      }
+    },
+    { claudeMd: '# placeholder' },
+  );
+});
+
+test('--ensure-container follows a SYMLINKED CLAUDE.md and writes the real file (link survives)', () => {
+  // A dotfile repo linking ~/.claude/CLAUDE.md into a git checkout is a common
+  // setup. The tmp must land beside the REAL file (same filesystem → the rename is
+  // atomic) and must replace the real file, not clobber the link with a regular one.
+  if (process.platform === 'win32') return;
+  withFeedbackEnv(
+    {},
+    ({ base, claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      const realPath = join(base, 'dotfiles-CLAUDE.md');
+      const before = '# Global (kept in a dotfile repo)\n';
+      writeFileSync(realPath, before);
+      rmSync(claudeMdPath, { force: true });
+      symlinkSync(realPath, claudeMdPath);
+      assert.equal(runFb(['--ensure-container']).status, 0);
+      assert.ok(lstatSync(claudeMdPath).isSymbolicLink(), 'the symlink must still be a symlink');
+      const real = readFileSync(realPath, 'utf-8');
+      assert.ok(real.startsWith(before), 'the real file keeps its content');
+      assert.ok(real.includes('<learned_behaviors>'), 'the container lands in the REAL file');
+    },
+    { claudeMd: '# placeholder' },
+  );
+});
+
+test('a DANGLING symlink target is build-failed, not target-missing (existsSync lies about it)', () => {
+  // existsSync FOLLOWS the link and finds nothing, so a broken link read as the
+  // benign first-run state: the gate stayed green with zero rules loaded, and a
+  // --write would have replaced the link with a regular file.
+  if (process.platform === 'win32') return;
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ base, claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      rmSync(claudeMdPath, { force: true });
+      symlinkSync(join(base, 'no-such-file.md'), claudeMdPath);
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(
+        rep.targets.claude.buildErrorKind,
+        'build-failed',
+        `a dangling symlink must not pass as the benign first-run state: ${JSON.stringify(rep.targets.claude)}`,
+      );
+      assert.match(rep.targets.claude.buildError, /dangling symlink/);
+      // and --ensure-container must not silently no-op on it either
+      const ens = runFb(['--ensure-container']);
+      assert.notEqual(ens.status, 0, '--ensure-container must fail on a dangling symlink');
+      assert.match(ens.stderr, /dangling symlink/);
+      assert.ok(
+        !existsSync(join(base, 'no-such-file.md')),
+        '--ensure-container must not materialize the missing link target',
+      );
+    },
+    { claudeMd: '# placeholder' },
+  );
+});
+
+// ── BLOCKER 2: the container predicate was a first-occurrence substring search.
+// Inverted tags made it read false FOREVER (so --ensure-container appended pair
+// after pair and --write never succeeded — a state the tool created and could not
+// leave), and a pair inside a comment or a fence made it read true (so the region
+// was written into inert text).
+suite('feedback-sync.mjs — container classification (BLOCKER 2)');
+
+const LB_PAIR = '<learned_behaviors>\n</learned_behaviors>';
+
+test('INVERTED tags (close before open) are build-failed, and --ensure-container REFUSES to append', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      const before = readFileSync(claudeMdPath, 'utf-8');
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(
+        rep.targets.claude.buildErrorKind,
+        'build-failed',
+        `inverted tags are corruption, not "no container": ${JSON.stringify(rep.targets.claude)}`,
+      );
+      assert.match(rep.targets.claude.buildError, /corrupt/i);
+      const ens = runFb(['--ensure-container']);
+      assert.notEqual(ens.status, 0, '--ensure-container must FAIL rather than append');
+      assert.match(ens.stderr, /refusing to append/i);
+      assert.match(ens.stderr, /BY HAND/);
+      assert.equal(
+        readFileSync(claudeMdPath, 'utf-8'),
+        before,
+        'a refusing --ensure-container must not add a single byte (a blind append is unfixable)',
+      );
+    },
+    { claudeMd: '# Global\n</learned_behaviors>\n<learned_behaviors>\n' },
+  );
+});
+
+test('the corrupt-container remedy is a HAND repair, never `--ensure-container` (it refuses)', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runFb }) => {
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      const remedy = rep.targets.claude.buildErrorRemedy || '';
+      assert.match(remedy, /BY HAND/, `remedy must send the human to a hand repair: ${remedy}`);
+      assert.ok(
+        !/Run `hypomnema feedback-sync --ensure-container`/.test(remedy),
+        `remedy must not name a command that refuses this exact case: ${remedy}`,
+      );
+    },
+    { claudeMd: '# Global\n</learned_behaviors>\n<learned_behaviors>\n' },
+  );
+});
+
+test('DUPLICATE container pairs are build-failed (which pair owns the region is unanswerable)', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runFb }) => {
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(rep.targets.claude.buildErrorKind, 'build-failed');
+      assert.match(rep.targets.claude.buildError, /2 opening and 2 closing/);
+    },
+    { claudeMd: `# Global\n${LB_PAIR}\n\n## Later\n${LB_PAIR}\n` },
+  );
+});
+
+test('an UNPAIRED open tag is build-failed (a CLAUDE.md that merely quotes the tag in prose)', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runFb }) => {
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(rep.targets.claude.buildErrorKind, 'build-failed');
+      assert.match(rep.targets.claude.buildError, /no closing/);
+    },
+    { claudeMd: '# Global\n<learned_behaviors>\n- a rule with no closing tag\n' },
+  );
+});
+
+test('a container inside an HTML COMMENT does not count as present (scenario B)', () => {
+  // --ensure-container used to no-op ("already there") and placement wrote the
+  // managed region INSIDE the comment, where nothing reads it — and the hook then
+  // saw that as ordinary drift and kept rewriting it, forever.
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ claudeHome, runFb }) => {
+      const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(
+        rep.targets.claude.buildErrorKind,
+        'build-failed',
+        'a commented-out pair is not a container',
+      );
+      assert.match(rep.targets.claude.buildError, /container not found/);
+      // ensure-container must PROVISION a real one, not no-op
+      assert.equal(runFb(['--ensure-container']).status, 0);
+      const after = readFileSync(claudeMdPath, 'utf-8');
+      assert.equal(runFb(['--write']).status, 0, 'the provisioned container must be writable');
+      const written = readFileSync(claudeMdPath, 'utf-8');
+      const block = written.indexOf('HYPO:FEEDBACK-SYNC:START');
+      const commentEnd = written.indexOf('-->');
+      assert.ok(block > commentEnd, 'the managed region must land OUTSIDE the HTML comment');
+      assert.ok(after.includes('<!-- example:'), 'the example comment itself is left alone');
+    },
+    {
+      claudeMd:
+        '# Global\n<!-- example: <learned_behaviors></learned_behaviors> goes here -->\n\nprose\n',
+    },
+  );
+});
+
+test('a container inside a CODE FENCE does not count as present', () => {
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ runFb }) => {
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(rep.targets.claude.buildErrorKind, 'build-failed');
+      assert.match(rep.targets.claude.buildError, /container not found/);
+    },
+    { claudeMd: `# Global\n\n\`\`\`md\n${LB_PAIR}\n\`\`\`\n` },
+  );
+});
+
+test('a container quoted in INLINE CODE does not make a real container look duplicated', () => {
+  // A CLAUDE.md that mentions the tag in prose (`<learned_behaviors>`) alongside
+  // the real container must still be PRESENT, not corrupt — otherwise documenting
+  // the mechanism breaks it.
+  withFeedbackEnv(
+    { 'rule-a': FB_GLOBAL_L1 },
+    ({ claudeHome, runFb }) => {
+      assert.equal(runFb(['--write']).status, 0, 'a prose mention must not break the container');
+      const c = readFileSync(join(claudeHome, 'CLAUDE.md'), 'utf-8');
+      const open = c.indexOf('\n<learned_behaviors>');
+      const block = c.indexOf('HYPO:FEEDBACK-SYNC:START');
+      assert.ok(
+        block > open,
+        'the region lands inside the REAL container, not at the prose mention',
+      );
+    },
+    {
+      claudeMd:
+        '# Global\n\nNever hand-edit `<learned_behaviors>` or `</learned_behaviors>` — it is a projection.\n\n<learned_behaviors>\n</learned_behaviors>\n',
+    },
+  );
+});
+
+// ── CONCERN 7: a side-file I/O error hard-blocked /compact and the blocker named
+// `--ensure-container`, a command that only ever touches CLAUDE.md and could not
+// fix a permission bit if it tried. A gate whose own named remedy cannot open it.
+suite('feedback-sync.mjs — side-file I/O is a warning, not a blocker (CONCERN 7)');
+
+test('an unreadable side file is a sideWarning, NOT build-failed', () => {
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ memDir, runFb }) => {
+    assert.equal(runFb(['--write']).status, 0);
+    const side = join(memDir, 'feedback_rule-a.md');
+    chmodSync(side, 0o000);
+    try {
+      const r = runFb(['--check', '--json']);
+      const rep = JSON.parse(r.stdout);
+      assert.equal(
+        rep.targets.memory.buildError,
+        undefined,
+        `a side-file permission error must not be a build failure: ${r.stdout}`,
+      );
+      assert.ok(
+        (rep.targets.memory.sideWarnings || []).some((w) => /cannot read side file/.test(w)),
+        `it must still be REPORTED, never swallowed: ${r.stdout}`,
+      );
+      assert.match(
+        rep.targets.memory.sideWarnings.join(' '),
+        /feedback_rule-a\.md/,
+        'the warning must name the exact path whose permissions need fixing',
+      );
+    } finally {
+      chmodSync(side, 0o644);
+    }
+  });
+});
+
+test('an unreadable side file does NOT block /compact (the hook reports a notice)', () => {
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages', 'feedback'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'feedback', 'rule-a.md'), fbPage(FB_GLOBAL_L1));
+    },
+    (dir) => {
+      const home = mkdtempSync(join(tmpdir(), 'hypo-fbhook-sidefile-'));
+      const projectId = process.cwd().replace(/[/.]/g, '-');
+      const memDir = join(home, '.claude', 'projects', projectId, 'memory');
+      try {
+        mkdirSync(memDir, { recursive: true });
+        writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgRoot: REPO }));
+        writeFileSync(
+          join(home, '.claude', 'CLAUDE.md'),
+          '# Global\n<learned_behaviors>\n</learned_behaviors>\n',
+        );
+        writeFileSync(join(memDir, 'MEMORY.md'), '# Memory Index\n');
+        // a sync-owned side file the process cannot read
+        const side = join(memDir, 'feedback_rule-a.md');
+        writeFileSync(side, '<!-- HYPO:FEEDBACK-SYNC source=rule-a -->\nstale\n');
+        chmodSync(side, 0o000);
+        try {
+          const r = runHook('hypo-personal-check.mjs', '', { HYPO_DIR: dir, HOME: home });
+          const out = JSON.parse(r.stdout);
+          assert.notEqual(
+            out.decision,
+            'block',
+            `a side-file permission error must not block /compact: ${r.stdout}`,
+          );
+          // Non-vacuity: prove the MEMORY target really was evaluated here (a
+          // skipped target would make the assertion above pass for free). The
+          // unreadable side file reads as drift, so the gate's self-heal --write
+          // rewrites it — atomically, over a file it could not even read.
+          chmodSync(side, 0o644);
+          assert.match(
+            readFileSync(side, 'utf-8'),
+            /HYPO:FEEDBACK-SYNC source=rule-a/,
+            'the memory target must actually have been evaluated and re-synced',
+          );
+        } finally {
+          chmodSync(side, 0o644);
+        }
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+test('a PRIMARY target I/O error still BLOCKS, and its remedy is the permission fix (not --ensure-container)', () => {
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runFb }) => {
+    const claudeMdPath = join(claudeHome, 'CLAUDE.md');
+    chmodSync(claudeMdPath, 0o000);
+    try {
+      const rep = JSON.parse(runFb(['--check', '--json']).stdout);
+      assert.equal(
+        rep.targets.claude.buildErrorKind,
+        'build-failed',
+        'the primary target still hard-fails',
+      );
+      const remedy = rep.targets.claude.buildErrorRemedy || '';
+      assert.match(remedy, /permissions/i, `remedy must be the permission fix: ${remedy}`);
+      assert.match(remedy, /chmod/, 'remedy must name the concrete command');
+      assert.ok(
+        !/Run `hypomnema feedback-sync --ensure-container`/.test(remedy),
+        `remedy must not prescribe a command that cannot fix a permission bit: ${remedy}`,
+      );
+    } finally {
+      chmodSync(claudeMdPath, 0o644);
+    }
+  });
+});
+
+test('doctor WARNS (never fails) on a side-file permission error and names the path', () => {
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withDoctorFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ memDir, runFb, runDoctor }) => {
+    assert.equal(runFb(['--write']).status, 0);
+    const side = join(memDir, 'feedback_rule-a.md');
+    chmodSync(side, 0o000);
+    try {
+      const { fb } = runDoctor();
+      const hit = fb.find((c) => /side file/i.test(c.label));
+      assert.ok(hit, `expected a side-file entry: ${JSON.stringify(fb)}`);
+      assert.equal(hit.status, 'warn', 'a side-file I/O error must warn, not fail');
+      assert.match(hit.detail, /feedback_rule-a\.md/, 'the exact path must be named');
+      assert.match(hit.detail, /permissions/i, 'the permission fix must be named');
+      assert.ok(
+        !fb.some((c) => c.status === 'fail'),
+        `a side-file error must not produce a doctor FAIL: ${JSON.stringify(fb)}`,
+      );
+    } finally {
+      chmodSync(side, 0o644);
+    }
+  });
+});
 
 suite('feedback-sync.mjs — Track B source-loader golden (byte-identical)');
 
@@ -23305,6 +24125,187 @@ test('stripScissors drops the --verbose diff from the >8 line onward', () => {
   assert.ok(out.includes('body clean'));
   assert.ok(!out.includes('fix #9'));
   assert.equal(stripScissors('plain\nmessage'), 'plain\nmessage'); // no scissors → unchanged
+});
+
+// ── CONCERN 4: unicode bypass tricks (zero-width chars, full-width confusables)
+// must not slip an attribution trailer past the regex. Every fixture below is
+// built from explicit \u escapes, never typed as a literal invisible/confusable
+// byte in this source file — a copy-pasted zero-width character in a test
+// fixture is invisible in a diff review, which is exactly the property this
+// regression exists to catch, so the test itself must not rely on it either.
+suite('scanText — unicode-bypass normalization (CONCERN 4)');
+
+test('a zero-width character wedged inside "Co-Authored-By:" is still caught', () => {
+  const withZWJ = 'Co\u200D-Authored-By: Claude <noreply@anthropic.com>';
+  const hits = scanText(withZWJ, ATTRIBUTION_PATTERNS);
+  assert.ok(
+    hits.some((h) => h.pattern === 'Co-Authored-By:'),
+    `zero-width-joiner bypass must still be caught: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('every zero-width character in the stripped set is defeated (U+200B/U+200C/U+200D/U+FEFF)', () => {
+  for (const zw of ['\u200B', '\u200C', '\u200D', '\uFEFF']) {
+    const trailer = `Co-${zw}Authored-By: Claude`;
+    const hits = scanText(trailer, ATTRIBUTION_PATTERNS);
+    assert.ok(
+      hits.some((h) => h.pattern === 'Co-Authored-By:'),
+      `U+${zw.codePointAt(0).toString(16).toUpperCase().padStart(4, '0')} must not defeat the scan`,
+    );
+  }
+});
+
+test('a full-width colon confusable ("Co-Authored-By\uFF1A") is still caught (NFKC fold)', () => {
+  const fullwidth = 'Co-Authored-By\uFF1A Claude <noreply@anthropic.com>';
+  const hits = scanText(fullwidth, ATTRIBUTION_PATTERNS);
+  assert.ok(
+    hits.some((h) => h.pattern === 'Co-Authored-By:'),
+    `full-width colon confusable must NFKC-fold and still be caught: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('normalization adds no false positive on ordinary ASCII prose', () => {
+  assert.equal(scanText('normal prose about co-authoring a book', ATTRIBUTION_PATTERNS).length, 0);
+  assert.equal(scanText('see PR #50 and ADR 0040', BLOCKED_PATTERNS).length, 0);
+});
+
+test('a zero-width character inside a tracker id (ISSUE-N) is still caught', () => {
+  // The bypass is not attribution-specific: scanText normalizes for every
+  // caller, tracker-ids included, since both share the same function.
+  const hits = scanText('see ISSUE\u200B-49 in the wiki');
+  assert.ok(
+    hits.some((h) => h.pattern === 'ISSUE-N'),
+    `zero-width bypass inside a tracker id must still be caught: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('CLI --commit-msg: a zero-width-obfuscated attribution trailer is still rejected', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(
+      f,
+      Buffer.from(
+        `feat(gate): thing\n\nCo\u200D-Authored-By: Claude <noreply@anthropic.com>\n`,
+        'utf-8',
+      ),
+    );
+    const r = runChecker(['--commit-msg', f]);
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /Co-Authored-By:/i);
+  });
+});
+
+// ── BLOCKER: markdown-ENCODING bypasses. Every surface this gate reads is
+// rendered as GFM before a human sees it, so the test is "does it RENDER as the
+// banned string", not "do the bytes match". All five encodings below rendered as
+// a live trailer / tracker id and walked straight through the raw regex.
+suite('scanText — markdown-encoding bypasses (entities, escapes, inline HTML)');
+
+test('a NUMERIC HTML entity cannot hide the trailing colon (Co-Authored-By&#58;)', () => {
+  const hits = scanText('Co-Authored-By&#58; Claude <noreply@anthropic.com>', ATTRIBUTION_PATTERNS);
+  assert.ok(
+    hits.some((h) => h.pattern === 'Co-Authored-By:'),
+    `&#58; renders as ":" — the trailer ships: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('a HEX entity cannot hide the robot-emoji footer marker (&#x1F916;)', () => {
+  const hits = scanText('&#x1F916; Generated with [Claude Code]', ATTRIBUTION_PATTERNS);
+  assert.ok(
+    hits.some((h) => h.pattern === 'robot-emoji footer'),
+    `&#x1F916; renders as the robot emoji: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('a NAMED HTML entity cannot hide a colon or a hash (&colon; / &num;)', () => {
+  assert.ok(
+    scanText('Co-Authored-By&colon; Claude', ATTRIBUTION_PATTERNS).length > 0,
+    '&colon; must decode',
+  );
+  assert.ok(scanText('closes fix &num;37 now').length > 0, '&num; must decode to #');
+});
+
+test('an entity cannot hide a tracker id separator (ISSUE&#45;49)', () => {
+  const hits = scanText('closes ISSUE&#45;49 in the wiki');
+  assert.ok(
+    hits.some((h) => h.pattern === 'ISSUE-N'),
+    `&#45; renders as "-": ${JSON.stringify(hits)}`,
+  );
+});
+
+test('an entity cannot hide a word gap (Generated&#32;with)', () => {
+  assert.ok(
+    scanText('Generated&#32;with [Claude Code]', ATTRIBUTION_PATTERNS).some(
+      (h) => h.pattern === 'Generated with',
+    ),
+    '&#32; renders as a space',
+  );
+});
+
+test('a markdown BACKSLASH escape cannot hide the colon (Co-Authored-By\\:)', () => {
+  const hits = scanText('Co-Authored-By\\: Claude <noreply@anthropic.com>', ATTRIBUTION_PATTERNS);
+  assert.ok(
+    hits.some((h) => h.pattern === 'Co-Authored-By:'),
+    `\\: renders as ":" in GFM: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('an inline HTML comment cannot SPLIT a trailer (Co<!--x-->-Authored-By:)', () => {
+  const hits = scanText('Co<!--x-->-Authored-By: Claude', ATTRIBUTION_PATTERNS);
+  assert.ok(
+    hits.some((h) => h.pattern === 'Co-Authored-By:'),
+    `a comment renders as nothing, so the trailer is contiguous to a reader: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('an inline HTML TAG cannot split a trailer or a tracker id (<span>, <b>)', () => {
+  assert.ok(
+    scanText('Co<span></span>-Authored-By: Claude', ATTRIBUTION_PATTERNS).length > 0,
+    'a tag renders as nothing between the two halves',
+  );
+  assert.ok(scanText('closes ISSUE-<b></b>49 here').length > 0, 'same for a tracker id');
+});
+
+test('a trailer hidden INSIDE an HTML comment is STILL caught (the two views do not cancel)', () => {
+  // The HTML-removed view deletes the comment — but the primary view keeps it, and
+  // the union is what is reported. Deleting comments outright (a one-view fix)
+  // would have re-opened the exact hole the PR-surface gate closed earlier.
+  const hits = scanText(
+    '<!-- Co-Authored-By: Claude <noreply@anthropic.com> -->',
+    ATTRIBUTION_PATTERNS,
+  );
+  assert.ok(
+    hits.some((h) => h.pattern === 'Co-Authored-By:'),
+    `a comment does not render, but it still ships: ${JSON.stringify(hits)}`,
+  );
+});
+
+test('the two views never double-report the same hit', () => {
+  // `Co<!--x-->-Authored-By:` is found once (in the HTML-removed view); a plain
+  // trailer is found once (in the primary view). Neither is counted twice.
+  assert.equal(scanText('Co<!--x-->-Authored-By: Claude', ATTRIBUTION_PATTERNS).length, 1);
+  assert.equal(scanText('Co-Authored-By: Claude', ATTRIBUTION_PATTERNS).length, 1);
+  // two genuine hits on one line stay two
+  assert.equal(scanText('ISSUE-1 and ISSUE-2 here').length, 2);
+  assert.equal(scanText('ISSUE-1 and ISSUE-1 twice').length, 2);
+});
+
+test('the new normalization adds no false positive on ordinary prose or code', () => {
+  assert.equal(scanText('A&B, 100% &amp; more — see PR #50 and (#9)').length, 0);
+  assert.equal(scanText('const re = /\\bISSUE-\\d+\\b/gi; // matcher, no literal id').length, 0);
+  assert.equal(scanText('<https://example.com/issues> and <br/> line break').length, 0);
+  assert.equal(scanText('an unknown &entity; stays put').length, 0);
+  assert.equal(scanText('prose about co-authoring a book', ATTRIBUTION_PATTERNS).length, 0);
+});
+
+test('CLI --commit-msg: an entity-encoded attribution trailer is rejected', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(f, 'feat(gate): thing\n\nCo-Authored-By&#58; Claude <noreply@anthropic.com>\n');
+    const r = runChecker(['--commit-msg', f]);
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /Co-Authored-By:/i);
+  });
 });
 
 function runChecker(args, env = {}) {
@@ -30661,6 +31662,205 @@ test('package.json files: every listed scripts/ path exists on disk', () => {
   }
 });
 
+// ── PR surface gate ──────────────────────────────────────────────────────────
+// The PR title/body is a public artifact that is not a file in the repo, so no
+// file-scanning gate ever saw it: a tracker id shipped in a PR title past a green
+// Tracker-id gate, and 8 of 47 post-ban commits carried an attribution trailer.
+suite('PR surface gate (check-pr-surface)');
+
+// The template's OWN instructional comment used to quote a "Generated with"
+// footer, which is why the reworded version below carries NO banned literal:
+// the attribution scan now reads the RAW body (comments included, BLOCKER 1),
+// so a fixture that still quoted the old phrasing would self-trip.
+const PR_TEMPLATE_COMMENT = [
+  '<!--',
+  'PR title: Conventional Commits plus a scope. Keep any internal tracker id',
+  '(FEAT-/IMPR-/ISSUE-/PRAC-) out of the title and body.',
+  '',
+  'Body language: write the full body TWICE, once under `# English` and once',
+  'under `# 한국어`. Do NOT add a tool-attribution footer or a session URL of',
+  'any kind.',
+  '-->',
+].join('\n');
+
+// Every required subheading per .github/PULL_REQUEST_TEMPLATE.md, matched by
+// checkPrSurface's own EN_SUBHEADINGS/KO_SUBHEADINGS lists.
+const EN_SUBHEADINGS = ['What changed', 'Why', 'How', 'Manual verification', 'Migration notes'];
+const KO_SUBHEADINGS = ['변경 내용', '이유', '방법', '수동 검증', '마이그레이션 노트'];
+
+// A single language block, fully filled by default (every required subheading,
+// each with real content) — a fixture built from this is what "actually filled
+// the template" means, not just "carries the H1". `omit` drops named
+// subheadings; `empty` keeps every subheading but writes no content under any
+// of them (the unfilled-template shape).
+function languageBlock(h1, subheadings, { omit = [], empty = false } = {}) {
+  const lines = [`# ${h1}`, ''];
+  for (const s of subheadings) {
+    if (omit.includes(s)) continue;
+    lines.push(`## ${s}`, '');
+    if (!empty) lines.push(`Detail for ${s}.`, '');
+  }
+  return lines;
+}
+
+function changelogBlock(changelog) {
+  return changelog === null ? [] : ['## Changelog', '', ...changelog, ''];
+}
+
+function checklistBlock(checklist) {
+  return checklist ? ['## Checklist', '', '- [x] `npm test` passes locally', ''] : [];
+}
+
+// Compose a PR body from named blocks, in a given ORDER — the default order
+// matches the template exactly. Passing a reordered `order` array is how the
+// section-order regression tests build an out-of-order body without
+// duplicating the whole block-construction logic.
+function prBody({
+  english = true,
+  korean = true,
+  changelog = null,
+  checklist = true,
+  engOpts = {},
+  korOpts = {},
+  order = ['english', 'korean', 'changelog', 'checklist'],
+} = {}) {
+  const blocks = {
+    english: english ? languageBlock('English', EN_SUBHEADINGS, engOpts) : [],
+    korean: korean ? languageBlock('한국어', KO_SUBHEADINGS, korOpts) : [],
+    changelog: changelogBlock(changelog),
+    checklist: checklistBlock(checklist),
+  };
+  const lines = [PR_TEMPLATE_COMMENT, ''];
+  for (const key of order) lines.push(...blocks[key]);
+  return lines.join('\n');
+}
+
+const GOOD_CHANGELOG = ['- EN: Add a PR surface gate.', '- KO: PR 표면 게이트를 추가한다.'];
+const GOOD_TITLE = 'feat(ci): gate the PR title and body';
+// A body that is ACTUALLY a filled template: both language blocks carry every
+// required subheading with real content, in the right order.
+const goodBody = () => prBody({ changelog: GOOD_CHANGELOG });
+
+function rulesOf(res) {
+  return res.violations.map((v) => v.rule);
+}
+
+test('PR surface: a template-compliant title/body passes (no false positive)', () => {
+  const res = checkPrSurface({ title: GOOD_TITLE, body: goodBody() });
+  assert.equal(
+    res.ok,
+    true,
+    `expected clean, got: ${res.violations.map((v) => `${v.rule}/${v.detail}`).join(' | ')}`,
+  );
+  assert.equal(res.violations.length, 0);
+});
+
+test('PR surface: the reworded template instructional comment does not self-trip any rule', () => {
+  // The comment used to quote "Generated with ..." and relied on a
+  // comment-stripping exemption to avoid tripping the attribution scan
+  // (BLOCKER 1). The exemption is gone; the fix is that the comment no longer
+  // carries any banned literal, so the RAW scan finds nothing here.
+  const res = checkPrSurface({ title: GOOD_TITLE, body: goodBody() });
+  assert.equal(
+    res.violations.filter((v) => v.rule === 'attribution').length,
+    0,
+    'reworded template instructional comment must not self-trip the attribution scan',
+  );
+});
+
+test('PR surface: an attribution trailer hidden inside an HTML comment is REJECTED (BLOCKER 1)', () => {
+  // The exact hole that shipped: comment-stripping the body before the
+  // attribution scan let `<!-- Co-Authored-By: ... -->` through clean, because
+  // GitHub does not RENDER an HTML comment — but the raw body text (what
+  // `gh pr create --body-file` actually submits) still carries it.
+  const body = goodBody() + '\n<!-- Co-Authored-By: Claude <noreply@anthropic.com> -->\n';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(
+    res.ok,
+    false,
+    'an attribution trailer inside an HTML comment must still be rejected',
+  );
+  const hit = res.violations.find((v) => v.rule === 'attribution');
+  assert.ok(hit, 'expected an attribution violation even though the trailer is commented out');
+  assert.equal(hit.surface, 'body');
+});
+
+test('PR surface: Co-Authored-By trailer in the body is caught', () => {
+  const body = goodBody() + '\nCo-Authored-By: Claude <noreply@anthropic.com>\n';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'attribution');
+  assert.ok(hit, 'expected an attribution violation');
+  assert.equal(hit.surface, 'body');
+  assert.match(hit.detail, /Co-Authored-By:/i);
+});
+
+test('PR surface: a full-width-colon confusable attribution trailer (CONCERN 4) is still rejected', () => {
+  // \uFF1A (fullwidth colon) NFKC-folds to ASCII ':' — written as an explicit
+  // escape, never a literal confusable byte, in this source file.
+  const body = goodBody() + `\nCo-Authored-By\uFF1A Claude <noreply@anthropic.com>\n`;
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false, 'full-width colon confusable must not bypass the PR-surface gate');
+  assert.ok(res.violations.some((v) => v.rule === 'attribution'));
+});
+
+test('PR surface: Claude-Session trailer in the body is caught', () => {
+  const body = goodBody() + '\nClaude-Session: https://claude.ai/code/session_01Urs3\n';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false);
+  const attribution = res.violations.filter((v) => v.rule === 'attribution');
+  // Trips two patterns: the trailer key and the session URL.
+  assert.ok(attribution.some((v) => /Claude-Session:/i.test(v.detail)));
+  assert.ok(attribution.some((v) => /claude\.ai\/code\/session/i.test(v.detail)));
+});
+
+test('PR surface: the robot-emoji "Generated with" footer is caught (both patterns)', () => {
+  const body = goodBody() + '\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false);
+  const attribution = res.violations.filter((v) => v.rule === 'attribution');
+  assert.ok(
+    attribution.some((v) => /Generated with/i.test(v.detail)),
+    'expected "Generated with"',
+  );
+  assert.ok(
+    attribution.some((v) => /🤖/.test(v.detail)),
+    'expected the robot-emoji marker',
+  );
+});
+
+test('PR surface: attribution in the TITLE is caught', () => {
+  const res = checkPrSurface({
+    title: 'feat(ci): gate the PR surface 🤖 Generated with [Claude Code]',
+    body: goodBody(),
+  });
+  assert.equal(res.ok, false);
+  assert.ok(res.violations.some((v) => v.rule === 'attribution' && v.surface === 'title'));
+});
+
+test('PR surface: a tracker id in the PR TITLE is caught (the hole that shipped)', () => {
+  // This exact shape passed CI: the Tracker-id gate scans the checkout, and a PR
+  // title is not a file in the checkout.
+  const res = checkPrSurface({ title: 'feat(gate): close ISSUE-49', body: goodBody() });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'tracker-ids');
+  assert.ok(hit, 'expected a tracker-id violation');
+  assert.equal(hit.surface, 'title');
+  assert.match(hit.detail, /ISSUE-49/);
+});
+
+test('PR surface: tracker ids in the body are caught (all wiki prefixes)', () => {
+  for (const id of ['ISSUE-49', 'FEAT-12', 'IMPR-3', 'PRAC-7', 'fix #37']) {
+    const body = goodBody() + `\nImplements ${id} from the wiki.\n`;
+    const res = checkPrSurface({ title: GOOD_TITLE, body });
+    assert.equal(res.ok, false, `${id} should be blocked`);
+    assert.ok(
+      res.violations.some((v) => v.rule === 'tracker-ids' && v.surface === 'body'),
+      `${id} should be a body tracker-id violation`,
+    );
+  }
+});
+
 test('package.json files: no shipped script imports a script that is not shipped', () => {
   const root = new URL('../', import.meta.url);
   const pkg = JSON.parse(readFileSync(new URL('package.json', root), 'utf-8'));
@@ -30676,6 +31876,756 @@ test('package.json files: no shipped script imports a script that is not shipped
     [],
     `shipped modules import unshipped files (they would crash on npm install):\n` +
       v.map((x) => `  ${x.from} → ${x.resolved}`).join('\n'),
+  );
+});
+
+test('PR surface: a legitimate GitHub ref (#123 / PR #50) is NOT flagged', () => {
+  const body = goodBody() + '\nFollows up on #123 and PR #50.\n';
+  const res = checkPrSurface({ title: 'feat(ci): gate the PR surface (#194)', body });
+  assert.equal(res.ok, true, 'GitHub refs are legitimate and must never be flagged');
+});
+
+test('PR surface: a CRLF body (GitHub web-UI edit) still passes — no false positive', () => {
+  // The `edited` trigger fires on web-UI edits, whose bodies come back CRLF, so
+  // CRLF is a COMMON input to this gate rather than an edge case. A compliant body
+  // must pass whatever the line endings are, and a dirty one must still be caught.
+  const crlf = (s) => s.replace(/\n/g, '\r\n');
+  const clean = checkPrSurface({ title: GOOD_TITLE, body: crlf(goodBody()) });
+  assert.equal(
+    clean.ok,
+    true,
+    `CRLF body must not false-positive: ${clean.violations.map((v) => v.rule).join(', ')}`,
+  );
+  const dirty = checkPrSurface({
+    title: GOOD_TITLE,
+    body: crlf(goodBody() + '\nCo-Authored-By: Claude\n'),
+  });
+  assert.equal(dirty.ok, false, 'CRLF must not smuggle an attribution trailer through');
+});
+
+test('PR surface: a missing `# English` block is caught', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ english: false, changelog: GOOD_CHANGELOG }),
+  });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'bilingual');
+  assert.ok(hit);
+  assert.match(hit.detail, /English/);
+});
+
+test('PR surface: a missing `# 한국어` block is caught', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ korean: false, changelog: GOOD_CHANGELOG }),
+  });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'bilingual');
+  assert.ok(hit);
+  assert.match(hit.detail, /한국어/);
+});
+
+test('PR surface: a missing `## Changelog` section is caught', () => {
+  const res = checkPrSurface({ title: GOOD_TITLE, body: prBody({ changelog: null }) });
+  assert.equal(res.ok, false);
+  assert.ok(rulesOf(res).includes('changelog'));
+});
+
+test('PR surface: `## Changelog` with an unfilled `- EN:` / `- KO:` is caught', () => {
+  // The template ships these lines EMPTY; an unedited template must not pass.
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ changelog: ['- EN:', '- KO:'] }),
+  });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'changelog');
+  assert.ok(hit);
+  assert.match(hit.detail, /EN:/);
+  assert.match(hit.detail, /KO:/);
+});
+
+test('PR surface: `## Changelog` missing only the KO line is caught', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ changelog: ['- EN: Add a PR surface gate.'] }),
+  });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'changelog');
+  assert.ok(hit);
+  assert.match(hit.detail, /KO:/);
+});
+
+test('PR surface: `## Changelog` of `None` passes (internal-only change)', () => {
+  assert.equal(
+    checkPrSurface({ title: GOOD_TITLE, body: prBody({ changelog: ['None'] }) }).ok,
+    true,
+  );
+  assert.equal(
+    checkPrSurface({ title: GOOD_TITLE, body: prBody({ changelog: ['- None'] }) }).ok,
+    true,
+  );
+});
+
+test('PR surface: a missing `## Checklist` section is caught', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ changelog: GOOD_CHANGELOG, checklist: false }),
+  });
+  assert.equal(res.ok, false);
+  assert.ok(rulesOf(res).includes('checklist'));
+});
+
+// ── BLOCKER 2: template compliance was a heading-existence check, not a
+// structure check ─────────────────────────────────────────────────────────
+
+test('PR surface: headings that exist ONLY inside a code fence are rejected (not real headings)', () => {
+  // A body that wraps its entire structure in a fenced code block used to pass:
+  // hasHeading() scanned raw text and did not know it was looking at example
+  // text inside ``` fences.
+  const fenced = ['```', goodBody(), '```'].join('\n');
+  const res = checkPrSurface({ title: GOOD_TITLE, body: fenced });
+  assert.equal(res.ok, false, 'fenced-only headings must not satisfy the template check');
+  assert.ok(
+    rulesOf(res).includes('bilingual'),
+    'a fence-only body has no REAL # English / # 한국어',
+  );
+});
+
+test('PR surface: a body with sections out of order is rejected', () => {
+  // # 한국어 before # English.
+  const swapped = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({
+      changelog: GOOD_CHANGELOG,
+      order: ['korean', 'english', 'changelog', 'checklist'],
+    }),
+  });
+  assert.equal(swapped.ok, false);
+  assert.ok(rulesOf(swapped).includes('order'), 'Korean-before-English must be an order violation');
+
+  // ## Changelog before # 한국어.
+  const changelogFirst = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({
+      changelog: GOOD_CHANGELOG,
+      order: ['english', 'changelog', 'korean', 'checklist'],
+    }),
+  });
+  assert.equal(changelogFirst.ok, false);
+  assert.ok(rulesOf(changelogFirst).includes('order'));
+
+  // ## Checklist before ## Changelog.
+  const checklistFirst = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({
+      changelog: GOOD_CHANGELOG,
+      order: ['english', 'korean', 'checklist', 'changelog'],
+    }),
+  });
+  assert.equal(checklistFirst.ok, false);
+  assert.ok(rulesOf(checklistFirst).includes('order'));
+});
+
+test('PR surface: correctly-ordered sections do not trip the order rule', () => {
+  assert.ok(!rulesOf(checkPrSurface({ title: GOOD_TITLE, body: goodBody() })).includes('order'));
+});
+
+test('PR surface: a language block missing a required subheading is rejected', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ changelog: GOOD_CHANGELOG, engOpts: { omit: ['Why'] } }),
+  });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'template-sections');
+  assert.ok(hit, 'expected a template-sections violation');
+  assert.match(hit.detail, /English/);
+  assert.match(hit.detail, /Why/);
+});
+
+test('PR surface: the Korean block missing a required subheading is rejected', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ changelog: GOOD_CHANGELOG, korOpts: { omit: ['이유'] } }),
+  });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'template-sections');
+  assert.ok(hit, 'expected a template-sections violation');
+  assert.match(hit.detail, /한국어/);
+  assert.match(hit.detail, /이유/);
+});
+
+test('PR surface: a language block with every subheading but NO content is rejected (empty)', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ changelog: GOOD_CHANGELOG, engOpts: { empty: true } }),
+  });
+  assert.equal(res.ok, false);
+  const hit = res.violations.find((v) => v.rule === 'template-sections');
+  assert.ok(hit, 'headings-only English block must be rejected as empty');
+  assert.match(hit.detail, /no content/);
+});
+
+test('PR surface: a fully filled template (every subheading, real content, correct order) passes', () => {
+  const res = checkPrSurface({ title: GOOD_TITLE, body: goodBody() });
+  assert.equal(
+    res.ok,
+    true,
+    `expected clean: ${res.violations.map((v) => `${v.rule}/${v.detail}`).join(' | ')}`,
+  );
+});
+
+test('PR surface: an empty body reports the structural rules, does not throw', () => {
+  for (const body of ['', null, undefined]) {
+    const res = checkPrSurface({ title: GOOD_TITLE, body });
+    assert.equal(res.ok, false);
+    for (const rule of ['bilingual', 'changelog', 'checklist']) {
+      assert.ok(rulesOf(res).includes(rule), `empty body should report ${rule}`);
+    }
+  }
+});
+
+test('PR surface: EVERY violation carries a non-empty, actionable fix', () => {
+  // A gate that reports a violation with no way through gets worked around
+  // instead of obeyed, so the fix field is load-bearing, not decoration.
+  const res = checkPrSurface({
+    title: 'feat(gate): close ISSUE-49 🤖 Generated with [Claude Code]',
+    body: 'Co-Authored-By: Claude <noreply@anthropic.com>\n',
+  });
+  assert.equal(res.ok, false);
+  assert.ok(res.violations.length >= 5, 'fixture should trip every rule');
+  for (const v of res.violations) {
+    assert.equal(typeof v.fix, 'string', `${v.rule}: fix must be a string`);
+    assert.ok(v.fix.trim().length > 0, `${v.rule}: fix must not be empty`);
+    assert.ok(typeof v.detail === 'string' && v.detail.length > 0, `${v.rule}: detail required`);
+    assert.ok(['title', 'body'].includes(v.surface), `${v.rule}: surface must be title|body`);
+    // Every fix names a concrete command the author can run.
+    assert.match(v.fix, /gh pr edit/, `${v.rule}: fix must name the command that resolves it`);
+  }
+});
+
+test('ATTRIBUTION_PATTERNS is a separate export, NOT merged into BLOCKED_PATTERNS', () => {
+  // BLOCKED_PATTERNS is applied by `--all` to the whole shipped tree, where docs
+  // (CLAUDE.md, the PR template) legitimately QUOTE an attribution trailer while
+  // telling you not to write one. Merging the two sets would fail the repo scan.
+  const blockedNames = new Set(BLOCKED_PATTERNS.map((p) => p.name));
+  for (const p of ATTRIBUTION_PATTERNS) {
+    assert.ok(!blockedNames.has(p.name), `${p.name} must not leak into BLOCKED_PATTERNS`);
+  }
+  assert.ok(!TAG_BODY_PATTERNS.some((p) => ATTRIBUTION_PATTERNS.includes(p)));
+  // The doc line that QUOTES a trailer stays clean under the file-scan patterns.
+  const doc = 'Do NOT add any "Generated with ..." footer, no Co-Authored-By: line.';
+  assert.equal(scanText(doc, BLOCKED_PATTERNS).length, 0);
+  assert.equal(scanText(doc, [...BLOCKED_PATTERNS, ...DECISION_PATTERNS]).length, 0);
+  // ...and is caught by the attribution set, which only authored surfaces use.
+  assert.ok(scanText(doc, ATTRIBUTION_PATTERNS).length > 0);
+});
+
+test('ATTRIBUTION_PATTERNS: every regex is global (a non-global re hangs scanText)', () => {
+  // scanText drives re.exec() in a while loop with manual lastIndex handling: a
+  // non-global regex never advances, so the loop spins forever — the suite hangs
+  // instead of failing.
+  for (const p of ATTRIBUTION_PATTERNS) {
+    assert.ok(p.re.global, `${p.name}: regex must carry the /g flag`);
+    assert.equal(typeof p.name, 'string');
+    assert.equal(typeof p.label, 'string');
+  }
+});
+
+test('CLI --commit-msg: rejects an attribution trailer (exit 1)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(
+      f,
+      'feat(gate): add the PR surface gate\n\nBody prose.\n\nCo-Authored-By: Claude <noreply@anthropic.com>\n',
+    );
+    const r = runChecker(['--commit-msg', f]);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Co-Authored-By:/i);
+    assert.match(r.stderr, /no attribution/i); // the way out is printed
+  });
+});
+
+test('CLI --commit-msg: rejects a Claude-Session trailer and a robot footer (exit 1)', () => {
+  withTmpDir((dir) => {
+    for (const trailer of [
+      'Claude-Session: https://claude.ai/code/session_01Urs3',
+      '🤖 Generated with [Claude Code](https://claude.com/claude-code)',
+    ]) {
+      const f = join(dir, 'MSG');
+      writeFileSync(f, `feat(gate): thing\n\nBody prose.\n\n${trailer}\n`);
+      assert.equal(runChecker(['--commit-msg', f]).status, 1, `${trailer} must be rejected`);
+    }
+  });
+});
+
+test('CLI --commit-msg: a clean message still passes (attribution scan adds no false positive)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(f, 'feat(ci): gate the PR title and body (#194)\n\nSee PR #50. ADR 0040.\n');
+    const r = runChecker(['--commit-msg', f]);
+    assert.equal(r.status, 0, r.stderr);
+  });
+});
+
+// ── --commit-range: the CI backstop (BLOCKER: commit-msg hook has no CI
+// counterpart, so --no-verify + a clean PR body let a trailer reach `main`) ──
+function commitIn(dir, msg) {
+  const opts = { cwd: dir, encoding: 'utf-8' };
+  spawnSync('git', ['add', '-A'], opts);
+  spawnSync('git', ['commit', '-q', '-m', msg], opts);
+  return spawnSync('git', ['rev-parse', 'HEAD'], opts).stdout.trim();
+}
+
+test('CLI --commit-range: rejects an attribution trailer on ANY commit in the range', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const base = commitIn(dir, 'chore: base');
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    commitIn(dir, 'feat: clean commit');
+    writeFileSync(join(dir, 'c.txt'), 'three\n');
+    // The dirty commit sits in the MIDDLE of the range, not just at HEAD — the
+    // range scan must not stop at the tip.
+    commitIn(dir, 'feat: dirty commit\n\nCo-Authored-By: Claude <noreply@anthropic.com>');
+    writeFileSync(join(dir, 'd.txt'), 'four\n');
+    const trueHead = commitIn(dir, 'chore: trailing clean commit');
+    const r = runChecker(['--commit-range', `${base}..${trueHead}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /Co-Authored-By:/i);
+    assert.match(r.stderr, /no attribution/i); // the way out is printed
+  });
+});
+
+test('CLI --commit-range: a tracker id in a commit message anywhere in the range is caught', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const base = commitIn(dir, 'chore: base');
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const head = commitIn(dir, 'feat: thing\n\nImplements fix #99.');
+    const r = runChecker(['--commit-range', `${base}..${head}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /fix #99/);
+  });
+});
+
+test('CLI --commit-range: a clean range passes (exit 0)', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const base = commitIn(dir, 'chore: base');
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const head = commitIn(dir, 'feat: thing (#101)\n\nSee PR #50. ADR 0040.');
+    const r = runChecker(['--commit-range', `${base}..${head}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 0, r.stderr);
+  });
+});
+
+test('--commit-msg and --commit-range agree on the SAME message (one judgment, ADR 0046)', () => {
+  // Proves the two entry points cannot drift: both must reject (or both must
+  // accept) the identical message text, because both call judgeMessage().
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const base = commitIn(dir, 'chore: base');
+    const msg = 'feat: thing\n\nCo-Authored-By: Claude <noreply@anthropic.com>';
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const head = commitIn(dir, msg);
+
+    const msgFile = join(dir, 'MSG');
+    writeFileSync(msgFile, msg + '\n');
+    const single = runChecker(['--commit-msg', msgFile], { CHECK_TRACKER_ROOT: dir });
+    const range = runChecker(['--commit-range', `${base}..${head}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(single.status, 1, single.stderr);
+    assert.equal(range.status, 1, range.stderr);
+    assert.match(single.stderr, /Co-Authored-By:/i);
+    assert.match(range.stderr, /Co-Authored-By:/i);
+  });
+});
+
+test('CLI --commit-range: an unresolvable range exits 2 (git error), not a crash', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    commitIn(dir, 'chore: base');
+    const r = runChecker(['--commit-range', 'deadbeefdead..cafebabecafe'], {
+      CHECK_TRACKER_ROOT: dir,
+    });
+    assert.equal(r.status, 2);
+  });
+});
+
+test('CLI --commit-range: missing range argument exits with usage (2)', () => {
+  assert.equal(runChecker(['--commit-range']).status, 2);
+});
+
+// ── BLOCKER: SQUASH merge. The pr-surface job scans base.sha..head.sha — the PR
+// BRANCH's commits. The message that actually lands on `main` is composed in the
+// merge dialog, never existed on the branch, and was in NO range any job scanned.
+// A trailer typed there ships to a public `main` with every check green.
+test('CLI --push-range: an attribution trailer in the pushed (squash) commit is caught', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const before = commitIn(dir, 'chore: base');
+    // the squash commit: its message exists ONLY on main, never on the PR branch
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const after = commitIn(
+      dir,
+      'feat: squashed (#194)\n\nCo-Authored-By: Claude <noreply@anthropic.com>',
+    );
+    const r = runChecker(['--push-range', `${before}..${after}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /Co-Authored-By:/i);
+    assert.match(r.stderr, /no attribution/i); // the way out is printed
+  });
+});
+
+test('CLI --push-range: a tracker id in the pushed commit is caught', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const before = commitIn(dir, 'chore: base');
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const after = commitIn(dir, 'feat: thing\n\nCloses ISSUE-49.');
+    const r = runChecker(['--push-range', `${before}..${after}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /ISSUE-49/);
+  });
+});
+
+test('CLI --push-range: an all-zero `before` (first push / force-push) falls back to the tip, not to nothing', () => {
+  // GitHub sends 40 zeros as github.event.before on a branch's first push, and a
+  // stale sha after a force-push. `before..after` would blow up (exit 2 — red for
+  // the wrong reason) or scan nothing at all. Scanning the tip is less than the
+  // full range and infinitely more than zero.
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    commitIn(dir, 'chore: base');
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const after = commitIn(
+      dir,
+      'feat: dirty tip\n\nCo-Authored-By: Claude <noreply@anthropic.com>',
+    );
+    const r = runChecker(['--push-range', `${'0'.repeat(40)}..${after}`], {
+      CHECK_TRACKER_ROOT: dir,
+    });
+    assert.equal(r.status, 1, `the tip must still be scanned: ${r.stdout}${r.stderr}`);
+    assert.match(r.stderr, /Co-Authored-By:/i);
+  });
+});
+
+test('CLI --push-range: an unresolvable `before` (discarded by a force-push) falls back to the tip', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    commitIn(dir, 'chore: base');
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const after = commitIn(dir, 'feat: dirty tip\n\nCo-Authored-By: Claude');
+    const r = runChecker(['--push-range', `deadbeefdeadbeefdeadbeefdeadbeefdeadbeef..${after}`], {
+      CHECK_TRACKER_ROOT: dir,
+    });
+    assert.equal(r.status, 1, `a stale before must not swallow the scan: ${r.stdout}${r.stderr}`);
+  });
+});
+
+test('CLI --push-range: a ROOT commit (no parent) is scanned as a single commit, not a crash', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const root = commitIn(dir, 'chore: root\n\nCo-Authored-By: Claude');
+    const r = runChecker(['--push-range', `${'0'.repeat(40)}..${root}`], {
+      CHECK_TRACKER_ROOT: dir,
+    });
+    assert.equal(r.status, 1, `a root commit has no ^1 to fall back to: ${r.stdout}${r.stderr}`);
+  });
+});
+
+test('CLI --push-range: a clean push passes (exit 0)', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const before = commitIn(dir, 'chore: base');
+    writeFileSync(join(dir, 'b.txt'), 'two\n');
+    const after = commitIn(dir, 'feat: thing (#101)\n\nSee PR #50. ADR 0040.');
+    const r = runChecker(['--push-range', `${before}..${after}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 0, r.stderr);
+  });
+});
+
+test('CLI --push-range: missing / malformed argument exits with usage (2)', () => {
+  assert.equal(runChecker(['--push-range']).status, 2);
+  assert.equal(runChecker(['--push-range', 'not-a-range']).status, 2);
+});
+
+test('CI: a push to main scans the commit messages the push ADDED (squash-merge hole)', () => {
+  // Without this job the squash-merge message — the one that actually lands on
+  // `main` — is scanned by nothing at all: the pr-surface job only sees the PR
+  // branch's own commits, and the push workflow only ran file scanners.
+  const ci = readFileSync(join(REPO, '.github', 'workflows', 'ci.yml'), 'utf-8');
+  assert.match(
+    ci,
+    /check-tracker-ids\.mjs --push-range/,
+    'ci.yml must scan the commit messages a push to main adds',
+  );
+  assert.match(ci, /github\.event\.before/, 'the push range starts at github.event.before');
+  assert.match(ci, /github\.event\.after/, 'the push range ends at github.event.after');
+  // The job must actually run on push (the pr-surface job is skipped there).
+  assert.match(
+    ci,
+    /if:\s*github\.event_name == 'push'/,
+    'the commit-message scan must be gated on the push event',
+  );
+});
+
+test('CI: pr-surface job checks out fetch-depth:0 and scans the PR commit range', () => {
+  // Regression for BLOCKER 3: a shallow checkout (the default) does not have the
+  // base commit locally, so `base..head` cannot resolve without fetch-depth:0.
+  const ci = readFileSync(join(REPO, '.github', 'workflows', 'ci.yml'), 'utf-8');
+  assert.match(
+    ci,
+    /fetch-depth:\s*0/,
+    'pr-surface checkout must use fetch-depth: 0 to resolve base..head',
+  );
+  assert.match(
+    ci,
+    /check-tracker-ids\.mjs --commit-range/,
+    'ci.yml must scan the PR commit range, not just the title/body',
+  );
+  assert.match(ci, /base\.sha/);
+  assert.match(ci, /head\.sha/);
+});
+
+function runPrSurface(args, env = {}) {
+  return spawnSync(process.execPath, [join(SCRIPTS, 'check-pr-surface.mjs'), ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: SESSION_TMP_HOME, GITHUB_EVENT_PATH: '', ...env },
+  });
+}
+
+test('CLI --github-event: a dirty PR payload exits 1 and prints every fix', () => {
+  withTmpDir((dir) => {
+    const ev = join(dir, 'event.json');
+    writeFileSync(
+      ev,
+      JSON.stringify({
+        pull_request: {
+          title: 'feat(gate): close ISSUE-49',
+          body: 'no template here\n\n🤖 Generated with [Claude Code]\n',
+        },
+      }),
+    );
+    const r = runPrSurface([`--github-event=${ev}`]);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /ISSUE-49/);
+    assert.match(r.stderr, /Generated with/i);
+    assert.match(r.stderr, /fix:/); // the resolution path is printed, not just the verdict
+    assert.match(r.stderr, /gh pr edit/);
+  });
+});
+
+test('CLI --github-event: a compliant PR payload exits 0', () => {
+  withTmpDir((dir) => {
+    const ev = join(dir, 'event.json');
+    writeFileSync(ev, JSON.stringify({ pull_request: { title: GOOD_TITLE, body: goodBody() } }));
+    const r = runPrSurface([`--github-event=${ev}`]);
+    assert.equal(r.status, 0, r.stderr);
+  });
+});
+
+test('CLI --github-event: a null body (empty PR) is a violation, not a crash', () => {
+  withTmpDir((dir) => {
+    const ev = join(dir, 'event.json');
+    writeFileSync(ev, JSON.stringify({ pull_request: { title: GOOD_TITLE, body: null } }));
+    const r = runPrSurface([`--github-event=${ev}`, '--json']);
+    assert.equal(r.status, 1);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.ok(out.violations.some((v) => v.rule === 'bilingual'));
+  });
+});
+
+test('CLI --github-event: a non-pull_request payload passes through (push events)', () => {
+  withTmpDir((dir) => {
+    const ev = join(dir, 'event.json');
+    writeFileSync(ev, JSON.stringify({ ref: 'refs/heads/main' }));
+    assert.equal(runPrSurface([`--github-event=${ev}`]).status, 0);
+  });
+});
+
+test('CLI --title/--body-file: local pre-flight mode works', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'BODY.md');
+    writeFileSync(f, goodBody());
+    assert.equal(runPrSurface([`--title=${GOOD_TITLE}`, `--body-file=${f}`]).status, 0);
+    writeFileSync(f, goodBody() + '\nCo-Authored-By: Claude\n');
+    assert.equal(runPrSurface([`--title=${GOOD_TITLE}`, `--body-file=${f}`]).status, 1);
+  });
+});
+
+test('CI: the pull_request trigger lists `edited` (else a body edit bypasses the gate)', () => {
+  // Default types are [opened, synchronize, reopened]. Without `edited`, an author
+  // opens a clean PR, then edits an attribution footer into the body and NO job
+  // re-runs. The gate would be a two-step bypass.
+  const ci = readFileSync(join(REPO, '.github', 'workflows', 'ci.yml'), 'utf-8');
+  const types = ci.match(/^\s*types:\s*\[(.+)\]\s*$/m);
+  assert.ok(types, 'ci.yml pull_request trigger must declare types:');
+  for (const t of ['opened', 'edited', 'reopened', 'synchronize']) {
+    assert.match(types[1], new RegExp(`\\b${t}\\b`), `pull_request types must include ${t}`);
+  }
+  assert.match(ci, /check-pr-surface\.mjs/, 'ci.yml must run the pr-surface gate');
+  // As a TRIGGER KEY (a prose mention in a comment explaining why it is not used
+  // is fine). pull_request_target would run fork code with a write-scoped token
+  // for no benefit: the title and body are already in the event payload.
+  assert.ok(!/^\s*pull_request_target:/m.test(ci), 'pull_request_target must not be a trigger');
+});
+
+// ── BLOCKER: ADR / decisions pointers were left out of the PR-surface scan
+// entirely, so the one rule that names `decisions/NNNN` had no enforcement on the
+// one surface an agent writes by hand. The `## Changelog` block keeps the same
+// exemption CHANGELOG.md has in the file gate — and only that block.
+suite('PR surface gate — ADR pointers (BLOCKER 4)');
+
+test('PR surface: `ADR NNNN` in the PR BODY is rejected', () => {
+  const body = goodBody() + '\nRationale lives in ADR 0031.\n';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false, 'an ADR pointer resolves to nothing outside the private wiki');
+  const hit = res.violations.find((v) => v.rule === 'tracker-ids' && /ADR/.test(v.detail));
+  assert.ok(hit, `expected an ADR violation: ${JSON.stringify(res.violations)}`);
+  assert.equal(hit.surface, 'body');
+});
+
+test('PR surface: `ADR-NNNN` and `decisions/NNNN` in the body are rejected', () => {
+  for (const ref of ['ADR-0031', 'decisions/0031-foo.md']) {
+    const res = checkPrSurface({ title: GOOD_TITLE, body: goodBody() + `\nSee ${ref}.\n` });
+    assert.equal(res.ok, false, `${ref} must be blocked`);
+    assert.ok(res.violations.some((v) => v.rule === 'tracker-ids' && v.surface === 'body'));
+  }
+});
+
+test('PR surface: an ADR pointer in the TITLE is rejected', () => {
+  const res = checkPrSurface({ title: 'feat(sync): implement ADR 0031', body: goodBody() });
+  assert.equal(res.ok, false);
+  assert.ok(
+    res.violations.some((v) => v.rule === 'tracker-ids' && v.surface === 'title'),
+    'the title has no changelog exemption',
+  );
+});
+
+test('PR surface: an ADR pointer INSIDE the `## Changelog` block is ALLOWED', () => {
+  // The release collector copies this block verbatim into CHANGELOG.md, which is
+  // itself ADR-exempt in the file gate. Blocking it here would make a line the
+  // file gate explicitly allows unwritable through the only path that writes it.
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({
+      changelog: ['- EN: Adopt the projection model from ADR 0031.', '- KO: ADR 0031 반영.'],
+    }),
+  });
+  assert.equal(
+    res.ok,
+    true,
+    `the changelog block keeps CHANGELOG.md's ADR exemption: ${res.violations.map((v) => v.detail).join(' | ')}`,
+  );
+});
+
+test('PR surface: the changelog exemption does NOT leak past the section boundary', () => {
+  // Only the `## Changelog` body is exempt. The section ends at the next heading;
+  // an ADR ref under `## Checklist` is as public as one anywhere else.
+  const body = prBody({ changelog: GOOD_CHANGELOG }) + '\n- [x] filed ADR 0031\n';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false, 'the exemption must stop at the Changelog section boundary');
+  assert.ok(res.violations.some((v) => /ADR/.test(v.detail)));
+});
+
+test('PR surface: a tracker id inside `## Changelog` is STILL rejected (only ADR is exempt)', () => {
+  const res = checkPrSurface({
+    title: GOOD_TITLE,
+    body: prBody({ changelog: ['- EN: Close ISSUE-49.', '- KO: ISSUE-49 종료.'] }),
+  });
+  assert.equal(res.ok, false, 'the CHANGELOG exemption covers ADR refs only, never tracker ids');
+  assert.ok(res.violations.some((v) => v.rule === 'tracker-ids' && /ISSUE-49/.test(v.detail)));
+});
+
+test('commit messages still ALLOW `ADR NNNN` (this change does not touch that judgment)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'MSG');
+    writeFileSync(f, 'feat: thing (#101)\n\nImplements ADR 0040.\n');
+    assert.equal(
+      runChecker(['--commit-msg', f]).status,
+      0,
+      'the commit-msg gate has always let ADR refs through — that stays true',
+    );
+  });
+});
+
+// ── BLOCKER: a raw HTML block fooled the structural view. `<pre>` + a perfect
+// template + `</pre>` passed every heading check while GitHub rendered a code
+// listing with no headings in it at all.
+suite('PR surface gate — raw HTML blocks and indented code (BLOCKER 6)');
+
+test('PR surface: a body wrapped in <pre> does NOT satisfy the template check', () => {
+  const body = '<pre>\n' + goodBody() + '\n</pre>';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false, 'inside <pre>, a `#` line is preformatted text, not a heading');
+  assert.ok(rulesOf(res).includes('bilingual'), 'no REAL # English / # 한국어 heading renders');
+  assert.ok(rulesOf(res).includes('changelog'));
+  assert.ok(rulesOf(res).includes('checklist'));
+});
+
+test('PR surface: <code> / <div> blocks do not satisfy the template check either', () => {
+  // GFM type 6/7 blocks end at a BLANK line, so the fixture carries none — that is
+  // the only shape in which these tags actually hide the whole template, and it is
+  // the shape the check has to catch. (`<pre>` above is type 1: blank lines do not
+  // end it, which is why it is the dangerous one.)
+  const contiguous = [
+    ...languageBlock('English', EN_SUBHEADINGS),
+    ...languageBlock('한국어', KO_SUBHEADINGS),
+    ...changelogBlock(GOOD_CHANGELOG),
+    ...checklistBlock(true),
+  ].filter((l) => l.trim() !== '');
+  for (const tag of ['code', 'div']) {
+    const body = `<${tag}>\n${contiguous.join('\n')}\n</${tag}>`;
+    const res = checkPrSurface({ title: GOOD_TITLE, body });
+    assert.equal(res.ok, false, `<${tag}> block content must not count as structure`);
+    assert.ok(rulesOf(res).includes('bilingual'), `<${tag}>: headings inside are not headings`);
+  }
+});
+
+test('PR surface: a 4-space-indented body does NOT satisfy the template check', () => {
+  const indented = goodBody()
+    .split('\n')
+    .map((l) => (l.trim() === '' ? l : '    ' + l))
+    .join('\n');
+  const res = checkPrSurface({ title: GOOD_TITLE, body: indented });
+  assert.equal(res.ok, false, 'a 4-space indent makes it a code block, not headings');
+  assert.ok(rulesOf(res).includes('bilingual'));
+});
+
+test('PR surface: an attribution trailer inside <pre> is STILL rejected (structure ≠ scan)', () => {
+  // Stripping HTML blocks is a STRUCTURAL concern only. The attribution/tracker
+  // scan still reads the RAW body: hiding a trailer in a <pre> block does not
+  // un-ship it.
+  const body = goodBody() + '\n<pre>\nCo-Authored-By: Claude <noreply@anthropic.com>\n</pre>\n';
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false);
+  assert.ok(res.violations.some((v) => v.rule === 'attribution'));
+});
+
+test('PR surface: a compliant body that MENTIONS html/indentation still passes (no false positive)', () => {
+  // The stripping must not eat real content: an indented continuation line inside
+  // a paragraph is a lazy continuation, not a code block, and an inline `<br>` in
+  // prose does not open a block.
+  const body = prBody({ changelog: GOOD_CHANGELOG }).replace(
+    'Detail for Why.',
+    'Detail for Why,\n    wrapped and indented as a lazy continuation with a <br> in it.',
+  );
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(
+    res.ok,
+    true,
+    `a compliant body must survive the block stripping: ${res.violations.map((v) => `${v.rule}/${v.detail}`).join(' | ')}`,
   );
 });
 

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -31955,8 +31955,7 @@ test('PR surface: `## Changelog` with an unfilled `- EN:` / `- KO:` is caught', 
   assert.equal(res.ok, false);
   const hit = res.violations.find((v) => v.rule === 'changelog');
   assert.ok(hit);
-  assert.match(hit.detail, /EN:/);
-  assert.match(hit.detail, /KO:/);
+  assert.match(hit.detail, /empty EN line/);
 });
 
 test('PR surface: `## Changelog` missing only the KO line is caught', () => {
@@ -31967,7 +31966,7 @@ test('PR surface: `## Changelog` missing only the KO line is caught', () => {
   assert.equal(res.ok, false);
   const hit = res.violations.find((v) => v.rule === 'changelog');
   assert.ok(hit);
-  assert.match(hit.detail, /KO:/);
+  assert.match(hit.detail, /missing or empty KO line/);
 });
 
 test('PR surface: `## Changelog` of `None` passes (internal-only change)', () => {
@@ -32578,22 +32577,34 @@ test('commit messages still ALLOW `ADR NNNN` (this change does not touch that ju
 // ── BLOCKER: a raw HTML block fooled the structural view. `<pre>` + a perfect
 // template + `</pre>` passed every heading check while GitHub rendered a code
 // listing with no headings in it at all.
-suite('PR surface gate — raw HTML blocks and indented code (BLOCKER 6)');
+// The structural check does NOT model raw HTML blocks, and these two tests pin
+// that as a decision rather than leaving a silent gap for a later round to
+// "fix". Wrapping a PR body in <pre> or <div> makes GitHub render it as a code
+// listing, so strictly its `#` lines are not headings and the template check
+// should reject it. An earlier round built a GFM block parser to say so, and
+// paid for it with an unbounded stream of edge cases (block types 3-5, entity-
+// encoded tags, `&Tab;`).
+//
+// It is not worth it, because it defends against nobody. This gate is
+// maintainer-only tooling on trusted input; the actor is an agent following its
+// harness, and no agent wraps a PR body in a div by accident. Someone who does
+// it deliberately has only fooled themselves into an unreadable PR — self-harm,
+// not a failure mode. The rule that actually matters survives untouched, and the
+// third test here is what proves it: the banned-string scan reads the RAW body,
+// so an attribution trailer inside <pre> is still rejected.
+suite('PR surface gate — HTML blocks are not modeled (accepted, by design)');
 
-test('PR surface: a body wrapped in <pre> does NOT satisfy the template check', () => {
+test('PR surface: a body wrapped in <pre> SATISFIES the template check (accepted self-harm)', () => {
   const body = '<pre>\n' + goodBody() + '\n</pre>';
   const res = checkPrSurface({ title: GOOD_TITLE, body });
-  assert.equal(res.ok, false, 'inside <pre>, a `#` line is preformatted text, not a heading');
-  assert.ok(rulesOf(res).includes('bilingual'), 'no REAL # English / # 한국어 heading renders');
-  assert.ok(rulesOf(res).includes('changelog'));
-  assert.ok(rulesOf(res).includes('checklist'));
+  assert.equal(
+    res.ok,
+    true,
+    'the structural check reads the text, not GitHub rendering: an agent does not do this by accident',
+  );
 });
 
-test('PR surface: <code> / <div> blocks do not satisfy the template check either', () => {
-  // GFM type 6/7 blocks end at a BLANK line, so the fixture carries none — that is
-  // the only shape in which these tags actually hide the whole template, and it is
-  // the shape the check has to catch. (`<pre>` above is type 1: blank lines do not
-  // end it, which is why it is the dangerous one.)
+test('PR surface: <code> / <div> blocks are likewise not modeled', () => {
   const contiguous = [
     ...languageBlock('English', EN_SUBHEADINGS),
     ...languageBlock('한국어', KO_SUBHEADINGS),
@@ -32603,8 +32614,7 @@ test('PR surface: <code> / <div> blocks do not satisfy the template check either
   for (const tag of ['code', 'div']) {
     const body = `<${tag}>\n${contiguous.join('\n')}\n</${tag}>`;
     const res = checkPrSurface({ title: GOOD_TITLE, body });
-    assert.equal(res.ok, false, `<${tag}> block content must not count as structure`);
-    assert.ok(rulesOf(res).includes('bilingual'), `<${tag}>: headings inside are not headings`);
+    assert.equal(res.ok, true, `<${tag}>: no GFM block parser, by design`);
   }
 });
 
@@ -32629,9 +32639,9 @@ test('PR surface: an attribution trailer inside <pre> is STILL rejected (structu
 });
 
 test('PR surface: a compliant body that MENTIONS html/indentation still passes (no false positive)', () => {
-  // The stripping must not eat real content: an indented continuation line inside
-  // a paragraph is a lazy continuation, not a code block, and an inline `<br>` in
-  // prose does not open a block.
+  // Prose an author really writes: a wrapped line that happens to be indented, and
+  // an inline `<br>`. Neither is structure, and neither may cost the author a
+  // violation.
   const body = prBody({ changelog: GOOD_CHANGELOG }).replace(
     'Detail for Why.',
     'Detail for Why,\n    wrapped and indented as a lazy continuation with a <br> in it.',
@@ -32640,7 +32650,172 @@ test('PR surface: a compliant body that MENTIONS html/indentation still passes (
   assert.equal(
     res.ok,
     true,
-    `a compliant body must survive the block stripping: ${res.violations.map((v) => `${v.rule}/${v.detail}`).join(' | ')}`,
+    `a compliant body must not trip the structural check: ${res.violations.map((v) => `${v.rule}/${v.detail}`).join(' | ')}`,
+  );
+});
+
+// GFM renders an ATX heading indented 0-3 spaces and treats 4+ as code. The gate
+// used to anchor every heading at column 0, so a body whose headings carried a
+// single stray space was rejected for `bilingual`, `changelog` and `checklist` at
+// once — a legitimate, correctly-rendering PR blocked outright, which is the worst
+// failure a gate has. The ` {0,3}` bound on every heading matcher is what fixes it,
+// and it is also what lets the indented-code stripper go: at 4 spaces the matchers
+// simply stop matching, so the heading is code again with no state machine to
+// maintain.
+suite('PR surface gate — GFM heading indent (0-3 renders, 4+ is code)');
+
+test('PR surface: headings indented 0-3 spaces are headings (a stray space must not block a PR)', () => {
+  for (const n of [0, 1, 2, 3]) {
+    const indent = ' '.repeat(n);
+    const body = goodBody()
+      .split('\n')
+      .map((l) => (/^#/.test(l) ? indent + l : l))
+      .join('\n');
+    const res = checkPrSurface({ title: GOOD_TITLE, body });
+    assert.equal(
+      res.ok,
+      true,
+      `${n}-space indent renders as a heading on GitHub, so it must pass: ${res.violations.map((v) => v.rule).join(',')}`,
+    );
+  }
+});
+
+// The other half of the ATX shape. A closing run of `#` is optional and means
+// nothing to GFM, so `## Changelog ##` is the same H2 — and rejecting it is the
+// same false positive as rejecting a one-space indent, wearing a different hat.
+test('PR surface: optional closing hashes (`## Changelog ##`) are a heading, not a violation', () => {
+  const body = goodBody()
+    .split('\n')
+    .map((l) => (/^#/.test(l) ? `${l} ${l.match(/^#+/)[0]}` : l))
+    .join('\n');
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(
+    res.ok,
+    true,
+    `GFM renders these as ordinary headings: ${res.violations.map((v) => v.rule).join(',')}`,
+  );
+  assert.deepEqual(
+    parseChangelogBlock(body),
+    { en: 'Add a PR surface gate.', ko: 'PR 표면 게이트를 추가한다.' },
+    'and the collector reads the same heading',
+  );
+});
+
+test('PR surface: a 4-space heading indent is code, not a heading (no stripper needed)', () => {
+  const body = goodBody()
+    .split('\n')
+    .map((l) => (/^#/.test(l) ? '    ' + l : l))
+    .join('\n');
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, false, '4 spaces makes it an indented code block');
+  assert.ok(rulesOf(res).includes('bilingual'));
+});
+
+// The gate is what PROMISES the release collector will find the changelog block.
+// If the two disagree about what counts as a `## Changelog` heading, the gate goes
+// green and the change then vanishes from the release notes — the exact silent
+// accident the gate exists to prevent. So they read the body through one shared
+// parser (lib/pr-body.mjs), and these tests are what keep them in step.
+//
+// `usable` is deliberately strict: a `malformed` result is NOT a collected entry.
+// An earlier version of this test asked only `!== null`, which counted every
+// malformed object as a success and hid a whole class of disagreement.
+const collectorUsable = (body) => {
+  const r = parseChangelogBlock(body);
+  return r !== null && r !== undefined && !r.malformed;
+};
+
+test('PR surface: the gate and the release collector agree on an indented `## Changelog`', () => {
+  for (const n of [0, 1, 2, 3, 4]) {
+    const indent = ' '.repeat(n);
+    const body = goodBody()
+      .split('\n')
+      .map((l) => (/^#/.test(l) ? indent + l : l))
+      .join('\n');
+    const gateOk = checkPrSurface({ title: GOOD_TITLE, body }).ok;
+    const usable = collectorUsable(body);
+    assert.equal(
+      gateOk,
+      usable,
+      `${n}-space indent: gate ${gateOk ? 'accepts' : 'rejects'} but the collector ` +
+        `${usable ? 'reads' : 'CANNOT read'} the changelog — a green gate whose entry never reaches CHANGELOG.md`,
+    );
+  }
+});
+
+// The shapes the gate used to wave through and the collector then choked on at
+// release time, when the PR could no longer be edited. The gate now runs the
+// collector's own parse, so the author hears about it while it is still one
+// `gh pr edit` away.
+test('PR surface: a changelog block the collector calls malformed is rejected AT THE PR', () => {
+  const malformed = [
+    ['None with a period', ['None.']],
+    ['a duplicated EN line', ['- EN: a', '- EN: b', '- KO: 가']],
+    ['None mixed with EN/KO', ['None', '- EN: a', '- KO: 가']],
+  ];
+  for (const [what, changelog] of malformed) {
+    const body = prBody({ changelog });
+    const res = checkPrSurface({ title: GOOD_TITLE, body });
+    assert.equal(
+      res.ok,
+      false,
+      `${what}: the collector cannot read this, so the gate must not pass it`,
+    );
+    assert.ok(
+      res.violations.some((v) => v.rule === 'changelog'),
+      `${what}: reported as a changelog violation`,
+    );
+    assert.equal(
+      collectorUsable(body),
+      false,
+      `${what}: (and the collector really does reject it)`,
+    );
+  }
+});
+
+test('PR surface: the shapes that DO collect still pass (- EN/- KO, None, - None, * None)', () => {
+  for (const changelog of [['- EN: a thing', '- KO: 어떤 것'], ['None'], ['- None'], ['* None']]) {
+    const body = prBody({ changelog });
+    const res = checkPrSurface({ title: GOOD_TITLE, body });
+    assert.equal(
+      res.ok,
+      true,
+      `${JSON.stringify(changelog)} must pass: ${res.violations.map((v) => `${v.rule}/${v.detail}`).join(' | ')}`,
+    );
+    assert.equal(collectorUsable(body), true, `${JSON.stringify(changelog)}: and it collects`);
+  }
+});
+
+// The bug that made the shared parser necessary. A PR whose body SHOWS a changelog
+// block inside a fence — a PR about the template, or about the collector itself —
+// used to hand the collector the EXAMPLE, which then shipped in CHANGELOG.md while
+// the real note was never seen. The gate passed it, because the gate masks fences
+// and found the real heading further down. Nobody was attacking anything; someone
+// wrote documentation.
+test('PR surface: a fenced changelog EXAMPLE does not become the release note', () => {
+  const body = [
+    ...languageBlock('English', EN_SUBHEADINGS),
+    ...languageBlock('한국어', KO_SUBHEADINGS),
+    '## How the block looks',
+    '',
+    '```markdown',
+    '## Changelog',
+    '- EN: Example only.',
+    '- KO: 예시일 뿐.',
+    '```',
+    '',
+    '## Changelog',
+    '- EN: the real note',
+    '- KO: 진짜 노트',
+    '',
+    ...checklistBlock(true),
+  ].join('\n');
+  const res = checkPrSurface({ title: GOOD_TITLE, body });
+  assert.equal(res.ok, true, 'the real section is there, so the gate passes');
+  assert.deepEqual(
+    parseChangelogBlock(body),
+    { en: 'the real note', ko: '진짜 노트' },
+    'the collector must publish the REAL note, not the fenced example above it',
   );
 });
 


### PR DESCRIPTION
# English

## What changed

Two public surfaces the repo's file gates cannot see, a PR's title and body, and the commit message, are now checked for the rules that were being broken on them: no tool-attribution footer, no wiki-internal tracker id, and a body that actually follows `.github/PULL_REQUEST_TEMPLATE.md`.

Along the way the gate stopped trying to reimplement GitHub's markdown renderer, and the release collector stopped reading PR bodies its own way.

## Why

`gh pr create --body` replaces the template outright, so the template never loads on the path an agent actually uses. Its bilingual blocks, `## Changelog` and `## Checklist` were skipped silently every time. The release collector builds CHANGELOG.md from the `## Changelog` block of merged PRs, so a missing block is not cosmetic: the change vanishes from the next release notes.

The same hole let two banned things through. The harness system prompt tells an agent to append a tool-attribution trailer, which this repo forbids; 8 of 47 commits after the ban carried one anyway. And a private tracker id (`ISSUE-N`, `fix #N`) in a PR title sailed past a green tracker-id gate, because that gate scans files, staged blobs, commit messages and tag bodies, never a PR title.

Two more problems were found while building it, and both are fixed here.

**The gate rejected PRs that render perfectly.** Its heading matchers were anchored at column 0. GFM renders an ATX heading indented up to 3 spaces, and lets a heading carry a closing run of `#`. So a body whose headings had one stray leading space was rejected for `bilingual`, `changelog` and `checklist` at once, and `## Changelog ##` was rejected too. Blocking a valid PR is the worst thing a gate can do.

**A green gate did not mean the changelog entry would be published.** The gate and the release collector read the same PR body for the same `## Changelog` block, separately, and disagreed. The collector read the body verbatim, so a PR that *demonstrates* a changelog block inside a code fence (a PR about the template, or about the collector itself) handed it the example. The example shipped in CHANGELOG.md and the real note was never seen, with the gate green, because the gate masks fences and found the real heading further down. In the other direction, the gate judged the block's contents by looser rules of its own: `None.` with a period, or a duplicated `- EN:` line, passed the gate and then came out of the collector as `malformed` at release time, when the PR could no longer be edited.

## How

The gate runs in CI on `pull_request` (including `edited`, or a body edit would bypass it) and locally as a pre-flight. It is maintainer-only tooling and is not in `package.json` `files`, so it does not ship to npm.

Banned-string scanning reuses the file gate's scanner and pattern sets, so the two surfaces cannot disagree about what a tracker id is, and it reads the **raw** body. A trailer hidden in an HTML comment does not render, but it still ships in the body text, so it is still rejected.

The structural check deliberately does **not** model GFM's renderer. An earlier round grew one (a 60-tag HTML block list, block types 1/6/7, an indented-code state machine) chasing the fidelity to say that a body wrapped in `<pre>` is a code listing, not headings. Four review rounds found four holes in it, each round a new one. It was aimed at nobody: this gate runs on trusted input, and the actor is an agent following its harness, not an adversary. So the renderer is gone, and a body wrapped in `<pre>` now satisfies the structural check. That is self-harm, not a failure mode, and the rule that matters is untouched, because the banned-string scan reads the raw body.

What replaced it is the line GFM actually draws: 0-3 spaces of indent is a heading, 4+ is code, and a closing run of `#` means nothing. That bound also fixes the false positive above, and it is why the indented-code machine could go: at 4 spaces the matchers simply stop matching.

The gate and the collector now read the body through one shared parser (`lib/pr-body.mjs`), so the gate reports the collector's own verdict while the author can still act on it, and what passes the gate is what lands in CHANGELOG.md. Merging the two parsers cost nothing: 486 to 424 lines across the three modules.

Every violation carries a `fix` naming the exact command that clears it (`gh pr edit <N> --title …` / `--body-file <file>`). A gate that reports a problem without a way out gets bypassed rather than obeyed.

## Manual verification

`npm test`: 1564 pass, 0 fail.

Each new guard was checked by reverting the fix and confirming the test goes red, not by watching it pass:

- Reverting the heading indent bound turns the false-positive test red (a 1-space indent rejected for `bilingual,changelog,checklist`).
- Reverting only the collector turns the gate/collector agreement test red in the opposite direction: the gate accepts, the collector does not find the block.
- Reverting the fence masking in the shared parser turns the fenced-example test red with the sentence that describes the accident: the collector publishes the example instead of the real note.

Exercised through the real CLI, not only the pure function:

- A valid body whose headings carry one leading space: exits 0 (it was rejected before).
- An attribution trailer hidden inside an HTML comment: exits 1, with the line number and the fix.
- A `## Changelog` block reading `None.`: exits 1, naming the collector's own reason, while the PR can still be edited.

The ship-surface gate still passes (127 files, 0 closure violations), so the new module did not widen what npm publishes.

## Migration notes

None. Nothing here ships to users.

---

# 한국어

## 변경 내용

레포의 파일 게이트가 볼 수 없는 두 공개 표면, PR 제목과 본문 그리고 커밋 메시지에 대해 실제로 어겨지고 있던 규칙을 검사한다. 도구 attribution 푸터 금지, 위키 내부 트래커 id 금지, 그리고 본문이 `.github/PULL_REQUEST_TEMPLATE.md`를 실제로 따르는지.

작업 중에 게이트는 GitHub 마크다운 렌더러를 재현하려는 시도를 접었고, 릴리스 collector는 PR 본문을 제멋대로 읽는 것을 그만두었다.

## 이유

`gh pr create --body`는 템플릿을 통째로 대체한다. 그래서 에이전트가 실제로 쓰는 경로에서는 템플릿이 아예 로드되지 않는다. 이중 언어 블록과 `## Changelog`, `## Checklist`가 매번 조용히 건너뛰어졌다. 릴리스 collector는 머지된 PR의 `## Changelog` 블록으로 CHANGELOG.md를 만든다. 블록이 없으면 그 변경은 다음 릴리스 노트에서 사라진다. 미관 문제가 아니다.

같은 구멍으로 금지된 두 가지가 새어 나갔다. 하네스 시스템 프롬프트는 에이전트에게 도구 attribution 푸터를 붙이라고 지시하는데 이 레포는 그것을 금지한다. 금지 이후 커밋 47개 중 8개가 그래도 푸터를 달고 있었다. 그리고 PR 제목의 비공개 트래커 id(`ISSUE-N`, `fix #N`)는 green인 트래커 id 게이트를 그냥 통과했다. 그 게이트는 파일과 staged blob, 커밋 메시지, 태그 본문을 훑지 PR 제목은 보지 않기 때문이다.

만들면서 두 가지 문제를 더 찾았고, 둘 다 여기서 고친다.

**게이트가 정상적으로 렌더되는 PR을 거부하고 있었다.** 헤딩 매처가 0열에 고정돼 있었다. GFM은 3칸까지 들여쓴 ATX 헤딩을 렌더하고, 닫는 `#` 묶음도 허용한다. 그래서 헤딩에 공백 하나만 앞에 붙어도 `bilingual`, `changelog`, `checklist` 세 가지로 한꺼번에 거부됐고, `## Changelog ##`도 거부됐다. 정당한 PR을 막는 것은 게이트가 할 수 있는 최악의 일이다.

**게이트가 green이어도 changelog 항목이 실릴 거라는 보장이 없었다.** 게이트와 릴리스 collector가 같은 PR 본문의 같은 `## Changelog` 블록을 따로 읽고 서로 다른 답을 냈다. collector는 본문을 그대로 읽었다. 그래서 코드 펜스 안에 changelog 블록을 *예시로 보여주는* PR(템플릿에 관한 PR이나 collector 자신에 관한 PR)에서는 그 예시를 집어갔다. 예시가 CHANGELOG.md에 실리고 진짜 노트는 아무도 못 본 채 게이트는 green이었다. 게이트는 펜스를 가리고 그 아래의 진짜 헤딩을 찾았기 때문이다. 반대 방향도 있었다. 게이트는 블록 내용을 자기만의 느슨한 기준으로 판정했다. 마침표가 붙은 `None.`이나 중복된 `- EN:` 줄은 게이트를 통과한 뒤, PR을 더 이상 고칠 수 없는 릴리스 시점에 collector에서 `malformed`로 튀어나왔다.

## 방법

게이트는 CI의 `pull_request`에서 돈다(`edited`를 포함한다. 아니면 본문만 수정해서 우회된다). 로컬에서는 사전 점검으로 돈다. 메인테이너 전용 도구이고 `package.json`의 `files`에 없으므로 npm으로 출하되지 않는다.

금지 문자열 스캔은 파일 게이트의 스캐너와 패턴 집합을 그대로 쓴다. 두 표면이 "트래커 id란 무엇인가"를 두고 어긋날 수 없게 하려는 것이다. 그리고 **raw** 본문을 읽는다. HTML 주석에 숨긴 trailer는 렌더되지 않지만 본문 텍스트로는 그대로 실려 나가므로, 여전히 거부한다.

구조 검사는 GFM 렌더러를 **의도적으로 모델링하지 않는다.** 이전 라운드에서 렌더러를 만들었다(60개 태그 목록, 블록 타입 1/6/7, 들여쓰기 코드 상태기계). `<pre>`로 감싼 본문은 헤딩이 아니라 코드 목록이라고 말하기 위한 충실도였다. 검토 4라운드가 구멍 4개를 찾았고 매 라운드마다 새 것이 나왔다. 이 방어는 아무도 겨냥하지 않았다. 이 게이트는 신뢰된 입력에서 돌고, 상대는 적대자가 아니라 하네스를 따르는 에이전트다. 그래서 렌더러를 걷어냈고, `<pre>`로 감싼 본문은 이제 구조 검사를 통과한다. 그건 자해지 실패 모드가 아니다. 정작 중요한 규칙은 그대로다. 금지 문자열 스캔이 raw 본문을 읽기 때문이다.

대신 GFM이 실제로 긋는 선을 넣었다. 들여쓰기 0~3칸은 헤딩, 4칸 이상은 코드, 닫는 `#` 묶음은 아무 의미 없음. 이 경계가 위의 false positive를 고치고, 들여쓰기 상태기계를 지울 수 있게 한 이유이기도 하다. 4칸에서는 매처가 그냥 매칭을 멈춘다.

게이트와 collector는 이제 하나의 공유 파서(`lib/pr-body.mjs`)로 본문을 읽는다. 그래서 게이트가 collector의 판정을 작성자가 아직 손쓸 수 있을 때 알려주고, 게이트를 통과한 것이 CHANGELOG.md에 실리는 것이 된다. 파서를 합치는 데 비용은 들지 않았다. 세 모듈 합계가 486줄에서 424줄로 줄었다.

모든 위반에는 그것을 해소하는 정확한 명령이 `fix`로 붙는다(`gh pr edit <N> --title …` / `--body-file <file>`). 나가는 길을 알려주지 않는 게이트는 지켜지는 대신 우회된다.

## 수동 검증

`npm test`: 1564 통과, 0 실패.

새로 넣은 방어는 통과를 확인한 것이 아니라, 고친 것을 되돌려 테스트가 실제로 빨개지는지 확인했다.

- 헤딩 들여쓰기 경계를 되돌리면 false positive 테스트가 빨개진다(1칸 들여쓰기가 `bilingual,changelog,checklist`로 거부됨).
- collector만 되돌리면 게이트/collector 합의 테스트가 반대 방향으로 빨개진다. 게이트는 받아들이는데 collector가 블록을 못 찾는다.
- 공유 파서의 펜스 마스킹을 되돌리면 펜스 예시 테스트가, 그 사고를 그대로 서술하는 문장과 함께 빨개진다. collector가 진짜 노트 대신 예시를 싣는다.

순수 함수만이 아니라 실제 CLI로도 확인했다.

- 헤딩에 공백 한 칸이 앞에 붙은 정상 본문: exit 0 (이전에는 거부됐다).
- HTML 주석 안에 숨긴 attribution trailer: exit 1, 줄 번호와 수정 방법을 함께 출력.
- `None.`이라고 적힌 `## Changelog` 블록: exit 1, collector 자신의 사유를 대며 거부. PR을 아직 고칠 수 있는 시점에.

출하 표면 게이트도 그대로 통과한다(127 파일, 폐포 위반 0). 새 모듈이 npm 배포 범위를 넓히지 않았다.

## 마이그레이션 노트

없음. 이 변경에서 사용자에게 출하되는 것은 없다.

---

## Changelog

None

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
