### PR TITLE
fix(upgrade): surface a stale hypo-guide.md instead of leaving it silently drifted

### DIFF
--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -213,24 +213,56 @@ const SHARED_FILES = _hookConfig.shared ?? [];
 
 // ── checks ───────────────────────────────────────────────────────────────────
 
-function checkSchemaVersion(hypoDir) {
-  const pkgPath = join(TEMPLATES, 'SCHEMA.md');
-  const hypoPath = join(hypoDir, 'SCHEMA.md');
+// Shared by SCHEMA.md and hypo-guide.md: both templates carry a top-level
+// `version:` frontmatter stamp, and both are compared the same way — installed
+// copy vs. the package's own template — without ever writing to hypoPath. This
+// function is read-only; nothing downstream may use its return value to
+// overwrite the installed file (hand-authored wiki files are never
+// silently clobbered).
+function checkTemplateVersion(hypoDir, filename) {
+  const pkgPath = join(TEMPLATES, filename);
+  const hypoPath = join(hypoDir, filename);
 
   const pkgVersion = existsSync(pkgPath)
     ? parseVersion((parseFrontmatter(readFileSync(pkgPath, 'utf-8')) ?? {}).version)
     : null;
-  const hypoVersion = existsSync(hypoPath)
+
+  const hypoExists = existsSync(hypoPath);
+  const hypoVersion = hypoExists
     ? parseVersion((parseFrontmatter(readFileSync(hypoPath, 'utf-8')) ?? {}).version)
     : null;
+
+  // File present but carries no `version:` frontmatter field at all — a
+  // pre-versioning install (the file predates this stamp existing). This is
+  // deliberately distinguished from "file missing entirely" (still routed to
+  // bumpType's 'unknown' below): a bare `bumpType(null, pkgVersion)` cannot
+  // tell the two apart, and folding this case into plain 'unknown' is exactly
+  // what let an already-installed, unstamped hypo-guide.md report "up to
+  // date" — the file this check exists to catch. The caller decides whether
+  // 'unstamped' counts as drift; this helper only classifies.
+  const unstamped = hypoExists && !hypoVersion && !!pkgVersion;
 
   return {
     installed: hypoVersion?.raw ?? null,
     current: pkgVersion?.raw ?? null,
-    bump: bumpType(hypoVersion, pkgVersion),
+    bump: unstamped ? 'unstamped' : bumpType(hypoVersion, pkgVersion),
     hypoPath,
     pkgPath,
   };
+}
+
+function checkSchemaVersion(hypoDir) {
+  return checkTemplateVersion(hypoDir, 'SCHEMA.md');
+}
+
+// hypo-guide.md had no update channel at all — upgrade.mjs never
+// looked at it, and init.mjs only ever writes it once (skip if present), so an
+// installed vault's copy went permanently stale the moment the shipped template
+// changed, with no signal to the user. This check restores visibility (a warning
+// on drift) without adding a write path: --apply still never touches an
+// installed hypo-guide.md, exactly like SCHEMA.md's existing Option C contract.
+function checkGuideVersion(hypoDir) {
+  return checkTemplateVersion(hypoDir, 'hypo-guide.md');
 }
 
 // Target-aware: the same core-hook integrity check runs against ~/.claude/hooks/
@@ -891,6 +923,7 @@ const managesClaudeCore = !pluginMode && (!dualInstallCoreConflict || args.allow
 const dualSkip = dualInstallCoreConflict && !args.allowDualInstall;
 
 const schema = checkSchemaVersion(args.hypoDir);
+const guide = checkGuideVersion(args.hypoDir);
 const hooks = checkHookFiles(claudeHooksDir);
 const settings = checkSettingsJson(claudeSettingsPath, claudeHooksDir);
 const pkgJson = checkPkgJson();
@@ -953,7 +986,19 @@ const missingSettingsCodex = settingsCodex
 const invalidSettingsCodex = settingsCodex
   ? settingsCodex.some((s) => s.status === 'invalid-json')
   : false;
-const schemaDrift = schema.bump !== 'none' && schema.bump !== 'unknown' && schema.bump !== 'ahead';
+// SCHEMA.md keeps its pre-existing behavior: 'unstamped' is deliberately NOT
+// counted as drift here (SCHEMA.md is user-owned vocabulary, Option C — an
+// unstamped SCHEMA.md was already the "cannot compare" case before this
+// classification existed, and no SCHEMA test exercises it as actionable).
+const schemaDrift =
+  schema.bump !== 'none' &&
+  schema.bump !== 'unknown' &&
+  schema.bump !== 'ahead' &&
+  schema.bump !== 'unstamped';
+// hypo-guide.md: 'unstamped' DOES count as drift — this is the exact shape of
+// an already-installed pre-versioning vault, the population this change targets.
+// Excluding it (as the old unknown-only check did) is the bug this fixes.
+const guideDrift = guide.bump !== 'none' && guide.bump !== 'unknown' && guide.bump !== 'ahead';
 // Dual-install: when core is skipped, hypo-pkg.json is deliberately left
 // pointing at the PLUGIN's package root (preserved identity), so checkPkgJson()
 // reports it 'stale' relative to this npm/manual PKG_ROOT. That mismatch is
@@ -1139,6 +1184,7 @@ const hasDrift =
   (managesClaudeCore && claudeCoreDrift) ||
   pkgJsonDrift ||
   schemaDrift ||
+  guideDrift ||
   hypoignore.status === 'needs-migration' ||
   gitignore.status === 'needs-migration' ||
   extDrift ||
@@ -1155,6 +1201,7 @@ if (args.json) {
         coreManagedBy: managesClaudeCore ? 'self' : pluginMode ? 'plugin' : 'plugin-enabled',
         dualInstallOverride: args.allowDualInstall,
         schema,
+        guide,
         hooks,
         settings,
         pkgJson,
@@ -1254,6 +1301,12 @@ if (schema.bump === 'none') {
   lines.push(
     `⚠ SCHEMA version    ${schema.installed} (installed is ahead of package ${schema.current})`,
   );
+} else if (schema.bump === 'unstamped') {
+  // Not counted as drift for SCHEMA.md (Option C, unchanged) — still surfaced
+  // as advisory-only visibility, same spirit as the pre-existing 'unknown' text.
+  lines.push(
+    `⚠ SCHEMA version    installed has no version stamp (pre-versioning copy), package=${schema.current} (cannot compare automatically)`,
+  );
 } else if (schema.bump === 'major') {
   lines.push(
     `✗ SCHEMA version    ${schema.installed} → ${schema.current}  [MAJOR — --apply writes MIGRATION report; SCHEMA must be merged manually]`,
@@ -1261,6 +1314,33 @@ if (schema.bump === 'none') {
 } else {
   lines.push(
     `⚠ SCHEMA version    ${schema.installed} → ${schema.current}  [minor update — review and update SCHEMA.md manually]`,
+  );
+}
+
+// hypo-guide.md version stamp. Visibility only — a drift warning,
+// never a write: --apply must not overwrite an installed hypo-guide.md, since a
+// user may have customized it (same Option C contract as SCHEMA.md above).
+if (guide.bump === 'none') {
+  lines.push(`✓ hypo-guide.md     v${guide.installed} (up to date)`);
+} else if (guide.bump === 'unknown') {
+  lines.push(
+    `⚠ hypo-guide.md     installed=${guide.installed ?? 'not found (no version stamp)'}, package=${guide.current ?? 'not found'} (cannot compare)`,
+  );
+} else if (guide.bump === 'ahead') {
+  lines.push(
+    `⚠ hypo-guide.md     v${guide.installed} (installed is ahead of package v${guide.current})`,
+  );
+} else if (guide.bump === 'unstamped') {
+  // The target case: the file exists (this is not a fresh/missing
+  // install) but predates the version stamp entirely. Counted as drift above
+  // (guideDrift) — the message must be actionable, not "cannot compare",
+  // since a pre-versioning copy silently reporting "up to date" was the bug.
+  lines.push(
+    `⚠ hypo-guide.md     installed copy has no version stamp (pre-versioning stale copy; package=v${guide.current}) — review templates/hypo-guide.md and update your copy manually; --apply does not overwrite it`,
+  );
+} else {
+  lines.push(
+    `⚠ hypo-guide.md     v${guide.installed} → v${guide.current}  [package template changed — review templates/hypo-guide.md and update your copy manually; --apply does not overwrite it]`,
   );
 }
 
@@ -1577,6 +1657,7 @@ const totalDrift =
   claudeCoreCount +
   (pkgJsonDrift ? 1 : 0) +
   (schemaDrift ? 1 : 0) +
+  (guideDrift ? 1 : 0) +
   (hypoignore.status === 'needs-migration' ? hypoignore.missing.length : 0) +
   (gitignore.status === 'needs-migration' ? gitignore.missing.length : 0) +
   extCheck.actions.filter(

--- a/templates/hypo-guide.md
+++ b/templates/hypo-guide.md
@@ -2,6 +2,7 @@
 title: Wiki Operations Guide
 type: reference
 updated: YYYY-MM-DD
+version: 1
 tags: [wiki, guide, operations]
 ---
 

--- a/tests/upgrade.test.mjs
+++ b/tests/upgrade.test.mjs
@@ -485,6 +485,194 @@ test('--apply migration report tags are all in installed SCHEMA vocab', () => {
   });
 });
 
+// ── ISSUE-55: hypo-guide.md version stamp / staleness warning ──────────────
+// hypo-guide.md previously had no update channel at all: upgrade.mjs never
+// checked it, and init.mjs only ever writes it once. These tests prove the
+// new drift check fires (red proof: same suite also proves it stays silent
+// when the stamps match, and that --apply never rewrites the installed file).
+suite('upgrade.mjs — hypo-guide.md version drift (ISSUE-55)');
+
+test('guide.bump is "none" when installed hypo-guide.md matches the package template', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      assert.ok('guide' in out, 'JSON output missing top-level guide field');
+      assert.equal(
+        out.guide.bump,
+        'none',
+        `freshly-init'd hypo-guide.md should match the package template: ${JSON.stringify(out.guide)}`,
+      );
+    });
+  });
+});
+
+// Red proof: roll the installed stamp back one version and confirm the drift
+// check actually distinguishes it from the matching case above — turning the
+// stamp-compare off (or leaving the stamps equal) would make this pass
+// silently too, which is exactly the ISSUE-55 regression this test is for.
+test('guide.bump is non-none and the report warns when installed hypo-guide.md is stale', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const guidePath = join(hypoDir, 'hypo-guide.md');
+      writeFileSync(
+        guidePath,
+        readFileSync(guidePath, 'utf-8').replace(/^version: .+$/m, 'version: 0'),
+      );
+
+      const jsonR = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(jsonR.stdout);
+      // 0 → 1 is a major-shaped bump per bumpType(); ISSUE-55 only needs "not up
+      // to date", not a major/minor distinction (no migration-report behavior
+      // hangs off this one, unlike SCHEMA.md).
+      assert.equal(
+        out.guide.bump,
+        'major',
+        `expected a major-shaped bump from v0 to package v1: ${JSON.stringify(out.guide)}`,
+      );
+      assert.equal(jsonR.status, 1, 'stale hypo-guide.md must count as drift (non-zero exit)');
+
+      const textR = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`], home);
+      assert.ok(
+        /hypo-guide\.md.*package template changed/.test(textR.stdout),
+        `text report must warn about stale hypo-guide.md: ${textR.stdout}`,
+      );
+    });
+  });
+});
+
+// ISSUE-19 guard: the drift warning must never come with a write path. Confirm
+// --apply leaves a customized hypo-guide.md byte-equal, exactly like the SCHEMA.md
+// Option C contract above.
+test('--apply never overwrites an installed hypo-guide.md, even when stale', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const guidePath = join(hypoDir, 'hypo-guide.md');
+      const customized =
+        readFileSync(guidePath, 'utf-8').replace(/^version: .+$/m, 'version: 0') +
+        '\n<!-- user note -->\n';
+      writeFileSync(guidePath, customized);
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+
+      const after = readFileSync(guidePath, 'utf-8');
+      assert.equal(
+        after,
+        customized,
+        'user hypo-guide.md must be byte-equal after --apply (visibility only, no overwrite)',
+      );
+    });
+  });
+});
+
+// codex pre-commit review BLOCKER: an already-installed vault's hypo-guide.md
+// predates the version stamp entirely (no `version:` line at all, not merely
+// an old value) — that is the actual shape of every existing installed copy,
+// and it is exactly the case the v0-rollback test above does NOT cover (that
+// test only ever strips the VALUE, never the whole line). Before this fix,
+// stripping the line entirely made checkTemplateVersion() fall through to
+// bumpType(null, pkgVersion) === 'unknown', which was excluded from
+// guideDrift — so the file this feature exists to catch reported
+// "up to date" with exit 0.
+test('guide.bump is "unstamped" (counted as drift) when the version line is removed entirely', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const guidePath = join(hypoDir, 'hypo-guide.md');
+      // Remove the whole `version:` line — not just its value — to match a
+      // pre-versioning installed copy exactly.
+      const stripped = readFileSync(guidePath, 'utf-8')
+        .split('\n')
+        .filter((line) => !/^version:\s/.test(line))
+        .join('\n');
+      writeFileSync(guidePath, stripped);
+
+      const jsonR = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(jsonR.stdout);
+      assert.equal(
+        out.guide.bump,
+        'unstamped',
+        `expected bump 'unstamped' for a version-line-less hypo-guide.md: ${JSON.stringify(out.guide)}`,
+      );
+      assert.equal(
+        jsonR.status,
+        1,
+        `an unstamped installed hypo-guide.md must count as drift (exit 1), not "up to date": ${jsonR.stdout}`,
+      );
+
+      const textR = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`], home);
+      assert.ok(
+        !/Result: Hypomnema is up to date/.test(textR.stdout),
+        `must not report "up to date" for an unstamped hypo-guide.md: ${textR.stdout}`,
+      );
+      assert.ok(
+        /hypo-guide\.md\s+installed copy has no version stamp/.test(textR.stdout),
+        `text report must give an actionable "no version stamp" warning, not "cannot compare": ${textR.stdout}`,
+      );
+
+      // ISSUE-19: still no write path, even for the unstamped case.
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, `--apply failed: ${r.stderr}`);
+      assert.equal(
+        readFileSync(guidePath, 'utf-8'),
+        stripped,
+        'an unstamped hypo-guide.md must still be byte-equal after --apply (no overwrite)',
+      );
+    });
+  });
+});
+
+// SCHEMA.md interaction guard: checkTemplateVersion() is shared between
+// SCHEMA.md and hypo-guide.md, so the 'unstamped' classification must not
+// change SCHEMA.md's existing (pre-ISSUE-55) drift behavior — SCHEMA.md is
+// user-owned vocabulary (Option C) and an unstamped copy was already
+// non-actionable ("cannot compare") before this classification existed.
+test('an unstamped SCHEMA.md is classified but NOT counted as drift (SCHEMA behavior unchanged)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const schemaPath = join(hypoDir, 'SCHEMA.md');
+      const stripped = readFileSync(schemaPath, 'utf-8')
+        .split('\n')
+        .filter((line) => !/^version:\s/.test(line))
+        .join('\n');
+      writeFileSync(schemaPath, stripped);
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.schema.bump,
+        'unstamped',
+        `expected the shared classifier to report 'unstamped' for SCHEMA.md too: ${JSON.stringify(out.schema)}`,
+      );
+      assert.equal(
+        r.status,
+        0,
+        `SCHEMA.md's unstamped case must stay non-actionable (exit 0, unchanged behavior): ${r.stdout}`,
+      );
+    });
+  });
+});
+
 // ── ISSUE-6: plugin-mode guard (upgrade.mjs) ───────────────────
 // When /hypo:upgrade runs as the Claude Code PLUGIN, the core hooks/commands/
 // settings are provided by the plugin loader, not ~/.claude/. The manual-model


### PR DESCRIPTION
# English

## What changed

`hypo-guide.md` now carries a `version:` frontmatter stamp (like `SCHEMA.md`), and
`upgrade` compares the installed copy's stamp against the package template. When the
installed copy has drifted, `upgrade` warns and exits non-zero. It never overwrites the
installed file.

An installed copy that has no stamp at all (a pre-versioning vault, which is the exact
population this fixes) is classified as its own `unstamped` state and counted as drift,
with an actionable message. The shared version helper only classifies; each caller
decides whether a state counts as drift, so `SCHEMA.md`'s existing behavior is unchanged.

## Why

`hypo-guide.md` is a runtime instruction file the model reads and follows at
session-close, but `upgrade` only ever refreshed `SCHEMA.md`, and `init` skips a file
that already exists. So once the shipped template changed, an installed vault's copy
went permanently stale with no channel to even surface it. A fix landed in the package
template never reached installed vaults, and the model kept following the stale copy.

The needed change is visibility, not an overwrite: overwriting a hand-edited runtime
file would reintroduce the "clobber a user's page" problem. So `upgrade` warns and
points at the template; the user updates their copy by hand.

## How

`checkTemplateVersion` distinguishes three cases: stamped-and-comparable, file missing
(`unknown`, cannot compare), and file present but unstamped (`unstamped`). For
`hypo-guide.md`, `unstamped` and any real version drift both count toward the drift
total and the non-zero exit. `--apply` has no write path for `hypo-guide.md` at all.

## Manual verification

- `node tests/runner.mjs --file=upgrade` (50 passed), including the SCHEMA regressions.
- Unstamped repro: removing the whole `version:` line from an installed `hypo-guide.md`
  gives `guide.bump: "unstamped"`, exit 1, and an actionable report line (not "up to
  date"). Confirmed red first: with the old exclusion the same case exited 0.
- `--apply` on a customized, stale `hypo-guide.md` leaves it byte-equal.
- `npm test` (1593 passed) and `npm run check:tracker-ids` pass.
- Observed live: this repo's pre-commit check printed the new warning against this
  machine's own unstamped vault copy.

## Migration notes

On the first `upgrade` after this ships, an existing vault whose `hypo-guide.md`
predates the stamp is reported as `unstamped` drift with a manual-update pointer.
Nothing is overwritten; the user reviews `templates/hypo-guide.md` and updates their
copy by hand.

---

# 한국어

## 변경 내용

`hypo-guide.md`에 `version:` frontmatter 스탬프가 붙고(`SCHEMA.md`처럼), `upgrade`가 설치된
사본의 스탬프를 패키지 템플릿과 비교한다. 설치본이 drift했으면 `upgrade`가 경고하고 non-zero로
종료한다. 설치 파일을 절대 덮어쓰지 않는다.

스탬프가 아예 없는 설치본(pre-versioning 볼트, 이 수정이 겨냥한 바로 그 population)은 별도
`unstamped` 상태로 분류되어 drift로 집계되고 actionable 메시지가 나간다. 공유 버전 헬퍼는 분류만
하고, drift로 칠지는 각 호출자가 정하므로 `SCHEMA.md`의 기존 동작은 그대로다.

## 이유

`hypo-guide.md`는 모델이 session-close 때 읽고 따르는 런타임 지시서인데, `upgrade`는 `SCHEMA.md`만
갱신했고 `init`은 이미 있는 파일을 skip한다. 그래서 배포 템플릿이 바뀌면 설치된 볼트의 사본은 그것을
드러낼 채널조차 없이 영구 stale해졌다. 패키지 템플릿에 반영된 수정이 설치 볼트에 도달하지 못하고,
모델은 stale 사본을 계속 따랐다.

필요한 건 덮어쓰기가 아니라 가시성이다. 수기 수정된 런타임 파일을 덮어쓰면 "사용자 페이지 clobber"
문제가 재발한다. 그래서 `upgrade`는 경고하고 템플릿을 가리키며, 사용자가 사본을 수기로 갱신한다.

## 방법

`checkTemplateVersion`이 세 경우를 구분한다: 스탬프 있음+비교 가능, 파일 없음(`unknown`, 비교 불가),
파일은 있는데 스탬프 없음(`unstamped`). `hypo-guide.md`는 `unstamped`와 실제 버전 drift 둘 다 drift
합계와 non-zero 종료에 들어간다. `--apply`에는 `hypo-guide.md` 쓰기 경로가 아예 없다.

## 수동 검증

- `node tests/runner.mjs --file=upgrade`(50 passed), SCHEMA 회귀 포함.
- unstamped 재현: 설치된 `hypo-guide.md`에서 `version:` 줄을 통째로 지우면 `guide.bump: "unstamped"`,
  exit 1, actionable 리포트 라인("up to date" 아님). red 먼저 확인: 옛 제외 로직에선 같은 경우가 exit 0.
- 커스터마이즈된 stale `hypo-guide.md`에 `--apply`해도 byte-equal.
- `npm test`(1593 passed)와 `npm run check:tracker-ids` 통과.
- 라이브 관찰: 이 repo의 pre-commit 체크가 이 머신의 무스탬프 볼트 사본에 대해 새 경고를 출력했다.

## 마이그레이션 노트

이 변경 배포 후 첫 `upgrade`에서, `hypo-guide.md`가 스탬프 이전 시절인 기존 볼트는 `unstamped`
drift로 수기 갱신 안내와 함께 보고된다. 아무것도 덮어쓰지 않으며, 사용자가 `templates/hypo-guide.md`를
검토해 사본을 수기로 갱신한다.

---

## Changelog

- EN: `/hypo:upgrade` now warns when an installed hypo-guide.md has drifted from (or predates the versioning of) the shipped template, instead of leaving it silently stale (#209)
- KO: `/hypo:upgrade`가 설치된 hypo-guide.md가 배포 템플릿과 어긋나거나(버전 스탬프 이전이거나) 할 때 조용히 stale로 두지 않고 경고 (#209)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
