### PR TITLE
fix(lint): keep `_`-dir pages linkable so --strict can reach green

### DIFF
--- a/scripts/lib/wikilink.mjs
+++ b/scripts/lib/wikilink.mjs
@@ -8,21 +8,24 @@
 //   - scripts/crystallize.mjs (page collection, link extraction)
 //
 // Shared-resolver consolidation. Before this lib, each script carried its own copy of
-// collectPages + a slug-form deriver, drifting in subtle ways. The four
+// collectPages + a slug-form deriver, drifting in subtle ways. The five
 // collectPages variants are NOT interchangeable — they differ deliberately in
 // traversal/security/output-shape policy (codex design review, CONCERN):
 //
 //   - rename uses lstat + skips symlinks   → a vault scan can never escape via a
 //     symlinked dir/file (security boundary).
 //   - lint skips `_`-prefixed DIRECTORIES  → pages/feedback/_drafts scaffolds
-//     stay out of the lint set, while `_`-prefixed FILES (e.g. _index.md) lint.
+//     stay out of the lint SET, while `_`-prefixed FILES (e.g. _index.md) lint.
+//   - linkable is lint WITHOUT that dir skip → the same pages stay reachable as
+//     wikilink destinations. Not linting a page and not being able to link to it
+//     are separate policies; lint feeds this into its link-target catalog only.
 //   - crystallize skips ANY `.`-prefixed entry (dir AND file).
-//   - graph/lint/rename skip only `.`-prefixed FILES.
-//   - graph/crystallize emit raw `rel`/`slug`; lint keeps OS-native `rel`
-//     (its own buildSlugMap POSIX-normalizes downstream); rename/graph
+//   - graph/lint/linkable/rename skip only `.`-prefixed FILES.
+//   - graph/crystallize emit raw `rel`/`slug`; lint/linkable keep OS-native `rel`
+//     (lint's buildSlugMap POSIX-normalizes downstream); rename/graph
 //     POSIX-normalize the slug at scan time.
 //
-// So this lib exposes ONE walker core plus four NAMED PRESETS, not a pile of
+// So this lib exposes ONE walker core plus five NAMED PRESETS, not a pile of
 // boolean flags — each preset pins exactly one caller's historical behavior and
 // is fixed by a unit test. readdirSync order is preserved verbatim (NO sort):
 // graph's bare-first slug index is order-sensitive (first page wins a shared
@@ -75,6 +78,29 @@ export function collectPagesLint(dir, root, ignorePatterns = []) {
     {
       skipDotFile: true,
       skipUnderscoreDir: true,
+      shape: (full) => ({ path: full, rel: relative(root, full) }),
+    },
+    [],
+  );
+}
+
+// lint link-target catalog: collectPagesLint WITHOUT the `_`-dir skip.
+//
+// Not linting a page and not being able to link to it are different things. The
+// `_`-dir skip exists so draft/spec scaffolds don't have to satisfy the schema —
+// it was never meant to make them unreachable. Sharing one list for both jobs
+// made lint report a live file as a broken wikilink, and under --strict that is
+// an error, so a vault could not reach a green gate no matter how clean it was.
+// lint feeds this into buildSlugMap's extraTargets (verbatim full slugs, no bare
+// or dir-relative aliases): `_specs/<name>/spec.md` repeats across specs, and a
+// bare `spec` alias would swallow unrelated broken links.
+export function collectPagesLinkable(dir, root, ignorePatterns = []) {
+  return walkMarkdown(
+    dir,
+    root,
+    ignorePatterns,
+    {
+      skipDotFile: true,
       shape: (full) => ({ path: full, rel: relative(root, full) }),
     },
     [],

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -30,7 +30,7 @@ import {
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
 import { FAILURE_TYPE_ENUM } from './lib/failure-type.mjs';
-import { collectPagesLint, slugForms } from './lib/wikilink.mjs';
+import { collectPagesLint, collectPagesLinkable, slugForms } from './lib/wikilink.mjs';
 import { parseFrontmatter, SEQUENCE_ENTRY_RE } from './lib/frontmatter.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
@@ -487,8 +487,17 @@ const args = parseArgs(process.argv);
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects', 'journal'].map((d) => join(args.hypoDir, d));
 const pages = scanDirs.flatMap((d) => collectPagesLint(d, args.hypoDir, ignorePatterns));
+// Pages under `_`-prefixed dirs are deliberately not linted, but they are real
+// files and a link to one is not broken. Catalog them as link targets only, as
+// verbatim full slugs (extraTargets gets no derived aliases — a bare `spec` from
+// every `_specs/<name>/spec.md` would mask unrelated broken links).
+const lintedRels = new Set(pages.map((p) => p.rel));
+const underscoreDirTargets = scanDirs
+  .flatMap((d) => collectPagesLinkable(d, args.hypoDir, ignorePatterns))
+  .filter((p) => !lintedRels.has(p.rel))
+  .map((p) => p.rel.replace(/\.md$/, '').replace(/\\/g, '/'));
 const linkTargets = collectLinkTargets(args.hypoDir, ignorePatterns);
-const slugMap = buildSlugMap(pages, linkTargets);
+const slugMap = buildSlugMap(pages, [...linkTargets, ...underscoreDirTargets]);
 const tagVocab = parseSchemaVocab(args.hypoDir);
 const pageDirs = parseSchemaPageDirs(args.hypoDir);
 // Accepted page types = hardcoded core ∪ the vault SCHEMA's taxonomy. Union (not

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -109,6 +109,7 @@ import {
 import { checkPrSurface } from '../scripts/lib/check-pr-surface.mjs';
 import {
   collectPagesLint,
+  collectPagesLinkable,
   collectPagesGraph,
   collectPagesRename,
   collectPagesCrystallize,
@@ -11784,6 +11785,62 @@ test('genuinely missing links are still W4 broken (no false negative)', () => {
   assert.ok(
     broken.includes('nope'),
     `missing bare slug must stay broken: ${JSON.stringify(broken)}`,
+  );
+});
+
+// ── `_`-dir pages: not linted, but still linkable (ISSUE-57) ─────────────────
+// The `_`-dir skip keeps draft/spec scaffolds out of the lint set. It used to
+// also drop them from the link-target catalog, so a link to a file that plainly
+// exists was reported broken — and under --strict that error made a green gate
+// unreachable. Scanning and referencing are now separate.
+
+test('a page under a `_`-dir is a valid link target (not a false broken link)', () => {
+  const { broken } = lintWiki({
+    'projects/p/_specs/freshness/spec.md': '# spec (no frontmatter: `_`-dir is not linted)\n',
+    'pages/index.md': wlPage('reference', 'see [[projects/p/_specs/freshness/spec]]'),
+  });
+  assert.ok(
+    !broken.includes('projects/p/_specs/freshness/spec'),
+    `a live file under a _-dir must resolve: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('a page under a `_`-dir is still NOT linted (the skip itself survives)', () => {
+  // No frontmatter at all. If the `_`-dir page had entered the lint set this
+  // would raise W1/no-frontmatter, which is exactly what the skip prevents.
+  const { errors, broken } = lintWiki({
+    'projects/p/_specs/freshness/spec.md': '# bare spec, no frontmatter\n',
+    'pages/index.md': wlPage('reference', 'see [[projects/p/_specs/freshness/spec]]'),
+  });
+  assert.equal(broken.length, 0);
+  assert.ok(
+    !errors.some((e) => e.file.includes('_specs')),
+    `_-dir pages must stay out of the lint set: ${JSON.stringify(errors)}`,
+  );
+});
+
+test('a missing page under a `_`-dir is still W4 broken (no false negative)', () => {
+  const { broken } = lintWiki({
+    'projects/p/_specs/freshness/spec.md': '# real one\n',
+    'pages/index.md': wlPage('reference', 'ghost [[projects/p/_specs/not-here/spec]]'),
+  });
+  assert.ok(
+    broken.includes('projects/p/_specs/not-here/spec'),
+    `a _-dir path that does not exist must stay broken: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('`_`-dir link targets get NO bare alias (they cannot mask unrelated links)', () => {
+  // Every spec lives at _specs/<name>/spec.md, so a derived bare `spec` alias
+  // would resolve any stray [[spec]] and swallow real broken links. Link targets
+  // are added verbatim — full slug only.
+  const { broken } = lintWiki({
+    'projects/p/_specs/freshness/spec.md': '# spec\n',
+    'pages/index.md': wlPage('reference', 'bare [[spec]]'),
+  });
+  assert.ok(
+    broken.includes('spec'),
+    `bare [[spec]] must NOT resolve to a _-dir page: ${JSON.stringify(broken)}`,
   );
 });
 
@@ -25961,6 +26018,16 @@ test('collectPages presets enforce distinct traversal policy', () => {
 
     // lint: `_`-dir skipped (no c), `_`-file kept, symlink + `.`-dir followed
     assert.deepEqual(names(collectPagesLint(dir, dir, [])), ['_keep', 'a', 'b', 'h', 'link']);
+    // linkable: lint's set PLUS `_`-dir pages (c) — they are not linted but are
+    // still real files, so a wikilink to one is not broken.
+    assert.deepEqual(names(collectPagesLinkable(dir, dir, [])), [
+      '_keep',
+      'a',
+      'b',
+      'c',
+      'h',
+      'link',
+    ]);
     // graph: most permissive — `_`-dir and `.`-dir and symlink all followed
     assert.deepEqual(names(collectPagesGraph(dir, dir, [])), ['_keep', 'a', 'b', 'c', 'h', 'link']);
     // rename: symlink skipped (security boundary), no link


### PR DESCRIPTION
# English

## What changed

lint no longer reports a live file as a broken wikilink just because it sits under a `_`-prefixed directory.

A new `collectPagesLinkable` preset (lint's traversal policy minus the `_`-dir skip) feeds the link-target catalog. The lint set itself is unchanged: pages under `_`-dirs are still not linted.

## Why

The `_`-dir skip keeps draft and spec scaffolds (`pages/feedback/_drafts`, `projects/*/_specs/*`) out of the lint set so they don't have to satisfy the schema. That is intended.

But `collectPagesLint` served two jobs at once: the pages to lint, *and* the valid link destinations. So the skip leaked into the second job, and a page under such a directory became unreachable. lint flagged W4 (broken wikilink) on a file that plainly exists.

Under `--strict`, where W4 is promoted to an error, this made a green gate unreachable. A vault could clean every real violation and still exit 1 on phantom errors. Measured on a real vault:

```
✗ projects/x/roadmap.md: Broken wikilink: [[projects/x/_specs/wiki-freshness-usage-signals/spec]]
✗ projects/x/competitive-adoption_detail.md: Broken wikilink: [[... same ...]]
2 error(s), 0 warning(s)
```

Both point at a spec file that exists. The only workaround was to demote a legitimate link to a code span, i.e. damage the knowledge graph to satisfy a tool bug.

This also blocks anyone from opting a commit gate into `--strict`: the promotion is documented as forward-looking, but a vault that turned it on would be red on day one through no fault of its own.

## How

The link targets are added through `buildSlugMap`'s `extraTargets`, which deliberately derives no bare or dir-relative aliases. That restraint is load-bearing here: every spec lives at `_specs/<name>/spec.md`, so a derived bare `spec` would resolve any stray `[[spec]]` and swallow unrelated broken links. Only verbatim full slugs go in.

Scanning (do not lint this page) and referencing (you cannot link to this page) are now separate policies.

`wikilink.mjs` documents "ONE walker core plus N NAMED PRESETS, each fixed by a unit test". The header contract is updated from four to five, and the traversal-policy test covers the fifth.

## Manual verification

Ran the modified lint against a real vault, before and after:

```
# before (this repo's HEAD)
$ node scripts/lint.mjs --hypo-dir ~/vault --strict
2 error(s), 0 warning(s)

# after
$ node scripts/lint.mjs --hypo-dir ~/vault --strict
✓ No lint issues found
```

False-negative probe. Planted three links in one page: one real `_`-dir target, one `_`-dir path that does not exist, one ordinary missing page. Only the two ghosts were flagged:

```
✗ pages/__probe.md: Broken wikilink: [[projects/x/_specs/definitely-not-here/spec]]
✗ pages/__probe.md: Broken wikilink: [[pages/nonexistent-page-xyz]]
2 error(s)
```

Full suite on a clean clone: 1568 passed, 0 failed. `npm run lint`: clean.

## Migration notes

None. No config, schema, or vault layout changes. A vault that was reporting phantom W4s stops reporting them; nothing that was previously green turns red.

---

# 한국어

## 변경 내용

`_` 접두 디렉터리 아래에 있다는 이유만으로 lint가 실재하는 파일을 broken wikilink로 잡던 문제를 고쳤다.

`collectPagesLinkable` 프리셋(lint의 순회 정책에서 `_`-dir 스킵만 뺀 것)을 추가하고, 링크 대상 카탈로그를 거기서 만든다. lint 검사 대상 자체는 그대로다. `_`-dir 아래 문서는 여전히 검사받지 않는다.

## 이유

`_`-dir 스킵은 draft·spec scaffold(`pages/feedback/_drafts`, `projects/*/_specs/*`)를 lint set에서 빼서 스키마를 안 지켜도 되게 한다. 여기까지는 의도된 동작이다.

문제는 `collectPagesLint`가 두 가지 일을 겸했다는 것이다. 검사할 페이지 목록이면서, 동시에 유효한 링크 대상 목록이었다. 그래서 스킵이 두 번째 일에까지 번졌고, 그 디렉터리 아래 문서를 아무도 가리킬 수 없게 됐다. 멀쩡히 존재하는 파일에 lint가 W4(깨진 wikilink)를 붙였다.

`--strict`에서는 W4가 error로 승격되므로, 이건 green 게이트를 **도달 불가능**하게 만들었다. 볼트가 실제 위반을 전부 청소해도 유령 error 때문에 exit 1이었다. 실제 볼트에서 측정한 결과:

```
✗ projects/x/roadmap.md: Broken wikilink: [[projects/x/_specs/wiki-freshness-usage-signals/spec]]
✗ projects/x/competitive-adoption_detail.md: Broken wikilink: [[... 동일 ...]]
2 error(s), 0 warning(s)
```

둘 다 실재하는 spec 파일을 가리킨다. 회피책은 정당한 링크를 코드스팬으로 강등하는 것뿐이었다. 도구 버그에 맞추자고 지식 그래프를 훼손하는 셈이다.

커밋 게이트를 `--strict`로 켜는 것도 이것 때문에 막혀 있었다. 승격 기능은 "앞으로 쓸 것"으로 문서화돼 있지만, 그걸 켠 볼트는 자기 잘못 없이 첫날부터 red다.

## 방법

링크 대상은 `buildSlugMap`의 `extraTargets`로 넣는다. 이 경로는 의도적으로 bare나 dir-relative 별칭을 만들지 않는다. 그 절제가 여기서 핵심이다. spec은 전부 `_specs/<name>/spec.md`에 살기 때문에, bare `spec` 별칭을 만들면 아무 `[[spec]]`이나 해소되면서 무관한 깨진 링크를 삼켜버린다. full slug만 그대로 넣는다.

스캔(이 페이지를 검사하지 않는다)과 참조(이 페이지를 가리킬 수 없다)를 이제 별개 정책으로 분리했다.

`wikilink.mjs`는 "워커 코어 하나 + 이름 붙은 프리셋 N개, 각각 유닛 테스트로 고정"을 계약으로 명시한다. 헤더의 four를 five로 갱신하고, 순회 정책 테스트가 다섯 번째 프리셋을 검증한다.

## 수동 검증

수정한 lint를 실제 볼트에 돌려 전후를 비교했다.

```
# 전 (이 레포 HEAD)
$ node scripts/lint.mjs --hypo-dir ~/vault --strict
2 error(s), 0 warning(s)

# 후
$ node scripts/lint.mjs --hypo-dir ~/vault --strict
✓ No lint issues found
```

미탐 검사. 한 페이지에 링크 세 개를 심었다. 실재하는 `_`-dir 대상, 존재하지 않는 `_`-dir 경로, 평범하게 없는 페이지. 유령 둘만 정확히 잡혔다.

```
✗ pages/__probe.md: Broken wikilink: [[projects/x/_specs/definitely-not-here/spec]]
✗ pages/__probe.md: Broken wikilink: [[pages/nonexistent-page-xyz]]
2 error(s)
```

깨끗한 clone에서 전체 스위트 1568 통과, 0 실패. `npm run lint` 통과.

## 마이그레이션 노트

None. 설정·스키마·볼트 레이아웃 변경이 없다. 유령 W4를 보고하던 볼트가 그걸 멈출 뿐, 원래 green이던 것이 red로 바뀌지 않는다.

---

## Changelog

- EN: lint no longer reports pages under `_`-prefixed directories (draft and spec scaffolds) as broken wikilinks. They stay unlinted, but they are now valid link targets, so `--strict` can reach a green gate (#198).
- KO: `_` 접두 디렉터리(draft·spec scaffold) 아래 문서를 lint가 더는 깨진 wikilink로 보고하지 않는다. 검사 대상에서 빠지는 건 그대로지만 링크 대상으로는 유효해져서, `--strict`가 green 게이트에 도달할 수 있다 (#198).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
