### PR TITLE
chore(format): bring 5 pre-existing files to prettier style

### DIFF
--- a/scripts/check-bilingual.mjs
+++ b/scripts/check-bilingual.mjs
@@ -114,7 +114,9 @@ if (mode === '--changelog') {
   if (result.koreanExempt) {
     ok(`CHANGELOG.md [${version}] — pre-cutoff version, English-only (Korean exempt).`);
   } else {
-    ok(`CHANGELOG.md [${version}] — ${result.hangulCount} Hangul chars across "#### 한국어" sub-blocks.`);
+    ok(
+      `CHANGELOG.md [${version}] — ${result.hangulCount} Hangul chars across "#### 한국어" sub-blocks.`,
+    );
   }
 } else if (mode === '--tag') {
   const ref = args[1];

--- a/scripts/lib/changelog-classify.mjs
+++ b/scripts/lib/changelog-classify.mjs
@@ -48,7 +48,7 @@ export const SECTION = {
 export const SECTION_TITLE = {
   'new-features': 'New Features',
   'bug-fixes': 'Bug Fixes',
-  'chores': 'Chores',
+  chores: 'Chores',
 };
 
 // Tracker-ID -> section, in precedence order. A change carries one tracker in

--- a/scripts/lib/page-usage.mjs
+++ b/scripts/lib/page-usage.mjs
@@ -144,7 +144,9 @@ export function aggregateColdCandidates(
   const candidates = pageList
     .filter(
       (p) =>
-        hasInbound.has(p.slug) && !intersects(p.forms, recentForms) && scopeVisible(p.scope, device),
+        hasInbound.has(p.slug) &&
+        !intersects(p.forms, recentForms) &&
+        scopeVisible(p.scope, device),
     )
     .map((p) => ({ slug: p.slug, title: p.title }));
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -481,7 +481,8 @@ const GITIGNORE_REQUIRED_ENTRIES = [
   },
   {
     pattern: '*.lock',
-    comment: '# Append-lock files (transient <target>.lock; a crashed holder can leave a stale one)',
+    comment:
+      '# Append-lock files (transient <target>.lock; a crashed holder can leave a stale one)',
   },
 ];
 

--- a/tests/audit-report.test.mjs
+++ b/tests/audit-report.test.mjs
@@ -7,14 +7,7 @@ import assert from 'node:assert/strict';
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { test, suite } from './harness.mjs';
-import {
-  run,
-  runStop,
-  runWithHome,
-  withGrowthWiki,
-  withTmpDir,
-  withTmpHome,
-} from './helpers.mjs';
+import { run, runStop, runWithHome, withGrowthWiki, withTmpDir, withTmpHome } from './helpers.mjs';
 
 // ── weekly-report.mjs (Lane E) ───────────────────────────────────────────────
 

--- a/tests/capture.test.mjs
+++ b/tests/capture.test.mjs
@@ -4,7 +4,14 @@
 // build on each other; suites may not — that is what lets the runner shard.
 
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync, lstatSync } from 'node:fs';
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  symlinkSync,
+  lstatSync,
+} from 'node:fs';
 import { join, basename } from 'node:path';
 import { test, suite } from './harness.mjs';
 import {

--- a/tests/fixtures/changelog-classify.snapshot.json
+++ b/tests/fixtures/changelog-classify.snapshot.json
@@ -1,54 +1,249 @@
 {
   "_comment": "Snapshot fixture for lib/changelog-classify.mjs (changelog-pr-guide T2). Real Conventional-Commit subjects across all 11 released versions, each locked to its expected { section, basis }. Verified by hand against format.md section 3 (tracker-ID first, type second, Chores fallback). Catches reclassification regressions. NOT shipped (tests/ is absent from package.json files). Section keys: new-features | bug-fixes | chores. Basis: tracker | type | fallback. Notable locks: a `feat(...)` commit tagged IMPR-/PRAC- lands in chores (tracker beats type); a `docs(...)` commit tagged ISSUE- lands in bug-fixes. ISSUE-N appears in real 1.3.1 subjects because check-tracker-ids (which blocks ISSUE-N in commit messages) only landed in 1.3.2 (#102).",
   "entries": [
-    { "version": "1.0.0", "title": "feat: add /hypo:init command and init script (§9-2)", "section": "new-features", "basis": "type" },
-    { "version": "1.0.0", "title": "fix: apply Codex review fixes to /hypo:doctor (§9-3)", "section": "bug-fixes", "basis": "type" },
+    {
+      "version": "1.0.0",
+      "title": "feat: add /hypo:init command and init script (§9-2)",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.0.0",
+      "title": "fix: apply Codex review fixes to /hypo:doctor (§9-3)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
 
-    { "version": "1.0.1", "title": "feat(init): install slash commands to ~/.claude/commands/hypo with SHA tracking", "section": "new-features", "basis": "type" },
-    { "version": "1.0.1", "title": "fix(uninstall): preserve user-modified slash commands with SHA gate", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.0.1", "title": "docs(readme): document plugin + npm install paths, env precedence, ingest behaviour", "section": "chores", "basis": "type" },
+    {
+      "version": "1.0.1",
+      "title": "feat(init): install slash commands to ~/.claude/commands/hypo with SHA tracking",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.0.1",
+      "title": "fix(uninstall): preserve user-modified slash commands with SHA gate",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.0.1",
+      "title": "docs(readme): document plugin + npm install paths, env precedence, ingest behaviour",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.1.0", "title": "feat(cli): route `hypomnema <upgrade|doctor|uninstall>` to the right script", "section": "new-features", "basis": "type" },
-    { "version": "1.1.0", "title": "fix(privacy): auto-commit and auto-stage honor .hypoignore", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.1.0", "title": "chore(github): add issue, PR, and security policy templates", "section": "chores", "basis": "type" },
+    {
+      "version": "1.1.0",
+      "title": "feat(cli): route `hypomnema <upgrade|doctor|uninstall>` to the right script",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.1.0",
+      "title": "fix(privacy): auto-commit and auto-stage honor .hypoignore",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.1.0",
+      "title": "chore(github): add issue, PR, and security policy templates",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.2.0", "title": "feat(schema): SCHEMA 2.0 bump + v1→v2 migration report guidance (ADR 0034) (#60)", "section": "new-features", "basis": "type" },
-    { "version": "1.2.0", "title": "fix(feedback-sync): MEMORY projection cross-project pollution (ADR 0031 §4) (#59)", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.2.0", "title": "chore: strip rot-prone references from code comments (Phase 1) (#58)", "section": "chores", "basis": "type" },
-    { "version": "1.2.0", "title": "chore(release): v1.2.0 (#61)", "section": "chores", "basis": "type" },
+    {
+      "version": "1.2.0",
+      "title": "feat(schema): SCHEMA 2.0 bump + v1→v2 migration report guidance (ADR 0034) (#60)",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.2.0",
+      "title": "fix(feedback-sync): MEMORY projection cross-project pollution (ADR 0031 §4) (#59)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.2.0",
+      "title": "chore: strip rot-prone references from code comments (Phase 1) (#58)",
+      "section": "chores",
+      "basis": "type"
+    },
+    {
+      "version": "1.2.0",
+      "title": "chore(release): v1.2.0 (#61)",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.2.1", "title": "feat(skills): add /qa-features and /qa-before-ship dev workflows (#67)", "section": "new-features", "basis": "type" },
-    { "version": "1.2.1", "title": "fix(resume): strip HTML comments + skip _template fallback (placeholder leak) (#68)", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.2.1", "title": "chore(release): v1.2.1 (#69)", "section": "chores", "basis": "type" },
+    {
+      "version": "1.2.1",
+      "title": "feat(skills): add /qa-features and /qa-before-ship dev workflows (#67)",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.2.1",
+      "title": "fix(resume): strip HTML comments + skip _template fallback (placeholder leak) (#68)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.2.1",
+      "title": "chore(release): v1.2.1 (#69)",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.3.0", "title": "feat(release): enforce bilingual CHANGELOG + annotated tag at publish-time (#70)", "section": "new-features", "basis": "type" },
-    { "version": "1.3.0", "title": "refactor(feedback-sync): extract per-mode source loaders + byte-identical golden tests (#77)", "section": "chores", "basis": "type" },
-    { "version": "1.3.0", "title": "chore(ci): bump actions/checkout + actions/setup-node to v5 (#73)", "section": "chores", "basis": "type" },
-    { "version": "1.3.0", "title": "fix(close-gate): scope session-close lint to touched files + coherent marker gate (#80)", "section": "bug-fixes", "basis": "type" },
+    {
+      "version": "1.3.0",
+      "title": "feat(release): enforce bilingual CHANGELOG + annotated tag at publish-time (#70)",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.0",
+      "title": "refactor(feedback-sync): extract per-mode source loaders + byte-identical golden tests (#77)",
+      "section": "chores",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.0",
+      "title": "chore(ci): bump actions/checkout + actions/setup-node to v5 (#73)",
+      "section": "chores",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.0",
+      "title": "fix(close-gate): scope session-close lint to touched files + coherent marker gate (#80)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
 
-    { "version": "1.3.1", "title": "fix(upgrade): guard manual/npm --apply from double-registering core when plugin is enabled (ISSUE-8) (#98)", "section": "bug-fixes", "basis": "tracker" },
-    { "version": "1.3.1", "title": "docs(resume): correct --hypo-dir resolution-order comment (ISSUE-2) (#93)", "section": "bug-fixes", "basis": "tracker" },
-    { "version": "1.3.1", "title": "ci(release): add GitHub Release step + idempotent publish guard (#92)", "section": "chores", "basis": "type" },
+    {
+      "version": "1.3.1",
+      "title": "fix(upgrade): guard manual/npm --apply from double-registering core when plugin is enabled (ISSUE-8) (#98)",
+      "section": "bug-fixes",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.3.1",
+      "title": "docs(resume): correct --hypo-dir resolution-order comment (ISSUE-2) (#93)",
+      "section": "bug-fixes",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.3.1",
+      "title": "ci(release): add GitHub Release step + idempotent publish guard (#92)",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.3.2", "title": "feat(session-log): shard session logs by day (YYYY-MM-DD.md) (#118)", "section": "new-features", "basis": "type" },
-    { "version": "1.3.2", "title": "fix(lint): resolve vault-convention wikilinks instead of false-flagging them (#121)", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.3.2", "title": "feat(gate): block wiki-internal tracker IDs in OSS-public artifacts (#102)", "section": "new-features", "basis": "type" },
-    { "version": "1.3.2", "title": "chore(docs): scrub wiki-ADR pointers from user-facing docs + scope-gated guard (#111)", "section": "chores", "basis": "type" },
+    {
+      "version": "1.3.2",
+      "title": "feat(session-log): shard session logs by day (YYYY-MM-DD.md) (#118)",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.2",
+      "title": "fix(lint): resolve vault-convention wikilinks instead of false-flagging them (#121)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.2",
+      "title": "feat(gate): block wiki-internal tracker IDs in OSS-public artifacts (#102)",
+      "section": "new-features",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.2",
+      "title": "chore(docs): scrub wiki-ADR pointers from user-facing docs + scope-gated guard (#111)",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.3.3", "title": "fix(close): user-close hard gate on session-close marker writers (ADR 0055) (#129)", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.3.3", "title": "fix(close-gate): whitelist close-activity to authoritative artifacts (ADR 0057) (#131)", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.3.3", "title": "chore(commands): make hypo:* descriptions trigger-rich (#127)", "section": "chores", "basis": "type" },
+    {
+      "version": "1.3.3",
+      "title": "fix(close): user-close hard gate on session-close marker writers (ADR 0055) (#129)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.3",
+      "title": "fix(close-gate): whitelist close-activity to authoritative artifacts (ADR 0057) (#131)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.3",
+      "title": "chore(commands): make hypo:* descriptions trigger-rich (#127)",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.3.4", "title": "fix(catalog): dedup template injection + scan-exclude generated root artifacts (#133)", "section": "bug-fixes", "basis": "type" },
-    { "version": "1.3.4", "title": "chore(release): v1.3.4 (#134)", "section": "chores", "basis": "type" },
+    {
+      "version": "1.3.4",
+      "title": "fix(catalog): dedup template injection + scan-exclude generated root artifacts (#133)",
+      "section": "bug-fixes",
+      "basis": "type"
+    },
+    {
+      "version": "1.3.4",
+      "title": "chore(release): v1.3.4 (#134)",
+      "section": "chores",
+      "basis": "type"
+    },
 
-    { "version": "1.4.0", "title": "feat(feedback): add optional failure_type enum to feedback frontmatter (FEAT-1) (#141)", "section": "new-features", "basis": "tracker" },
-    { "version": "1.4.0", "title": "feat(sync): abort merge conflicts to never leave a half-merged tree (FEAT-17) (#135)", "section": "new-features", "basis": "tracker" },
-    { "version": "1.4.0", "title": "feat(lint): reject invalid-YAML frontmatter + reconcile types with SCHEMA (IMPR-3) (#140)", "section": "chores", "basis": "tracker" },
-    { "version": "1.4.0", "title": "feat(release): README-version floor gate + maintainer release checklist (IMPR-14) (#138)", "section": "chores", "basis": "tracker" },
-    { "version": "1.4.0", "title": "feat(release): assert version consistency + plugin-path smoke (IMPR-12) (#137)", "section": "chores", "basis": "tracker" },
-    { "version": "1.4.0", "title": "feat(audit): stamp session_id/device on session-log shard + index.jsonl (PRAC-17) (#136)", "section": "chores", "basis": "tracker" },
-    { "version": "1.4.0", "title": "refactor(lib): extract shared wikilink resolver to lib/wikilink.mjs (IMPR-13) (#139)", "section": "chores", "basis": "tracker" },
-    { "version": "1.4.0", "title": "chore(release): v1.4.0 (#142)", "section": "chores", "basis": "type" }
+    {
+      "version": "1.4.0",
+      "title": "feat(feedback): add optional failure_type enum to feedback frontmatter (FEAT-1) (#141)",
+      "section": "new-features",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.4.0",
+      "title": "feat(sync): abort merge conflicts to never leave a half-merged tree (FEAT-17) (#135)",
+      "section": "new-features",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.4.0",
+      "title": "feat(lint): reject invalid-YAML frontmatter + reconcile types with SCHEMA (IMPR-3) (#140)",
+      "section": "chores",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.4.0",
+      "title": "feat(release): README-version floor gate + maintainer release checklist (IMPR-14) (#138)",
+      "section": "chores",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.4.0",
+      "title": "feat(release): assert version consistency + plugin-path smoke (IMPR-12) (#137)",
+      "section": "chores",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.4.0",
+      "title": "feat(audit): stamp session_id/device on session-log shard + index.jsonl (PRAC-17) (#136)",
+      "section": "chores",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.4.0",
+      "title": "refactor(lib): extract shared wikilink resolver to lib/wikilink.mjs (IMPR-13) (#139)",
+      "section": "chores",
+      "basis": "tracker"
+    },
+    {
+      "version": "1.4.0",
+      "title": "chore(release): v1.4.0 (#142)",
+      "section": "chores",
+      "basis": "type"
+    }
   ]
 }


### PR DESCRIPTION
# English

## What changed

Reformats 7 files that were already on `main` in a pre-Prettier style, bringing
them to the repository's Prettier style. This is `prettier --write` output only:
`scripts/check-bilingual.mjs`, `scripts/lib/changelog-classify.mjs`,
`scripts/lib/page-usage.mjs`, `scripts/upgrade.mjs`,
`tests/fixtures/changelog-classify.snapshot.json`, `tests/audit-report.test.mjs`,
and `tests/capture.test.mjs`. No logic changes.

## Why

`npm run format:check` has been red on `main` for these 7 files, so every
unrelated PR inherits a failing format gate as CI noise. This restores a clean
`format:check` so the gate means what it says again.

## How

Ran the project formatter and staged only the 7 files it touched. The changes
are line wraps (long import lists), redundant-quote removal on an object key,
and JSON indentation in the snapshot fixture. The fixture is parsed by value in
the changelog-classify tests, so reformatting it does not change any assertion.

## Manual verification

- `npm run format:check` gives "All matched files use Prettier code style!"
- `npm test` gives 1568 passed, 0 failed (no new failures vs. `main`)

## Migration notes

None.

---

# 한국어

## 변경 내용

`main`에 이미 있던 Prettier 이전 스타일 파일 7개를 저장소 Prettier 스타일로
맞춘다. `prettier --write` 출력 그대로다: `scripts/check-bilingual.mjs`,
`scripts/lib/changelog-classify.mjs`, `scripts/lib/page-usage.mjs`,
`scripts/upgrade.mjs`, `tests/fixtures/changelog-classify.snapshot.json`,
`tests/audit-report.test.mjs`, `tests/capture.test.mjs`. 로직 변경은 없다.

## 이유

이 7개 파일 때문에 `main`에서 `npm run format:check`가 계속 빨간 상태였고,
그래서 무관한 PR마다 실패하는 format 게이트를 CI 노이즈로 물려받았다. 게이트가
다시 제 뜻대로 동작하도록 clean 상태로 되돌린다.

## 방법

프로젝트 포매터를 돌리고 바뀐 7개 파일만 스테이징했다. 변경은 줄바꿈(긴 import
목록), 객체 키의 불필요한 따옴표 제거, snapshot fixture의 JSON 들여쓰기다. 이 fixture는
changelog-classify 테스트에서 값으로 파싱되므로, 재포매팅이 단언을 바꾸지 않는다.

## 수동 검증

- `npm run format:check` 결과 "All matched files use Prettier code style!"
- `npm test` 결과 1568 passed, 0 failed (`main` 대비 새 실패 0)

## 마이그레이션 노트

None.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [x] `npm test` passes locally
- [ ] `npm run lint` passes locally. Note: lint targets the wiki vault, not repo code; its 2 pre-existing errors live in `projects/guardia/**` vault pages and are unrelated to this format-only change
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (no user-facing change)
- [x] Filled the `## Changelog` block above (None: internal-only, no user-visible effect)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
