### PR TITLE
fix(close): bind session-close payload to its session

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -37,6 +37,7 @@ Payload shape (`project` + 4 content fields required; `log` optional/derived; `o
 ```json
 {
   "project": "<project-name>",
+  "sessionId": "<current session id — the SAME value you pass to --session-id>",
   "date": "YYYY-MM-DD",
   "sessionState": { "content": "<full body of projects/<name>/session-state.md>" },
   "projectHot": { "content": "<full body of projects/<name>/hot.md>" },
@@ -52,6 +53,7 @@ Payload shape (`project` + 4 content fields required; `log` optional/derived; `o
 Field rules:
 
 - `project`: **required**. Slug of the project being closed (matches a `projects/<slug>/` directory). Must be a single path segment, charset `A-Za-z0-9._-`, with at least one alphanumeric and not a dot-only name (`.`, `..`, `...`). Apply never infers the target from recency; a same-date pointer-table tie could otherwise write the close into the wrong project (B-3). A missing, malformed, or non-existent value fails the apply before any write.
+- `sessionId`: recommended. The current session id, the same value you pass to `--session-id`. When present, apply refuses (`stage='session-id-mismatch'`, exit 1, nothing written) if it does not equal `--session-id`, so a payload file another session overwrote cannot be applied under this session's marker. It is a string self-check, not the transcript resolver; authority still comes from `--session-id`. Optional for backward-compat: omitting it or setting it to `null` skips the check (fail-open), but an empty string `""` counts as a mismatch and is refused. Omit only if you genuinely cannot determine the id.
 - `date` — optional. Defaults to today (local). Must be `YYYY-MM-DD` if supplied.
 - `openQuestions` — optional. Include only when `pages/open-questions.md` exists and changed this session.
 - `log`: optional. Omit it by default (apply derives the canonical `## [date] session | <project>` line from your `sessionLog` heading). Supply it only for a custom log.md line, which must still be a canonical `session | <project>` heading, or the apply fails at `stage='pre-apply-verification'`.
@@ -61,7 +63,7 @@ Notes:
 
 - `sessionState` / `projectHot` / `rootHot` / `openQuestions` are **overwrite** (full-file content). `sessionLog` / `log` are **append** (entry-level idempotency — exact-entry dedup, safe to re-run).
 - Frontmatter `updated:` is NOT auto-fixed. If your payload's `updated:` is stale, the post-apply verification gate will fail with `stage='post-apply-verification'` and you must fix the payload and retry.
-- Write the payload to a temp path, e.g. `/tmp/hypo-session-close-<YYYY-MM-DD>.json`.
+- Write the payload to a **session-scoped** temp path, e.g. `/tmp/hypo-session-close-<session-id>.json`, using the same `<session-id>` you pass below. A date-based path (`<YYYY-MM-DD>`) collides when two sessions close on the same day: the second write silently overwrites the first, and the wrong payload gets applied. The `sessionId` field above is the second line of defense if a path is ever reused anyway.
 
 Content guidance for each slot:
 
@@ -81,7 +83,7 @@ Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that p
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs \
   --apply-session-close \
-  --payload=/tmp/hypo-session-close-<YYYY-MM-DD>.json \
+  --payload=/tmp/hypo-session-close-<session-id>.json \
   --session-id=<current-session-id> \
   --hypo-dir="<path>" \
   --json
@@ -144,6 +146,7 @@ The result JSON includes a `stage` field when `ok: false`. Branch on it:
 
 | `stage` | What broke | How to recover |
 |---|---|---|
+| `session-id-mismatch` | The payload's `sessionId` is a non-empty string that does not equal `--session-id`, so this file was authored for a different session (a reused or overwritten temp path). Caught **before** any write. Absent or `null` `sessionId` fails open (no check); an empty string counts as a mismatch. | Rebuild the payload for THIS session and write it to a session-scoped path (`/tmp/hypo-session-close-<session-id>.json`), then re-run. No payload bytes were written. |
 | `pre-apply-verification` | A payload heading does not match the freshness contract the close gate enforces: `sessionLog.entry` has no dated `## [YYYY-MM-DD] …` heading, or an explicit `log.entry` is not the canonical `## [date] session | <project>` line. Caught **before** any write. | Fix the heading in the payload (the session-log entry needs a bracketed dated heading; the log line needs `session \| <project>` after the date, colon or space delimiter), then re-run. No payload bytes were written. |
 | `preflight-lint` | A payload file (append target: session-log / log.md) has a pre-existing blocking lint error. | Fix the lint error in that file, then re-run. No payload bytes were written. (Debt outside the payload files is a non-blocking notice, not this stage.) |
 | `post-apply-verification` | A mandatory file's `updated:` frontmatter is stale (≠ today) after apply. | Edit the payload's stale `content` (or supply correct `date`), then re-run. Writes are idempotent — re-applying a corrected payload is safe. |

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -582,6 +582,13 @@ function validatePayloadShape(payload) {
   if (payload.date !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(String(payload.date))) {
     errs.push('payload.date, when present, must be YYYY-MM-DD');
   }
+  if (
+    payload.sessionId !== undefined &&
+    payload.sessionId !== null &&
+    typeof payload.sessionId !== 'string'
+  ) {
+    errs.push('payload.sessionId, when present, must be a string');
+  }
   return errs;
 }
 
@@ -961,6 +968,43 @@ function applySessionClose(args) {
         ? JSON.stringify(out, null, 2)
         : `✗ payload schema invalid:\n  ${schemaErrs.join('\n  ')}`,
     );
+    process.exit(1);
+  }
+
+  // Payload↔session binding (cross-session payload collision). The payload temp
+  // file is now written to a session-scoped path (see commands/crystallize.md), so
+  // two same-day sessions no longer share a file. This is the belt to that
+  // suspenders: if the payload names
+  // the session it was authored for, it must be THIS one — the --session-id whose
+  // transcript already cleared close authority above. A mismatch means the file on
+  // disk is not this session's close (a stray or hand-reused path handed us another
+  // session's payload), and applying it would stamp that content with this session's
+  // marker while the original session's record vanishes — the exact loss this
+  // guard exists to prevent. Refuse before a byte is written.
+  //
+  // Absent field → fail open: older payloads predate this field, and Part 1's unique
+  // path already prevents the collision. So the check only ever tightens; it never
+  // rejects a close it would otherwise have allowed on a matching (or absent) id. It
+  // is deliberately identity-based, not cwd-based: closing project B from a session
+  // whose cwd is project A stays supported (payload.project is authoritative), so a
+  // legitimately cross-project close is untouched.
+  if (
+    payload.sessionId !== undefined &&
+    payload.sessionId !== null &&
+    payload.sessionId !== args.sessionId
+  ) {
+    const msg =
+      `payload.sessionId ${JSON.stringify(payload.sessionId)} does not match --session-id ` +
+      `${JSON.stringify(args.sessionId)}: this payload was authored for a different session, so ` +
+      `it is not this session's close. Refusing before any write (cross-session guard).`;
+    const out = {
+      ok: false,
+      stage: 'session-id-mismatch',
+      error: msg,
+      applied: [],
+      committed: false,
+    };
+    console.log(args.json ? JSON.stringify(out, null, 2) : `✗ ${msg}`);
     process.exit(1);
   }
 

--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -112,6 +112,8 @@ If `markerWritten: true`, ask: "Session closed. Would you like to also run knowl
 - `transcript-unresolved`: the id resolved no transcript, so it is most likely a background-task or Agent-thread uuid rather than the main conversation's. Get the right one and re-run.
 - `no-user-close-signal`: the transcript is this session's, and the user never asked to close in wording the gate recognizes (e.g. "세션 마무리까지 진행해줘" falls outside the close-signal set). Re-running the same id changes nothing. Confirm intent once with `AskUserQuestion` (header "세션", one option **세션 마무리**); if the user picks it, that answer becomes a recognized close signal, so the same command now applies everything: writes, commit, and marker. If the user declines, the session stays open and nothing is written. Do NOT change the close-signal matcher.
 
+**If `ok: false` with `stage: "session-id-mismatch"`,** the payload carries a `sessionId` that is not the `--session-id` you passed, so this file was authored for a different session (a reused or overwritten temp path). Nothing was written. Do not force it: rebuild the payload for THIS session (write it to a session-scoped path, e.g. `/tmp/hypo-session-close-<session-id>.json`) and re-run.
+
 If the apply succeeded but `markerWritten: false`, branch on `markerSkipReason` (`compact-gate-not-ok`, `commit-failed: …`, `marker-did-not-land`): surface it verbatim and resolve the underlying blocker before re-running.
 
 ### If the close came back `ok: false, stage: "proposal-pending"`

--- a/tests/crystallize-apply.test.mjs
+++ b/tests/crystallize-apply.test.mjs
@@ -542,3 +542,119 @@ test('preflight (#40 codex-P2): post-apply-lint failure + fixed payload retry �
     assert.equal(out.lint.postApply.ok, true, 'post-apply lint should now pass');
   });
 });
+
+// ── ISSUE-61: payload↔session binding (cross-session guard) ───────────────────
+// The session-close payload temp path used to be date-based, so two same-day
+// sessions clobbered each other's file; the winner's payload then applied under
+// the loser's --session-id marker, and the loser's record vanished. Part 1 moves
+// the documented path to a session-scoped name; this optional `sessionId` field
+// is the second line of defense: when present it must equal --session-id, so a
+// payload authored by another session is refused before any write. Absent → fail
+// open (older payloads; Part 1 already prevents the collision).
+
+suite('crystallize.mjs payload↔session binding (ISSUE-61)');
+
+test('payload.sessionId ≠ --session-id → session-id-mismatch, zero bytes', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionId = 'authored-by-another-session';
+    // A distinct entry a successful apply WOULD append. Its absence proves the
+    // guard blocked the write — and proves the test red: strip the guard and the
+    // unknown field is simply ignored, so this entry lands and the assert fails.
+    // The payload also rewrites overwrite targets (session-state, both hot files)
+    // that a successful apply touches BEFORE the shard append. Assert the whole
+    // committed tree is untouched — not just the shard — so a future guard misplaced
+    // after the overwrites but before the append can't pass this vacuously. `git
+    // diff --quiet` ignores the untracked .payload.json runApply drops in.
+    const marker = `MISMATCH-MUST-NOT-APPEAR-${today}`;
+    payload.sessionState = {
+      content: `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n## 다음 작업\n\n- ${marker}\n`,
+    };
+    payload.sessionLog = { entry: `## [${today}] ${marker}\n` };
+    const shard = join(dir, 'projects', 'test-project', 'session-log', `${today}.md`);
+    const before = existsSync(shard) ? readFileSync(shard, 'utf-8') : '';
+
+    const r = runApply(dir, payload, { sessionId: 'this-real-session' });
+    assert.equal(r.status, 1, `mismatch must exit 1: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(
+      out.stage,
+      'session-id-mismatch',
+      `stage must be session-id-mismatch: ${r.stdout}`,
+    );
+    assert.deepEqual(out.applied, [], 'nothing may be reported applied');
+    assert.equal(out.committed, false, 'nothing may be committed');
+    const tracked = spawnSync('git', ['diff', '--quiet'], { cwd: dir });
+    assert.equal(tracked.status, 0, 'no committed file may be modified on reject');
+    const after = existsSync(shard) ? readFileSync(shard, 'utf-8') : '';
+    assert.equal(after, before, 'shard must be byte-untouched');
+    assert.ok(!after.includes(marker), 'the payload entry must not have been appended');
+  });
+});
+
+test('payload.sessionId == --session-id → proceeds past the guard', () => {
+  withWiki(null, (dir, today) => {
+    const sid = 'matching-session';
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionId = sid;
+    payload.sessionLog = { entry: `## [${today}] match-entry\n` };
+    payload.log = { entry: `## [${today}] session | test-project — match\n` };
+    const r = runApply(dir, payload, { sessionId: sid });
+    assert.equal(r.status, 0, `matching id must succeed: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.notEqual(out.stage, 'session-id-mismatch');
+  });
+});
+
+test('payload without sessionId → guard fails open, apply proceeds', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    assert.equal(payload.sessionId, undefined, 'baseline payload carries no sessionId');
+    payload.sessionLog = { entry: `## [${today}] no-sessionid-entry\n` };
+    payload.log = { entry: `## [${today}] session | test-project — nosid\n` };
+    const r = runApply(dir, payload, { sessionId: 'any-session' });
+    assert.equal(r.status, 0, `absent sessionId must not block: ${r.stdout}`);
+    assert.equal(JSON.parse(r.stdout).ok, true);
+  });
+});
+
+test('payload.sessionId non-string → payload schema invalid', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionId = 12345;
+    const r = runApply(dir, payload, { sessionId: 'sid' });
+    assert.equal(r.status, 1, `non-string sessionId must fail: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.error, 'payload schema invalid');
+    assert.ok(
+      (out.details || []).some((d) => /sessionId/.test(d)),
+      `details must flag sessionId: ${r.stdout}`,
+    );
+  });
+});
+
+test('payload.sessionId null → treated as absent, guard fails open', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    payload.sessionId = null;
+    payload.sessionLog = { entry: `## [${today}] null-sessionid-entry\n` };
+    payload.log = { entry: `## [${today}] session | test-project — null\n` };
+    const r = runApply(dir, payload, { sessionId: 'any-session' });
+    assert.equal(r.status, 0, `null sessionId must fail open, not block: ${r.stdout}`);
+    assert.equal(JSON.parse(r.stdout).ok, true);
+  });
+});
+
+test('payload.sessionId empty string → mismatches any real id, refused', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    // "" is a valid string (passes schema) but equals no real --session-id, so it
+    // must reject rather than sneak through: an empty id is a bug, not a close.
+    payload.sessionId = '';
+    const r = runApply(dir, payload, { sessionId: 'real-session' });
+    assert.equal(r.status, 1, `empty-string sessionId must be refused: ${r.stdout}`);
+    assert.equal(JSON.parse(r.stdout).stage, 'session-id-mismatch');
+  });
+});


### PR DESCRIPTION
# English

## What changed

The session-close payload's temp path in the `/hypo:crystallize` guidance moves from a date-based name (`/tmp/hypo-session-close-<YYYY-MM-DD>.json`) to a session-scoped one (`<session-id>.json`). The payload also gains an optional `sessionId` field: when the apply path (`--apply-session-close`) sees it and it does not equal `--session-id`, it refuses before writing anything (`stage: "session-id-mismatch"`, `applied: []`, `committed: false`).

## Why

A date-based path has no session identity, so two sessions closing on the same day wrote the same file. The second write silently overwrote the first, and the surviving payload could then be applied under the first session's `--session-id` marker while the original session's record vanished with no error. That means one session's close content lands in another project under the wrong marker, silently.

## How

Two layers. The path change removes the collision at the source: two sessions never share a file. The `sessionId` self-check is defense-in-depth for the case where a path is reused anyway (a hand-edited or stale path): it ties the payload to the session that authored it. Absent or `null` `sessionId` fails open (older payloads predate the field, and the unique path already prevents the collision), so the check only ever tightens and never rejects a close it would otherwise allow. An empty string counts as a mismatch. It is deliberately identity-based, not working-directory-based, so closing project B from a session whose working dir is project A stays supported: `payload.project` remains the authoritative close target.

## Manual verification

No hook, template, or init flow changed (only `scripts/crystallize.mjs`, two command/skill docs, and tests), so the test suite covers it. Added six tests in a dedicated suite (mismatch refused with the whole committed tree byte-untouched via `git diff --quiet`, matching id proceeds, absent/null fail open, empty string refused, non-string rejected at schema). The mismatch and empty-string tests were proven red by disabling the guard. Full run: `npm test` 1574 passed / 0 failed; `parallel.mjs --shards=238` independent.

## Migration notes

None. Existing payloads without `sessionId` keep applying unchanged (fail-open).

---

# 한국어

## 변경 내용

`/hypo:crystallize`가 안내하는 session-close payload 임시 경로를 날짜 기반(`/tmp/hypo-session-close-<YYYY-MM-DD>.json`)에서 세션 기반(`<session-id>.json`)으로 바꿨다. payload에 optional `sessionId` 필드도 추가했다. apply 경로(`--apply-session-close`)가 이 필드를 보고 `--session-id`와 다르면 아무것도 쓰기 전에 거부한다(`stage: "session-id-mismatch"`, `applied: []`, `committed: false`).

## 이유

날짜 기반 경로는 세션 구분이 없어, 같은 날 두 세션이 close하면 같은 파일을 썼다. 뒤 write가 앞 것을 조용히 덮었고, 살아남은 payload가 앞 세션의 `--session-id` 마커로 apply될 수 있었다. 그동안 원 세션의 기록은 에러 없이 사라진다. 한 세션의 close 내용이 엉뚱한 프로젝트에 잘못된 마커로 조용히 실린다는 뜻이다.

## 방법

두 겹이다. 경로 변경은 충돌을 근본에서 없앤다(두 세션이 파일을 공유하지 않음). `sessionId` 자체검사는 경로가 어떤 이유로든 재사용될 때(손으로 고친 경로, stale 경로)를 위한 심층 방어로, payload를 작성한 세션에 묶는다. `sessionId`가 없거나 `null`이면 fail-open(기존 payload 호환, 유일 경로가 이미 충돌을 막음)이라 검사는 조이기만 할 뿐 원래 허용될 close를 거부하지 않는다. 빈 문자열은 불일치로 본다. cwd가 아니라 세션 정체 기반이라, 작업 디렉터리가 프로젝트 A인 세션에서 프로젝트 B를 close하는 흐름은 그대로 지원된다(`payload.project`가 권위 있는 close 대상).

## 수동 검증

훅·템플릿·init 흐름은 안 건드렸고(`scripts/crystallize.mjs`, command/skill 문서 2개, 테스트만), 테스트로 커버된다. 전용 suite에 6테스트 추가(불일치 거부 시 커밋된 트리 전체가 `git diff --quiet`로 무변경, 일치는 진행, 부재·null fail-open, 빈 문자열 거부, 비string은 스키마에서 거부). 불일치·빈문자열 테스트는 가드를 꺼서 red 증명했다. 전체 실행: `npm test` 1574 passed / 0 failed, `parallel.mjs --shards=238` 독립.

## 마이그레이션 노트

없음. `sessionId` 없는 기존 payload는 그대로 apply된다(fail-open).

---

## Changelog

- EN: Session-close no longer risks applying one session's payload under another's marker: the documented payload temp path is now session-scoped, and apply refuses a payload whose `sessionId` does not match `--session-id` (#204).
- KO: session-close가 한 세션의 payload를 다른 세션의 마커로 apply할 위험을 없앴다: payload 임시 경로를 세션 기반으로 바꾸고, `sessionId`가 `--session-id`와 다른 payload는 apply가 거부한다 (#204).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
