### PR TITLE
fix(hooks): parse git status with -z so non-ASCII wiki paths commit

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1557,16 +1557,34 @@ export function commitWikiChanges(hypoDir) {
     spawnSync('git', ['-C', hypoDir, ...args], { encoding: 'utf-8', timeout: 30000 });
   if (git('rev-parse', '--is-inside-work-tree').status !== 0)
     return { committed: false, reason: `not a git repository: ${hypoDir}` };
-  const porcelain = git('status', '--porcelain', '-uall');
+  // `-z`: NUL-separated records with verbatim paths — no surrounding quotes and
+  // no octal escaping, so non-ASCII paths (Korean page names are normal input
+  // here) survive intact. Without it, `core.quotepath=true` (the default) yields
+  // `"pages/\355\225\234\352\270\200.md"` and the old quote-strip parser fed that
+  // literal, non-existent path to `git add` — failing the whole commit.
+  // `-z`: NUL-separated records with verbatim paths — no surrounding quotes and
+  // no octal escaping, so non-ASCII paths (Korean page names are normal input
+  // here) survive intact. Without it, `core.quotepath=true` (the default) yields
+  // `"pages/\355\225\234\352\270\200.md"` and the old quote-strip parser fed that
+  // literal, non-existent path to `git add` — failing the whole commit.
+  const porcelain = git('status', '--porcelain', '-uall', '-z');
   if (porcelain.status !== 0)
     return { committed: false, reason: `git status failed in ${hypoDir}` };
   // `.hypoignore` is the project privacy boundary. `git add -A` ignores it, so
   // enumerate changed paths, drop ignored ones, then stage explicitly.
   const ignorePatterns = loadHypoIgnore(hypoDir);
   const paths = [];
-  for (const line of (porcelain.stdout || '').split('\n')) {
-    if (!line) continue;
-    const file = line.slice(3).replace(/^"|"$/g, '').split(' -> ').pop().trim();
+  const records = (porcelain.stdout || '').split('\0');
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i];
+    if (!rec) continue;
+    const xy = rec.slice(0, 2);
+    const file = rec.slice(3); // `XY <path>`; the destination path for a rename/copy
+    // A rename OR copy emits two records (`to\0from`); consume the trailing
+    // `from`. Copy `C` records only appear under `status.renames=copies`, but
+    // when they do, missing this skip feeds the `from` path to `git add` as a
+    // bogus pathspec — the exact auto-commit failure this parser fixes.
+    if (xy[0] === 'R' || xy[1] === 'R' || xy[0] === 'C' || xy[1] === 'C') i++;
     if (!file) continue;
     if (ignorePatterns.length > 0 && isIgnored(join(hypoDir, file), hypoDir, ignorePatterns))
       continue;
@@ -3384,7 +3402,15 @@ export function computeSessionGrowth(hypoDir) {
     // more expensive `git diff HEAD --unified=0` — Stop hook P95 win.
     // `-uall` expands untracked directories so a brand-new `pages/new.md`
     // isn't hidden behind a single `?? pages/` line.
-    const porcelain = spawnSync('git', ['-C', hypoDir, 'status', '--porcelain', '-uall'], {
+    // `-z`: NUL-separated, verbatim paths (see commitWikiChanges). The old
+    // newline/quote-strip parser left octal escapes in place, so Korean page
+    // names silently failed the `pages/`·`projects/` scope match and dropped
+    // out of the growth count.
+    // `-z`: NUL-separated, verbatim paths (see commitWikiChanges). The old
+    // newline/quote-strip parser left octal escapes in place, so Korean page
+    // names silently failed the `pages/`·`projects/` scope match and dropped
+    // out of the growth count.
+    const porcelain = spawnSync('git', ['-C', hypoDir, 'status', '--porcelain', '-uall', '-z'], {
       encoding: 'utf-8',
       timeout: 5000,
     });
@@ -3398,10 +3424,14 @@ export function computeSessionGrowth(hypoDir) {
     // intentionally excluded — they're scaffolding, not page growth.
     const inPagesScope = (file) =>
       file.endsWith('.md') && (file.startsWith('pages/') || file.startsWith('projects/'));
-    for (const line of (porcelain.stdout || '').split('\n')) {
-      if (!line) continue;
-      const xy = line.slice(0, 2);
-      const file = line.slice(3).replace(/^"|"$/g, '').split(' -> ').pop().trim();
+    const records = (porcelain.stdout || '').split('\0');
+    for (let i = 0; i < records.length; i++) {
+      const rec = records[i];
+      if (!rec) continue;
+      const xy = rec.slice(0, 2);
+      const file = rec.slice(3); // destination path for a rename/copy
+      // A rename OR copy emits two records (`to\0from`); consume the trailing `from`.
+      if (xy[0] === 'R' || xy[1] === 'R' || xy[0] === 'C' || xy[1] === 'C') i++;
       if (!inPagesScope(file)) continue;
       if (xy === '??') {
         untrackedMd.push(file);
@@ -3409,7 +3439,8 @@ export function computeSessionGrowth(hypoDir) {
         continue;
       }
       hasTrackedMdChange = true;
-      if (xy.includes('A')) addedPages++;
+      // A copy's destination is a brand-new page, so it counts as added like `A`.
+      if (xy.includes('A') || xy.includes('C')) addedPages++;
       else if (xy.includes('M') || xy.includes('R')) updatedPages++;
     }
     if (!hasTrackedMdChange && untrackedMd.length === 0) return empty;

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -22,6 +22,7 @@ import {
   buildProjectSuggestionLine,
   findBackfillCandidate,
   buildBackfillSuggestionLine,
+  computeSessionGrowth,
 } from '../hooks/hypo-shared.mjs';
 import { test, suite } from './harness.mjs';
 import {
@@ -1704,6 +1705,128 @@ test('commitWikiChanges: respects .hypoignore (ignored file not staged)', () => 
     const tracked = spawnSync('git', ['-C', dir, 'ls-files'], { encoding: 'utf-8' }).stdout;
     assert.ok(!/secret\.md/.test(tracked), `secret.md must not be committed: ${tracked}`);
     assert.ok(/public\.md/.test(tracked), `public.md must be committed: ${tracked}`);
+  });
+});
+
+// ── ISSUE-50: porcelain `-z` parser — non-ASCII paths survive ──────────────
+
+suite('ISSUE-50 — porcelain -z parser: non-ASCII (Korean) paths');
+
+test('commitWikiChanges: a Korean filename commits under core.quotepath=true', () => {
+  withSyncedWiki((dir) => {
+    // Pin quotepath true (the git default) so the octal-escaping that breaks the
+    // old parser reproduces regardless of the developer's global config. Old
+    // parser: strips the outer quotes but leaves `\355\225...` → `git add` on a
+    // non-existent literal path fails → the whole commit fails, no marker.
+    spawnSync('git', ['-C', dir, 'config', 'core.quotepath', 'true']);
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', '한글.md'), '# 한글\n');
+    writeFileSync(join(dir, 'pages', 'ascii.md'), '# ascii\n');
+    const res = commitWikiChanges(dir);
+    assert.equal(
+      res.committed,
+      true,
+      `Korean filename must not break the commit: ${JSON.stringify(res)}`,
+    );
+    assert.equal(
+      hypoIsClean(dir).uncommitted,
+      false,
+      'the Korean page must be committed, leaving no uncommitted work',
+    );
+    // -z so ls-files reports the real name, not an escaped one
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', '-z'], {
+      encoding: 'utf-8',
+    }).stdout.split('\0');
+    assert.ok(
+      tracked.includes('pages/한글.md'),
+      `Korean page must be tracked: ${JSON.stringify(tracked)}`,
+    );
+  });
+});
+
+test('commitWikiChanges: a staged rename to a Korean name commits (the `from` record is consumed)', () => {
+  withSyncedWiki((dir) => {
+    spawnSync('git', ['-C', dir, 'config', 'core.quotepath', 'true']);
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(
+      join(dir, 'pages', 'old.md'),
+      '# seed page with enough body to be a clean rename\n',
+    );
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed']);
+    spawnSync('git', ['-C', dir, 'mv', 'pages/old.md', 'pages/새이름.md']);
+    const res = commitWikiChanges(dir);
+    assert.equal(res.committed, true, `rename must commit cleanly: ${JSON.stringify(res)}`);
+    assert.equal(hypoIsClean(dir).uncommitted, false, 'rename fully committed');
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', '-z'], {
+      encoding: 'utf-8',
+    }).stdout.split('\0');
+    assert.ok(
+      tracked.includes('pages/새이름.md') && !tracked.includes('pages/old.md'),
+      `rename must be applied: ${JSON.stringify(tracked)}`,
+    );
+  });
+});
+
+test('commitWikiChanges: a staged copy (status.renames=copies) commits, not a truncated pathspec', () => {
+  withSyncedWiki((dir) => {
+    // With copy detection on, staging a copy of a tracked file WHILE that source
+    // is itself modified makes `--porcelain -z` emit a `C  dest\0src` two-record
+    // entry (plus a separate `M src`). Git only reports the copy this way when the
+    // source appears in the same diff — a bare identical copy is just `A`. If the
+    // parser does not consume the `src` record (as it does for renames), it hands
+    // git a mangled pathspec (`es/source.md`) and the whole commit dies — the same
+    // failure `-z` fixes for renames.
+    spawnSync('git', ['-C', dir, 'config', 'core.quotepath', 'true']);
+    spawnSync('git', ['-C', dir, 'config', 'status.renames', 'copies']);
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'source.md'), 'line1\nline2\nline3\nline4\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed source']);
+    // copy the source, then modify the source, and stage both → `C dest\0src` + `M src`
+    writeFileSync(join(dir, 'pages', 'copied.md'), 'line1\nline2\nline3\nline4\n');
+    writeFileSync(join(dir, 'pages', 'source.md'), 'line1\nline2\nline3\nline4\nEXTRA\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    // sanity: the fixture really produces a `C` record (else this tests nothing)
+    const porcelain = spawnSync('git', ['-C', dir, 'status', '--porcelain', '-z'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(
+      porcelain.split('\0')[0].startsWith('C'),
+      `fixture must emit a copy record: ${JSON.stringify(porcelain)}`,
+    );
+    const res = commitWikiChanges(dir);
+    assert.equal(
+      res.committed,
+      true,
+      `copy record must not break the commit: ${JSON.stringify(res)}`,
+    );
+    assert.equal(hypoIsClean(dir).uncommitted, false, 'copy fully committed');
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', '-z'], {
+      encoding: 'utf-8',
+    }).stdout.split('\0');
+    assert.ok(
+      tracked.includes('pages/copied.md') && tracked.includes('pages/source.md'),
+      `both source and copy must be tracked: ${JSON.stringify(tracked)}`,
+    );
+  });
+});
+
+test('computeSessionGrowth: a Korean untracked page contributes its wikilinks', () => {
+  withGrowthWiki((dir) => {
+    // The old parser leaves the path escaped, so `readFileSync(escaped)` throws
+    // and the page's wikilinks are silently dropped from the growth count. The
+    // page-scope prefix still matches the escaped path, so addedPages alone does
+    // NOT prove the fix — the wikilink body read is the discriminating signal.
+    spawnSync('git', ['-C', dir, 'config', 'core.quotepath', 'true']);
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', '한글.md'), '# 한글\n\n[[target-one]] and [[target-two]]\n');
+    const g = computeSessionGrowth(dir);
+    assert.ok(g.addedPages >= 1, `Korean page must count as added: ${JSON.stringify(g)}`);
+    assert.ok(
+      g.newWikilinks >= 2,
+      `wikilinks inside the Korean page must be counted (old parser reads an escaped path and finds none): ${JSON.stringify(g)}`,
+    );
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`commitWikiChanges` and `computeSessionGrowth` in `hooks/hypo-shared.mjs` now parse
`git status --porcelain -z` (NUL-separated, verbatim paths) instead of the newline
format, and consume the trailing `from` record that a rename (`R`) or copy (`C`)
emits.

## Why

With git's default `core.quotepath=true`, a non-ASCII path is octal-escaped and
quoted in porcelain output (`"pages/\355\225\234...md"`). The old parser stripped the
outer quotes but left the escaping in place, so it handed `git add` a literal,
non-existent pathspec. A single Korean page name (normal input for a Korean-language
wiki) made `git add` fail with `pathspec ... did not match`, which failed the whole
auto-commit and left the session-close marker unwritten (the session looked closed via
`ok: true` but the Stop chain kept re-prompting). The same parser in
`computeSessionGrowth` silently dropped those pages from the growth count.

## How

`-z` output carries no quoting and no escaping, so paths survive intact regardless of
`core.quotepath`. A rename or copy is two NUL records (`to\0from`); the loop reads the
destination and skips the trailing source record. Copy records only appear under
`status.renames=copies`, but when they do, the old single-`R` handling would re-break
the exact failure this fixes.

## Manual verification

- Clean-repo repro (bug and fix): in a fresh repo with `core.quotepath=true`, a
  `pages/한글.md` made the old parser feed `git add` the escaped literal and fail. The
  `-z` parser stages `pages/한글.md` and commits.
- Copy repro: with `status.renames=copies`, a staged copy of a modified source emits
  `C  dest\0src\0M src`. The old `R`-only skip fed git the truncated pathspec
  `es/source.md` and failed: reproduced red, then green with the `C` skip.
- Regression tests (`node tests/runner.mjs --grep="Korean|copy"`): Korean filename,
  Korean rename, staged copy, and Korean-page growth wikilinks. Each was confirmed red
  against the old parser before the fix.
- `npm test` (1593 passed) and `npm run check:tracker-ids` pass.
- Recommended before merge: a live session that creates a non-ASCII page and closes,
  confirming the deployed Stop-hook auto-commit writes the marker (the escaping only
  surfaces through the real hook path).

## Migration notes

None. Behavior only changes for trees that previously failed to commit; existing
commits and metrics are unaffected.

---

# 한국어

## 변경 내용

`hooks/hypo-shared.mjs`의 `commitWikiChanges`와 `computeSessionGrowth`가 개행 형식 대신
`git status --porcelain -z`(NUL 구분, verbatim 경로)를 파싱하고, rename(`R`)·copy(`C`)가
내보내는 뒤따르는 `from` 레코드를 소비한다.

## 이유

git 기본값 `core.quotepath=true`에서 비ASCII 경로는 porcelain 출력에서 8진 이스케이프되고
따옴표로 감싸진다(`"pages/\355\225\234...md"`). 옛 파서는 바깥 따옴표만 벗기고 이스케이프는
남겨서, 디스크에 없는 리터럴 pathspec을 `git add`에 넘겼다. 한글 파일명 하나(한국어 위키에선
정상 입력)만으로 `git add`가 `pathspec ... did not match`로 실패해 auto-commit 전체가 죽고
session-close 마커가 안 찍혔다(`ok: true`라 닫힌 듯 보이지만 Stop 체인이 계속 재프롬프트).
`computeSessionGrowth`의 같은 파서는 그 페이지들을 성장 지표에서 조용히 누락했다.

## 방법

`-z` 출력은 따옴표도 이스케이프도 없어 `core.quotepath`와 무관하게 경로가 온전하다. rename·copy는
NUL 2레코드(`to\0from`)이므로 루프가 대상 경로를 읽고 뒤따르는 원본 레코드를 건너뛴다. copy 레코드는
`status.renames=copies`에서만 나타나지만, 그때 옛 `R` 전용 처리는 이 수정이 막는 실패를 그대로
재발시킨다.

## 수동 검증

- clean-repo 재현(버그·수정): `core.quotepath=true`인 새 repo에서 `pages/한글.md`가 옛 파서에
  이스케이프 리터럴을 넘겨 `git add`를 실패시켰고, `-z` 파서는 `pages/한글.md`를 스테이징·커밋한다.
- copy 재현: `status.renames=copies`에서 수정된 source의 staged copy가 `C  dest\0src\0M src`를
  내보내고, 옛 `R` 전용 skip은 잘린 pathspec `es/source.md`를 넘겨 실패했다. red 재현 후 `C` skip으로 green.
- 회귀 테스트(`node tests/runner.mjs --grep="Korean|copy"`): 한글 파일명, 한글 rename, staged copy,
  한글 페이지 성장 wikilink. 각각 수정 전 옛 파서에서 red임을 확인했다.
- `npm test`(1593 passed)와 `npm run check:tracker-ids` 통과.
- 머지 전 권장: 비ASCII 페이지를 만들고 close하는 라이브 세션으로 배포된 Stop-hook auto-commit이
  마커를 쓰는지 확인(이스케이프는 실제 훅 경로에서만 드러난다).

## 마이그레이션 노트

None. 이전에 커밋에 실패하던 트리에서만 동작이 바뀌며, 기존 커밋·지표는 영향 없다.

---

## Changelog

- EN: Fixed wiki auto-commit dying when a page path contains non-ASCII characters (e.g. Korean filenames), which left the session-close marker unwritten (#208)
- KO: 페이지 경로에 비ASCII 문자(예: 한글 파일명)가 있으면 위키 auto-commit이 죽어 session-close 마커가 안 찍히던 문제 수정 (#208)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
