### PR TITLE
fix(root): stop reporting an unfound vault as an empty success

### DIFF
--- a/scripts/graph.mjs
+++ b/scripts/graph.mjs
@@ -16,7 +16,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+import { resolveHypoRootInfo, checkVaultOrExit, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
 import { collectPagesGraph, extractWikilinks } from './lib/wikilink.mjs';
 
@@ -29,7 +29,11 @@ function parseArgs(argv) {
     else if (arg.startsWith('--format=')) args.format = arg.slice(9);
     else if (arg.startsWith('--min-edges=')) args.minEdges = parseInt(arg.slice(12), 10) || 0;
   }
-  if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
+  if (!args.hypoDir) {
+    const info = resolveHypoRootInfo();
+    args.hypoDir = info.root;
+    args.hypoDirSource = info.source;
+  }
   return args;
 }
 
@@ -150,6 +154,9 @@ function formatDot(pages, graph, minEdges) {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
+// Only validate the auto-resolved path (env/marker/default). An explicit
+// --hypo-dir=<path> (tests, other tooling) is trusted as-is, valid or not.
+if (args.hypoDirSource) checkVaultOrExit(args.hypoDir, args.hypoDirSource);
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects'].map((d) => join(args.hypoDir, d));

--- a/scripts/lib/hypo-root.mjs
+++ b/scripts/lib/hypo-root.mjs
@@ -26,13 +26,20 @@ export function expandHome(p) {
 }
 
 /**
- * Resolve the Hypomnema root directory.
+ * Resolve the Hypomnema root directory, along with how it was resolved.
  * Checks HYPO_DIR env → hypo-config.md scan → ~/hypomnema default.
- * @returns {string} absolute path to Hypomnema root
+ *
+ * The `source` lets a caller tell "the user pointed us somewhere and it's
+ * empty" (an explicit misconfiguration worth failing loud on) apart from
+ * "nobody configured anything and none of the usual spots had a vault
+ * either" (a silent fallback, worth a quiet notice at most). resolveHypoRoot()
+ * itself collapses both into the same path, on purpose, for every caller that
+ * only ever wants a directory to hand to fs calls.
+ * @returns {{ root: string, source: 'env'|'marker'|'default' }}
  */
-export function resolveHypoRoot() {
+export function resolveHypoRootInfo() {
   if (process.env.HYPO_DIR) {
-    return expandHome(process.env.HYPO_DIR);
+    return { root: expandHome(process.env.HYPO_DIR), source: 'env' };
   }
 
   const candidates = [
@@ -46,8 +53,51 @@ export function resolveHypoRoot() {
   ];
 
   for (const c of candidates) {
-    if (existsSync(join(c, 'hypo-config.md'))) return c;
+    if (existsSync(join(c, 'hypo-config.md'))) return { root: c, source: 'marker' };
   }
 
-  return join(HOME, 'hypomnema');
+  return { root: join(HOME, 'hypomnema'), source: 'default' };
+}
+
+/**
+ * Resolve the Hypomnema root directory.
+ * Checks HYPO_DIR env → hypo-config.md scan → ~/hypomnema default.
+ * @returns {string} absolute path to Hypomnema root
+ */
+export function resolveHypoRoot() {
+  return resolveHypoRootInfo().root;
+}
+
+/**
+ * Validate a resolved root against the hypo-config.md marker, for the
+ * read-only CLIs only (lint/stats/graph/query). Two failure classes need
+ * different loudness:
+ *   - `source === 'env'`: the caller pointed HYPO_DIR at a path with no
+ *     vault there — an explicit misconfiguration. Fail loud: stderr + exit 1.
+ *   - `source === 'default'` (or a stale `'marker'` hit): nobody configured
+ *     anything and none of the usual spots had a vault. CI (lint-runner,
+ *     release.yml) intentionally runs this way and must keep exiting 0 — but
+ *     the CLI must stop silently reporting "no issues found" / "no results"
+ *     as if it had actually scanned a wiki. Print a visible notice and tell
+ *     the caller, so it can adjust its own empty-result copy, then continue.
+ * A caller that received `hypoDir` from an explicit --hypo-dir=<path> flag
+ * (tests, other tooling) never calls this — that path is not auto-resolved
+ * and is trusted as-is, valid or not.
+ * @param {string} root
+ * @param {'env'|'marker'|'default'} source
+ * @returns {boolean} true when the vault is missing (caller should suppress
+ *   its own "nothing found" messaging in favor of this notice already
+ *   printed); false when a real vault was found and normal scanning should
+ *   proceed.
+ */
+export function checkVaultOrExit(root, source) {
+  if (existsSync(join(root, 'hypo-config.md'))) return false;
+
+  if (source === 'env') {
+    console.error(`Hypomnema vault not found at HYPO_DIR=${root} (no hypo-config.md).`);
+    process.exit(1);
+  }
+
+  console.error('No Hypomnema vault found. Set HYPO_DIR or run inside a vault; nothing to scan.');
+  return true;
 }

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -18,7 +18,7 @@
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { join, extname, basename } from 'path';
-import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+import { resolveHypoRootInfo, checkVaultOrExit, expandHome } from './lib/hypo-root.mjs';
 import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import {
@@ -43,7 +43,11 @@ function parseArgs(argv) {
     else if (arg === '--fix') args.fix = true;
     else if (arg === '--strict') args.strict = true;
   }
-  if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
+  if (!args.hypoDir) {
+    const info = resolveHypoRootInfo();
+    args.hypoDir = info.root;
+    args.hypoDirSource = info.source;
+  }
   return args;
 }
 
@@ -483,6 +487,9 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs, validTypes) {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
+// Only validate the auto-resolved path (env/marker/default). An explicit
+// --hypo-dir=<path> (tests, other tooling) is trusted as-is, valid or not.
+if (args.hypoDirSource) checkVaultOrExit(args.hypoDir, args.hypoDirSource);
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects', 'journal'].map((d) => join(args.hypoDir, d));

--- a/scripts/query.mjs
+++ b/scripts/query.mjs
@@ -18,7 +18,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, extname } from 'path';
-import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+import { resolveHypoRootInfo, checkVaultOrExit, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import { currentDevice, scopeVisible, readVisibilityScope } from '../hooks/hypo-shared.mjs';
 
@@ -32,7 +32,11 @@ function parseArgs(argv) {
     else if (arg.startsWith('--limit=')) args.limit = parseInt(arg.slice(8), 10) || 10;
     else if (arg === '--json') args.json = true;
   }
-  if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
+  if (!args.hypoDir) {
+    const info = resolveHypoRootInfo();
+    args.hypoDir = info.root;
+    args.hypoDirSource = info.source;
+  }
   return args;
 }
 
@@ -96,6 +100,12 @@ if (!args.query) {
   process.exit(1);
 }
 
+// Only validate the auto-resolved path (env/marker/default). An explicit
+// --hypo-dir=<path> (tests, other tooling) is trusted as-is, valid or not.
+const vaultMissing = args.hypoDirSource
+  ? checkVaultOrExit(args.hypoDir, args.hypoDirSource)
+  : false;
+
 const terms = args.query.toLowerCase().split(/\s+/).filter(Boolean);
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects'].map((d) => join(args.hypoDir, d));
@@ -131,8 +141,16 @@ if (args.json) {
   console.log(JSON.stringify(top, null, 2));
 } else {
   if (top.length === 0) {
-    console.log(`No results for: ${args.query}`);
-    console.log(`→ 관련 페이지가 없습니다. 새 지식이 있다면 /hypo:ingest 로 추가해 보세요.`);
+    // vaultMissing: nothing was actually scanned (no HYPO_DIR / no vault
+    // found). Both "No results for: …" and the "관련 페이지가 없습니다" CTA would
+    // misreport real knowledge as absent, so suppress the whole no-results
+    // block. The stderr notice from checkVaultOrExit already told the user why
+    // this run found nothing, and it did not search a vault to invite them to
+    // /hypo:ingest into one that may already hold the answer.
+    if (!vaultMissing) {
+      console.log(`No results for: ${args.query}`);
+      console.log(`→ 관련 페이지가 없습니다. 새 지식이 있다면 /hypo:ingest 로 추가해 보세요.`);
+    }
   } else {
     console.log(`Found ${results.length} result(s) for "${args.query}" (showing ${top.length}):\n`);
     for (const r of top) {

--- a/scripts/stats.mjs
+++ b/scripts/stats.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, extname } from 'path';
-import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
+import { resolveHypoRootInfo, checkVaultOrExit, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isIgnored, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
@@ -26,7 +26,11 @@ function parseArgs(argv) {
     if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--json') args.json = true;
   }
-  if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
+  if (!args.hypoDir) {
+    const info = resolveHypoRootInfo();
+    args.hypoDir = info.root;
+    args.hypoDirSource = info.source;
+  }
   return args;
 }
 
@@ -88,6 +92,9 @@ function getLastActivity(hypoDir) {
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
+// Only validate the auto-resolved path (env/marker/default). An explicit
+// --hypo-dir=<path> (tests, other tooling) is trusted as-is, valid or not.
+if (args.hypoDirSource) checkVaultOrExit(args.hypoDir, args.hypoDirSource);
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const pageFiles = collectMdFiles(join(args.hypoDir, 'pages'), [], args.hypoDir, ignorePatterns);

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -103,7 +103,9 @@ function runWithHome(script, args = [], home) {
 
 // ── lib/hypo-root.mjs ────────────────────────────────────────────────────────
 
-const { expandHome, resolveHypoRoot } = await import(`${SCRIPTS}/lib/hypo-root.mjs`);
+const { expandHome, resolveHypoRoot, resolveHypoRootInfo, checkVaultOrExit } = await import(
+  `${SCRIPTS}/lib/hypo-root.mjs`
+);
 
 // ── lib/core-hooks.mjs (exit-free hooks.json loader) ─────────────────────────
 
@@ -689,6 +691,7 @@ export {
   buildCleanWikiTree,
   buildHookCommand,
   buildOutput,
+  checkVaultOrExit,
   closeFileTargets,
   closeFileTargetsForProject,
   closeFileTargetsGlobal,
@@ -755,6 +758,7 @@ export {
   readVisibilityScope,
   recordLookupUsage,
   resolveHypoRoot,
+  resolveHypoRootInfo,
   resolveInstallFile,
   resolveTranscriptBySessionId,
   run,

--- a/tests/lib-core.test.mjs
+++ b/tests/lib-core.test.mjs
@@ -4,10 +4,20 @@
 // build on each other; suites may not — that is what lets the runner shard.
 
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test, suite } from './harness.mjs';
-import { HOME, SCRIPTS, expandHome, resolveHypoRoot } from './helpers.mjs';
+import {
+  HOME,
+  SCRIPTS,
+  SESSION_TMP_HOME,
+  checkVaultOrExit,
+  expandHome,
+  resolveHypoRoot,
+  resolveHypoRootInfo,
+} from './helpers.mjs';
 
 suite('expandHome()');
 
@@ -66,6 +76,216 @@ test('finds wiki by hypo-config.md marker', () => {
     );
   } finally {
     if (orig !== undefined) process.env.HYPO_DIR = orig;
+  }
+});
+
+// ── ISSUE-51: fail-open resolveHypoRoot → resolveHypoRootInfo + checkVaultOrExit ──
+//
+// A no-marker "default" path is not the same failure as a no-marker "env"
+// path: the former is CI's normal, intentional shape (lint-runner, release.yml
+// run without a vault at all and must keep exiting 0); the latter is a user
+// pointing HYPO_DIR at nothing, which should fail loud instead of silently
+// reporting an empty wiki as "no issues found" / "no results".
+
+suite('resolveHypoRootInfo()');
+
+test('HYPO_DIR env var → source "env"', () => {
+  const orig = process.env.HYPO_DIR;
+  process.env.HYPO_DIR = '/tmp/custom-wiki-info';
+  try {
+    const info = resolveHypoRootInfo();
+    assert.equal(info.root, '/tmp/custom-wiki-info');
+    assert.equal(info.source, 'env');
+  } finally {
+    if (orig === undefined) delete process.env.HYPO_DIR;
+    else process.env.HYPO_DIR = orig;
+  }
+});
+
+// homedir() is read once at hypo-root.mjs module load (`const HOME =
+// homedir();`), so overriding process.env.HOME after this test file has
+// already imported it has no effect in-process. Exercise the marker-scan
+// branch in a fresh child process instead, where $HOME is read cold.
+test('marker found (fresh process, $HOME override) → source "marker"', () => {
+  const fakeHome = mkdtempSync(join(tmpdir(), 'hypo-info-marker-'));
+  try {
+    const wikiDir = join(fakeHome, 'hypomnema');
+    const script = `
+      import { mkdirSync, writeFileSync } from 'node:fs';
+      import { join } from 'node:path';
+      mkdirSync(${JSON.stringify(wikiDir)}, { recursive: true });
+      writeFileSync(join(${JSON.stringify(wikiDir)}, 'hypo-config.md'), '# marker\\n');
+      const { resolveHypoRootInfo } = await import(${JSON.stringify(join(SCRIPTS, 'lib/hypo-root.mjs'))});
+      const info = resolveHypoRootInfo();
+      console.log(JSON.stringify(info));
+    `;
+    const r = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: fakeHome, HYPO_DIR: '' },
+    });
+    assert.equal(r.status, 0, `probe process should exit 0: ${r.stderr}`);
+    const info = JSON.parse(r.stdout.trim());
+    assert.equal(info.source, 'marker');
+    assert.equal(info.root, wikiDir);
+  } finally {
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test('no env, no marker anywhere → source "default", root is ~/hypomnema', () => {
+  const orig = process.env.HYPO_DIR;
+  delete process.env.HYPO_DIR;
+  try {
+    const info = resolveHypoRootInfo();
+    if (info.source === 'default') {
+      assert.equal(info.root, join(HOME, 'hypomnema'));
+    } else {
+      // a real vault exists on this machine at one of the candidate paths —
+      // acceptable, mirrors the existing resolveHypoRoot() suite's tolerance.
+      assert.equal(info.source, 'marker');
+    }
+  } finally {
+    if (orig !== undefined) process.env.HYPO_DIR = orig;
+  }
+});
+
+test('resolveHypoRoot() stays byte-identical to resolveHypoRootInfo().root', () => {
+  const orig = process.env.HYPO_DIR;
+  process.env.HYPO_DIR = '/tmp/back-compat-check';
+  try {
+    assert.equal(resolveHypoRoot(), resolveHypoRootInfo().root);
+  } finally {
+    if (orig === undefined) delete process.env.HYPO_DIR;
+    else process.env.HYPO_DIR = orig;
+  }
+});
+
+suite('checkVaultOrExit()');
+
+test('marker present → returns false, does not exit', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-vault-ok-'));
+  try {
+    writeFileSync(join(dir, 'hypo-config.md'), '# marker\n');
+    assert.equal(checkVaultOrExit(dir, 'marker'), false);
+    assert.equal(checkVaultOrExit(dir, 'default'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('no marker, source "default" → returns true, does not exit (CI-safe path)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-vault-missing-'));
+  try {
+    // Must NOT throw / exit — this is the branch CI's lint-runner and
+    // release.yml depend on staying exit-0 without a vault at all.
+    assert.equal(checkVaultOrExit(dir, 'default'), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The `source === 'env'` + no-marker branch calls process.exit(1) directly and
+// so cannot be exercised in-process without killing the test runner — it is
+// covered below via spawned child processes against the real CLIs instead.
+
+suite('read CLIs (lint/stats/graph/query) — vault validation at the entry point');
+
+function spawnCli(script, args, env) {
+  return spawnSync(process.execPath, [join(SCRIPTS, script), ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+}
+
+test('HYPO_DIR set to a marker-less path → lint.mjs exits 1 with a loud error', () => {
+  const badDir = mkdtempSync(join(tmpdir(), 'hypo-env-nomarker-'));
+  try {
+    const r = spawnCli('lint.mjs', [], {
+      HOME: SESSION_TMP_HOME,
+      HYPO_DIR: badDir,
+    });
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}. stderr: ${r.stderr}`);
+    assert.ok(
+      r.stderr.includes('Hypomnema vault not found at HYPO_DIR='),
+      `expected loud HYPO_DIR error in stderr, got: ${r.stderr}`,
+    );
+  } finally {
+    rmSync(badDir, { recursive: true, force: true });
+  }
+});
+
+test('no HYPO_DIR, no vault found anywhere → lint.mjs exits 0 but warns on stderr (CI-safe)', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-'));
+  try {
+    const r = spawnCli('lint.mjs', [], {
+      HOME: noVaultHome,
+      HYPO_DIR: '',
+    });
+    assert.equal(r.status, 0, `expected exit 0 (CI-safe), got ${r.status}. stderr: ${r.stderr}`);
+    assert.ok(
+      r.stderr.includes('No Hypomnema vault found'),
+      `expected visible vault-missing notice on stderr, got: ${r.stderr}`,
+    );
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+test('query.mjs: no vault → does not claim "관련 페이지가 없습니다", shows vault notice instead', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-query-'));
+  try {
+    const r = spawnCli('query.mjs', ['--q=anything'], {
+      HOME: noVaultHome,
+      HYPO_DIR: '',
+    });
+    assert.equal(r.status, 0, `expected exit 0 (CI-safe), got ${r.status}. stderr: ${r.stderr}`);
+    assert.ok(
+      !r.stdout.includes('관련 페이지가 없습니다'),
+      `no-vault run must not claim "no matching pages" as if it had scanned one: ${r.stdout}`,
+    );
+    assert.ok(
+      !r.stdout.includes('No results for'),
+      `no-vault run must not print the "No results for:" line either, since nothing was scanned: ${r.stdout}`,
+    );
+    assert.ok(
+      r.stderr.includes('No Hypomnema vault found'),
+      `expected visible vault-missing notice on stderr, got: ${r.stderr}`,
+    );
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+test('valid vault via HYPO_DIR (marker present) → all 4 read CLIs behave as before', () => {
+  const validDir = mkdtempSync(join(tmpdir(), 'hypo-valid-vault-'));
+  try {
+    writeFileSync(join(validDir, 'hypo-config.md'), '# marker\n');
+    const env = { HOME: SESSION_TMP_HOME, HYPO_DIR: validDir };
+
+    const lintR = spawnCli('lint.mjs', [], env);
+    assert.equal(lintR.status, 0, `lint should exit 0: ${lintR.stderr}`);
+    assert.ok(!lintR.stderr.includes('No Hypomnema vault found'));
+    assert.ok(!lintR.stderr.includes('vault not found'));
+
+    const statsR = spawnCli('stats.mjs', ['--json'], env);
+    assert.equal(statsR.status, 0, `stats should exit 0: ${statsR.stderr}`);
+    assert.ok(!statsR.stderr.includes('No Hypomnema vault found'));
+    const statsJson = JSON.parse(statsR.stdout);
+    assert.equal(typeof statsJson.pages.total, 'number');
+
+    const graphR = spawnCli('graph.mjs', [], env);
+    assert.equal(graphR.status, 0, `graph should exit 0: ${graphR.stderr}`);
+    assert.ok(!graphR.stderr.includes('No Hypomnema vault found'));
+
+    const queryR = spawnCli('query.mjs', ['--q=nothing-matches-this'], env);
+    assert.equal(queryR.status, 0, `query should exit 0: ${queryR.stderr}`);
+    assert.ok(!queryR.stderr.includes('No Hypomnema vault found'));
+    assert.ok(
+      queryR.stdout.includes('관련 페이지가 없습니다'),
+      'a real (empty) vault should still show the normal ingest suggestion',
+    );
+  } finally {
+    rmSync(validDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
# English

## What changed

`resolveHypoRoot()` used to fall through to a `~/hypomnema` default without checking it
exists, so the read CLIs (`lint`, `stats`, `graph`, `query`) scanned a nonexistent path and
reported an empty wiki as success (exit 0). Now:

- `resolveHypoRootInfo()` returns `{ root, source: 'env' | 'marker' | 'default' }`;
  `resolveHypoRoot()` keeps its old signature and just returns `.root`, so the other importers
  are untouched.
- `checkVaultOrExit(root, source)`, run by the four read CLIs at entry when the directory was
  auto-resolved (never for an explicit `--hypo-dir`), fails loud (exit 1) when `HYPO_DIR`
  points at a vault-less path, and prints a visible notice while still exiting 0 when nothing
  was configured and no vault was found.
- `query` no longer prints `No results for: …` or the ingest CTA when no vault was scanned;
  the stderr notice already explains why.

## Why

The fail-open was silent and wrong. `query` answered "no results" for knowledge that exists
in a vault it never found, inviting duplicate pages; `lint` returned green on an empty scan,
neutralizing the quality gate. A misconfigured `HYPO_DIR` should say so, not pretend the wiki
is empty.

## How

The one constraint that shaped the fix: CI's lint job and `release.yml` run `npm run lint`
with no `HYPO_DIR` and no vault, and must keep exiting 0. So only an explicit `HYPO_DIR`
pointed at a vault-less path fails loud; the unconfigured no-vault case stays exit 0 but is no
longer silent.

## Manual verification

```
env -u HYPO_DIR node scripts/lint.mjs ; echo $?     # exit 0, stderr "No Hypomnema vault found" (CI-safe)
env HYPO_DIR=/tmp/nope node scripts/lint.mjs ; echo $?   # exit 1, "vault not found at HYPO_DIR=..."
env -u HYPO_DIR HOME=$(mktemp -d) node scripts/query.mjs --q=anything   # no "No results for:" on stdout
npm test                                            # 1584 passed, 0 failed
```

Red proof: reverting the four CLIs and the resolver to HEAD makes the new tests fail (the
`HYPO_DIR` exit-1, the CI-safe notice, and the query no-results-suppression cases all regress).

## Migration notes

None. Behavior only changes when a vault could not be resolved; a configured, valid vault is
unaffected.

---

# 한국어

## 변경 내용

`resolveHypoRoot()`가 존재 검증 없이 `~/hypomnema` 기본값으로 흘러가, read CLI(`lint`·`stats`·
`graph`·`query`)가 없는 경로를 스캔하고 빈 위키를 성공(exit 0)으로 보고했다. 이제:

- `resolveHypoRootInfo()`가 `{ root, source: 'env' | 'marker' | 'default' }`를 반환하고,
  `resolveHypoRoot()`는 기존 시그니처 그대로 `.root`만 반환해 다른 호출부는 안 건드린다.
- `checkVaultOrExit(root, source)`를 4개 read CLI가 진입점에서(자동 해석된 경우에만, 명시
  `--hypo-dir`는 제외) 실행한다. `HYPO_DIR`가 볼트 없는 경로를 가리키면 exit 1로 실패하고,
  아무것도 설정 안 됐고 볼트도 없으면 눈에 보이는 통지를 내되 exit 0을 유지한다.
- `query`는 스캔한 볼트가 없으면 `No results for: …`도 ingest 안내도 찍지 않는다. stderr 통지가
  이유를 이미 설명한다.

## 이유

fail-open이 조용하고 틀렸다. `query`는 못 찾은 볼트에 실재하는 지식을 "결과 없음"으로 답해 중복
페이지를 유도했고, `lint`는 빈 스캔에 green을 내 품질 게이트를 무력화했다. `HYPO_DIR` 오설정은
위키가 비었다고 위장할 게 아니라 그렇다고 말해야 한다.

## 방법

수정을 좌우한 제약 하나: CI의 lint 잡과 `release.yml`이 `HYPO_DIR` 없이·볼트 없이 `npm run lint`를
돌리고 exit 0을 유지해야 한다. 그래서 `HYPO_DIR`를 명시했는데 볼트가 없는 경우만 loud하게 실패하고,
미설정·볼트없음은 exit 0을 유지하되 더는 조용하지 않다.

## 수동 검증

```
env -u HYPO_DIR node scripts/lint.mjs ; echo $?     # exit 0, stderr "No Hypomnema vault found" (CI-safe)
env HYPO_DIR=/tmp/nope node scripts/lint.mjs ; echo $?   # exit 1, "vault not found at HYPO_DIR=..."
env -u HYPO_DIR HOME=$(mktemp -d) node scripts/query.mjs --q=anything   # stdout에 "No results for:" 없음
npm test                                            # 1584 passed, 0 failed
```

Red 증명: 4개 CLI와 resolver를 HEAD로 되돌리면 새 테스트가 실패한다(`HYPO_DIR` exit-1, CI-safe
통지, query 결과-없음 억제 케이스 전부 회귀).

## 마이그레이션 노트

None. 볼트를 해석하지 못한 경우에만 동작이 바뀐다. 설정된 유효 볼트는 영향 없음.

---

## Changelog

- EN: The read commands (lint, stats, graph, query) no longer report an empty wiki as success when the vault cannot be found: a misconfigured HYPO_DIR now fails with a clear error, and an unconfigured run prints a visible notice instead of a silent "no results". (#207)
- KO: read 명령(lint, stats, graph, query)이 볼트를 못 찾을 때 빈 위키를 성공으로 보고하지 않습니다: HYPO_DIR 오설정은 명확한 에러로 실패하고, 미설정 실행은 조용한 "결과 없음" 대신 눈에 보이는 통지를 냅니다. (#207)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
