### PR TITLE
feat(skills): ship /hypo:debate and the orchestration-patterns reference

### DIFF
--- a/qa-runs/2026-07-16.md
+++ b/qa-runs/2026-07-16.md
@@ -1,0 +1,61 @@
+# QA run 2026-07-16: /hypo:debate skill (PR #206)
+
+Dogfood QA of the new `/hypo:debate` skill shipped in PR #206. The skill was
+exercised end-to-end on a real wiki claim (its primary "re-verify a wiki claim"
+path), following `skills/debate/SKILL.md` as written.
+
+## QA1: discoverability (structural)
+
+- Frontmatter is `description`-only with the directory name (`debate`) as the skill
+  name, matching the other shipped skills (`skills/crystallize/SKILL.md`). Verified.
+- `plugin.json` maps `"skills": "./skills/"`, so `skills/debate/` is auto-discovered
+  with no manifest change. An identically-formatted copy placed under
+  `~/.claude/skills/` earlier in this session was picked up in the available-skills
+  list, confirming the format is discoverable.
+- Note: a fully live `/hypo:debate` slash invocation needs the plugin installed at
+  a version that includes this PR; that install-and-invoke step is left for after
+  merge + `/hypo:upgrade`. This run verifies the skill's _content_ is executable.
+
+## QA2: functional dogfood (three-phase debate on a real claim)
+
+Target claim: the wiki page `learnings/codex-2worker-convergence-high-confidence`
+asserts "codex 2-worker independent convergence = near-certain real defect". This
+session produced four fresh data points (PR #206 and #207, each a `2:codex`
+review), so the claim was re-verifiable against real evidence.
+
+- **Phase 1 (interrogate)** produced falsifiable claims: does convergence imply
+  correctness, or can correlated inputs (same prompt, same repo state) make both
+  workers wrong the same way? Is two workers enough?
+- **Phase 2 (verify)** against this session's evidence:
+  - PR #206 review: both workers converged on the same finding set (1 BLOCKER + 4
+    CONCERN); all were judged real and accepted. Convergence -> real defects. TRUE.
+  - PR #207 review: both workers converged on two findings. One (query still
+    printing "No results" with no vault) was real and fixed. One (an `ISSUE-N`
+    reference in a `tests/` comment) was a FALSE POSITIVE: CLAUDE.md explicitly
+    allows tracker ids under `tests/`, and the gate passes for that reason. Both
+    workers missed the same exemption because the shared review prompt did not
+    mention it. Convergence -> a correlated-error false positive.
+- **Phase 3 (synthesize)**: verdict **partially**. The headline claim overstates;
+  convergence is high-confidence but not infallible when inputs are correlated. The
+  page's existing "적용" already prescribes cross-checking a converged finding in
+  code, which is exactly what caught the #207 false positive. Durable artifact
+  landed: the page gained a counterexample section and a `verify_by` /
+  `verify_by_date` (committed in the wiki vault), so it now enters the verify cycle.
+
+## Result
+
+- The skill's instructions drove a coherent three-phase debate that produced a real,
+  useful refinement to a wiki claim and a durable artifact, as the skill requires.
+- The reference link `skills/debate/references/orchestration-patterns.md` resolves
+  and was cited in the synthesis (expert-pool mitigation for correlated reviewers).
+- Gate: `npm run check:pack-surface` (snapshot includes both files), tracker-ids,
+  prettier all green; `npm test` 1574 passed on this branch.
+
+## Limitation
+
+- The primary trigger path (`/hypo:verify` overdue -> debate) could not be run
+  against a live overdue page: the vault currently has 0 overdue pages (172 of 174
+  lack `verify_by` entirely). The same three-phase protocol was exercised via the
+  "re-verify a claim" entry instead. The overdue-to-debate wiring is structural in
+  the SKILL.md (it reads `verify_by` / `verify_by_date` / `last_reviewed`) but not
+  observed against live overdue data in this run.

--- a/skills/debate/SKILL.md
+++ b/skills/debate/SKILL.md
@@ -1,0 +1,88 @@
+---
+description: Structured debate to re-verify a wiki knowledge claim before you trust it, or to harden a hard-to-reverse decision into a durable wiki record. Runs a fixed order (interrogate, then verify against code and docs, then synthesize). Use when hypo:verify flags a page as overdue and you need to actually re-check its claim, when a decision is hard to reverse (architecture, refactor, external API integration) and should leave an ADR, or when the user asks to "debate", "stress-test", or "verify this claim". Skip it for reversible or already-obvious calls.
+---
+
+You are running `/hypo:debate`. It formalizes an informal practice (a two-worker adversarial
+review) into a reproducible fixed order, so the same rigor applies every time.
+
+The premise: separate the mind that **generates and interrogates** from the mind that
+**verifies**. Interrogation without verification lets a plausible wrong answer survive;
+verification without interrogation confirms a wrong premise with precision. The order is
+fixed for that reason.
+
+The debate always ends in a durable wiki artifact: a refreshed page, a correction, or an
+ADR. A debate that leaves nothing on disk was just a conversation. This is the producer
+reviewer pattern applied to a single claim; for the orchestration vocabulary it belongs to,
+see [references/orchestration-patterns.md](references/orchestration-patterns.md).
+
+## Two uses
+
+1. **Re-verify a wiki claim (primary).** `/hypo:verify` surfaces pages whose `verify_by_date`
+   is overdue (or that carry no `verify_by` question at all). This skill is the deep re-check
+   behind that prompt: does the page's `verify_by` question still hold against the current
+   code and docs? The outcome updates the page exactly as `/hypo:verify` Step 4 does (see
+   below), with the debate supplying the evidence.
+2. **Harden a hard-to-reverse decision.** Architecture choices, refactor direction, external
+   API or dependency integration, where the first-pass answer is often wrong (concurrency,
+   migrations, security boundaries, distributed state). The decision must land as an ADR or a
+   wiki page; if it would not, it is not big enough for a debate.
+
+## When not to use
+
+- A change whose diff you can state in one sentence. Just do it.
+- A reversible call, an already-obvious choice, or a one-off lookup. The debate's fixed cost
+  exceeds its value.
+
+## Fixed three phases
+
+### Phase 1. Interrogate (do not answer yet)
+
+Attack the claim or decision. Build a list of questions, not conclusions.
+
+- Surface hidden assumptions: "this rests on X being true. What if X is false?"
+- Stand up at least two alternatives (three including the incumbent). Best and worst case of
+  each.
+- List failure modes: how does this decision bite six months from now?
+- Output: a list of **falsifiable claims**. Each must be resolvable to true / false by code,
+  docs, or a command ("p95 under 50ms", not "it will be fast"). For a wiki claim, restate the
+  page's `verify_by` question in a form you can actually check against the current code or
+  docs.
+
+### Phase 2. Verify (against code, docs, and the wiki)
+
+Check each Phase 1 claim, one at a time. Do not invent new claims here.
+
+- Read the code, find the docs, run the command. Judge each claim true / false / unknown.
+- Unknown is unknown. A zero-result grep is not proof of absence.
+- For a wiki claim, check it against the page's own cited sources and the code or docs it
+  describes, not against memory.
+- For genuine independence, hand this phase to a reviewer who did not run the interrogation
+  (a fresh-context subagent, or a second person). Self-review of your own interrogation
+  breeds confirmation bias.
+- Output: a **per-claim verdict table** (claim, verdict, evidence line or command).
+
+### Phase 3. Synthesize
+
+Reconcile Phases 1 and 2 into one outcome, and write it down.
+
+- Build the conclusion only from claims that survived verification. For each rejected
+  alternative, leave one line on why it fell.
+- Name the residual risk (remaining unknowns, fail-open points) alongside the outcome. Do not
+  hide it.
+- Land the durable artifact:
+  - Wiki claim: answer the page's `verify_by` question **yes / no / partially**. On yes,
+    refresh `last_reviewed` to today and push `verify_by_date` forward. On no or partially,
+    edit the page to correct it, then refresh both fields. This is exactly `/hypo:verify`
+    Step 4; the debate is what earns the answer.
+  - Decision: record it as an ADR (or a wiki page) holding the **decision, rationale, and
+    residual risk**. That record, not the discussion, is the deliverable.
+
+## Execution notes
+
+- Run the three phases inline in order, or split only Phase 2 out to an independent reviewer.
+  That independence contributes the most to decision quality (the verifier's fresh context).
+- Keep the boundary between interrogation (1) and verification (2). If a new alternative
+  occurs during verification, note it for Phase 1 and finish verifying the current claims
+  before opening a new round. Mixing the two blurs both.
+- Do not accept a reviewer's verdict uncritically. The final call at synthesis stays with the
+  person running the debate.

--- a/skills/debate/references/orchestration-patterns.md
+++ b/skills/debate/references/orchestration-patterns.md
@@ -1,0 +1,83 @@
+# Multi-agent orchestration patterns
+
+A shared vocabulary for designing multi-agent work. `/hypo:debate` is one instance of it
+(the producer-reviewer pattern). When you orchestrate several agents around your wiki work,
+name the pattern first, then build.
+
+The one selection rule: **does the next stage need a barrier?** If not, pipeline. If it must
+see everything at once, fan-out / fan-in. If several angles look at the same target, expert
+pool. If one agent must grade another's output, producer-reviewer. If one place must hold the
+decision, supervisor. If delegation spawns more delegation, hierarchical.
+
+## 1. Pipeline
+
+Each item flows through the stages independently. No barrier between stages, so item A can be
+in stage 3 while item B is still in stage 1. With enough parallel capacity, wall-clock trends
+toward the slowest single-item chain rather than the sum of per-stage worsts (setting aside
+pipeline fill and drain). With limited capacity, items queue and it degrades toward the
+barrier case.
+
+- Use when: every item runs the same chain and items do not wait on each other (per-file
+  transforms, a find then fix then verify done per item).
+- Mistake: adding a barrier because you think a stage needs all prior results. That is
+  fan-out / fan-in, not a pipeline. Do any flatten / map / filter inside a stage.
+
+## 2. Fan-out / fan-in
+
+Spread work in parallel (fan-out), then gather all of it at a barrier (fan-in) to merge,
+dedup, or aggregate. Justified only when stage N needs every result of stage N-1 together.
+
+- Use when: dedup across the full set before an expensive downstream step, early-exit when
+  the total is zero, or a result that must be compared against all the others.
+- Mistake: forgetting the barrier's wait cost. Fast workers idle waiting on slow ones. Use it
+  only when you genuinely need all results.
+
+## 3. Expert pool
+
+Several agents look at the same target through **different lenses** at once. Each holds a
+different expertise (correctness, security, performance, reproducibility) or a different
+viewpoint, blind to what the others see.
+
+- Use when: one search angle cannot find everything, or a defect can break in more than one
+  way. The goal is **perspective diversity**, not redundant voting.
+- Mistake: giving N agents the same prompt and calling it an expert pool. That is just
+  redundancy. The lenses must actually differ.
+
+## 4. Producer-reviewer
+
+A producer makes something and an **independent** reviewer verifies it adversarially. Use it
+when the maker should not grade their own work. Prompt the reviewer to find why it is wrong
+first. `/hypo:debate` is this pattern applied to one claim.
+
+- Use when: catching defects in a change, a design, or an artifact from a fresh context.
+- Mistake: handing the reviewer the producer's rationale. The reviewer should see the target,
+  not the conclusion, to stay independent. Do not accept the review uncritically; the final
+  call stays with the orchestrator.
+
+## 5. Supervisor
+
+One orchestrator delegates to workers and integrates the results. The **decision and the
+human gate stay with the orchestrator**; only the heavy execution goes down.
+
+- Use when: keeping the main context for decisions while isolating large raw material or
+  diffs in subagents. When you delegate, hand over everything the main context knows: the
+  goal, the read / write scope, the constraints already confirmed, the verify command, the
+  return schema.
+- Mistake: treating a worker's output as evidence. It is a candidate. Trust it blindly and
+  you get a phantom backlog.
+
+## 6. Hierarchical delegation
+
+A tree of delegation: a higher worker re-delegates to lower ones. Splits a large problem into
+sub-problems handled by depth.
+
+- Use when: a breadth or depth one orchestrator cannot hold (a large migration, a broad
+  audit).
+- Mistake: allowing unbounded nesting depth. Keep the hierarchy to a controlled one or two
+  levels, and do not let a subagent open its own sub-delegation without a reason.
+
+## When not to reach for multi-agent at all
+
+If the main context already holds the material and the task finishes faster than the delegation
+overhead, do it inline. Before picking a pattern, ask whether the work is worth splitting. Most
+single lookups are not.

--- a/tests/fixtures/npm-pack.files.json
+++ b/tests/fixtures/npm-pack.files.json
@@ -392,6 +392,14 @@
     "exec": false
   },
   {
+    "path": "skills/debate/SKILL.md",
+    "exec": false
+  },
+  {
+    "path": "skills/debate/references/orchestration-patterns.md",
+    "exec": false
+  },
+  {
     "path": "skills/graph/SKILL.md",
     "exec": false
   },


### PR DESCRIPTION
# English

## What changed

Ships a new plugin skill, `/hypo:debate`, plus a bundled reference it cites.

- `skills/debate/SKILL.md`: a structured-debate skill with a fixed order (interrogate,
  then verify against code and docs, then synthesize). Its primary use is re-verifying a wiki
  claim behind a `hypo:verify` overdue prompt; its secondary use hardens a hard-to-reverse
  decision into an ADR. Either way it must land a durable wiki artifact.
- `skills/debate/references/orchestration-patterns.md`: a six-pattern multi-agent
  orchestration catalog the skill points at (debate is the producer-reviewer pattern).
- `tests/fixtures/npm-pack.files.json`: the pack-surface snapshot, plus the two shipped
  files.

## Why

Two peer projects ship these as product: one distributes a structured-debate skill, another a
multi-agent pattern kit. Hypomnema already ships user-facing skills, so adopting these as
maintainer-local notes would not match what users of comparable tools get. The debate skill
is themed to hypomnema's own domain: the primary path re-verifies wiki knowledge and updates
the page's `verify_by_date` / `last_reviewed`, tying it to `/hypo:verify` rather than standing
apart as generic advice.

## How

The skill re-verification path mirrors `/hypo:verify` Step 4 exactly: on a yes answer it
refreshes `last_reviewed` and pushes `verify_by_date` forward; on no or partially it edits the
page, then refreshes both. `plugin.json` maps `skills` to `./skills/`, so the new directory is
auto-discovered with no manifest change. `skills/` is already in `package.json` `files`, so
the two files ship; the pack-surface snapshot was regenerated to record them.

## Manual verification

```
node scripts/check-tracker-ids.mjs skills/debate/**        # OK, no tracker ids
npm run check:pack-surface                                 # ship surface matches snapshot
npx prettier --check skills/debate/**                      # style OK
npm test                                                   # 1574 passed, 0 failed
```

Pending before merge: a live-session check that `/hypo:debate` is discovered and runs its
three phases in a real Claude Code session (a skill's behavior is only observable in-session).

## Migration notes

None. New skill, auto-discovered on install or upgrade.

---

# 한국어

## 변경 내용

새 플러그인 스킬 `/hypo:debate`와 그 스킬이 참조하는 레퍼런스를 배포한다.

- `skills/debate/SKILL.md`: 고정 순서(심문 → 코드·문서 대조 검증 → 합성)의 구조화 디베이트
  스킬. 주 용도는 `hypo:verify`가 overdue로 띄운 위키 주장을 깊게 재검증하는 것, 보조 용도는
  되돌리기 힘든 결정을 ADR로 경화하는 것. 어느 쪽이든 durable한 위키 산출물로 끝난다.
- `skills/debate/references/orchestration-patterns.md`: 스킬이 참조하는 멀티에이전트 6패턴
  카탈로그(디베이트는 그중 생산-검토 패턴).
- `tests/fixtures/npm-pack.files.json`: pack-surface 스냅샷에 배포 2파일 추가.

## 이유

동종 프로젝트 둘이 이걸 제품으로 배포한다(하나는 구조화 디베이트 스킬, 하나는 멀티에이전트
패턴 kit). hypomnema도 이미 사용자용 스킬을 배포하므로, 이걸 메인테이너 개인 메모로만 두면
동종 도구 사용자가 받는 것과 어긋난다. 디베이트 스킬은 hypomnema 도메인에 결합했다: 주 경로가
위키 지식을 재검증하고 페이지의 `verify_by_date` / `last_reviewed`를 갱신해, 범용 조언으로
따로 놀지 않고 `/hypo:verify`에 묶인다.

## 방법

스킬의 재검증 경로는 `/hypo:verify` Step 4를 그대로 따른다: yes면 `last_reviewed` 갱신 +
`verify_by_date` 전진, no/partially면 페이지를 고치고 두 필드 갱신. `plugin.json`이 `skills`를
`./skills/`로 매핑해 새 디렉터리가 매니페스트 변경 없이 자동 탐지된다. `skills/`는 이미
`package.json` `files`에 있어 두 파일이 배포되고, pack-surface 스냅샷을 재생성해 이를 기록했다.

## 수동 검증

```
node scripts/check-tracker-ids.mjs skills/debate/**        # OK, tracker id 없음
npm run check:pack-surface                                 # ship surface 스냅샷 일치
npx prettier --check skills/debate/**                      # 스타일 OK
npm test                                                   # 1574 passed, 0 failed
```

머지 전 미결: `/hypo:debate`가 실제 Claude Code 세션에서 탐지되고 3단계가 도는지 라이브 확인
(스킬 동작은 세션 안에서만 관찰 가능).

## 마이그레이션 노트

None. 새 스킬, 설치·업그레이드 시 자동 탐지.

---

## Changelog

- EN: New `/hypo:debate` skill: structured debate (interrogate, verify, synthesize) to re-verify an overdue wiki claim or harden a decision into an ADR, with a bundled six-pattern orchestration reference. (#206)
- KO: 새 `/hypo:debate` 스킬: 구조화 디베이트(심문, 검증, 합성)로 overdue 위키 주장을 재검증하거나 결정을 ADR로 경화하고, 멀티에이전트 6패턴 레퍼런스를 함께 배포. (#206)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
