### PR TITLE
docs(pr-template): document the fix #N ban and the Changelog ADR carve-out

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,11 @@ docs/CONTRIBUTING.md.
 
 PR title: Conventional Commits plus a scope, e.g.
 `feat(feedback): add failure_type enum`. Keep any internal tracker id
-(FEAT-/IMPR-/ISSUE-/PRAC-) out of the title and body.
+(FEAT-/IMPR-/ISSUE-/PRAC-N, or a `fix #N`) out of the title and body. A wiki
+ADR pointer (`ADR NNNN`, `decisions/NNNN`) is the one carve-out, and only
+inside the `## Changelog` block below; it stays banned everywhere else in the
+title and body. The `check-pr-surface` gate enforces all of this on the title
+and body (the `check:tracker-ids` file gate covers everything inside the repo).
 
 Body language: write the full body TWICE, once under `# English` and once
 under `# 한국어` (this repo ships bilingual docs). The `## Changelog` and
@@ -83,7 +87,12 @@ you do NOT edit CHANGELOG.md directly in this PR. Internal-only change
 
 Rules:
 - Reference the PR by number only (`#123`). No internal tracker ids
-  (FEAT-/IMPR-/ISSUE-/PRAC-) on this public surface.
+  (FEAT-/IMPR-/ISSUE-/PRAC-N) and no `fix #N` on this public surface.
+- One carve-out lives HERE: this `## Changelog` block, and only this block,
+  may cite a wiki decision pointer (`ADR NNNN`, `decisions/NNNN`) for the
+  decision behind a release. The release collector copies this block verbatim
+  into CHANGELOG.md, which is itself ADR-exempt. Anywhere else in the PR the
+  pointer stays banned.
 - No em dashes. Use a colon, comma, or parentheses.
 - The section is inferred from your Conventional Commit type: feat -> New
   Features, fix -> Bug Fixes, everything else (chore/refactor/docs/ci) ->


### PR DESCRIPTION
# English

## What changed

The PR template now spells out three rules the surface gates already
enforce but the template left implicit:

- A `fix #N` reference is banned on the title and body, alongside the
  `FEAT-/IMPR-/ISSUE-/PRAC-N` prefix family it already named.
- A wiki ADR pointer (`ADR NNNN`, `decisions/NNNN`) is the one carve-out,
  and only inside the `## Changelog` block; it stays banned everywhere else
  in the title and body.
- `check-pr-surface` is what enforces this on the title and body (the
  `check:tracker-ids` file gate covers everything inside the repo).

## Why

The template is where a contributor reads the ship-surface rules before
opening a PR. It listed only the prefix family, so `fix #N` and the
Changelog-only ADR carve-out were undocumented on the one surface an author
authors by hand. A rule that is enforced by a gate but absent from the
template reads as a surprise CI failure instead of a known constraint.

## How

Two edits to `.github/PULL_REQUEST_TEMPLATE.md`: the top authoring comment
and the `## Changelog` Rules block. Placeholders stay in `N` / `NNNN` form
so the template file itself does not trip `check:tracker-ids` (verified).

## Manual verification

```
node scripts/check-tracker-ids.mjs .github/PULL_REQUEST_TEMPLATE.md   # OK, exit 0
npx prettier --check .github/PULL_REQUEST_TEMPLATE.md                 # style OK
grep -n '—' .github/PULL_REQUEST_TEMPLATE.md                          # no em dash
```

## Migration notes

None.

---

# 한국어

## 변경 내용

PR 템플릿이 표면 게이트가 이미 강제하지만 템플릿엔 빠져 있던 세 규칙을 명시한다.

- `fix #N` 참조도 title·body에서 금지된다(기존에 적혀 있던
  `FEAT-/IMPR-/ISSUE-/PRAC-N` 접두 계열과 동일).
- 위키 ADR 포인터(`ADR NNNN`, `decisions/NNNN`)는 유일한 예외이며, `## Changelog`
  블록 안에서만 허용된다. title·body의 다른 어디서도 금지다.
- 이것을 title·body에 강제하는 건 `check-pr-surface`다(repo 안의 모든 파일은
  `check:tracker-ids` 파일 게이트가 담당).

## 이유

템플릿은 기여자가 PR을 열기 전에 ship-surface 규칙을 읽는 자리다. 접두 계열만
적혀 있어서 `fix #N`과 Changelog 한정 ADR 예외는 정작 사람이 손으로 쓰는 표면에
문서화돼 있지 않았다. 게이트는 막는데 템플릿엔 없는 규칙은 알려진 제약이 아니라
느닷없는 CI 실패로 보인다.

## 방법

`.github/PULL_REQUEST_TEMPLATE.md` 두 곳 수정: 상단 작성 주석과 `## Changelog`
Rules 블록. placeholder는 `N` / `NNNN` 형태로 유지해 템플릿 파일 자체가
`check:tracker-ids`에 걸리지 않게 했다(검증 완료).

## 수동 검증

```
node scripts/check-tracker-ids.mjs .github/PULL_REQUEST_TEMPLATE.md   # OK, exit 0
npx prettier --check .github/PULL_REQUEST_TEMPLATE.md                 # 스타일 OK
grep -n '—' .github/PULL_REQUEST_TEMPLATE.md                          # em dash 없음
```

## 마이그레이션 노트

None.

---

## Changelog

None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
