### PR TITLE
test: open a suite for each of the 17 unsuited banner regions

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -418,7 +418,7 @@ Everything uses Node built-ins only. Fixtures are built in code with scoped help
 
 **Selection is by suite, never by test.** `suite(label)` opens a selection unit, and
 `--shard=i/n` keeps a whole suite in one process, in order. So tests inside one suite may build
-on each other, and suites may not build on each other. `node tests/parallel.mjs --shards=220`
+on each other, and suites may not build on each other. `node tests/parallel.mjs --shards=237`
 runs every suite alone in a fresh process and is the proof of that invariant. Run it whenever
 you add or split a suite.
 
@@ -429,7 +429,7 @@ you add or split a suite.
 | `node tests/runner.mjs --grep=<regex>` | just the matching tests, in seconds |
 | `node tests/runner.mjs --file=lint` | one area file |
 | `node tests/parallel.mjs --by-file` | one process per area file |
-| `node tests/parallel.mjs --shards=220` | every suite alone: the order-independence proof |
+| `node tests/parallel.mjs --shards=237` | every suite alone: the order-independence proof |
 
 Round-robin is the default rather than one-process-per-file, and the reason is measured, not
 assumed: on a 2026 laptop the whole suite runs in about 70s round-robined and about 100s

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -663,6 +663,7 @@ test('guard: does NOT derive when the session-log heading is the gap (T5 AC)', (
 });
 
 // ── B-1: closeCandidateSlugs disk-gates log.md slugs (ghost-slug fix) ──────────
+suite('B-1: closeCandidateSlugs disk-gates log.md slugs');
 test('B-1: a log.md slug with no projects/<slug>/ dir is not a close candidate', () => {
   withTmpDir((dir) => {
     const today = todayLocal();
@@ -1068,6 +1069,7 @@ test('replay-auto-minimal-crystallize-on-incomplete-close: HYPO_SKIP_GATE=1 → 
 // A read-only review/debug session (≥5 Read/Grep/Glob/Bash, no mutation) is now
 // "substantial". The block still requires a wrap-up signal; pure-volume alone
 // must NOT block (close-intent gate unchanged).
+suite('6a: read-only investigation sessions reach the close-intent gate');
 function readonlyInvestigationLines(n) {
   const tools = ['Read', 'Grep', 'Glob', 'Bash'];
   return Array.from({ length: n }, (_, i) => ({

--- a/tests/close-hooks-gate.test.mjs
+++ b/tests/close-hooks-gate.test.mjs
@@ -326,6 +326,7 @@ test('output is always valid JSON regardless of prompt', () => {
 
 // ── replay-compact-guard-detects-slash-clear (ADR 0022 Layer 2) ──
 // @fix #25: replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE
+suite('replay-compact-guard-detects-slash-clear (ADR 0022 Layer 2)');
 
 test('replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE', () => {
   const r = runHook('hypo-compact-guard.mjs', { prompt: '/clear' });
@@ -774,6 +775,7 @@ test('HYPO_SKIP_GATE=1 bypasses an incomplete session close', () => {
 // @fix #26: replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (negative control)
 // Capacity bypass (wiki-context-critical.json ≥90%) was removed. Spec §7.5:
 // the only bypass paths are HYPO_SKIP_GATE env / transcript user-role message.
+suite('replay-personal-check-bypass-order (ADR 0022 amendment 2026-05-13)');
 
 test('replay-personal-check-bypass-order: wiki-context-critical.json does NOT bypass (negative control)', () => {
   withWiki(

--- a/tests/crystallize-apply.test.mjs
+++ b/tests/crystallize-apply.test.mjs
@@ -213,6 +213,7 @@ test('ISSUE-42 F1: a colon-form log entry is the sole today signal → dangling 
 });
 
 // ── fix #39: probe early-exit (option D) ─────────────────────────────────────
+suite('fix #39: probe early-exit (option D)');
 
 test('probe (#39): no payload + gate ok → exit 0 with alreadyComplete', () => {
   // buildCleanWikiTree() leaves the wiki in a passing-gate state for `today`.
@@ -325,6 +326,7 @@ test('payload via stdin (`--payload=-`) works the same as a file', () => {
 });
 
 // ── fix #40: helper lint preflight + post-apply check ───────────────────────
+suite('fix #40: helper lint preflight + post-apply check');
 
 test('preflight (Bug B): pre-existing blocker in a NON-payload file → does NOT abort, apply proceeds (scoped)', () => {
   // Bug B fix: lint debt OUTSIDE the files this close writes (here a malformed

--- a/tests/feedback.test.mjs
+++ b/tests/feedback.test.mjs
@@ -586,6 +586,7 @@ test('feedback-sync --check --json: a target file that is simply MISSING stays t
 });
 
 // ── feedback-sync hardening regressions ──────────────────────────────────────
+suite('feedback-sync hardening regressions');
 
 test('feedback-sync-crlf-block-idempotent: CRLF managed block is recognized, no duplicate region', () => {
   withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ claudeHome, runFb }) => {
@@ -691,6 +692,7 @@ test('feedback-sync-stale-side-file-removed: demoting a page deletes its feedbac
 });
 
 // ── second-pass review fixes (HIGH cap / HIGH provenance / MEDIUM container / LOW) ──
+suite('second-pass review fixes (HIGH cap / HIGH provenance / MEDIUM container / LOW)');
 
 test('feedback-sync-stale-skips-non-sync-file: hand-written feedback_*.md is NOT deleted', () => {
   withFeedbackEnv({ 'rule-a': FB_GLOBAL_L1 }, ({ memDir, runFb }) => {
@@ -2504,6 +2506,7 @@ test('feedback.mjs create: invalid scope vocabulary (project:.) → exit 1 (Trac
 });
 
 // ── FEAT-1: --failure-type create + append rules ────────────────────────────
+suite('FEAT-1: --failure-type create + append rules');
 const FB_BASE_ARGS = (dir, topic) => [
   `--topic=${topic}`,
   '--entry=항상 X를 한다.',

--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -294,6 +294,7 @@ test('feedback invalid scope → error', () => {
 // v1.2 regex `^project:[a-z0-9][a-z0-9-]*$` rejected them, forcing a
 // `--project-id=<slug>` override; v1.3 relaxes the shared FEEDBACK_SCOPE_RE to
 // `^(global|project:[A-Za-z0-9_-]+)$`. These cover the lint stage of the
+suite('Track D (OQ-34): scope regex accepts cwd-derived project-ids');
 // create → lint → projection consistency chain plus the hardening edges from
 // the codex design review (`.` excluded → no `project:.`/`project:..`; spaces
 // still rejected = documented limit).
@@ -371,6 +372,7 @@ test('feedback invalid tier → error', () => {
 });
 
 // ── FEAT-1: optional failure_type enum ──────────────────────────────────────
+suite('FEAT-1: optional failure_type enum');
 test('feedback failure_type valid value → no error', () => {
   const { r } = lintWithSchema(
     'pages/feedback/x.md',
@@ -1279,6 +1281,7 @@ test('genuinely missing links are still W4 broken (no false negative)', () => {
 // also drop them from the link-target catalog, so a link to a file that plainly
 // exists was reported broken — and under --strict that error made a green gate
 // unreachable. Scanning and referencing are now separate.
+suite('`_`-dir pages: not linted, but still linkable (ISSUE-57)');
 
 test('a page under a `_`-dir is a valid link target (not a false broken link)', () => {
   const { broken } = lintWiki({

--- a/tests/parallel.mjs
+++ b/tests/parallel.mjs
@@ -18,7 +18,7 @@
  *                by an order of magnitude in size, so wall clock is whatever the
  *                biggest file takes and the small processes idle.
  *
- *   --shards=220 Every suite alone in a fresh process. This is the proof that no
+ *   --shards=237 Every suite alone in a fresh process. This is the proof that no
  *                suite depends on another having run first — the thing that
  *                licenses sharding at all. Run it when you add or split a suite.
  *

--- a/tests/pr-pack-surface.test.mjs
+++ b/tests/pr-pack-surface.test.mjs
@@ -476,6 +476,7 @@ test('PR surface: a missing `## Checklist` section is caught', () => {
 
 // ── BLOCKER 2: template compliance was a heading-existence check, not a
 // structure check ─────────────────────────────────────────────────────────
+suite('BLOCKER 2: template compliance is a structure check, not heading-existence');
 
 test('PR surface: headings that exist ONLY inside a code fence are rejected (not real headings)', () => {
   // A body that wraps its entire structure in a fenced code block used to pass:
@@ -668,6 +669,7 @@ test('CLI --commit-msg: a clean message still passes (attribution scan adds no f
 
 // ── --commit-range: the CI backstop (BLOCKER: commit-msg hook has no CI
 // counterpart, so --no-verify + a clean PR body let a trailer reach `main`) ──
+suite('--commit-range: the CI backstop');
 function commitIn(dir, msg) {
   const opts = { cwd: dir, encoding: 'utf-8' };
   spawnSync('git', ['add', '-A'], opts);
@@ -762,6 +764,7 @@ test('CLI --commit-range: missing range argument exits with usage (2)', () => {
 // BRANCH's commits. The message that actually lands on `main` is composed in the
 // merge dialog, never existed on the branch, and was in NO range any job scanned.
 // A trailer typed there ships to a public `main` with every check green.
+suite('BLOCKER: squash-merge trailer escapes the branch-range scan (--push-range)');
 test('CLI --push-range: an attribution trailer in the pushed (squash) commit is caught', () => {
   withTmpDir((dir) => {
     gitRepo(dir);

--- a/tests/proposal-base.test.mjs
+++ b/tests/proposal-base.test.mjs
@@ -1828,6 +1828,7 @@ test('payload schema: invalid date format → exit 1', () => {
 });
 
 // ── B-1: payload.log optional + apply auto-derives the root log.md entry ──────
+suite('B-1: payload.log optional + apply auto-derives the root log.md entry');
 test('B-1: apply without payload.log auto-derives the canonical log.md entry (exit 0)', () => {
   withWiki(
     (dir) => {

--- a/tests/upgrade.test.mjs
+++ b/tests/upgrade.test.mjs
@@ -176,6 +176,7 @@ test('--apply .hypoignore migration appends .cache/ and is idempotent', () => {
 });
 
 // ── B5: .gitignore migration mirrors .cache/ (page-usage privacy) ────────────
+suite('B5: .gitignore migration mirrors .cache/ (page-usage privacy)');
 test('--apply .gitignore migration appends .cache/, git-ignores the log, idempotent', () => {
   withTmpHome((home) => {
     withTmpDir((dir) => {


### PR DESCRIPTION
# English

## What changed

Adds a `suite()` to each of the 17 "banner regions" in `tests/`. A banner region is a
`// ── ` header followed by `test()`s that had no `suite()` before the next one. The suite
total goes from 220 to 237. `tests/parallel.mjs`, `docs/ARCHITECTURE.md`, and the local
CLAUDE.md have their `--shards=220` references bumped to 237.

## Why

Those 118 tests were silently inheriting the previous `suite()`, so they shared its shard
and its output heading instead of being their own selection unit. That means `--shard=i/n`
could not isolate them, and the run output filed them under an unrelated heading. Making
each a real suite gives it an independent shard slot and heading.

## How

One `suite('<label>')` line after each banner, before its first `test()`. The harness's
`suite()` is a marker call that opens the next selection unit, not a block wrapper. No test
bodies changed; tests are only reclassified, so the count stays at 1568.

## Manual verification

- `node tests/parallel.mjs --shards=237`: all 237 suites run in fresh processes with no
  order-dependency failure (1568 passed, 0 failed). This proves that splitting these regions
  did not surface a hidden cross-suite dependency.
- `npm test`: 1568 passed, 0 failed.

## Migration notes

None.

---

# 한국어

## 변경 내용

`tests/`의 "배너 구간" 17개 각각에 `suite()`를 추가한다. 배너 구간이란 `// ── ` 헤더 뒤에
`test()`가 나오지만 다음 `suite()` 전까지 새 선택 단위가 없던 곳이다. suite 총수가 220에서
237이 된다. `tests/parallel.mjs`, `docs/ARCHITECTURE.md`, 로컬 CLAUDE.md의 `--shards=220`
참조도 237로 갱신한다.

## 이유

이 118개 test가 직전 `suite()`를 조용히 상속해, 그 suite와 같은 shard, 같은 출력 heading에
묶여 있었다(자기 선택 단위가 아니었다). 그래서 `--shard=i/n`이 이들을 분리하지 못했고, 실행
출력도 무관한 heading 아래에 찍혔다. 각각을 진짜 suite로 만들면 독립 shard 슬롯과 heading을
갖는다.

## 방법

각 배너 뒤, 첫 `test()` 앞에 `suite('<label>')` 한 줄을 넣는다. 이 하네스의 `suite()`는 블록
래퍼가 아니라 다음 선택 단위를 여는 marker 호출이다. test 본문은 바뀌지 않았고 재분류만 했으므로
개수는 1568 그대로다.

## 수동 검증

- `node tests/parallel.mjs --shards=237`: 237개 suite가 fresh process로 실행되며 order 의존성
  실패 0(1568 passed, 0 failed). 이 구간들을 쪼개도 숨은 suite 간 의존성이 없음을 증명한다.
- `npm test`: 1568 passed, 0 failed.

## 마이그레이션 노트

None.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [x] `npm test` passes locally (1568 passed, 0 failed)
- [x] `npm run lint`: n/a here (lint targets the wiki vault, not repo test files)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (ARCHITECTURE shard count updated; no user-facing behavior change)
- [x] Filled the `## Changelog` block above (None: test-only reclassification)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
