### PR TITLE
test(runner): shard the suite across processes and fix the order dependence it exposed

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,9 @@ hypomnema/
 │   ├── Home.md, Overview.md, hypo-automation.md, hypo-help.md
 │   ├── pages/_index.md
 │   └── projects/_template/
-├── tests/runner.mjs          ← no-dependency test runner
+├── tests/
+│   ├── runner.mjs                ← no-dependency test runner (one flat script)
+│   └── parallel.mjs              ← runs the runner as N sharded processes (`npm test`)
 ├── docs/                     ← ARCHITECTURE.md, CONTRIBUTING.md
 ├── .claude-plugin/plugin.json← plugin manifest
 └── package.json              ← npm metadata, no runtime deps
@@ -408,6 +410,8 @@ Default patterns: `*.pdf`, `*.zip`, `*.pem`, `*.env`, `*.key`, `*.crt`, `*creden
 | **Total** | Run `npm test` for the live count |
 
 Run with `npm test`. The runner uses only Node.js built-ins; tests create scoped temp dirs and clean up after themselves. The count above is a layout sketch — exact totals shift as lanes ship, so `npm test` is the source of truth.
+
+`npm test` shards `tests/runner.mjs` across processes via `tests/parallel.mjs` (one suite goes to exactly one shard, in order) and merges the shard reports. `npm run test:serial` runs the whole suite in one process; the two are verdict-identical. While iterating, `node tests/runner.mjs --grep=<regex>` runs just the matching tests.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node tests/runner.mjs",
+    "test": "node tests/parallel.mjs",
+    "test:serial": "node tests/runner.mjs",
     "lint": "node scripts/lint.mjs",
     "fix:verify": "node scripts/fix-status-verify.mjs",
     "graph": "node scripts/graph.mjs",

--- a/tests/parallel.mjs
+++ b/tests/parallel.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * tests/parallel.mjs — run tests/runner.mjs as N concurrent shards.
+ *
+ * The runner is one flat script and every test body carries its own fixture
+ * cost (tmp dirs, git repos, spawned children), so it is bound by process
+ * startup and disk, not by anything a single Node process can overlap. Cutting
+ * the suites across N processes is the only lever that moves wall clock.
+ *
+ * Shards do not share state: runner.mjs selects whole suites by index, and each
+ * suite builds and tears down its own fixtures under a HOME pinned to a tmp dir.
+ * Verdicts come back as JSON files rather than parsed stdout, so an interleaved
+ * or truncated console cannot change a verdict.
+ *
+ * Usage:
+ *   node tests/parallel.mjs                  # cpu-count shards
+ *   node tests/parallel.mjs --shards=4
+ *   node tests/parallel.mjs --grep=proposal  # pass-through to the runner
+ *   node tests/parallel.mjs --timing
+ *   node tests/parallel.mjs --json=<path>    # merged machine-readable report
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir, cpus } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const RUNNER = join(HERE, 'runner.mjs');
+
+const ARGV = process.argv.slice(2);
+
+function die(msg) {
+  console.error(msg);
+  process.exit(2);
+}
+
+// Same reasoning as the runner's own check: a silently ignored `--shardz=4` or
+// a bare `--grep` would run the default shape and report a green nobody asked
+// for. Value flags demand a value; boolean flags refuse one; nothing repeats.
+const VALUE_FLAGS = new Set(['shards', 'grep', 'json']);
+const BOOL_FLAGS = new Set(['timing']);
+const KNOWN = [...VALUE_FLAGS, ...BOOL_FLAGS];
+
+const ARGS = new Map();
+for (const arg of ARGV) {
+  const m = /^--([a-zA-Z-]+)(?:=([\s\S]*))?$/.exec(arg);
+  const name = m?.[1];
+  if (!name || !KNOWN.includes(name)) {
+    die(`unknown argument: ${arg}\nknown: ${KNOWN.map((f) => `--${f}`).join(' ')}`);
+  }
+  const value = m[2];
+  if (VALUE_FLAGS.has(name) && !value) die(`--${name} needs a value: --${name}=<value>`);
+  if (BOOL_FLAGS.has(name) && value !== undefined) die(`--${name} takes no value`);
+  if (ARGS.has(name)) die(`--${name} given more than once`);
+  ARGS.set(name, VALUE_FLAGS.has(name) ? value : true);
+}
+
+function argValue(name) {
+  const v = ARGS.get(name);
+  return typeof v === 'string' ? v : undefined;
+}
+
+const SHARDS = (() => {
+  const raw = argValue('shards') ?? process.env.HYPO_TEST_SHARDS;
+  if (raw === undefined) return Math.max(1, cpus().length);
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) die(`--shards expects a positive integer, got: ${raw}`);
+  return n;
+})();
+
+// --shards and --json are ours. --shard, --child and the report path are ours
+// to set, so a caller cannot fight us for them.
+const PASSTHROUGH = ARGV.filter((a) => !a.startsWith('--shards=') && !a.startsWith('--json='));
+const TIMING = ARGS.has('timing');
+const JSON_OUT = argValue('json');
+
+const tmp = mkdtempSync(join(tmpdir(), 'hypo-shards-'));
+
+function runShard(index) {
+  return new Promise((resolve) => {
+    const report = join(tmp, `shard-${index}.json`);
+    const args = [
+      RUNNER,
+      `--shard=${index}/${SHARDS}`,
+      `--json=${report}`,
+      '--child',
+      ...PASSTHROUGH,
+    ];
+    // HOME is deliberately inherited, not pinned. A shard must see exactly what
+    // `node tests/runner.mjs` sees, or the two stop being verdict-identical: the
+    // hermeticity guard snapshots the real ~/.claude to prove no test wrote
+    // there, and the manifest test reads the real wiki under ~/hypomnema. Pin
+    // HOME here and both keep passing while testing nothing. The runner pins
+    // HOME on the children *it* spawns, which is where the invariant belongs.
+    const child = spawn(process.execPath, args);
+
+    // Kept apart. The runner prints passes to stdout and failures to stderr,
+    // and scripts/lib/fix-status-verify.mjs reads both; folding one into the
+    // other would quietly rewrite which stream a failure arrives on.
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (d) => (out += d));
+    child.stderr.on('data', (d) => (err += d));
+
+    const started = Date.now();
+    const finish = (fields) =>
+      resolve({ index, seconds: (Date.now() - started) / 1000, out, err, ...fields });
+
+    // A shard that cannot even be spawned resolves like a crash rather than
+    // rejecting: one dead shard must not take the whole run's report with it.
+    child.on('error', (e) => finish({ crashed: true, code: null, crashReason: e.message }));
+
+    child.on('close', (code, signal) => {
+      if (!existsSync(report)) {
+        // No report means the shard died before its summary: a crash, not a
+        // failing assertion. A silent zero here would read as "nothing to run".
+        finish({ crashed: true, code, crashReason: `exit ${code}, no report written` });
+        return;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(readFileSync(report, 'utf-8'));
+      } catch (e) {
+        finish({ crashed: true, code, crashReason: `unreadable report: ${e.message}` });
+        return;
+      }
+      // A readable report is not on its own a verdict. The runner's contract is
+      // exit 1 when it failed and exit 0 when it did not; anything else (a
+      // signal, an exit code from somewhere past the summary) means the process
+      // did not end the way it says it did, and trusting the file would turn a
+      // dead shard into a green one.
+      const expected = parsed.failed > 0 ? 1 : 0;
+      if (signal || code !== expected) {
+        finish({
+          crashed: true,
+          code,
+          crashReason: signal
+            ? `killed by ${signal} after writing its report`
+            : `exit ${code}, but its report says ${parsed.failed} failed (expected exit ${expected})`,
+          ...parsed,
+        });
+        return;
+      }
+      finish({ crashed: false, code, ...parsed });
+    });
+  });
+}
+
+const wall = Date.now();
+// Progress goes to stderr. It lands in completion order, which is inherently
+// nondeterministic, and stdout is a contract: fix-status-verify parses it.
+console.error(`running ${SHARDS} shards of tests/runner.mjs`);
+
+const results = await Promise.all(
+  Array.from({ length: SHARDS }, (_, i) =>
+    runShard(i + 1).then((r) => {
+      const label = `  shard ${r.index}/${SHARDS}`;
+      if (r.crashed) {
+        console.error(`${label}  CRASHED (${r.crashReason}) after ${r.seconds.toFixed(1)}s`);
+      } else {
+        const verdict = r.failed > 0 ? `${r.failed} failed` : 'green';
+        console.error(`${label}  ${r.passed} passed, ${verdict}  (${r.seconds.toFixed(1)}s)`);
+      }
+      return r;
+    }),
+  ),
+);
+
+rmSync(tmp, { recursive: true, force: true });
+
+results.sort((a, b) => a.index - b.index);
+
+// Replay every shard's console, in shard order, on the stream it came from.
+// This is not decoration: the `  ✓ name` / `  ✗ name` lines are a contract.
+// scripts/lib/fix-status-verify.mjs parses them out of `npm test` output to map
+// a fix number to its verdict, and swallowing them would make that tool see an
+// empty test run and mis-report every fix as untested.
+for (const r of results) {
+  if (r.out) process.stdout.write(r.out);
+  if (r.err) process.stderr.write(r.err);
+}
+
+const crashed = results.filter((r) => r.crashed);
+const passed = results.reduce((n, r) => n + (r.passed ?? 0), 0);
+const failed = results.reduce((n, r) => n + (r.failed ?? 0), 0);
+const allFailures = results.flatMap((r) => r.failures ?? []);
+
+console.log(`\n${'─'.repeat(40)}`);
+console.log(
+  `  ${passed} passed, ${failed} failed  (${((Date.now() - wall) / 1000).toFixed(1)}s wall)`,
+);
+
+if (TIMING) {
+  const timings = results.flatMap((r) => r.timings ?? []);
+  const slowest = timings.sort((a, b) => b.ms - a.ms).slice(0, 25);
+  const bodySeconds = timings.reduce((sum, t) => sum + t.ms, 0) / 1000;
+  console.log(
+    `\n  slowest 25 of ${timings.length} (${bodySeconds.toFixed(1)}s inside test bodies)`,
+  );
+  for (const { name, ms } of slowest) {
+    console.log(`  ${(ms / 1000).toFixed(2).padStart(7)}s  ${name}`);
+  }
+}
+
+if (JSON_OUT) {
+  writeFileSync(
+    JSON_OUT,
+    JSON.stringify({
+      shards: SHARDS,
+      passed,
+      failed,
+      crashed: crashed.map((r) => ({ shard: r.index, code: r.code, reason: r.crashReason })),
+      failures: allFailures,
+    }),
+  );
+}
+
+for (const r of crashed) {
+  console.error(`\n─── shard ${r.index}/${SHARDS} crashed: ${r.crashReason} ───`);
+}
+
+if (allFailures.length > 0) {
+  console.error(`\nFailed tests:`);
+  for (const { name, message } of allFailures) {
+    console.error(`  ✗ ${name}: ${message}`);
+  }
+}
+
+if (failed > 0 || crashed.length > 0) process.exit(1);

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -148,40 +148,173 @@ process.on('exit', () => {
   } catch {}
 });
 
+// Seed the session HOME with the one file the hooks need to find this checkout.
+// hypo-shared reads `pkgRoot` out of it and hands back null without it, and a
+// null PKG_ROOT makes hypo-personal-check skip lint entirely and report a clean
+// gate. Until this was written here, the file existed only as a side effect of
+// whichever init.mjs test happened to have run first in the same process, so
+// the PreCompact tests passed by luck of ordering: they went green under
+// --shards=8 and red under --shards=12, and red on their own under --grep.
+mkdirSync(join(SESSION_TMP_HOME, '.claude'), { recursive: true });
+writeFileSync(
+  join(SESSION_TMP_HOME, '.claude', 'hypo-pkg.json'),
+  JSON.stringify({ pkgRoot: REPO }),
+);
+
+// ── selection: shard / grep ──────────────────────────────────────────────────
+// This file is one flat script: every test body carries its own fixture cost
+// (a tmp dir, a git repo, a spawned child). Skipping a test body therefore
+// skips its cost, which is what makes both sharding and --grep worth anything.
+// Selection is per-SUITE, never per-test, so a suite whose tests build on each
+// other always lands in one shard, in order.
+
+const ARGV = process.argv.slice(2);
+
+function die(msg) {
+  console.error(msg);
+  process.exit(2);
+}
+
+// Every malformed flag exits 2. The failure mode being bought off here is not
+// a crash, it is a green: `--grepp=close` or a bare `--grep` would select
+// everything, run for minutes, and answer a question nobody asked.
+const VALUE_FLAGS = new Set(['shard', 'grep', 'json']);
+const BOOL_FLAGS = new Set(['timing', 'child']);
+const ARGS = parseFlags(ARGV, VALUE_FLAGS, BOOL_FLAGS, die);
+
+function parseFlags(argv, valueFlags, boolFlags, fail) {
+  const known = [...valueFlags, ...boolFlags];
+  const out = new Map();
+  for (const arg of argv) {
+    const m = /^--([a-zA-Z-]+)(?:=([\s\S]*))?$/.exec(arg);
+    const name = m?.[1];
+    if (!name || !known.includes(name)) {
+      fail(`unknown argument: ${arg}\nknown: ${known.map((f) => `--${f}`).join(' ')}`);
+    }
+    const value = m[2];
+    if (valueFlags.has(name) && !value) fail(`--${name} needs a value: --${name}=<value>`);
+    if (boolFlags.has(name) && value !== undefined) fail(`--${name} takes no value`);
+    if (out.has(name)) fail(`--${name} given more than once`);
+    out.set(name, valueFlags.has(name) ? value : true);
+  }
+  return out;
+}
+
+function argValue(name) {
+  const v = ARGS.get(name);
+  return typeof v === 'string' ? v : undefined;
+}
+
+const SHARD = (() => {
+  const raw = argValue('shard');
+  if (raw === undefined) return { index: 0, total: 1 };
+  const m = /^(\d+)\/(\d+)$/.exec(raw);
+  if (!m) die(`--shard expects i/n (1-based), got: ${raw}`);
+  const index = Number(m[1]) - 1;
+  const total = Number(m[2]);
+  if (total < 1 || index < 0 || index >= total) die(`--shard out of range: ${raw}`);
+  return { index, total };
+})();
+
+const GREP = (() => {
+  const raw = argValue('grep');
+  if (raw === undefined) return null;
+  try {
+    return new RegExp(raw, 'i');
+  } catch (err) {
+    die(`--grep is not a valid regex: ${err.message}`);
+  }
+})();
+
+const TIMING = ARGS.has('timing');
+const JSON_OUT = argValue('json');
+// Set by tests/parallel.mjs: our per-test lines still print (fix-status-verify
+// parses them), but the parent owns the one summary the reader should trust.
+const CHILD = ARGS.has('child');
+
 // ── minimal test harness ─────────────────────────────────────────────────────
 
 let passed = 0;
 let failed = 0;
+let skipped = 0;
 const failures = [];
+const timings = [];
 
-function test(name, fn) {
-  try {
-    fn();
-    console.log(`  ✓ ${name}`);
-    passed++;
-  } catch (err) {
+let suiteIndex = -1;
+// A test declared before the first suite() belongs to shard 1, so that a
+// sharded run covers it exactly once rather than once per shard.
+let suiteSelected = SHARD.index === 0;
+
+// Headings are printed lazily, on the suite's first selected test, so a --grep
+// run is a list of what ran rather than 216 headings over three results.
+let pendingHeading = null;
+
+function selected(name) {
+  if (!suiteSelected) return false;
+  if (GREP && !GREP.test(name)) return false;
+  if (pendingHeading !== null) {
+    console.log(`\n${pendingHeading}`);
+    pendingHeading = null;
+  }
+  return true;
+}
+
+function record(name, err, ms) {
+  timings.push({ name, ms });
+  if (err) {
     console.error(`  ✗ ${name}`);
     console.error(`    ${err.message}`);
     failures.push({ name, err });
     failed++;
+  } else {
+    console.log(`  ✓ ${name}`);
+    passed++;
+  }
+}
+
+function test(name, fn) {
+  if (!selected(name)) {
+    skipped++;
+    return;
+  }
+  const t0 = performance.now();
+  try {
+    const result = fn();
+    // test() cannot await. Hand it an async body and the promise is dropped:
+    // every assertion inside runs after this checkmark is printed, and a
+    // rejection can never fail the test. There are ~1500 test() calls next to
+    // 19 testAsync() ones, so the wrong one is always right there to copy.
+    // Fail loudly instead of passing vacuously.
+    if (result !== null && typeof result?.then === 'function') {
+      result.catch(() => {}); // the body still runs; do not surface it as an unhandled rejection
+      throw new Error(
+        'async body passed to test() — its assertions are never awaited; use await testAsync(...)',
+      );
+    }
+    record(name, null, performance.now() - t0);
+  } catch (err) {
+    record(name, err, performance.now() - t0);
   }
 }
 
 async function testAsync(name, fn) {
+  if (!selected(name)) {
+    skipped++;
+    return;
+  }
+  const t0 = performance.now();
   try {
     await fn();
-    console.log(`  ✓ ${name}`);
-    passed++;
+    record(name, null, performance.now() - t0);
   } catch (err) {
-    console.error(`  ✗ ${name}`);
-    console.error(`    ${err.message}`);
-    failures.push({ name, err });
-    failed++;
+    record(name, err, performance.now() - t0);
   }
 }
 
 function suite(label) {
-  console.log(`\n${label}`);
+  suiteIndex++;
+  suiteSelected = suiteIndex % SHARD.total === SHARD.index;
+  pendingHeading = suiteSelected ? label : null;
 }
 
 // ── fix-status-verify anchors (Phase 1, learned_behavior #6 half) ────────────
@@ -5687,7 +5820,11 @@ test('payload via stdin (`--payload=-`) works the same as a file', () => {
         '--payload=-',
         '--json',
       ],
-      { input: JSON.stringify(payload), encoding: 'utf-8' },
+      {
+        input: JSON.stringify(payload),
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: SESSION_TMP_HOME },
+      },
     );
     assert.equal(r.status, 0, `stdin apply failed: ${r.stdout}\n${r.stderr}`);
     const out = JSON.parse(r.stdout);
@@ -6076,7 +6213,7 @@ test('--apply .gitignore migration appends .cache/, git-ignores the log, idempot
       const ci = spawnSync(
         'git',
         ['-C', hypoDir, 'check-ignore', '-q', '--', '.cache/page-usage.jsonl'],
-        { encoding: 'utf-8' },
+        { encoding: 'utf-8', env: { ...process.env, HOME: SESSION_TMP_HOME } },
       );
       assert.equal(ci.status, 0, 'page-usage.jsonl must be git-ignored after migration');
 
@@ -11650,7 +11787,7 @@ function runStop(hookFile, dir) {
   return spawnSync(process.execPath, [join(HOOKS, hookFile)], {
     input: '{}',
     encoding: 'utf-8',
-    env: { ...process.env, HYPO_DIR: dir },
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
   });
 }
 
@@ -11790,7 +11927,7 @@ test('auto-stage skips .hypoignore-listed file_path', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-stage.mjs')], {
       input: JSON.stringify({ tool_input: { file_path: join(dir, '.cache', 'a.json') } }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0);
     const staged = spawnSync('git', ['-C', dir, 'diff', '--cached', '--name-only'], {
@@ -11810,7 +11947,7 @@ test('file-watch refuses to inject .hypoignore-matched file (e.g. .env)', () => 
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-file-watch.mjs')], {
       input: JSON.stringify({ file_path: secretPath }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
@@ -11832,7 +11969,7 @@ test('file-watch still injects non-ignored wiki file (e.g. hot.md)', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-file-watch.mjs')], {
       input: JSON.stringify({ file_path: hotPath }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
@@ -11873,7 +12010,7 @@ test('session-start refuses to inject .hypoignore-matched project hot/state', ()
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
       input: JSON.stringify({ cwd: work, session_id: 'test-fix48-ss' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(
@@ -11888,7 +12025,7 @@ test('session-start still injects non-ignored project hot/state', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
       input: JSON.stringify({ cwd: work, session_id: 'test-fix48-ss-ok' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0);
     assert.ok(
@@ -11926,7 +12063,7 @@ test('project hot with overdue verify_by_date gets STALE marker', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
       input: JSON.stringify({ cwd: work, session_id: 'test-a3-stale' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(/DATED_HOT_VALUE/.test(r.stdout), `expected hot injection: ${r.stdout}`);
@@ -11944,7 +12081,7 @@ test('derived project hot without verify_by_date gets no STALE marker', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
       input: JSON.stringify({ cwd: work, session_id: 'test-a3-nostale' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(/DATED_HOT_VALUE/.test(r.stdout), `expected hot injection: ${r.stdout}`);
@@ -11977,7 +12114,7 @@ test('session-start injects vault orientation when cwd is a project HIT ≠ vaul
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
       input: JSON.stringify({ cwd: work, session_id: 'test-impr19-ss' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.match(r.stdout, /\[WIKI VAULT:/, `expected vault orientation, got: ${r.stdout}`);
@@ -12000,7 +12137,7 @@ test('session-start omits vault orientation when cwd IS the vault root', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
       input: JSON.stringify({ cwd: dir, session_id: 'test-impr19-ss-vault' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(
@@ -12027,7 +12164,7 @@ test('session-start omits vault orientation when cwd is a vault SUBDIR (working_
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
       input: JSON.stringify({ cwd: subdir, session_id: 'test-impr19-ss-subdir' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(
@@ -12042,7 +12179,7 @@ test('cwd-change injects vault orientation when new cwd is a project HIT ≠ vau
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
       input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/other', session_id: 'test-impr19-cc' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.match(r.stdout, /\[WIKI VAULT:/, `expected vault orientation, got: ${r.stdout}`);
@@ -12055,7 +12192,7 @@ test('cwd-change refuses to inject .hypoignore-matched project hot.md', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
       input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/other' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(!/SECRET_HOT_VALUE/.test(r.stdout), `secret leaked through cwd-change: ${r.stdout}`);
@@ -12069,7 +12206,7 @@ test('cwd-change refuses to inject .hypoignore-matched global hot.md', () => {
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
       input: JSON.stringify({ new_cwd: '/tmp/nowhere-no-project', old_cwd: '/tmp/other' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(
@@ -12597,7 +12734,7 @@ function runFirstPrompt(sessionId) {
   return spawnSync(process.execPath, [join(HOOKS, 'hypo-first-prompt.mjs')], {
     input: JSON.stringify({ session_id: sessionId, prompt: 'unrelated weather question' }),
     encoding: 'utf-8',
-    env: { ...process.env, HYPO_DIR: '/tmp/nonexistent-hypo-99999' },
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: '/tmp/nonexistent-hypo-99999' },
   });
 }
 
@@ -12658,7 +12795,7 @@ test('replay-cwd-change-triggers-first-prompt: entering a project arms the marke
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
       input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/other-nonproject', session_id: sid }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     try {
@@ -12822,7 +12959,7 @@ test('replay-cwd-change-triggers-first-prompt: ignored hot.md does NOT arm the m
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
       input: JSON.stringify({ new_cwd: work, old_cwd: '/tmp/other-nonproject', session_id: sid }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     if (existsSync(markerPath(sid))) {
@@ -12840,7 +12977,7 @@ test('replay-cwd-change-triggers-first-prompt: same-project move does NOT arm th
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-cwd-change.mjs')], {
       input: JSON.stringify({ new_cwd: sub, old_cwd: work, session_id: sid }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     if (existsSync(markerPath(sid))) {
@@ -12855,7 +12992,7 @@ test('file-watch ignores file outside HYPO_DIR even without .hypoignore', () => 
     const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-file-watch.mjs')], {
       input: JSON.stringify({ file_path: '/etc/passwd' }),
       encoding: 'utf-8',
-      env: { ...process.env, HYPO_DIR: dir },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
     });
     assert.equal(r.status, 0);
     const out = JSON.parse(r.stdout);
@@ -12945,7 +13082,7 @@ function runStart(dir, cwd) {
   return spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
     input: JSON.stringify({ cwd: cwd || dir, session_id: 'test-growth' }),
     encoding: 'utf-8',
-    env: { ...process.env, HYPO_DIR: dir },
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
   });
 }
 
@@ -17214,7 +17351,7 @@ test('feedback projection conflict (hand-edited block) → still blocks, no auto
             `--hypo-dir=${dir}`,
             `--claude-home=${join(home, '.claude')}`,
           ],
-          { encoding: 'utf-8' },
+          { encoding: 'utf-8', env: { ...process.env, HOME: SESSION_TMP_HOME } },
         );
         writeFileSync(
           claudePath,
@@ -21353,7 +21490,7 @@ function runWebFetchHook(payload, env = {}) {
   return spawnSync(process.execPath, [join(HOOKS, 'hypo-web-fetch-ingest.mjs')], {
     input: typeof payload === 'string' ? payload : JSON.stringify(payload),
     encoding: 'utf-8',
-    env: { ...process.env, HYPO_DIR: '', ...env },
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: '', ...env },
   });
 }
 
@@ -22514,7 +22651,7 @@ function runShim(dir, extraEnv = {}) {
   return spawnSync(process.execPath, [join(dir, 'scripts', 'pre-commit-format.mjs')], {
     cwd: dir,
     encoding: 'utf-8',
-    env: { ...process.env, ...extraEnv },
+    env: { ...process.env, HOME: SESSION_TMP_HOME, ...extraEnv },
   });
 }
 
@@ -22660,6 +22797,7 @@ test('shim: invocation WITH sentinel honours GIT_INDEX_FILE (legitimate commit -
       encoding: 'utf-8',
       env: {
         ...process.env,
+        HOME: SESSION_TMP_HOME,
         GIT_INDEX_FILE: indexLock,
         HYPOMNEMA_HOOK_INVOCATION: '1',
       },
@@ -22699,7 +22837,7 @@ test('shim: direct invocation drops inherited GIT_INDEX_FILE (closes alternate-i
       encoding: 'utf-8',
       // Note: no HYPOMNEMA_HOOK_INVOCATION. Direct invocation must drop the
       // attacker-controlled GIT_INDEX_FILE.
-      env: { ...process.env, GIT_INDEX_FILE: attackIdx },
+      env: { ...process.env, HOME: SESSION_TMP_HOME, GIT_INDEX_FILE: attackIdx },
     });
     assert.equal(r.status, 0);
     const after = readFileSync(join(real, 'victim.txt'), 'utf-8');
@@ -22732,6 +22870,7 @@ test('shim: mixed-env (foreign GIT_DIR + real GIT_WORK_TREE + foreign GIT_INDEX_
       encoding: 'utf-8',
       env: {
         ...process.env,
+        HOME: SESSION_TMP_HOME,
         GIT_DIR: join(foreign, '.git'),
         GIT_WORK_TREE: real,
         GIT_INDEX_FILE: join(foreign, '.git', 'index'),
@@ -22789,6 +22928,7 @@ test('shim: foreign hypomnema-named repo via GIT_DIR/GIT_WORK_TREE → does NOT 
       encoding: 'utf-8',
       env: {
         ...process.env,
+        HOME: SESSION_TMP_HOME,
         GIT_DIR: join(foreign, '.git'),
         GIT_WORK_TREE: foreign,
       },
@@ -22818,7 +22958,7 @@ function runInstaller(dir, extraEnv = {}) {
   return spawnSync(process.execPath, [join(dir, 'scripts', 'install-git-hooks.mjs')], {
     cwd: dir,
     encoding: 'utf-8',
-    env: { ...cleanParent, ...extraEnv },
+    env: { ...cleanParent, HOME: SESSION_TMP_HOME, ...extraEnv },
   });
 }
 
@@ -22975,7 +23115,7 @@ test('installer: linked worktree → skips', () => {
     const r = spawnSync(process.execPath, [join(wt, 'scripts', 'install-git-hooks.mjs')], {
       cwd: wt,
       encoding: 'utf-8',
-      env: { ...cleanParent, HYPOMNEMA_HOOK_VERBOSE: '1' },
+      env: { ...cleanParent, HOME: SESSION_TMP_HOME, HYPOMNEMA_HOOK_VERBOSE: '1' },
     });
     assert.equal(r.status, 0);
     assert.match(r.stderr, /linked worktree|toplevel != expectedRoot/);
@@ -23529,7 +23669,7 @@ test('CLI: green fixture → exit 0', () => {
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
     assert.match(r.stdout, /verified/);
@@ -23566,7 +23706,7 @@ test('CLI: type:reference stub spec → exit 1 with STUB_SPEC', () => {
         `${process.execPath} ${runnerPath}`,
         '--json',
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}\n${r.stderr}`);
     const j = JSON.parse(r.stdout);
@@ -23604,7 +23744,7 @@ test('CLI: vacuous spec (anchors but 0 claims) → exit 1 with STUB_SPEC', () =>
         `${process.execPath} ${runnerPath}`,
         '--json',
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1);
     const j = JSON.parse(r.stdout);
@@ -23634,7 +23774,7 @@ test('CLI: missing anchor → exit 1 with NO_ANCHOR finding', () => {
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1);
     assert.match(r.stdout, /NO_ANCHOR/);
@@ -23672,7 +23812,7 @@ test('CLI: anchor names test that does not run → exit 1 with MISSING_TEST', ()
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1);
     assert.match(r.stdout, /MISSING_TEST/);
@@ -23707,7 +23847,7 @@ test('CLI: --json emits machine-readable report with ok flag', () => {
         `${process.execPath} ${runnerPath}`,
         '--json',
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 0);
     const j = JSON.parse(r.stdout);
@@ -23751,7 +23891,7 @@ test('CLI: anchored test fails → exit 1 with FAILING_TEST', () => {
         '--test-command',
         `${process.execPath} ${runnerPath}`,
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1);
     assert.match(r.stdout, /FAILING_TEST/);
@@ -23784,7 +23924,7 @@ test('CLI: test command exits nonzero → exit 1 with TEST_RUN_NONZERO_EXIT', ()
         `${process.execPath} ${runnerPath}`,
         '--json',
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1);
     const j = JSON.parse(r.stdout);
@@ -23831,7 +23971,7 @@ test('CLI: manifest adrKeyLine absent from corpus → exit 1 with ADR_LINE_MISSI
         `${process.execPath} ${runnerPath}`,
         '--json',
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}\n${r.stderr}`);
     const j = JSON.parse(r.stdout);
@@ -23868,7 +24008,7 @@ test('CLI: claimed+anchored fix with no manifest row → exit 1 with MANIFEST_MI
         `${process.execPath} ${runnerPath}`,
         '--json',
       ],
-      { encoding: 'utf-8', cwd: REPO },
+      { encoding: 'utf-8', cwd: REPO, env: { ...process.env, HOME: SESSION_TMP_HOME } },
     );
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}\n${r.stderr}`);
     const j = JSON.parse(r.stdout);
@@ -26193,7 +26333,7 @@ function runCollect(args, extraEnv = {}) {
   return spawnSync(process.execPath, [COLLECT, ...args], {
     cwd: REPO,
     encoding: 'utf-8',
-    env: { ...process.env, ...extraEnv },
+    env: { ...process.env, HOME: SESSION_TMP_HOME, ...extraEnv },
   });
 }
 
@@ -26687,7 +26827,7 @@ test('importing crystallize.mjs runs no CLI and exposes exactly the pure exports
       '-e',
       `import(${JSON.stringify(script)}).then((m) => process.stdout.write(Object.keys(m).sort().join(',')))`,
     ],
-    { encoding: 'utf-8' },
+    { encoding: 'utf-8', env: { ...process.env, HOME: SESSION_TMP_HOME } },
   );
   assert.equal(r.status, 0, `import must exit 0, got ${r.status}: ${r.stderr}`);
   assert.equal(
@@ -29843,7 +29983,7 @@ function runAutoStageHook(dir, sessionId, filePath, toolName = 'Edit', content =
   return spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-stage.mjs')], {
     input: JSON.stringify({ session_id: sessionId, tool_name: toolName, tool_input }),
     encoding: 'utf-8',
-    env: { ...process.env, HYPO_DIR: dir },
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
   });
 }
 
@@ -30360,7 +30500,11 @@ test('resume.mjs hides a machine-scoped session-state on a foreign device and sa
     const r = spawnSync(
       process.execPath,
       [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped'],
-      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devB' } },
+      {
+        cwd: work,
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DEVICE: 'devB' },
+      },
     );
     assert.ok(
       !SCOPED_BODIES.test(r.stdout),
@@ -30380,7 +30524,11 @@ test('resume.mjs still returns a machine-scoped session-state on its own device'
     const r = spawnSync(
       process.execPath,
       [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped'],
-      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devA' } },
+      {
+        cwd: work,
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DEVICE: 'devA' },
+      },
     );
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(
@@ -30397,7 +30545,11 @@ test('resume.mjs --json does not serialize a machine-scoped body on a foreign de
     const r = spawnSync(
       process.execPath,
       [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped', '--json'],
-      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devB' } },
+      {
+        cwd: work,
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DEVICE: 'devB' },
+      },
     );
     assert.ok(
       !SCOPED_BODIES.test(r.stdout),
@@ -30417,7 +30569,11 @@ test('resume.mjs returns a visible session-state while hiding a scoped-out hot.m
     const r = spawnSync(
       process.execPath,
       [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=scoped'],
-      { cwd: work, encoding: 'utf-8', env: { ...process.env, HYPO_DEVICE: 'devB' } },
+      {
+        cwd: work,
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DEVICE: 'devB' },
+      },
     );
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     assert.ok(
@@ -32819,13 +32975,42 @@ test('PR surface: a fenced changelog EXAMPLE does not become the release note', 
   );
 });
 
-console.log(`\n${'─'.repeat(40)}`);
-console.log(`  ${passed} passed, ${failed} failed`);
+if (!CHILD) {
+  console.log(`\n${'─'.repeat(40)}`);
+  console.log(`  ${passed} passed, ${failed} failed${skipped ? `, ${skipped} not selected` : ''}`);
+}
+
+if (TIMING && !CHILD) {
+  const slowest = [...timings].sort((a, b) => b.ms - a.ms).slice(0, 25);
+  const total = timings.reduce((sum, t) => sum + t.ms, 0);
+  console.log(`\n  slowest 25 of ${timings.length} (${(total / 1000).toFixed(1)}s in test bodies)`);
+  for (const { name, ms } of slowest) {
+    console.log(`  ${(ms / 1000).toFixed(2).padStart(7)}s  ${name}`);
+  }
+}
+
+// The parent in tests/parallel.mjs merges these files rather than parsing our
+// stdout, so a shard's verdict survives interleaved output and truncation.
+if (JSON_OUT) {
+  writeFileSync(
+    JSON_OUT,
+    JSON.stringify({
+      shard: `${SHARD.index + 1}/${SHARD.total}`,
+      passed,
+      failed,
+      skipped,
+      failures: failures.map(({ name, err }) => ({ name, message: err.message })),
+      timings,
+    }),
+  );
+}
 
 if (failed > 0) {
-  console.error(`\nFailed tests:`);
-  for (const { name, err } of failures) {
-    console.error(`  ✗ ${name}: ${err.message}`);
+  if (!CHILD) {
+    console.error(`\nFailed tests:`);
+    for (const { name, err } of failures) {
+      console.error(`  ✗ ${name}: ${err.message}`);
+    }
   }
   process.exit(1);
 }


### PR DESCRIPTION
# English

## What changed

`npm test` now shards `tests/runner.mjs` across processes via a new `tests/parallel.mjs`, and
drops from 205s to 56s. `npm run test:serial` keeps the old single-process path.

The runner keeps its shape (one flat script, no framework, `test()` / `suite()` unchanged, no
test body touched). It gains selection by suite (`--shard=i/n`), a name filter (`--grep`), timing,
a JSON report, and a flag parser that exits 2 on anything malformed.

Sharding then surfaced a defect that had nothing to do with speed. Five PreCompact tests were
passing only because an earlier `init.mjs` test had left `~/.claude/hypo-pkg.json` in the shared
session HOME. That fix is in here too.

## Why

At 205s a run, repairing a fixture meant a three-minute wait per iteration, so nobody ran the
suite while working; they ran it at the end, in bulk, and read a wall of output. The cost is not
in the runner, it is in the 1564 test bodies, each of which spawns children and builds git repos.
Cutting them across processes is the only lever that moves wall clock.

The second reason is the one that matters more. A test that only passes because another test ran
first is a test that proves nothing, and this suite had five of them.

## How

Selection is per **suite**, never per test: `suiteIndex % n === i-1`. A suite whose tests build on
each other therefore stays whole, in one process, in order. The parent merges the shards' JSON
reports rather than parsing their console, so an interleaved terminal cannot change a verdict.

But it still replays each shard's stdout and stderr, separately and in shard order, because those
`✓` / `✗` lines are a contract: `scripts/lib/fix-status-verify.mjs` shells out to `npm test` and
parses them to decide whether a claimed fix is actually proven. Swallowing them would have made
that tool see an empty test run and silently mis-report every fix. A shard whose exit code
disagrees with its own report counts as a crash, not as a green.

**The order-dependence bug.** `hypo-shared.mjs` resolves `PKG_ROOT` from
`$HOME/.claude/hypo-pkg.json` and returns `null` without it. A null `PKG_ROOT` makes
`hypo-personal-check` skip lint entirely and report a clean gate, so the five tests asserting that
it *blocks* went green while exercising nothing. The file existed only as a side effect of
whichever `init.mjs` test happened to run first in the same process. They were deterministically
red under `--shards=12`, and red on their own under `--grep`. The runner now seeds that file
explicitly.

Alongside it: every process a test spawns now has `HOME` pinned to the session temp dir. Roughly
30 spawns were inheriting the developer's real one, and hooks both read *and write* under
`~/.claude` (a version cache, `state/wiki-context-warning.json`). The runner process itself still
sees the real `HOME` on purpose, because the hermeticity guard snapshots `~/.claude` to prove no
test wrote there and the manifest test reads the wiki under `~/hypomnema`; pin it and both keep
passing while testing nothing.

Finally, `test()` now throws when handed an async body. It cannot await, so the promise was
dropped and the checkmark printed unconditionally. There are ~1500 `test()` calls next to 19
`testAsync()` ones, so the wrong one is always right there to copy.

## Manual verification

No hook, template, or init-flow change. Verified that the verdict does not depend on how the suite
is cut, which is the property the whole change rests on:

```
node tests/runner.mjs                    216s   1564 passed, 0 failed
node tests/parallel.mjs                   56s   1564 passed, 0 failed   (8 shards)
node tests/parallel.mjs --shards=12              1564 passed, 0 failed
node tests/parallel.mjs --shards=216      75s   1564 passed, 0 failed   (one process per suite)
npm run fix:verify                               test run: 1558 pass, 0 fail (exit 0)
```

The 216-shard run is the interesting one: it puts every suite in its own process, so any test still
leaning on another suite's side effects goes red. None do.

Both defects were also proven red before the fix, not just green after:

- `--shards=12` failed the same 5 PreCompact tests on two consecutive runs; each also failed alone
  under `--grep`. Green now under 8, 12, 16, 216, and serial.
- The async guard was exercised against a body that throws: without it the test prints a checkmark,
  with it the test fails.
- A shard forced to exit 9 after writing a green report is reported as CRASHED, and the parent
  exits 1.
- Malformed flags (`--grepp=x`, bare `--grep`, `--grep=`, `--timing=x`, a repeated flag,
  `--shards=0`) all exit 2 instead of silently running the whole suite.

## Migration notes

None.

---

# 한국어

## 변경 내용

`npm test`가 새 `tests/parallel.mjs`를 통해 `tests/runner.mjs`를 여러 프로세스로 쪼개 돌립니다.
205초에서 56초가 됐습니다. 기존 단일 프로세스 경로는 `npm run test:serial`로 남습니다.

러너의 모양은 그대로입니다(플랫 스크립트 하나, 프레임워크 없음, `test()` / `suite()` 계약 유지,
테스트 본문은 한 줄도 안 건드림). 여기에 suite 단위 선택(`--shard=i/n`), 이름 필터(`--grep`),
타이밍, JSON 리포트, 그리고 잘못된 플래그를 exit 2로 막는 파서가 붙습니다.

그리고 샤딩이 속도와 무관한 결함을 하나 드러냈습니다. PreCompact 테스트 5개가 앞선 `init.mjs`
테스트가 남긴 `~/.claude/hypo-pkg.json` 덕에만 통과하고 있었습니다. 그 수정도 함께 들어갑니다.

## 이유

한 번에 205초면 픽스처 하나 고칠 때마다 3분을 기다려야 합니다. 그래서 아무도 작업 중에는 테스트를
안 돌리고, 끝에 몰아서 돌린 뒤 출력 더미를 읽습니다. 비용은 러너가 아니라 1564개의 테스트 본문에
있습니다. 각자 자식 프로세스를 띄우고 git 저장소를 만듭니다. 이걸 프로세스로 쪼개는 것 말고는
벽시계 시간을 줄일 지렛대가 없습니다.

두 번째 이유가 더 중요합니다. **다른 테스트가 먼저 돌아야만 통과하는 테스트는 아무것도 증명하지
않습니다.** 이 suite에 그런 게 5개 있었습니다.

## 방법

선택은 테스트가 아니라 **suite** 단위입니다(`suiteIndex % n === i-1`). 그래서 앞 테스트에 기대는
suite도 한 프로세스 안에서 순서대로 통째로 돕니다. 부모는 샤드의 콘솔을 파싱하지 않고 JSON 리포트를
병합합니다. 터미널이 뒤섞여도 판정이 흔들리지 않게요.

그래도 각 샤드의 stdout과 stderr를 스트림별로, 샤드 순서대로 다시 흘려보냅니다. 그 `✓` / `✗` 줄이
계약이기 때문입니다. `scripts/lib/fix-status-verify.mjs`가 `npm test`를 실행해 그 줄을 파싱해서
수정이 실제로 증명됐는지 판정합니다. 삼켰다면 그 도구는 빈 테스트 실행을 보고 모든 수정을 조용히
잘못 보고했을 겁니다. 자기 리포트와 종료 코드가 어긋나는 샤드는 green이 아니라 크래시로 칩니다.

**순서 의존 버그.** `hypo-shared.mjs`는 `$HOME/.claude/hypo-pkg.json`에서 `PKG_ROOT`를 읽고, 없으면
`null`을 돌려줍니다. `PKG_ROOT`가 null이면 `hypo-personal-check`는 lint를 아예 건너뛰고 게이트가
깨끗하다고 보고합니다. 그래서 "차단해야 한다"를 단언하던 테스트 5개가 아무것도 검증하지 않은 채
green이었습니다. 그 파일은 같은 프로세스에서 먼저 돈 `init.mjs` 테스트의 부작용으로만 존재했습니다.
`--shards=12`에서 결정적으로 빨갛고, `--grep`으로 단독 실행해도 빨갛습니다. 이제 러너가 그 파일을
명시적으로 심습니다.

같이 들어간 것: 테스트가 띄우는 모든 프로세스에 `HOME`을 세션 임시 디렉터리로 못 박았습니다. 약 30곳이
개발자의 실제 홈을 상속하고 있었는데, 훅은 `~/.claude` 아래를 읽기만 하는 게 아니라 **씁니다**(버전
캐시, `state/wiki-context-warning.json`). 러너 프로세스 자신은 일부러 실제 `HOME`을 봅니다. hermeticity
guard가 `~/.claude`를 스냅샷해 아무도 안 썼음을 증명하고, manifest 테스트가 `~/hypomnema`의 위키를
읽기 때문입니다. 여기까지 박으면 둘 다 통과하면서 아무것도 검증하지 않게 됩니다.

마지막으로 `test()`에 async 본문을 넘기면 이제 실패합니다. `test()`는 await를 못 하므로 프로미스가
버려지고 체크마크가 무조건 찍혔습니다. `test()` 약 1500개 옆에 `testAsync()`가 19개니, 틀린 쪽이 항상
바로 옆에 있어 베끼기 쉽습니다.

## 수동 검증

훅·템플릿·init 흐름 변경은 없습니다. 이 변경 전체가 딛고 선 성질, 즉 **판정이 suite를 어떻게 쪼개든
같다**를 확인했습니다.

```
node tests/runner.mjs                    216초   1564 passed, 0 failed
node tests/parallel.mjs                   56초   1564 passed, 0 failed   (8샤드)
node tests/parallel.mjs --shards=12               1564 passed, 0 failed
node tests/parallel.mjs --shards=216      75초   1564 passed, 0 failed   (suite당 프로세스 1개)
npm run fix:verify                                test run: 1558 pass, 0 fail (exit 0)
```

216샤드 실행이 핵심입니다. 모든 suite를 각자 프로세스에 넣으므로, 아직 남의 부작용에 기대는 테스트가
있으면 빨개집니다. 없습니다.

두 결함 모두 고친 뒤 green만 확인한 게 아니라, 고치기 전에 빨간 것을 증명했습니다.

- `--shards=12`에서 연속 두 번 같은 PreCompact 5개가 실패했고, 각각 `--grep` 단독 실행에서도
  실패했습니다. 지금은 8·12·16·216·직렬 모두 green입니다.
- async 가드는 던지는 본문으로 시험했습니다. 가드가 없으면 체크마크가 찍히고, 있으면 실패합니다.
- green 리포트를 쓴 뒤 강제로 exit 9로 죽인 샤드는 CRASHED로 보고되고 부모는 exit 1을 냅니다.
- 잘못된 플래그(`--grepp=x`, 값 없는 `--grep`, `--grep=`, `--timing=x`, 중복 플래그, `--shards=0`)는
  전부 exit 2입니다. 조용히 전체 suite를 돌지 않습니다.

## 마이그레이션 노트

None.

---

## Changelog

None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
