### PR TITLE
docs(contributing): fix the ADR/decisions carve-out in tracker-id gating prose

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -244,7 +244,7 @@ After both blocks, language-neutral:
 
 - **PR title**: Conventional Commits plus a scope, e.g. `feat(feedback): add failure_type enum`. The type drives the CHANGELOG section (see the classification table below).
 - **Merge commit**: the squash-merge subject carries the PR number (`#123`). That is where `#N` comes from, not the PR title. The two conventions stay separate.
-- Internal tracker ids (`FEAT-`, `IMPR-`, `ISSUE-`, `PRAC-`) may appear in your local notes and in `tests/` / `qa-runs/` (where they aid test-to-issue traceability and never reach an installed user), but not in shipped code or workflow comments, and never on the published changelog and release surface: not in the CHANGELOG body, not in the PR `## Changelog` block, not in a tag annotation, not in a GitHub Release. The only identifier that ships in those is the PR number `#N`. `check-tracker-ids` gates every surface (`--all`/`--staged` for files, `--commit-msg` for messages, `--tag` for the tag body); the migration keeps the CHANGELOG body clean.
+- Internal tracker ids (`FEAT-`, `IMPR-`, `ISSUE-`, `PRAC-`, `fix #N`) may appear in your local notes and in `tests/` / `qa-runs/` (where they aid test-to-issue traceability and never reach an installed user), but not in shipped code or workflow comments, and never on the published changelog and release surface: not in the CHANGELOG body, not in the PR `## Changelog` block, not in a tag annotation, not in a GitHub Release. The only tracker identifier that ships in those is the PR number `#N`; the lone exception is the ADR carve-out noted below. `check-tracker-ids` gates the file, message, and tag surfaces (`--all`/`--staged` for files, `--commit-msg` for messages, `--tag` for the tag body), and `check-pr-surface` gates the PR title and body; the migration keeps the CHANGELOG body clean. `ADR NNNN` / `decisions/NNNN` are exempt on the changelog surfaces (the CHANGELOG body, the tag body, and the PR `## Changelog` block), where a release line legitimately cites the decision behind it.
 
 ### The `## Changelog` block
 
@@ -386,7 +386,9 @@ git commit -m "chore: release v<version>"
 #    Annotation body shape: English summary, then "---" on its own line,
 #    then a Korean summary block. The GitHub Release republishes this body
 #    verbatim, so keep it on the same public surface as the CHANGELOG: PR
-#    numbers (#N) only, no internal tracker ids (check-tracker-ids --tag gates it).
+#    numbers (#N) only, no `FEAT-`/`IMPR-`/`ISSUE-`/`PRAC-`/`fix #N` tracker
+#    ids (check-tracker-ids --tag gates it). Like the CHANGELOG, the tag body MAY cite
+#    `ADR NNNN` / `decisions/NNNN` for the decision behind a release.
 git tag -a v<version> -m "$(cat <<'EOF'
 Hypomnema v<version>: <one-line English summary>
 


### PR DESCRIPTION
# English

## What changed

Corrects the tracker-id gating prose in `docs/CONTRIBUTING.md` so it matches the
gate code. Three fixes: (1) `ADR NNNN` / `decisions/NNNN` are allowed on the
changelog surfaces (CHANGELOG body, tag body, PR `## Changelog` block), not
banned outright; (2) `fix #N` is part of the always-blocked tracker-id set and is
now listed; (3) `check-pr-surface` gates the PR title and body, alongside
`check-tracker-ids` for files, messages, and tag bodies.

## Why

The prose overstated the rule. It described a blanket ban on `ADR`/`decisions`
across every surface, but the code intentionally exempts them on the changelog
surfaces so a release line can cite the decision behind it, exactly the way
CHANGELOG history does. It also omitted `fix #N` from the blocked set and named
`check-tracker-ids` as the only gate. A contributor reading it would either strip
a legitimate ADR citation from a tag body or trust a gate list that was
incomplete.

## How

Reconciled the prose against the code: `ADR_EXEMPT_FILES` in
`scripts/check-tracker-ids.mjs` (the CHANGELOG file carve-out) and
`maskChangelogSection` in `scripts/lib/check-pr-surface.mjs` (the PR
`## Changelog` carve-out). Reviewed across two codex passes.

## Manual verification

- `npm run check:tracker-ids` exits 0 (the `ADR NNNN` / `fix #N` literals in the
  prose do not trip the gate).
- `npx prettier --check docs/CONTRIBUTING.md` is clean.
- Docs-only change; no test surface.

## Migration notes

None.

---

# 한국어

## 변경 내용

`docs/CONTRIBUTING.md`의 tracker-id 게이팅 서술을 게이트 코드에 맞게 정정한다. 세 가지다.
(1) `ADR NNNN` / `decisions/NNNN`은 전면 금지가 아니라 changelog surface(CHANGELOG 본문,
tag body, PR `## Changelog` 블록)에서 허용된다. (2) `fix #N`도 항상 차단되는 tracker-id
집합의 일부라 목록에 넣었다. (3) `check-pr-surface`가 PR title·body를 게이팅한다는 점을
`check-tracker-ids`(파일·메시지·tag body)와 함께 명시했다.

## 이유

서술이 규칙을 과장했다. `ADR`/`decisions`를 모든 surface에서 전면 금지라고 썼지만, 코드는
릴리스 라인이 그 결정을 인용할 수 있도록 changelog surface에서 의도적으로 예외를 둔다(CHANGELOG
히스토리가 그러하듯). `fix #N`도 차단 집합에서 빠졌고, `check-tracker-ids`를 유일한 게이트로
적었다. 이 문서를 읽은 기여자는 tag body에서 정당한 ADR 인용을 지우거나, 불완전한 게이트 목록을
믿게 된다.

## 방법

코드와 대조해 정정했다: `scripts/check-tracker-ids.mjs`의 `ADR_EXEMPT_FILES`(CHANGELOG 파일
예외)와 `scripts/lib/check-pr-surface.mjs`의 `maskChangelogSection`(PR `## Changelog` 예외).
codex 2라운드 검토를 거쳤다.

## 수동 검증

- `npm run check:tracker-ids` exit 0 (서술의 `ADR NNNN` / `fix #N` 리터럴이 게이트에 안 걸림).
- `npx prettier --check docs/CONTRIBUTING.md` clean.
- 문서 전용 변경, test surface 없음.

## 마이그레이션 노트

None.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [ ] `npm test` passes locally. Note: docs-only change with no test surface; not run
- [x] `npm run check:tracker-ids` passes (the relevant gate for this change)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (this IS the doc fix; no behavior change)
- [x] Filled the `## Changelog` block above (None: internal contributor doc, no user-visible effect)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
