### PR TITLE
fix(doctor,init): plugin-channel awareness + pkg-pointer integrity + dry-run parity

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -44,10 +44,31 @@ import {
 } from './lib/extensions.mjs';
 import { sha256, readFileIfRegular, readPkgJson } from './lib/pkg-json.mjs';
 import { resolveCliOnPath, classifyInstall } from '../hooks/version-check.mjs';
+import { isHypomnemaPluginEnabled } from './lib/plugin-detect.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
 const PKG_ROOT = join(SCRIPT_DIR, '..');
+
+// ── install channel ───────────────────────────────────────────────────────────
+//
+// A plugin-channel install registers its 14 core hooks straight out of the
+// package's own hooks/hooks.json (CLAUDE_PLUGIN_ROOT) — Claude Code auto-wires
+// them, they are never copied into ~/.claude/hooks and never listed in
+// ~/.claude/settings.json. checkHooks/checkSettingsJson used to treat that
+// empty state as "missing" and prescribe `/hypo:init`, which then copied +
+// registered the very same hooks a second time (every hook firing twice).
+//
+// `pluginMode` mirrors upgrade.mjs's own detector: this doctor.mjs is itself
+// running from a `.claude/plugins/…` root. `hypomnemaPluginEnabled` catches the
+// dual-install variant — a manual/npm doctor.mjs run while the plugin is ALSO
+// enabled in settings.json (see lib/plugin-detect.mjs; fails open on any
+// uncertainty). Either signal means Claude's core hook surface is
+// plugin-managed, not missing.
+const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
+const hypomnemaPluginEnabled =
+  !pluginMode && isHypomnemaPluginEnabled(join(HOME, '.claude', 'settings.json'));
+const coreManagedByPlugin = pluginMode || hypomnemaPluginEnabled;
 
 // Shown after every fatal package-integrity error. These conditions mean the
 // shipped hooks/hooks.json is missing or malformed — never a user mistake —
@@ -259,7 +280,7 @@ function checkFiles(hypoDir) {
   }
 }
 
-function checkHooks() {
+function checkHooks(coreManagedByPlugin) {
   const claudeHooks = join(HOME, '.claude', 'hooks');
   const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
 
@@ -270,6 +291,13 @@ function checkHooks() {
 
   if (missing === 0) {
     pass('Hook files installed', claudeHooks);
+  } else if (coreManagedByPlugin && missing === allFiles.length) {
+    // Plugin channel: an empty ~/.claude/hooks is the expected, healthy state
+    // (the plugin loader provides the hooks), not a missing install.
+    pass(
+      'Hook files installed',
+      `provided by the plugin loader (hooks/hooks.json) — none copied to ${claudeHooks} (expected)`,
+    );
   } else if (missing < allFiles.length) {
     warn('Hook files installed', `${missing}/${allFiles.length} missing in ${claudeHooks}`);
   } else {
@@ -277,10 +305,17 @@ function checkHooks() {
   }
 }
 
-function checkSettingsJson() {
+function checkSettingsJson(coreManagedByPlugin) {
   const settingsPath = join(HOME, '.claude', 'settings.json');
   if (!existsSync(settingsPath)) {
-    warn('settings.json hook registrations', 'settings.json not found');
+    if (coreManagedByPlugin) {
+      pass(
+        'settings.json hook registrations',
+        'provided by the plugin loader (hooks/hooks.json) — settings.json entries not required',
+      );
+    } else {
+      warn('settings.json hook registrations', 'settings.json not found');
+    }
     return;
   }
 
@@ -313,6 +348,13 @@ function checkSettingsJson() {
     warn(
       'settings.json hook registrations',
       `${registered}/${total} registered — run /hypo:init to merge missing entries`,
+    );
+  } else if (coreManagedByPlugin) {
+    // Same reasoning as checkHooks: the plugin loader never touches settings.json,
+    // so 0/total here is the expected plugin-channel state, not a missing install.
+    pass(
+      'settings.json hook registrations',
+      `0/${total} registered in settings.json — provided by the plugin loader (hooks/hooks.json) instead (expected)`,
     );
   } else {
     fail('settings.json hook registrations', `0/${total} registered — run /hypo:init`);
@@ -1312,6 +1354,121 @@ function checkStaleSibling() {
   }
 }
 
+// ── package integrity ─────────────────────────────────────────────────────────
+//
+// ~/.claude/hypo-pkg.json is a snapshot written once by init/upgrade and never
+// re-validated: nothing tracks whether pkgRoot still exists, whether its
+// package.json version still matches the recorded pkgVersion, or whether
+// pkgRoot points at a dev checkout instead of a distributed copy. Command and
+// skill script resolution was unified onto this one pointer, so a stale or
+// dev-pointing pkgRoot means the wiki silently runs uncommitted WIP.
+// All three checks are WARN, never FAIL — a dogfooding maintainer must be
+// able to ignore them on purpose.
+function checkPkgIntegrity(claudeHome) {
+  const pkgPath = join(claudeHome, 'hypo-pkg.json');
+  const meta = readPkgJson(pkgPath);
+  // Distinguish "no metadata file at all" (a fresh install — non-actionable, stay
+  // silent) from "a file is present but has no pkgRoot" (incomplete metadata that
+  // breaks runtime package resolution — warn rather than silently reading as OK).
+  // readPkgJson renames a corrupt file aside and returns {}, so after that the path
+  // no longer exists and this correctly falls into the silent fresh-install branch.
+  if (!existsSync(pkgPath)) return;
+  if (!meta || !meta.pkgRoot) {
+    warn(
+      'hypo-pkg.json pkgRoot',
+      `hypo-pkg.json has no pkgRoot field — metadata is incomplete; re-run /hypo:init or /hypo:upgrade`,
+    );
+    return;
+  }
+
+  const { pkgRoot, pkgVersion } = meta;
+
+  if (!existsSync(pkgRoot)) {
+    warn(
+      'hypo-pkg.json pkgRoot exists',
+      `${pkgRoot} does not exist — metadata is stale; re-run /hypo:init or /hypo:upgrade`,
+    );
+    return;
+  }
+  pass('hypo-pkg.json pkgRoot exists', pkgRoot);
+
+  let actualVersion = null;
+  let pkgJsonReadable = false;
+  try {
+    actualVersion = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf-8')).version;
+    pkgJsonReadable = true;
+  } catch {
+    warn('hypo-pkg.json version match', `${pkgRoot}/package.json is unreadable — cannot verify`);
+  }
+  // Every reachable state emits exactly one line: a silent skip here would read as
+  // "verified" on the health report when nothing was actually checked.
+  if (actualVersion) {
+    if (pkgVersion && actualVersion !== pkgVersion) {
+      warn(
+        'hypo-pkg.json version match',
+        `recorded pkgVersion is ${pkgVersion}, but pkgRoot's package.json is v${actualVersion} — ` +
+          `stale metadata; re-run /hypo:init or /hypo:upgrade`,
+      );
+    } else if (pkgVersion) {
+      pass('hypo-pkg.json version match', `v${actualVersion}`);
+    } else {
+      warn(
+        'hypo-pkg.json version match',
+        `metadata records no pkgVersion — cannot verify against pkgRoot's v${actualVersion}; ` +
+          `re-run /hypo:init or /hypo:upgrade`,
+      );
+    }
+  } else if (pkgJsonReadable) {
+    warn(
+      'hypo-pkg.json version match',
+      `${pkgRoot}/package.json has no "version" field — cannot verify`,
+    );
+  }
+
+  // dev-repo check: pkgRoot is a git working tree that is dirty or sits on a
+  // commit with no exact release tag. Normal users should point at a
+  // distributed copy (plugin cache or npm install), not a source checkout.
+  if (existsSync(join(pkgRoot, '.git'))) {
+    const status = spawnSync('git', ['-C', pkgRoot, 'status', '--porcelain'], {
+      encoding: 'utf-8',
+    });
+    const tag = spawnSync('git', ['-C', pkgRoot, 'describe', '--tags', '--exact-match'], {
+      encoding: 'utf-8',
+    });
+    // A non-zero `git describe` exit is the real "HEAD is not an exact tag" signal,
+    // but a spawn failure (git not installed, ENOENT) sets `.error` / a null status
+    // too. Treat those as "cannot classify" instead of silently mislabeling the
+    // pkgRoot as an untagged dev checkout. `git status --porcelain` must exit 0 on
+    // any real repo (clean OR dirty), so a non-zero status there means the repo is
+    // corrupt/inaccessible — also "cannot classify", not "untagged". `git describe`
+    // legitimately exits non-zero when HEAD carries no exact tag, so only its spawn
+    // (error/null status) disqualifies it, not a non-zero exit.
+    const gitUsable =
+      status.error == null && status.status === 0 && tag.error == null && tag.status != null;
+    if (!gitUsable) {
+      warn(
+        'hypo-pkg.json pkgRoot install kind',
+        `pkgRoot has a .git directory but git could not be run — cannot classify the install kind`,
+      );
+      return;
+    }
+    const dirty = status.stdout.trim().length > 0; // gitUsable already asserts status 0
+    const untagged = tag.status !== 0;
+    if (dirty || untagged) {
+      const reasons = [];
+      if (dirty) reasons.push('uncommitted changes');
+      if (untagged) reasons.push('HEAD is not an exact release tag');
+      warn(
+        'hypo-pkg.json pkgRoot install kind',
+        `pkgRoot looks like a development checkout (${reasons.join(', ')}) — normal users should ` +
+          `point at a distributed copy (plugin cache or npm install), not a source repo`,
+      );
+    } else {
+      pass('hypo-pkg.json pkgRoot install kind', 'pkgRoot is a clean, tagged checkout');
+    }
+  }
+}
+
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
@@ -1325,8 +1482,9 @@ if (rootOk) {
   checkBrokenLinks(args.hypoDir, ignorePatterns);
   checkVerifyBy(args.hypoDir, ignorePatterns);
 }
-checkHooks();
-checkSettingsJson();
+checkHooks(coreManagedByPlugin);
+checkSettingsJson(coreManagedByPlugin);
+checkPkgIntegrity(args.claudeHome);
 checkStaleSibling();
 if (args.codex) checkCodexPaths();
 if (rootOk) checkExtensions(args.hypoDir, args.claudeHome, 'claude');

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -32,7 +32,7 @@ import {
   renameSync,
   unlinkSync,
 } from 'fs';
-import { join, basename, dirname } from 'path';
+import { join, basename, dirname, isAbsolute } from 'path';
 import { homedir } from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -49,6 +49,7 @@ import {
 import { syncExtensions } from './lib/extensions.mjs';
 import { templateSchemaVersion } from './lib/template-schema-version.mjs';
 import { classifyInstall, downgradeGuardMessage } from '../hooks/version-check.mjs';
+import { isHypomnemaPluginEnabled, enabledHypomnemaPluginKey } from './lib/plugin-detect.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -472,34 +473,91 @@ function pkgJsonPath() {
  * install (no metadata), unparseable versions, the same package re-running itself,
  * --allow-downgrade, or --dry-run.
  */
-function maybeRefuseDowngrade(op, allowDowngrade, dryRun) {
-  if (allowDowngrade || dryRun) return;
+function maybeRefuseDowngrade(op, allowDowngrade, dryRun, durableRoot) {
+  if (allowDowngrade || dryRun || !PKG_VERSION) return;
   const active = readPkgJsonSafe(pkgJsonPath());
-  if (!active || !active.pkgVersion || !PKG_VERSION) return;
-  const verdict = classifyInstall(
-    { pkgRoot: PKG_ROOT, version: PKG_VERSION },
-    { pkgRoot: active.pkgRoot, version: active.pkgVersion },
-  );
-  if (verdict === 'downgrade') {
-    console.error(downgradeGuardMessage(PKG_VERSION, active.pkgVersion, op));
-    process.exit(2);
+  const candidates = [];
+  // The recorded metadata: catches a stale bin trying to downgrade a newer
+  // recorded install (the original guard).
+  if (active && active.pkgVersion) {
+    candidates.push({ pkgRoot: active.pkgRoot, version: active.pkgVersion });
+  }
+  // The positively-resolved durable (plugin) install, when it is a DIFFERENT root
+  // than this package. In an npm-first dual install the recorded pkgVersion is the
+  // stale npm one, so comparing only against it lets an OLDER npm init run against a
+  // NEWER plugin; also compare against the plugin's own version. readPkgVersionAt
+  // yields a version only for a usable root.
+  if (durableRoot && durableRoot !== PKG_ROOT) {
+    const durableVersion = readPkgVersionAt(durableRoot);
+    if (durableVersion) candidates.push({ pkgRoot: durableRoot, version: durableVersion });
+  }
+  for (const active of candidates) {
+    const verdict = classifyInstall(
+      { pkgRoot: PKG_ROOT, version: PKG_VERSION },
+      { pkgRoot: active.pkgRoot, version: active.version },
+    );
+    if (verdict === 'downgrade') {
+      console.error(downgradeGuardMessage(PKG_VERSION, active.version, op));
+      process.exit(2);
+    }
   }
 }
 
-function writePkgJson(dryRun, extraFields = {}) {
+function readPkgVersionAt(root) {
+  try {
+    const v = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')).version;
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// A pkgRoot is "usable" as a DURABLE install root only if it is an ABSOLUTE path to
+// a real package directory whose package.json carries a version. A relative path
+// (e.g. installPath ".") would be resolved against the caller's cwd and break the
+// vault git hook from any other directory; a version-less package.json cannot be
+// attributed a version without lying (see writePkgJson). A bare path that merely
+// exists is a pointer the runtime cannot resolve scripts through. Shared by the
+// registry resolution and the durable-root fallback so they agree on what is real.
+function usablePkgRoot(pkgRoot) {
+  return (
+    typeof pkgRoot === 'string' &&
+    pkgRoot.length > 0 &&
+    isAbsolute(pkgRoot) &&
+    existsSync(join(pkgRoot, 'package.json')) &&
+    readPkgVersionAt(pkgRoot) !== null
+  );
+}
+
+function writePkgJson(dryRun, extraFields = {}, root = PKG_ROOT) {
   const dest = pkgJsonPath();
   const existing = readPkgJsonSafe(dest);
+  // `root` is the DURABLE install root the runtime resolves scripts through
+  // (hooks/hypo-shared.mjs reads pkgRoot): PKG_ROOT for a normal install, the
+  // positively-resolved plugin cache root for a dual install (see resolveDurableRoot).
+  // pkgVersion is read from `root` too — stamping a dual-install pointer at the
+  // plugin with THIS npm package's version would make doctor's own version-match
+  // check contradict itself. schemaVersion describes the templates init writes,
+  // which always come from PKG_ROOT regardless of where scripts resolve.
   const merged = {
     ...existing,
-    pkgRoot: PKG_ROOT,
-    pkgVersion: PKG_VERSION,
+    pkgRoot: root,
+    pkgVersion: readPkgVersionAt(root) ?? PKG_VERSION,
     schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.1',
     ...extraFields,
   };
-  if (!dryRun) {
+  // Skip the write outright when the durable identity already matches what is on
+  // disk, rather than re-serialize an unchanged file. That keeps the dry-run and
+  // real write-sets identical: a real run must never silently rewrite a file a dry
+  // run reported as skipped. A genuine change (fresh identity, a version bump, or a
+  // dual-install correction from a stale npm pointer to the plugin root) is logged
+  // as "created" so it shows up in both write-sets. Log is emitted unconditionally
+  // (outside the dryRun guard) so a dry run previews exactly what a real run does.
+  const noWrite = JSON.stringify(merged) === JSON.stringify(existing);
+  if (!dryRun && !noWrite) {
     writePkgJsonAtomic(dest, merged);
-    log('created', dest);
   }
+  log(noWrite ? 'skipped' : 'created', noWrite ? `${dest} (durable pkgRoot unchanged)` : dest);
   return merged;
 }
 
@@ -642,19 +700,26 @@ function installPkgGitHook(dryRun) {
 const WIKI_PRE_COMMIT_MARKER_START = '# hypo-managed:pre-commit:start';
 const WIKI_PRE_COMMIT_MARKER_END = '# hypo-managed:pre-commit:end';
 
-function wikiPreCommitContent() {
-  const worker = join(PKG_ROOT, 'hooks', 'hypo-pre-commit.mjs');
+// `root` is the DURABLE install root the hook should resolve hypo-pre-commit.mjs
+// through — not necessarily PKG_ROOT. In a dual install (a manual/npm init while
+// the plugin is enabled) PKG_ROOT is the manual/npm checkout the dual-install
+// notice tells the user to uninstall; embedding it here would leave the vault's
+// git hook dangling the moment they do, breaking every wiki commit. The caller
+// passes the preserved plugin-owned root instead (see `durableRoot`), so the hook
+// points at the install that actually persists.
+function wikiPreCommitContent(root) {
+  const worker = join(root, 'hooks', 'hypo-pre-commit.mjs');
   // Single-quote escaping prevents shell expansion of special chars (e.g. $HOME, backticks) in path
   const escaped = worker.replace(/'/g, "'\\''");
   return `#!/bin/sh\n${WIKI_PRE_COMMIT_MARKER_START}\nnode '${escaped}'\nexit $?\n${WIKI_PRE_COMMIT_MARKER_END}\n`;
 }
 
-function installWikiPreCommitHook(hypoDir, dryRun, force) {
+function installWikiPreCommitHook(hypoDir, dryRun, force, root) {
   const gitDir = join(hypoDir, '.git');
   if (!existsSync(gitDir)) return; // no git repo — silently skip
   const hooksDir = join(gitDir, 'hooks');
   const hookPath = join(hooksDir, 'pre-commit');
-  const newContent = wikiPreCommitContent();
+  const newContent = wikiPreCommitContent(root);
 
   if (existsSync(hookPath)) {
     const existing = readFileSync(hookPath, 'utf-8');
@@ -841,6 +906,88 @@ function firstCommit(hypoDir, remote, dryRun) {
 
 const args = parseArgs(process.argv);
 
+// ── install channel ───────────────────────────────────────────────────────────
+//
+// A plugin-channel install already provides the 14 core hooks + slash commands
+// through the package's own hooks/hooks.json + commands/ (Claude Code auto-wires
+// them). Copying the same hooks into ~/.claude/hooks and registering the same
+// events in settings.json on top makes every core hook fire TWICE, the same
+// failure mode already fixed for `upgrade --apply`. `pluginMode` mirrors
+// upgrade.mjs's own detector (this init.mjs itself running from a
+// `.claude/plugins/…` root); `hypomnemaPluginEnabled` catches the dual-install
+// variant (a manual/npm init.mjs run while the plugin is ALSO enabled — see
+// lib/plugin-detect.mjs, fail-open on any uncertainty). Either signal means
+// Claude's core hook/command surface is plugin-managed already.
+const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
+const hypomnemaPluginEnabled =
+  !pluginMode && isHypomnemaPluginEnabled(join(HOME, '.claude', 'settings.json'));
+const coreManagedByPlugin = pluginMode || hypomnemaPluginEnabled;
+
+// Resolve the enabled Hypomnema plugin's REAL install root from the plugin
+// registry (~/.claude/plugins/installed_plugins.json). POSITIVE attribution: it
+// looks up the EXACT key that settings.json marks enabled (via
+// enabledHypomnemaPluginKey), not just any hypo-named entry — a disabled legacy or
+// other-marketplace entry must never be selected. Among that key's registry
+// entries it prefers the user-scope install (the one a plugin-enabled user runs),
+// falling back to any usable entry. Returns a usable absolute install root, or
+// null when the registry is absent/unreadable, names no entry for the enabled key,
+// or that entry is not a usable package dir.
+function resolveEnabledPluginRoot(settingsPath) {
+  const key = enabledHypomnemaPluginKey(settingsPath);
+  if (!key) return null;
+  let reg;
+  try {
+    reg = JSON.parse(
+      readFileSync(join(HOME, '.claude', 'plugins', 'installed_plugins.json'), 'utf-8'),
+    );
+  } catch {
+    return null;
+  }
+  const plugins =
+    reg && typeof reg.plugins === 'object' && !Array.isArray(reg.plugins) ? reg.plugins : null;
+  const entries = plugins && Array.isArray(plugins[key]) ? plugins[key] : null;
+  if (!entries) return null;
+  const paths = (scope) =>
+    entries
+      .filter((e) => e && (scope === undefined || e.scope === scope))
+      .map((e) => (typeof e.installPath === 'string' ? e.installPath : null))
+      .filter((p) => usablePkgRoot(p));
+  // Prefer the user-scope install, then any usable entry for this exact key.
+  return paths('user')[0] ?? paths(undefined)[0] ?? null;
+}
+
+// Non-mutating read of the recorded pkgRoot. resolveDurableRoot runs before init's
+// package validation and its "no writes before validation" guarantee, so it must
+// NOT use readPkgJsonSafe (which renames a corrupt hypo-pkg.json aside — a write).
+function recordedPkgRoot() {
+  try {
+    const v = JSON.parse(readFileSync(pkgJsonPath(), 'utf-8')).pkgRoot;
+    return typeof v === 'string' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// The durable install root that persistent artifacts (the vault's git pre-commit
+// hook, hypo-pkg.json) should point at. In a dual install PKG_ROOT is the
+// manual/npm checkout the dual-install notice tells the user to uninstall, so
+// point at the plugin's REAL cache root, positively resolved from the registry —
+// NOT at whatever pkgRoot is already recorded, which after an npm-first sequence
+// (npm init, enable plugin, npm init again) may itself be that soon-to-be-removed
+// npm root. Only if the registry cannot positively identify the plugin do we fall
+// back to a usable recorded pointer, then PKG_ROOT (never worse than pre-fix). In
+// true plugin mode PKG_ROOT already IS the plugin path; for npm-only it is the
+// only install.
+function resolveDurableRoot() {
+  if (!hypomnemaPluginEnabled) return PKG_ROOT;
+  const pluginRoot = resolveEnabledPluginRoot(join(HOME, '.claude', 'settings.json'));
+  if (pluginRoot) return pluginRoot;
+  const recorded = recordedPkgRoot();
+  if (usablePkgRoot(recorded)) return recorded;
+  return PKG_ROOT;
+}
+const durableRoot = resolveDurableRoot();
+
 // Validate hooks.json before any file writes so a bad package leaves no partial state
 const HOOK_MAP = args.hooks || args.codex ? loadHookMap() : null;
 
@@ -853,7 +1000,7 @@ const HOOK_MAP = args.hooks || args.codex ? loadHookMap() : null;
 // and, with `--codex`, writes ~/.codex hooks/settings. The guard no-ops on a fresh
 // install, same realpath'd pkgRoot (dev re-run / npm-link / post-commit sync),
 // --allow-downgrade, or --dry-run, so legitimate flows are unaffected.
-maybeRefuseDowngrade('init', args.allowDowngrade, args.dryRun);
+maybeRefuseDowngrade('init', args.allowDowngrade, args.dryRun, durableRoot);
 
 if (args.fromRemote) {
   // ── from-remote path: clone → read config → install hooks ──────────────────
@@ -929,16 +1076,29 @@ if (args.fromRemote) {
 
 // 4. hooks
 
+if (coreManagedByPlugin) {
+  log(
+    'skipped',
+    `Claude core hooks/settings/commands — provided by the plugin loader (${
+      pluginMode
+        ? 'this script is running from a Claude Code plugin install'
+        : 'the Hypomnema plugin is enabled in settings.json'
+    }); installing them here would register every hook twice. Use \`claude plugin update\` to upgrade instead.`,
+  );
+}
+
 let commandSHAs = null;
-if (args.commands) {
+if (args.commands && !coreManagedByPlugin) {
   const claudeCommands = join(HOME, '.claude', 'commands', 'hypo');
   commandSHAs = installCommands(claudeCommands, args.dryRun, args.forceCommands);
 }
 
 if (args.hooks) {
-  const claudeHooks = join(HOME, '.claude', 'hooks');
-  installHooks(claudeHooks, args.dryRun);
-  mergeSettingsJson(join(HOME, '.claude', 'settings.json'), claudeHooks, args.dryRun, HOOK_MAP);
+  if (!coreManagedByPlugin) {
+    const claudeHooks = join(HOME, '.claude', 'hooks');
+    installHooks(claudeHooks, args.dryRun);
+    mergeSettingsJson(join(HOME, '.claude', 'settings.json'), claudeHooks, args.dryRun, HOOK_MAP);
+  }
 }
 
 // Always record the active install identity (pkgRoot + pkgVersion), even for a
@@ -947,7 +1107,9 @@ if (args.hooks) {
 // the downgrade guard has nothing to compare against, so a later stale
 // sibling could repoint those surfaces unguarded. writePkgJson merges (...existing),
 // so this never clobbers a commands/extensions map written elsewhere.
-writePkgJson(args.dryRun, commandSHAs ? { commands: commandSHAs } : {});
+// Record hypo-pkg.json against the durable root (the plugin's real cache root in a
+// dual install, PKG_ROOT otherwise), the same root the wiki pre-commit hook uses.
+writePkgJson(args.dryRun, commandSHAs ? { commands: commandSHAs } : {}, durableRoot);
 
 // 4b. user extensions companion sync. Runs after
 // writePkgJson so the per-target SHA map is merged into the same hypo-pkg.json
@@ -1037,8 +1199,10 @@ if (args.hooks) {
   installPkgGitHook(args.dryRun);
 }
 
-// 8b. wiki pre-commit hook (.hypoignore last-line-of-defence guard — §6.8)
-installWikiPreCommitHook(args.hypoDir, args.dryRun, args.forceCommands);
+// 8b. wiki pre-commit hook (.hypoignore last-line-of-defence guard — §6.8).
+// Point it at the durable install root, not PKG_ROOT, so a dual install does not
+// embed a manual/npm path that dangles once the user uninstalls it.
+installWikiPreCommitHook(args.hypoDir, args.dryRun, args.forceCommands, durableRoot);
 
 // 9. first commit + push (skip when cloned from remote — already has commits)
 if (args.gitInit && !args.fromRemote) {

--- a/scripts/lib/plugin-detect.mjs
+++ b/scripts/lib/plugin-detect.mjs
@@ -38,11 +38,18 @@ export function isHypomnemaPluginEnabled(settingsPath) {
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
 
-  const enabled = parsed.enabledPlugins;
+  return enabledKeyFrom(parsed.enabledPlugins) !== null;
+}
+
+// The exact enabledPlugins KEY (`hypo@<marketplace>` / legacy
+// `hypomnema@<marketplace>`) whose value is strictly true, or null. Same matching
+// rules as isHypomnemaPluginEnabled, but returns the identifier so a caller can
+// look that exact plugin up in the install registry rather than guessing among all
+// hypo-named entries.
+function enabledKeyFrom(enabled) {
   // enabledPlugins is an object map `{ "<name>@<marketplace>": true|false }`.
   // Anything else (absent, array, scalar) → not enabled.
-  if (!enabled || typeof enabled !== 'object' || Array.isArray(enabled)) return false;
-
+  if (!enabled || typeof enabled !== 'object' || Array.isArray(enabled)) return null;
   for (const [key, value] of Object.entries(enabled)) {
     if (value !== true) continue; // strictly true only — no truthy coercion
     // Require a real `name@marketplace` shape: an `@` that is neither the first
@@ -54,7 +61,29 @@ export function isHypomnemaPluginEnabled(settingsPath) {
     const name = key.slice(0, at);
     // Match the current plugin name and the legacy one (pre-rename) so the
     // guard holds across the migration window. Exact, case-sensitive.
-    if (name === 'hypo' || name === 'hypomnema') return true;
+    if (name === 'hypo' || name === 'hypomnema') return key;
   }
-  return false;
+  return null;
+}
+
+/**
+ * @param {string} settingsPath  path to a Claude Code settings.json
+ * @returns {string|null} the exact `enabledPlugins` key of the enabled Hypomnema
+ *   plugin (`hypo@<marketplace>` or legacy `hypomnema@<marketplace>`), or null.
+ */
+export function enabledHypomnemaPluginKey(settingsPath) {
+  let raw;
+  try {
+    raw = readFileSync(settingsPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return enabledKeyFrom(parsed.enabledPlugins);
 }

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -4,10 +4,29 @@
 // build on each other; suites may not — that is what lets the runner shard.
 
 import assert from 'node:assert/strict';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  cpSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 import { test, suite } from './harness.mjs';
-import { NONEXISTENT_WIKI, run, runWithHome, withTmpDir, withTmpHome } from './helpers.mjs';
+import {
+  HOOKS,
+  NONEXISTENT_WIKI,
+  REPO,
+  SCRIPTS,
+  run,
+  runWithHome,
+  withTmpDir,
+  withTmpHome,
+} from './helpers.mjs';
 
 // ── doctor.mjs smoke tests ───────────────────────────────────────────────────
 
@@ -473,5 +492,421 @@ test('doctor-codex-paths: --codex flag triggers codex settings.json check', () =
     const out = JSON.parse(r.stdout);
     const settingsCheck = out.find((c) => c.label === 'Codex settings.json hook registrations');
     assert.ok(settingsCheck, 'Codex settings.json check not found');
+  });
+});
+
+// ── ISSUE-52: install-channel awareness (plugin channel false-negative) ───────
+// A plugin-channel install registers its core hooks straight out of the
+// package's own hooks/hooks.json — never into ~/.claude/hooks, never into
+// ~/.claude/settings.json. doctor used to treat that empty state as "missing"
+// and prescribe `/hypo:init`, which then double-registered every hook. Run a
+// COPY of doctor.mjs from a fake root whose path matches the plugin-cache
+// shape (`.claude/plugins/…`) so the channel detector (gated on doctor.mjs's
+// OWN script location, mirroring upgrade.mjs) actually fires.
+suite('doctor.mjs — plugin channel (ISSUE-52)');
+
+function withFakeDoctorInstall(underPlugins, fn) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-doc-'));
+  try {
+    const root = underPlugins
+      ? join(base, '.claude', 'plugins', 'cache', 'mp', 'hypomnema', '1.3.0')
+      : join(base, 'lib', 'node_modules', 'hypomnema');
+    mkdirSync(root, { recursive: true });
+    cpSync(SCRIPTS, join(root, 'scripts'), { recursive: true });
+    cpSync(HOOKS, join(root, 'hooks'), { recursive: true });
+    cpSync(join(REPO, 'package.json'), join(root, 'package.json'));
+    const home = join(base, 'home');
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    const wiki = join(base, 'wiki');
+    mkdirSync(wiki, { recursive: true });
+    writeFileSync(join(wiki, 'hypo-config.md'), '---\ntitle: config\ntype: reference\n---\n');
+    fn({ doctor: join(root, 'scripts', 'doctor.mjs'), root, home, wiki });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function runDoctorFrom(doctor, args, home) {
+  return spawnSync(process.execPath, [doctor, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HYPO_DIR: '', HOME: home },
+  });
+}
+
+test('plugin mode: empty ~/.claude/hooks passes, not fails', () => {
+  withFakeDoctorInstall(true, ({ doctor, home, wiki }) => {
+    const r = runDoctorFrom(doctor, [`--hypo-dir=${wiki}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const hookCheck = out.find((c) => c.label === 'Hook files installed');
+    assert.ok(hookCheck, 'Hook files installed check not found');
+    assert.equal(
+      hookCheck.status,
+      'pass',
+      `plugin channel with empty ~/.claude/hooks must pass: ${JSON.stringify(hookCheck)}`,
+    );
+  });
+});
+
+test('plugin mode: 0/N settings.json registrations passes, not fails', () => {
+  withFakeDoctorInstall(true, ({ doctor, home, wiki }) => {
+    const r = runDoctorFrom(doctor, [`--hypo-dir=${wiki}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const settingsCheck = out.find((c) => c.label === 'settings.json hook registrations');
+    assert.ok(settingsCheck, 'settings.json hook registrations check not found');
+    assert.equal(
+      settingsCheck.status,
+      'pass',
+      `plugin channel with 0 settings.json registrations must pass: ${JSON.stringify(settingsCheck)}`,
+    );
+  });
+});
+
+test('regression baseline: npm/manual channel with empty hooks still fails', () => {
+  withFakeDoctorInstall(false, ({ doctor, home, wiki }) => {
+    const r = runDoctorFrom(doctor, [`--hypo-dir=${wiki}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const hookCheck = out.find((c) => c.label === 'Hook files installed');
+    const settingsCheck = out.find((c) => c.label === 'settings.json hook registrations');
+    assert.equal(
+      hookCheck.status,
+      'fail',
+      'npm/manual channel with empty ~/.claude/hooks must still fail (baseline unaffected)',
+    );
+    assert.notEqual(
+      settingsCheck.status,
+      'pass',
+      'npm/manual channel with 0 settings.json registrations must not silently pass',
+    );
+  });
+});
+
+// ── ISSUE-54: hypo-pkg.json integrity (stale / dev-repo pointer) ─────────────
+suite('doctor.mjs — hypo-pkg.json integrity (ISSUE-54)');
+
+test('no hypo-pkg.json yet → no integrity checks reported (fresh install, non-actionable)', () => {
+  withTmpHome((home) => {
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const anyPkgCheck = out.find((c) => c.label.startsWith('hypo-pkg.json'));
+    assert.equal(anyPkgCheck, undefined, 'a fresh install with no metadata must report nothing');
+  });
+});
+
+test('pkgRoot does not exist on disk → warn, not fail', () => {
+  withTmpHome((home) => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(
+      join(home, '.claude', 'hypo-pkg.json'),
+      JSON.stringify({ pkgRoot: '/nonexistent/hypo-pkg-root', pkgVersion: '9.9.9' }),
+    );
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const rootCheck = out.find((c) => c.label === 'hypo-pkg.json pkgRoot exists');
+    assert.ok(rootCheck, 'hypo-pkg.json pkgRoot exists check not found');
+    assert.equal(rootCheck.status, 'warn', `missing pkgRoot must warn, not fail: ${r.stdout}`);
+  });
+});
+
+test('pkgVersion mismatch vs pkgRoot package.json → warn', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-'));
+    try {
+      cpSync(join(REPO, 'package.json'), join(base, 'package.json'));
+      const actualVersion = JSON.parse(readFileSync(join(base, 'package.json'), 'utf-8')).version;
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '0.0.1-definitely-stale' }),
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const versionCheck = out.find((c) => c.label === 'hypo-pkg.json version match');
+      assert.ok(versionCheck, 'hypo-pkg.json version match check not found');
+      assert.equal(
+        versionCheck.status,
+        'warn',
+        `version mismatch (recorded 0.0.1-definitely-stale vs actual ${actualVersion}) must warn: ${r.stdout}`,
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+test('pkgRoot is a dirty git working tree → warn about dev checkout', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-git-'));
+    try {
+      initGitRepo(base); // committed, clean, signing/hooks neutralized
+      // leave an uncommitted change → dirty working tree
+      writeFileSync(join(base, 'WIP.md'), 'work in progress');
+
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '1.0.0' }),
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const kindCheck = out.find((c) => c.label === 'hypo-pkg.json pkgRoot install kind');
+      assert.ok(kindCheck, 'hypo-pkg.json pkgRoot install kind check not found');
+      assert.equal(
+        kindCheck.status,
+        'warn',
+        `dirty/untagged pkgRoot must warn as a dev checkout: ${r.stdout}`,
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+// The version-match check must emit a line in EVERY reachable state — a silent
+// skip reads as "verified" on the health report when nothing was checked.
+test('pkgRoot package.json has no version field → warn, not silence', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-nover-'));
+    try {
+      writeFileSync(join(base, 'package.json'), JSON.stringify({ name: 'hypomnema' }));
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '1.0.0' }),
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const versionCheck = out.find((c) => c.label === 'hypo-pkg.json version match');
+      assert.ok(
+        versionCheck,
+        'a package.json with no version must still report a version-match line',
+      );
+      assert.equal(
+        versionCheck.status,
+        'warn',
+        `unverifiable version (no version field) must warn, not silently skip: ${r.stdout}`,
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+test('metadata records no pkgVersion → warn, not silence', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-nopkgver-'));
+    try {
+      writeFileSync(
+        join(base, 'package.json'),
+        JSON.stringify({ name: 'hypomnema', version: '1.0.0' }),
+      );
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base }), // pkgRoot present, pkgVersion absent
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const versionCheck = out.find((c) => c.label === 'hypo-pkg.json version match');
+      assert.ok(versionCheck, 'metadata with no pkgVersion must still report a version-match line');
+      assert.equal(
+        versionCheck.status,
+        'warn',
+        `unverifiable version (no recorded pkgVersion) must warn, not silently skip: ${r.stdout}`,
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+test('matching pkgVersion vs pkgRoot package.json → pass (no false warn)', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-match-'));
+    try {
+      writeFileSync(
+        join(base, 'package.json'),
+        JSON.stringify({ name: 'hypomnema', version: '2.3.4' }),
+      );
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '2.3.4' }),
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const versionCheck = out.find((c) => c.label === 'hypo-pkg.json version match');
+      assert.ok(versionCheck, 'version match check not found');
+      assert.equal(versionCheck.status, 'pass', `a healthy version match must pass: ${r.stdout}`);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+// A hypo-pkg.json that is PRESENT but has no pkgRoot is incomplete metadata that
+// breaks runtime resolution — it must warn, not read as a healthy silent state.
+// (A wholly absent file is the fresh-install case and stays silent.)
+test('metadata file present but no pkgRoot field → warn (not silent)', () => {
+  withTmpHome((home) => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'hypo-pkg.json'), JSON.stringify({ pkgVersion: '1.0.0' }));
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'hypo-pkg.json pkgRoot');
+    assert.ok(check, 'a present-but-incomplete hypo-pkg.json must report a pkgRoot line');
+    assert.equal(check.status, 'warn', `incomplete metadata (no pkgRoot) must warn: ${r.stdout}`);
+  });
+});
+
+// ── ISSUE-54 follow-up: dev-repo install-kind classification is locked per state.
+// The prior single dirty+untagged test could stay green even if untagged
+// classification regressed (dirtiness alone supplies the warn) or git failed to
+// run. These pin clean-tagged (pass), clean-untagged (warn, tag reason), and
+// git-unavailable (cannot classify) independently.
+function initGitRepo(base, { tag } = {}) {
+  writeFileSync(
+    join(base, 'package.json'),
+    JSON.stringify({ name: 'hypomnema', version: '1.0.0' }),
+  );
+  const q = { stdio: 'ignore' };
+  spawnSync('git', ['-C', base, 'init'], q);
+  spawnSync('git', ['-C', base, 'config', 'user.email', 'test@test.com'], q);
+  spawnSync('git', ['-C', base, 'config', 'user.name', 'Test'], q);
+  // Neutralize a host that globally sets commit/tag signing or a hooks path, so the
+  // fixture commit succeeds regardless of the maintainer's git config.
+  spawnSync('git', ['-C', base, 'config', 'commit.gpgsign', 'false'], q);
+  spawnSync('git', ['-C', base, 'config', 'tag.gpgsign', 'false'], q);
+  spawnSync('git', ['-C', base, 'config', 'core.hooksPath', '/dev/null'], q);
+  spawnSync('git', ['-C', base, 'add', '-A'], q);
+  const commit = spawnSync('git', ['-C', base, 'commit', '--no-verify', '-m', 'init'], {
+    encoding: 'utf-8',
+  });
+  assert.equal(commit.status, 0, `fixture commit must succeed: ${commit.stderr}`);
+  if (tag) {
+    const t = spawnSync('git', ['-C', base, 'tag', tag], { encoding: 'utf-8' });
+    assert.equal(t.status, 0, `fixture tag must succeed: ${t.stderr}`);
+  }
+}
+
+test('clean tagged pkgRoot → pass (not a dev checkout)', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-tagged-'));
+    try {
+      initGitRepo(base, { tag: 'v1.0.0' });
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '1.0.0' }),
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const kindCheck = out.find((c) => c.label === 'hypo-pkg.json pkgRoot install kind');
+      assert.ok(kindCheck, 'install kind check not found');
+      assert.equal(kindCheck.status, 'pass', `a clean tagged checkout must pass: ${r.stdout}`);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+test('clean but untagged pkgRoot → warn on the tag reason alone (not dirtiness)', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-untagged-'));
+    try {
+      initGitRepo(base); // committed, clean tree, no tag
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '1.0.0' }),
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const kindCheck = out.find((c) => c.label === 'hypo-pkg.json pkgRoot install kind');
+      assert.ok(kindCheck, 'install kind check not found');
+      assert.equal(kindCheck.status, 'warn', `a clean untagged checkout must warn: ${r.stdout}`);
+      assert.match(kindCheck.detail, /release tag/, 'the reason must be the missing tag');
+      assert.doesNotMatch(
+        kindCheck.detail,
+        /uncommitted/,
+        'a clean tree must not be reported as having uncommitted changes',
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+test('pkgRoot has .git but git cannot be run → warn "cannot classify" (not mislabeled untagged)', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-nogit-'));
+    try {
+      writeFileSync(
+        join(base, 'package.json'),
+        JSON.stringify({ name: 'hypomnema', version: '1.0.0' }),
+      );
+      mkdirSync(join(base, '.git')); // enters the dev-repo branch, but git can't run
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '1.0.0' }),
+      );
+      // Empty PATH so the child's `git` spawn fails with ENOENT. doctor runs via an
+      // absolute node path, so it still starts; other external-dep probes just
+      // report missing without crashing.
+      const emptyPath = mkdtempSync(join(tmpdir(), 'hypo-emptypath-'));
+      const r = spawnSync(
+        process.execPath,
+        [join(SCRIPTS, 'doctor.mjs'), `--hypo-dir=${NONEXISTENT_WIKI}`, '--json'],
+        {
+          encoding: 'utf-8',
+          env: { ...process.env, HYPO_DIR: '', HOME: home, PATH: emptyPath },
+        },
+      );
+      rmSync(emptyPath, { recursive: true, force: true });
+      const out = JSON.parse(r.stdout);
+      const kindCheck = out.find((c) => c.label === 'hypo-pkg.json pkgRoot install kind');
+      assert.ok(kindCheck, 'install kind check not found');
+      assert.equal(kindCheck.status, 'warn', `git-unavailable must warn: ${r.stdout}`);
+      assert.match(
+        kindCheck.detail,
+        /cannot classify/,
+        'must say it cannot classify, not mislabel as untagged',
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+// The distinct branch from the ENOENT case above: git IS runnable, but `git status`
+// itself exits nonzero because the repo is corrupt/inaccessible (an invalid .git).
+// That must also be "cannot classify", not a mislabel as an untagged dev checkout.
+test('pkgRoot .git is corrupt so git status exits nonzero → warn "cannot classify"', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-corruptgit-'));
+    try {
+      writeFileSync(
+        join(base, 'package.json'),
+        JSON.stringify({ name: 'hypomnema', version: '1.0.0' }),
+      );
+      mkdirSync(join(base, '.git')); // an empty .git dir → `git status` exits 128
+      mkdirSync(join(home, '.claude'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: base, pkgVersion: '1.0.0' }),
+      );
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const kindCheck = out.find((c) => c.label === 'hypo-pkg.json pkgRoot install kind');
+      assert.ok(kindCheck, 'install kind check not found');
+      assert.equal(kindCheck.status, 'warn', `corrupt-repo git status must warn: ${r.stdout}`);
+      assert.match(
+        kindCheck.detail,
+        /cannot classify/,
+        'a nonzero git status (corrupt repo) must be cannot-classify, not untagged',
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -5,8 +5,18 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync, cpSync } from 'node:fs';
-import { join } from 'node:path';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  statSync,
+  cpSync,
+  realpathSync,
+} from 'node:fs';
+import { join, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
 import {
@@ -17,6 +27,7 @@ import {
   deriveCoreHookBasenames,
   readCoreHooksConfig,
   run,
+  runWithHome,
   withTmpDir,
   withTmpHome,
 } from './helpers.mjs';
@@ -496,5 +507,511 @@ test('run() exports a HOME under tmpdir() that differs from real homedir()', () 
       r.stdout.startsWith(tmpdir()),
       `child HOME must live under tmpdir(), got ${r.stdout}`,
     );
+  });
+});
+
+// ── ISSUE-53: dry-run write-set must equal the real write-set ────────────────
+// writePkgJson() used to gate BOTH the write and the "Created" log entry
+// behind `if (!dryRun)` — every other write path in this file only gates the
+// write, and always logs, so dry-run can preview it. That meant a dry-run
+// never mentioned ~/.claude/hypo-pkg.json at all, so the reported write-set
+// was smaller than what the real run actually wrote — exactly the property
+// `--dry-run` promises never to have.
+suite('init.mjs — dry-run write-set parity (ISSUE-53)');
+
+function parseCreated(stdout) {
+  const m = stdout.match(/✓ Created \(\d+\):\n([\s\S]*?)(?:\n\n|$)/);
+  if (!m) return [];
+  return m[1]
+    .split('\n')
+    .map((l) => l.replace(/^\s*/, ''))
+    .filter(Boolean);
+}
+
+test('dry-run reports the exact same write-set as a real run', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const commonArgs = [
+        `--hypo-dir=${hypoDir}`,
+        '--no-hooks',
+        '--no-commands',
+        '--no-shell',
+        '--no-git-init',
+      ];
+
+      const dry = runWithHome('init.mjs', [...commonArgs, '--dry-run'], home);
+      assert.equal(dry.status, 0, `dry-run failed: ${dry.stderr}`);
+      const dryCreated = parseCreated(dry.stdout)
+        .map((p) => p.replace(hypoDir, '<hypoDir>').replace(home, '<home>'))
+        .sort();
+
+      // real run needs its own untouched hypoDir + home so it starts from the
+      // identical fresh state the dry-run measured.
+      const real = runWithHome('init.mjs', commonArgs, home);
+      assert.equal(real.status, 0, `real run failed: ${real.stderr}`);
+      const realCreated = parseCreated(real.stdout)
+        .map((p) => p.replace(hypoDir, '<hypoDir>').replace(home, '<home>'))
+        .sort();
+
+      assert.deepEqual(
+        dryCreated,
+        realCreated,
+        `dry-run write-set must equal the real write-set.\ndry: ${JSON.stringify(dryCreated)}\nreal: ${JSON.stringify(realCreated)}`,
+      );
+      assert.ok(
+        dryCreated.some((p) => p.includes('hypo-pkg.json')),
+        `dry-run must preview the hypo-pkg.json write: ${JSON.stringify(dryCreated)}`,
+      );
+      assert.ok(
+        existsSync(join(home, '.claude', 'hypo-pkg.json')),
+        'real run must have actually written hypo-pkg.json',
+      );
+    });
+  });
+});
+
+// ── ISSUE-52 (init side): plugin-channel install must not lay hooks/settings/
+// commands on top of a plugin install ────────────────────────────────────────
+// Mirrors upgrade.mjs's own plugin-mode guard (ISSUE-6): run a COPY of
+// init.mjs from a fake root whose path matches the plugin-cache shape
+// (`.claude/plugins/…`) so the channel detector (gated on init.mjs's own
+// script location) fires, and confirm the Claude core hook/settings/command
+// surface is skipped rather than double-installed.
+suite('init.mjs — plugin channel gating (ISSUE-52)');
+
+function withFakeInitInstall(underPlugins, fn) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-init-plugin-'));
+  try {
+    const root = underPlugins
+      ? join(base, '.claude', 'plugins', 'cache', 'mp', 'hypomnema', '1.3.0')
+      : join(base, 'lib', 'node_modules', 'hypomnema');
+    mkdirSync(root, { recursive: true });
+    cpSync(SCRIPTS, join(root, 'scripts'), { recursive: true });
+    cpSync(join(REPO, 'hooks'), join(root, 'hooks'), { recursive: true });
+    cpSync(join(REPO, 'commands'), join(root, 'commands'), { recursive: true });
+    cpSync(join(REPO, 'templates'), join(root, 'templates'), { recursive: true });
+    cpSync(join(REPO, 'package.json'), join(root, 'package.json'));
+    const home = join(base, 'home');
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    fn({ init: join(root, 'scripts', 'init.mjs'), root, home });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function runInitFrom(init, args, home) {
+  return spawnSync(process.execPath, [init, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HYPO_DIR: '', HOME: home },
+  });
+}
+
+test('plugin mode: does not install ~/.claude/hooks, settings.json entries, or commands', () => {
+  withFakeInitInstall(true, ({ init, home }) => {
+    const hypoDir = join(tmpdir(), `hypo-init-plugin-wiki-${process.pid}-${Date.now()}`);
+    try {
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `plugin-mode init should exit 0: ${r.stderr}`);
+      assert.equal(
+        existsSync(join(home, '.claude', 'hooks')),
+        false,
+        'plugin mode must NOT create ~/.claude/hooks (double-registration footgun)',
+      );
+      assert.equal(
+        existsSync(join(home, '.claude', 'commands', 'hypo')),
+        false,
+        'plugin mode must NOT create ~/.claude/commands/hypo',
+      );
+      const settingsPath = join(home, '.claude', 'settings.json');
+      if (existsSync(settingsPath)) {
+        assert.doesNotMatch(
+          readFileSync(settingsPath, 'utf-8'),
+          /hypo-session-start/,
+          'plugin mode must NOT register hook events into settings.json',
+        );
+      }
+      assert.match(
+        r.stdout,
+        /provided by the plugin loader/,
+        'plugin mode must log a skip explaining hooks/settings/commands are plugin-provided',
+      );
+    } finally {
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('regression baseline: npm/manual channel still installs hooks + settings', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
+    const hypoDir = join(tmpdir(), `hypo-init-npm-wiki-${process.pid}-${Date.now()}`);
+    try {
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `npm/manual init should exit 0: ${r.stderr}`);
+      assert.equal(
+        existsSync(join(home, '.claude', 'hooks', 'hypo-session-start.mjs')),
+        true,
+        'npm/manual channel must still install core hooks (baseline unaffected)',
+      );
+      const settingsPath = join(home, '.claude', 'settings.json');
+      assert.ok(existsSync(settingsPath), 'npm/manual channel must still write settings.json');
+      assert.match(
+        readFileSync(settingsPath, 'utf-8'),
+        /hypo-session-start/,
+        'npm/manual channel must still register hook events',
+      );
+    } finally {
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── ISSUE-52 follow-up: dual-install pointer preservation ────────────────────
+// A manual/npm init run while the Hypomnema plugin is ALSO enabled is a dual
+// install: init.mjs is NOT under `.claude/plugins/` (so pluginMode is off), but
+// isHypomnemaPluginEnabled fires on settings.json. The plugin owns the active
+// runtime hooks, which resolve lint/feedback through hypo-pkg.json.pkgRoot. So
+// init must skip the core surface AND preserve a valid plugin-owned pkgRoot
+// instead of clobbering it with the npm path — mirroring upgrade.mjs's dualSkip.
+// These exercise the settings-based branch the ISSUE-52 tests above (path-based
+// pluginMode) do not reach.
+suite('init.mjs — dual-install pointer preservation (ISSUE-52)');
+
+// The enabled key must match what registerPlugin puts in the registry: durable-root
+// resolution looks up the EXACT enabled identifier, not any hypo-named entry.
+const ENABLED_PLUGIN_KEY = 'hypo@marketplace';
+function enablePlugin(home) {
+  const claude = join(home, '.claude');
+  mkdirSync(claude, { recursive: true });
+  writeFileSync(
+    join(claude, 'settings.json'),
+    JSON.stringify({ enabledPlugins: { [ENABLED_PLUGIN_KEY]: true } }),
+  );
+}
+
+// A stand-in for the plugin cache root the pointer already names: a real package
+// directory (has package.json), which is what the preserve predicate requires —
+// a bare/empty dir is not a usable root and must fall through to the fallback.
+function makePluginRoot() {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-plugin-root-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'hypomnema', version: '1.0.0' }));
+  return dir;
+}
+
+test('dual install preserves an existing plugin-owned pkgRoot', () => {
+  withFakeInitInstall(false, ({ init, root, home }) => {
+    const pluginRoot = makePluginRoot();
+    const hypoDir = join(tmpdir(), `hypo-init-dual-wiki-${process.pid}-${Date.now()}`);
+    try {
+      enablePlugin(home);
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: pluginRoot, pkgVersion: '1.0.0' }),
+      );
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      // Same core-surface skip as plugin mode (the plugin loader owns the hooks).
+      assert.equal(
+        existsSync(join(home, '.claude', 'hooks')),
+        false,
+        'dual install must NOT create ~/.claude/hooks (plugin owns them)',
+      );
+      const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.equal(
+        meta.pkgRoot,
+        pluginRoot,
+        `dual install must preserve the plugin-owned pkgRoot, not clobber it with the npm root (${root})`,
+      );
+    } finally {
+      rmSync(pluginRoot, { recursive: true, force: true });
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Register the plugin in BOTH settings.json (enabledPlugins) and the plugin
+// registry (installed_plugins.json) so init can POSITIVELY resolve the plugin's
+// real cache root, rather than trusting whatever pkgRoot is recorded.
+function registerPlugin(home, pluginRoot, extraEntries = []) {
+  enablePlugin(home);
+  writeFileSync(
+    join(home, '.claude', 'plugins', 'installed_plugins.json'),
+    JSON.stringify({
+      version: 2,
+      plugins: {
+        [ENABLED_PLUGIN_KEY]: [...extraEntries, { scope: 'user', installPath: pluginRoot }],
+      },
+    }),
+  );
+}
+
+// Provenance: the recorded pointer is NOT trusted as plugin-owned. In an npm-first
+// sequence the pointer on disk is the manual/npm root itself; init must still send
+// the durable identity + pre-commit hook to the plugin's REAL registry root, or the
+// recommended npm uninstall dangles them.
+test('dual install corrects a stale npm pointer to the registry plugin root', () => {
+  withFakeInitInstall(false, ({ init, root, home }) => {
+    const pluginRoot = makePluginRoot();
+    const stalePointer = makePluginRoot(); // a usable dir standing in for the npm root
+    const hypoDir = mkdtempSync(join(tmpdir(), 'hypo-init-provenance-'));
+    try {
+      spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+      mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+      registerPlugin(home, pluginRoot);
+      // A pre-existing pointer at the (usable) npm root — the npm-first footgun.
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: stalePointer, pkgVersion: '0.5.0' }),
+      );
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.equal(
+        meta.pkgRoot,
+        pluginRoot,
+        'pkgRoot must be corrected to the positively-resolved registry plugin root, not the stale/npm pointer',
+      );
+      assert.notEqual(meta.pkgRoot, stalePointer, 'the stale pointer must not survive');
+      const hook = readFileSync(join(hypoDir, '.git', 'hooks', 'pre-commit'), 'utf-8');
+      assert.ok(
+        hook.includes(join(pluginRoot, 'hooks', 'hypo-pre-commit.mjs')),
+        `pre-commit must reference the registry plugin root: ${hook}`,
+      );
+      assert.ok(
+        !hook.includes(join(realpathSync(root), 'hooks', 'hypo-pre-commit.mjs')),
+        'pre-commit must not reference the manual/npm root',
+      );
+    } finally {
+      rmSync(pluginRoot, { recursive: true, force: true });
+      rmSync(stalePointer, { recursive: true, force: true });
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Idempotency / no silent rewrite: once the durable identity is on disk, a second
+// run is a genuine no-op — reported skipped, bytes untouched. This is the finding-#2
+// lock under the durable-identity model (a real run must not silently reformat a
+// file it reports as skipped). --no-hooks so writePkgJson is the sole writer.
+test('dual install is idempotent: a second run leaves hypo-pkg.json untouched', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
+    const pluginRoot = makePluginRoot();
+    const hypoDir = join(tmpdir(), `hypo-init-idem-${process.pid}-${Date.now()}`);
+    try {
+      mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+      registerPlugin(home, pluginRoot);
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      const args = [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init'];
+      const first = runInitFrom(init, args, home);
+      assert.equal(first.status, 0, `first init should exit 0: ${first.stderr}`);
+      const afterFirst = readFileSync(pkgPath, 'utf-8');
+      const second = runInitFrom(init, args, home);
+      assert.equal(second.status, 0, `second init should exit 0: ${second.stderr}`);
+      assert.equal(
+        readFileSync(pkgPath, 'utf-8'),
+        afterFirst,
+        'a second run must not rewrite/reformat an already-correct hypo-pkg.json',
+      );
+      assert.match(
+        second.stdout,
+        /durable pkgRoot unchanged/,
+        'the no-op write must be reported as skipped, not created',
+      );
+    } finally {
+      rmSync(pluginRoot, { recursive: true, force: true });
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Provenance must resolve the EXACT enabled key and prefer the user-scope install:
+// a non-user entry preceding the user one for the same key must not be selected.
+test('dual install prefers the user-scope registry entry over a preceding local entry', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
+    const userRoot = makePluginRoot();
+    const localRoot = makePluginRoot(); // a DIFFERENT project's local install, listed first
+    const hypoDir = join(tmpdir(), `hypo-init-scope-${process.pid}-${Date.now()}`);
+    try {
+      mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+      registerPlugin(home, userRoot, [
+        { scope: 'local', projectPath: '/some/other/project', installPath: localRoot },
+      ]);
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.equal(
+        meta.pkgRoot,
+        userRoot,
+        'the user-scope install must win over another scope listed first',
+      );
+      assert.notEqual(
+        meta.pkgRoot,
+        localRoot,
+        "another project's local install must not be selected",
+      );
+    } finally {
+      rmSync(userRoot, { recursive: true, force: true });
+      rmSync(localRoot, { recursive: true, force: true });
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// A relative installPath (e.g. ".") would resolve against the caller's cwd and
+// break the vault hook from any other directory, so it is not a usable durable
+// root; resolution falls back rather than recording a relative pointer.
+test('dual install rejects a relative registry installPath and falls back', () => {
+  withFakeInitInstall(false, ({ init, root, home }) => {
+    const hypoDir = join(tmpdir(), `hypo-init-relpath-${process.pid}-${Date.now()}`);
+    try {
+      enablePlugin(home);
+      mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+      writeFileSync(
+        join(home, '.claude', 'plugins', 'installed_plugins.json'),
+        JSON.stringify({
+          version: 2,
+          plugins: { [ENABLED_PLUGIN_KEY]: [{ scope: 'user', installPath: '.' }] },
+        }),
+      );
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.notEqual(
+        meta.pkgRoot,
+        '.',
+        'a relative installPath must never be recorded as pkgRoot',
+      );
+      assert.ok(isAbsolute(meta.pkgRoot), `recorded pkgRoot must be absolute: ${meta.pkgRoot}`);
+      assert.equal(
+        realpathSync(meta.pkgRoot),
+        realpathSync(root),
+        'with no usable registry root, resolution falls back to PKG_ROOT',
+      );
+    } finally {
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Downgrade protection must see the DURABLE (plugin) install, not just the recorded
+// metadata. In an npm-first dual install the recorded pkgVersion is the stale npm
+// one, so comparing only against it would let an older npm init run against a newer
+// plugin. The guard must refuse (exit 2) when this package is older than the plugin.
+test('dual install refuses to run an older npm init against a newer registry plugin', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
+    const pluginRoot = mkdtempSync(join(tmpdir(), 'hypo-plugin-newer-'));
+    // A plugin far newer than this package (the fake install copies the repo's
+    // package.json, whose version is well below 9.9.9).
+    writeFileSync(
+      join(pluginRoot, 'package.json'),
+      JSON.stringify({ name: 'hypomnema', version: '9.9.9' }),
+    );
+    const hypoDir = join(tmpdir(), `hypo-init-downgrade-${process.pid}-${Date.now()}`);
+    try {
+      mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+      registerPlugin(home, pluginRoot);
+      // Stale npm-first metadata whose recorded version alone would NOT trip the
+      // guard (it is older than this package), so only the durable-root comparison
+      // catches the downgrade.
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: pluginRoot, pkgVersion: '0.1.0' }),
+      );
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init'], home);
+      assert.equal(
+        r.status,
+        2,
+        `init must refuse (exit 2) as a downgrade vs the plugin: ${r.stdout}`,
+      );
+    } finally {
+      rmSync(pluginRoot, { recursive: true, force: true });
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('dual install falls back when the recorded pkgRoot is not a usable package dir', () => {
+  withFakeInitInstall(false, ({ init, root, home }) => {
+    // An existing directory that is NOT a package (no package.json): the runtime
+    // cannot resolve scripts through it, so preservation must NOT bless it.
+    const emptyRoot = mkdtempSync(join(tmpdir(), 'hypo-empty-root-'));
+    const hypoDir = join(tmpdir(), `hypo-init-dual-unusable-${process.pid}-${Date.now()}`);
+    try {
+      enablePlugin(home);
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: emptyRoot, pkgVersion: '1.0.0' }),
+      );
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.equal(
+        realpathSync(meta.pkgRoot),
+        realpathSync(root),
+        'an existing-but-unusable pkgRoot (no package.json) must fall back to PKG_ROOT, not be preserved',
+      );
+    } finally {
+      rmSync(emptyRoot, { recursive: true, force: true });
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('dual install writes fallback metadata when no prior pointer exists', () => {
+  withFakeInitInstall(false, ({ init, root, home }) => {
+    const hypoDir = join(tmpdir(), `hypo-init-dual-fresh-${process.pid}-${Date.now()}`);
+    try {
+      enablePlugin(home); // plugin enabled, but no hypo-pkg.json on disk yet
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      assert.ok(
+        existsSync(pkgPath),
+        'runtime needs a resolvable pointer — fallback must be written',
+      );
+      const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      // init derives PKG_ROOT from its own real script path; realpath both sides so
+      // the macOS /var → /private/var symlink does not make an equal path look unequal.
+      assert.equal(
+        realpathSync(meta.pkgRoot),
+        realpathSync(root),
+        'with no prior pointer to preserve, dual install falls back to its own PKG_ROOT so resolution is not left empty',
+      );
+    } finally {
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// The vault's git pre-commit hook embeds an absolute path to hypo-pre-commit.mjs.
+// In a dual install that path must be the DURABLE (plugin) root, not the manual/npm
+// PKG_ROOT the dual-install notice tells the user to uninstall — otherwise the hook
+// dangles the moment they do and every wiki commit fails.
+test('dual install points the wiki pre-commit hook at the durable plugin root', () => {
+  withFakeInitInstall(false, ({ init, root, home }) => {
+    const pluginRoot = makePluginRoot();
+    const hypoDir = mkdtempSync(join(tmpdir(), 'hypo-init-dual-hook-'));
+    try {
+      spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+      enablePlugin(home);
+      writeFileSync(
+        join(home, '.claude', 'hypo-pkg.json'),
+        JSON.stringify({ pkgRoot: pluginRoot, pkgVersion: '1.0.0' }),
+      );
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      const hook = readFileSync(join(hypoDir, '.git', 'hooks', 'pre-commit'), 'utf-8');
+      assert.ok(
+        hook.includes(join(pluginRoot, 'hooks', 'hypo-pre-commit.mjs')),
+        `pre-commit must reference the durable plugin root's worker: ${hook}`,
+      );
+      assert.ok(
+        !hook.includes(join(realpathSync(root), 'hooks', 'hypo-pre-commit.mjs')),
+        `pre-commit must NOT reference the manual/npm root that will be uninstalled: ${hook}`,
+      );
+    } finally {
+      rmSync(pluginRoot, { recursive: true, force: true });
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
# English

## What changed

`doctor` and `init` now understand the install channel. When Hypomnema is provided by the Claude Code plugin loader (the package runs from a `.claude/plugins/…` root, or the plugin is enabled in `~/.claude/settings.json`), the core 14 hooks, slash commands, and settings.json registrations come from the plugin's own `hooks/hooks.json`, so an empty `~/.claude/hooks` and zero settings.json entries are the healthy state:

- `doctor` stops reporting "hooks not installed" and stops prescribing a re-init that would double-register every core hook.
- `init` skips laying core hooks/settings/commands on top of a plugin-managed install.

In a dual install (a manual or npm `init` run while the plugin is also enabled), `init` keeps the plugin-owned install durable. `PKG_ROOT` in that run is the manual/npm checkout the dual-install notice tells the user to uninstall, so `init` positively resolves the enabled plugin's real cache root (it looks up the exact `enabledPlugins` key in `installed_plugins.json`, prefers the user-scope entry, and requires an absolute, versioned package directory) and points both `hypo-pkg.json.pkgRoot` and the vault's git pre-commit hook at that root. The downgrade guard also compares against the resolved plugin version, so an older npm `init` refuses to run against a newer plugin.

`doctor` also validates `~/.claude/hypo-pkg.json` (warn-only, never fail): a missing `pkgRoot`, a file present but missing its `pkgRoot` field, a `pkgVersion` that disagrees with the pkgRoot's `package.json` (or an unverifiable version), and a dirty or untagged dev-repo pointer where a distributed copy is expected. Each reachable state reports a line instead of reading as verified while silent.

`init --dry-run` previews the `hypo-pkg.json` write it always performed, so a dry run's reported write-set equals the real run's.

## Why

A plugin-channel user running `doctor` was told their hooks were missing and to re-run `init`, which then copied and registered the same hooks the plugin already provides, making every core hook fire twice. The same double-install happened if `init` was run directly. In a dual install, `init` additionally rewrote the plugin-owned `hypo-pkg.json` pointer (and the vault pre-commit hook) to the npm path; both resolve scripts through that path, so if the user later uninstalled npm as the dual-install notice advises, they were left dangling and lint/feedback and every wiki commit silently broke. And nothing ever re-validated `hypo-pkg.json` after it was first written, so a stale or dev-pointing root ran uncommitted work unnoticed. `--dry-run` under-reported its write-set, breaking the guarantee that a dry run previews exactly what a real run writes.

## How

- `scripts/lib/plugin-detect.mjs` gains `enabledHypomnemaPluginKey`, returning the exact enabled `hypo@marketplace` (or legacy `hypomnema@marketplace`) key; `isHypomnemaPluginEnabled` is expressed in terms of it. `doctor`/`init` combine the "plugin enabled" signal with the plugin-cache path check into `coreManagedByPlugin` and gate the core-surface logic on it.
- `init` resolves the durable root from the plugin registry (exact key, user scope, absolute + versioned), and both `writePkgJson` and the wiki pre-commit hook use it. The write is a no-op when the durable identity already matches disk. Resolution is non-mutating and runs before init's package validation.
- `checkPkgIntegrity` emits a line in every reachable state and treats a git spawn failure or a non-zero `git status` as "cannot classify" rather than mislabeling the pointer.
- The `--dry-run` fix moves the `log('created')` call outside the `if (!dryRun)` guard, matching every other write path in the file.

## Manual verification

Ran a dual-install scenario in a temp HOME (plugin enabled in settings.json, a plugin cache root registered in `installed_plugins.json`, and a seeded `hypo-pkg.json`), then `node scripts/init.mjs`:

```
⊘ Skipped / already exists:
  Claude core hooks/settings/commands — provided by the plugin loader ...
  <home>/.claude/hypo-pkg.json (durable pkgRoot unchanged)
```

- `hypo-pkg.json.pkgRoot` and the vault `.git/hooks/pre-commit` resolved to the registry plugin root, not the repo path.
- No `~/.claude/hooks` directory was created.

All 1620 tests pass; new regression tests assert each fix red-first (provenance resolution correcting a stale npm pointer, pre-commit-hook durability, downgrade-vs-plugin refusal, version-match completeness, dry-run/real write-set equality, per-state git classification). `prettier --check` is clean.

## Migration notes

None. Behavior only stops harmful writes; no on-disk migration is required. Two follow-ups are tracked separately: `upgrade.mjs`'s dual-install metadata handling still trusts the recorded pointer rather than resolving the plugin root (a consistency gap with this change), and a user who already double-registered hooks from a prior re-init is not auto-repaired here.

---

# 한국어

## 변경 내용

`doctor`와 `init`이 설치 채널을 인식한다. Hypomnema가 Claude Code 플러그인 로더로 제공될 때(패키지가 `.claude/plugins/…` 루트에서 실행되거나, `~/.claude/settings.json`에 플러그인이 활성화된 경우) 코어 훅 14개, 슬래시 커맨드, settings.json 등록이 모두 플러그인 자신의 `hooks/hooks.json`에서 오므로, 빈 `~/.claude/hooks`와 settings.json 등록 0건이 정상 상태다:

- `doctor`가 "hooks not installed"라고 보고하고 re-init을 권하던 것을 멈춘다(그 re-init이 코어 훅을 두 번 등록시켰다).
- `init`이 플러그인 관리 설치 위에 코어 훅/settings/커맨드를 덧씌우지 않는다.

dual install(플러그인이 켜진 상태에서 수동/npm `init` 실행)에서는 `init`이 플러그인 소유 설치를 durable하게 유지한다. 그 실행의 `PKG_ROOT`는 dual-install 안내가 지우라고 하는 수동/npm 체크아웃이므로, `init`은 활성 플러그인의 실제 캐시 루트를 positively resolve한다(`installed_plugins.json`에서 정확한 `enabledPlugins` 키를 조회하고, user 스코프 항목을 선호하며, 절대경로 + 버전 있는 패키지 디렉터리를 요구). 그리고 `hypo-pkg.json.pkgRoot`와 볼트의 git pre-commit 훅을 모두 그 루트로 가리킨다. downgrade 가드도 resolve된 플러그인 버전과 비교하므로, 더 오래된 npm `init`이 더 새로운 플러그인 위에서 실행되길 거부한다.

`doctor`는 `~/.claude/hypo-pkg.json`도 검증한다(warn 전용, fail 없음): `pkgRoot` 부재, 파일은 있으나 `pkgRoot` 필드 없음, pkgRoot의 `package.json`과 어긋나는(또는 검증 불가한) `pkgVersion`, 배포본이 있어야 할 자리의 dirty/untagged dev-repo 포인터. 도달 가능한 모든 상태가 한 줄을 내며, 조용히 "검증됨"처럼 읽히지 않는다.

`init --dry-run`은 늘 수행하던 `hypo-pkg.json` 쓰기를 미리보기에 포함하므로, dry-run이 보고하는 쓰기 집합이 실제 실행과 같아진다.

## 이유

플러그인 채널 사용자가 `doctor`를 돌리면 훅이 없다며 `init` 재실행을 권했고, 그 재실행이 플러그인이 이미 제공하는 훅을 복사·등록해 모든 코어 훅이 두 번 발화했다. `init`을 직접 돌려도 같은 이중 설치가 났다. dual install에서는 `init`이 플러그인 소유 `hypo-pkg.json` 포인터(그리고 볼트 pre-commit 훅)를 npm 경로로 다시 썼는데, 둘 다 그 경로로 스크립트를 resolve하므로, dual-install 안내대로 나중에 npm을 지우면 dangling되어 lint/feedback과 모든 위키 커밋이 조용히 깨졌다. 또 `hypo-pkg.json`은 최초 기록 후 재검증된 적이 없어, stale하거나 dev를 가리키는 루트가 커밋 안 된 작업을 모르게 실행했다. `--dry-run`은 쓰기 집합을 실제보다 적게 보고해, dry-run이 실제 쓰기를 그대로 미리 보여준다는 보장을 깼다.

## 방법

- `scripts/lib/plugin-detect.mjs`에 `enabledHypomnemaPluginKey`를 추가해 활성화된 정확한 `hypo@marketplace`(또는 레거시 `hypomnema@marketplace`) 키를 반환하고, `isHypomnemaPluginEnabled`를 그 위로 표현한다. `doctor`/`init`이 "플러그인 활성" 신호와 플러그인 캐시 경로 판정을 합쳐 `coreManagedByPlugin`으로 만들고, 코어 로직을 여기에 건다.
- `init`이 플러그인 registry에서 durable root를 resolve하고(정확한 키, user 스코프, 절대경로 + 버전), `writePkgJson`과 위키 pre-commit 훅이 그것을 쓴다. durable identity가 디스크와 이미 같으면 쓰기는 no-op이다. resolve는 비파괴이며 init의 패키지 검증 전에 실행된다.
- `checkPkgIntegrity`가 도달 가능한 모든 상태에서 한 줄을 내고, git spawn 실패나 non-zero `git status`를 untagged 오분류 대신 "cannot classify"로 처리한다.
- `--dry-run` 수정은 `log('created')` 호출을 `if (!dryRun)` 가드 밖으로 옮겨, 파일 내 다른 모든 쓰기 경로와 형태를 맞춘다.

## 수동 검증

임시 HOME에서 dual-install 시나리오를 구성하고(settings.json에 플러그인 활성, `installed_plugins.json`에 플러그인 캐시 루트 등록, `hypo-pkg.json` seed) `node scripts/init.mjs` 실행:

```
⊘ Skipped / already exists:
  Claude core hooks/settings/commands — provided by the plugin loader ...
  <home>/.claude/hypo-pkg.json (durable pkgRoot unchanged)
```

- `hypo-pkg.json.pkgRoot`와 볼트 `.git/hooks/pre-commit`이 repo 경로가 아니라 registry 플러그인 루트로 resolve됨.
- `~/.claude/hooks` 디렉터리가 생성되지 않음.

전체 1620개 테스트 통과. 새 회귀 테스트가 각 수정을 red-first로 검증한다(stale npm 포인터를 교정하는 provenance resolve, pre-commit 훅 durability, downgrade-vs-plugin 거부, version-match 완결성, dry-run/실제 쓰기 집합 일치, 상태별 git 분류). `prettier --check` 통과.

## 마이그레이션 노트

None. 해로운 쓰기를 멈출 뿐 디스크 마이그레이션은 필요 없다. 후속 두 건을 별도 추적한다: `upgrade.mjs`의 dual-install 메타데이터 처리는 아직 플러그인 루트를 resolve하지 않고 기록된 포인터를 신뢰한다(이 변경과의 일관성 갭). 그리고 이전 re-init으로 이미 훅을 이중 등록한 사용자는 여기서 자동 복구되지 않는다.

---

## Changelog

- EN: `doctor` and `init` recognize a plugin-channel install and stop double-registering core hooks; a dual install resolves the plugin's real root so `hypo-pkg.json` and the vault pre-commit hook stay durable after an npm uninstall; `doctor` validates the `hypo-pkg.json` pointer; `init --dry-run` previews the `hypo-pkg.json` write.
- KO: `doctor`와 `init`이 플러그인 채널 설치를 인식해 코어 훅 이중 등록을 멈추고, dual install에서 플러그인 실제 루트를 resolve해 npm 제거 후에도 `hypo-pkg.json`과 볼트 pre-commit 훅이 durable하게 유지되며, `doctor`가 `hypo-pkg.json` 포인터를 검증하고, `init --dry-run`이 `hypo-pkg.json` 쓰기를 미리 보여준다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
