### PR TITLE
fix(close): attribute the session-close marker from evidence, not recency

### DIFF
--- a/hooks/hypo-auto-minimal-crystallize.mjs
+++ b/hooks/hypo-auto-minimal-crystallize.mjs
@@ -123,10 +123,20 @@ function emitBlock(sessionId, transcriptPath, gate = null, opts = {}) {
   // an install/transcript path contains spaces (display text only — never exec'd
   // here).
   const transcriptHint = transcriptPath ? ` --transcript-path="${transcriptPath}"` : '';
+  // Recovery command carries EVIDENCE, never the recency-derived close.project.
+  // The evidence-backed attribution is a singleton close scope (transcript
+  // close-files ∪ this marker's projects); when it is unambiguous, embed it as
+  // --project so the re-run is one-shot instead of failing closed for lack of
+  // evidence. The session cwd (from the payload) rides along so the re-run's own
+  // session-cwd close check runs against the same project this Stop evaluated.
+  const scope = gate?.close?.scope || [];
+  const evidenceProject = scope.length === 1 ? scope[0] : null;
+  const projectHint = evidenceProject ? ` --project=${evidenceProject}` : '';
+  const cwdHint = opts.sessionCwd ? ` --session-cwd="${opts.sessionCwd}"` : '';
   const cliBase = PKG_ROOT ? `node "${join(PKG_ROOT, 'scripts', 'crystallize.mjs')}"` : null;
   const markCmd = cliBase
-    ? `${cliBase} --mark-session-closed --session-id=${sessionId}${transcriptHint}`
-    : `/hypo:crystallize (session_id=${sessionId}${transcriptHint})`;
+    ? `${cliBase} --mark-session-closed --session-id=${sessionId}${projectHint}${transcriptHint}${cwdHint}`
+    : `/hypo:crystallize (session_id=${sessionId}${projectHint}${transcriptHint})`;
   // The log-only escape hatch for a non-project (wiki/tooling-only)
   // session. Offered ONLY as an explicit alternative when a close blocker is
   // present — never as the default recovery, so a real project session is not
@@ -150,7 +160,9 @@ function emitBlock(sessionId, transcriptPath, gate = null, opts = {}) {
     // Only when a project-close blocker is what's holding the session: a
     // non-project session has nothing to close, so offer log-only as the way out
     // (Claude decides whether this session is project-scoped — no auto-attribution).
-    if (gate.blockers.some((b) => b.type === 'close')) {
+    // A session-cwd close blocker (the session's own cwd project is unstarted) is
+    // the same kind of project-close hold, so it gets the same escape.
+    if (gate.blockers.some((b) => b.type === 'close' || b.type === 'close-cwd')) {
       reason += ` If this was a non-project (wiki/tooling-only) session with no project to close, run \`${logOnlyCmd}\` instead (log-only close, no project attribution).`;
     }
   } else {
@@ -202,6 +214,9 @@ process.stdin.on('end', () => {
 
     const sessionId = payload.session_id || payload.sessionId || null;
     const transcriptPath = payload.transcript_path || payload.transcriptPath || null;
+    // Authoritative session cwd (the one verified cwd source) for the session-cwd
+    // close check below. Absent on older Claude Code payloads → the check is skipped.
+    const sessionCwd = payload.cwd || null;
 
     // 3. substantial-session gate. Pure Q&A / incidental-lookup sessions skip
     // the block; mutating sessions AND high-volume read-only investigations
@@ -220,10 +235,49 @@ process.stdin.on('end', () => {
       return;
     }
 
-    // 5. close already verified for this session_id.
-    if (sessionId && readSessionClosedMarker(HYPO_DIR, sessionId)) {
-      emitContinue();
-      return;
+    // Read-only /compact gate (same precompactGateStatus the real PreCompact hook
+    // uses) sharpens the block message and, with sessionCwd, backs the session-cwd
+    // close check below. The hook NEVER writes the marker here (file-header
+    // invariant); this is read-only. Any error → null → emitBlock falls back to the
+    // generic message (fail-open). Computed lazily: the common closed-session path
+    // (a project marker whose cwd project is complete) still short-circuits without
+    // paying the gate cost, unless a cwd signal makes the cwd check meaningful.
+    let gate = null;
+    const computeGate = () => {
+      try {
+        return precompactGateStatus(HYPO_DIR, {
+          ...(transcriptPath ? { transcriptPath } : {}),
+          ...(sessionCwd ? { sessionCwd } : {}),
+          ...(sessionId ? { sessionId } : {}),
+        });
+      } catch {
+        return null;
+      }
+    };
+
+    // 5. close already verified for this session_id — but a project marker only
+    // attests the project(s) it recorded. If THIS session's cwd project still has
+    // an unstarted close, honoring the marker would end the session green while
+    // that project stays open (the session-cwd false-green). So re-check the cwd
+    // project before accepting a project marker. A log-only marker (non-project
+    // session) is exempt, and without a cwd signal we accept the marker as before
+    // (back-compat with payloads that carry no cwd).
+    if (sessionId) {
+      const marker = readSessionClosedMarker(HYPO_DIR, sessionId);
+      if (marker) {
+        if (marker.scope === 'log-only' || !sessionCwd) {
+          emitContinue();
+          return;
+        }
+        gate = computeGate();
+        const cwdBlocked = !!gate?.blockers?.some((b) => b.type === 'close-cwd');
+        if (!cwdBlocked) {
+          emitContinue();
+          return;
+        }
+        // marker present but the session's cwd project close is incomplete: fall
+        // through to block, reusing the gate computed above.
+      }
     }
 
     // 6. block — but only when we have a session_id to address the recovery
@@ -234,18 +288,7 @@ process.stdin.on('end', () => {
       return;
     }
 
-    // Read-only /compact gate (same precompactGateStatus the real
-    // PreCompact hook uses) sharpens the block message — distinguishes "close
-    // is compact-ready, only the marker is missing" from "there are real
-    // blockers". The hook NEVER writes the marker here (file-header invariant);
-    // this is read-only. Any error → null → emitBlock falls back to the generic
-    // message (fail-open).
-    let gate = null;
-    try {
-      gate = precompactGateStatus(HYPO_DIR, transcriptPath ? { transcriptPath } : {});
-    } catch {
-      gate = null;
-    }
+    if (!gate) gate = computeGate();
 
     // Reconfirm decision (conditional-close-reconfirm): "close" and
     // "work-incomplete" together are exactly the case where the transcript's
@@ -269,7 +312,7 @@ process.stdin.on('end', () => {
       return;
     }
 
-    emitBlock(sessionId, transcriptPath, gate, { reconfirm: workIncomplete });
+    emitBlock(sessionId, transcriptPath, gate, { reconfirm: workIncomplete, sessionCwd });
   } catch (err) {
     // Fail-open on any unexpected error.
     process.stderr.write(`[hypo-auto-minimal-crystallize] error: ${err?.message ?? String(err)}\n`);

--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -42,6 +42,7 @@ process.stdin.on('data', (chunk) => (raw += chunk));
 process.stdin.on('end', () => {
   let transcriptPath = null;
   let sessionId = null;
+  let sessionCwd = null;
   try {
     const input = JSON.parse(raw || '{}');
     transcriptPath = input.transcript_path ?? null;
@@ -49,6 +50,11 @@ process.stdin.on('end', () => {
     // semantics (no project attribution) so /compact does not block a closed
     // non-project session on the active/phantom project's files.
     sessionId = input.session_id ?? input.sessionId ?? null;
+    // Authoritative session cwd for the session-cwd close check. This is the one
+    // verified cwd source (mirrors hypo-session-record); it lets /compact block a
+    // session whose own project close was never started, which the recency-based
+    // global status cannot see.
+    sessionCwd = input.cwd ?? null;
   } catch {
     /* fail-open */
   }
@@ -107,6 +113,7 @@ process.stdin.on('end', () => {
     gate = precompactGateStatus(HYPO_DIR, {
       transcriptPath,
       ...(sessionId ? { sessionId } : {}),
+      ...(sessionCwd ? { sessionCwd } : {}),
     });
   } catch (err) {
     // Defense-in-depth: precompactGateStatus fails open per-check, but if it ever

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -529,7 +529,12 @@ function _lastSeg(p) {
 // declines (null) so the caller falls back to recency. `projects` is the whole
 // universe (for the uniqueness gate); `eligible` restricts the answer.
 export function pickProjectByCwd(projects, cwd, opts = {}) {
-  const { eligible = null, realpathCwd = null, caseInsensitive = isCaseInsensitiveFs() } = opts;
+  const {
+    eligible = null,
+    realpathCwd = null,
+    caseInsensitive = isCaseInsensitiveFs(),
+    rejectAmbiguous = false,
+  } = opts;
   if (!cwd && !realpathCwd) return null;
   const eligibleSet = eligible ? new Set(eligible) : null;
   const isEligible = (slug) => !eligibleSet || eligibleSet.has(slug);
@@ -549,20 +554,35 @@ export function pickProjectByCwd(projects, cwd, opts = {}) {
     if (n && !cwds.includes(n)) cwds.push(n);
   }
 
-  // Tier 1: first cwd variant with any longest-prefix match wins.
+  // Tier 1: first cwd variant with any longest-prefix match wins. With
+  // rejectAmbiguous (session-cwd close check), two DISTINCT projects sharing the same
+  // longest matching working_dir (a monorepo config with no uniqueness invariant)
+  // is a genuine tie we must NOT break arbitrarily — silently picking the first
+  // would attribute a close to the wrong project and either mask a real failure
+  // (false-green) or block the wrong one (false-block). Decline the tie → null,
+  // so the caller degrades to the unresolved-cwd path instead of guessing.
   for (const c of cwds) {
     const cf = _fold(c, caseInsensitive);
     let bestSlug = null;
     let bestLen = -1;
+    let bestTied = false;
     for (const e of entries) {
       if (!isEligible(e.slug)) continue;
       const pf = _fold(e.path, caseInsensitive);
-      if ((cf === pf || cf.startsWith(`${pf}/`)) && e.path.length > bestLen) {
-        bestLen = e.path.length;
-        bestSlug = e.slug;
+      if (cf === pf || cf.startsWith(`${pf}/`)) {
+        if (e.path.length > bestLen) {
+          bestLen = e.path.length;
+          bestSlug = e.slug;
+          bestTied = false;
+        } else if (e.path.length === bestLen && e.slug !== bestSlug) {
+          bestTied = true;
+        }
       }
     }
-    if (bestSlug) return bestSlug;
+    if (bestSlug) {
+      if (bestTied && rejectAmbiguous) return null;
+      return bestSlug;
+    }
   }
 
   // Tier 2: unique-basename ancestor, but only when the chain points at exactly
@@ -1134,7 +1154,10 @@ export function sessionCloseGlobalStatus(hypoDir, opts = {}) {
 
   // primary = the recency project when it is itself today-active, else the first
   // today-active slug (stable order from the candidate set). Used only as the
-  // single-slug alias (marker `project` field, message header) — never to gate.
+  // single-slug alias for the message header and the flat `close.project` field.
+  // It is NEVER an attribution source: the marker is stamped from close evidence
+  // (explicit --project, transcript close-files, apply's payload.project), so this
+  // recency-derived value cannot leak into a marker and back into the next gate.
   const primary = recency && todayActive.includes(recency) ? recency : todayActive[0];
   const ordered = [primary, ...todayActive.filter((p) => p !== primary)];
 
@@ -1973,9 +1996,22 @@ export function writeSessionClosedMarker(hypoDir, sessionId, info = {}) {
     // attribution). Readers (precompactGateStatus / --check-session-close) key
     // the gate semantics on this field, so it must be recorded.
     const scope = info.scope === 'log-only' ? 'log-only' : 'project';
+    // v4 attribution discriminator (session-close attribution). `projects` is the evidence-based
+    // set this session actually closed — explicit --project ∪ transcript
+    // close-file edits ∪ apply's authoritative payload.project — and NEVER the
+    // recency primary. Its PRESENCE marks a v4 marker whose scope resolveCloseScope
+    // trusts directly; a pre-v4 marker carries only `project` and is treated as an
+    // uncorroborated legacy hint (see resolveCloseScope). `project` stays as
+    // projects[0] for back-compat with the flat-field readers.
+    const projects = Array.isArray(info.projects)
+      ? [...new Set(info.projects.filter(Boolean))]
+      : info.project
+        ? [info.project]
+        : [];
     const payload = {
       session_id: sessionId,
-      project: info.project || null,
+      project: info.project || projects[0] || null,
+      projects,
       scope,
       transcript_path: info.transcript_path || null,
       closed_at: new Date().toISOString(),
@@ -2387,7 +2423,18 @@ function projectsFromTouchedCloseFiles(transcriptPath, hypoDir) {
 export function resolveCloseScope(hypoDir, opts = {}, marker = null) {
   const scope = new Set(opts.closeScope || []);
   for (const p of projectsFromTouchedCloseFiles(opts.transcriptPath, hypoDir)) scope.add(p);
-  if (marker?.project) scope.add(marker.project);
+  // Marker attribution (session-close attribution). A v4 marker carries `projects` — the
+  // evidence-based set it closed (never recency) — trusted directly. A pre-v4
+  // legacy marker carries only `project` with no provenance, and that value may be
+  // recency-derived (the P1 bug). An uncorroborated legacy attribution must NOT
+  // enable partitioning, or a stale/wrong slug could demote a real failure to
+  // foreign debt. So a legacy `project` enters scope only when the direct signals
+  // above (explicit close scope or transcript close-file edits) already corroborate
+  // the SAME slug; otherwise it stays a display hint. This narrow gap self-heals as
+  // pre-v4 markers expire (7-day TTL).
+  if (Array.isArray(marker?.projects)) {
+    for (const p of marker.projects) if (p) scope.add(p);
+  }
   return scope;
 }
 
@@ -2422,7 +2469,15 @@ export function resolveCloseScope(hypoDir, opts = {}, marker = null) {
  * ignored.
  *
  * @param {string} hypoDir
- * @param {{lintScope?: Iterable<string>, transcriptPath?: string|null, claudeHome?: string, projectOverride?: string|null}} [opts]
+ * opts.sessionCwd (session-cwd close check): the authoritative cwd of the session being
+ * gated (hook payload.cwd, or the CLI --session-cwd flag — never process.cwd(),
+ * which is post-`cd` non-authoritative). When set and not log-only, the project
+ * that owns this cwd is checked for close-completeness as an INDEPENDENT blocker,
+ * catching a session whose own project close was never started. Unmatched/ambiguous
+ * cwd yields a best-effort notice, not a block. apply never passes it (its launch
+ * cwd may differ from the authoritative payload.project).
+ *
+ * @param {{lintScope?: Iterable<string>, transcriptPath?: string|null, claudeHome?: string, projectOverride?: string|null, sessionCwd?: string|null, sessionId?: string|null, logOnly?: boolean, closeScope?: string[]}} [opts]
  * @returns {{ok: boolean, close: object, blockers: {type:string,reason:string}[], notices: {type:string,reason:string,file?:string}[], driftTargets: string[], skipped: {lint:boolean, feedback:boolean}}}
  */
 export function precompactGateStatus(hypoDir, opts = {}) {
@@ -2571,6 +2626,64 @@ export function precompactGateStatus(hypoDir, opts = {}) {
           ...p.missing.map((f) => `${f} (missing)`),
           ...p.stale.map((f) => `${f} (stale)`),
         ].join(', ')}) — not blocking; that project's next close will fix it`,
+      });
+    }
+  }
+
+  // 3b. session-cwd close (session-cwd close check). The current session's cwd project is an
+  // INDEPENDENT close responsibility. sessionCloseGlobalStatus above only sees
+  // projects that left an authoritative close-activity trace (a session-log
+  // heading / log.md entry), so a project whose close was NEVER STARTED is
+  // invisible — and if the recency project was closed the same day, the gate would
+  // go green while this session's real project stays unclosed (the false-green this
+  // closes). Evaluate it here, AFTER the partition and OUTSIDE scopeSet /
+  // close.projects, so it can neither be demoted to foreign debt (partition) nor
+  // spawn a W8 design-history blocker (which derives from close.projects). log-only
+  // sessions are exempt (no project to close). apply never passes sessionCwd (its
+  // launch cwd may differ from the authoritative payload.project — a supported
+  // cross-project close), so this runs only on the read / mark paths.
+  if (!logOnly && opts.sessionCwd) {
+    const cwdProject = pickProjectByCwd(collectProjectWorkingDirs(hypoDir), opts.sessionCwd, {
+      rejectAmbiguous: true,
+    });
+    if (cwdProject) {
+      const s = sessionCloseFileStatus(hypoDir, { projectOverride: cwdProject });
+      if (!s.ok) {
+        // ALWAYS emit the typed close-cwd blocker when the cwd project's close is
+        // incomplete — never suppress it as a duplicate of the global `close`
+        // blocker. The Stop hook keys its marker re-check on this exact type, so
+        // hiding it (even when a `close` blocker names the same project) would let
+        // Stop honor a stale marker and end the session green (codex pre-commit
+        // BLOCKER). A second entry for the same slug is merely noisy, never wrong.
+        blockers.push({
+          type: 'close-cwd',
+          project: cwdProject,
+          reason: `session cwd project '${cwdProject}' has an incomplete session close: ${[
+            ...s.missing.map((f) => `${f} (missing)`),
+            ...s.stale.map((f) => `${f} (stale)`),
+          ].join(', ')}`,
+        });
+        // If the partition demoted this project to foreign debt, it is NOT another
+        // session's work — it is THIS session's, and we just BLOCKED on it. Remove
+        // it from BOTH the debt notice and close.debt so the status cannot report
+        // the same project as non-blocking debt and a blocker at once (codex
+        // pre-commit CONCERN: crystallize renders close_debt from close.debt).
+        for (let i = notices.length - 1; i >= 0; i--) {
+          if (notices[i].type === 'close-debt' && notices[i].project === cwdProject)
+            notices.splice(i, 1);
+        }
+        if (Array.isArray(close.debt))
+          close.debt = close.debt.filter((d) => d.project !== cwdProject);
+      }
+    } else {
+      // cwd is under no project working_dir, or ambiguously under several (a
+      // monorepo tie pickProjectByCwd declined): we cannot attribute a close
+      // responsibility, so we do NOT hard-block (nothing proves there is anything
+      // to close). Surface a best-effort notice so the coverage gap is visible.
+      notices.push({
+        type: 'close-cwd-unresolved',
+        reason:
+          'session cwd did not resolve to a unique project — the P2 cwd close check is best-effort here; pass --project or --log-only to be explicit',
       });
     }
   }

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -174,6 +174,7 @@ function parseArgs(argv) {
     else if (arg.startsWith('--session-id=')) args.sessionId = arg.slice(13);
     else if (arg.startsWith('--payload=')) args.payload = arg.slice(10);
     else if (arg.startsWith('--transcript-path=')) args.transcriptPath = expandHome(arg.slice(18));
+    else if (arg.startsWith('--session-cwd=')) args.sessionCwd = expandHome(arg.slice(14));
     else if (arg.startsWith('--project=')) args.project = arg.slice(10);
     else if (arg === '--force') args.force = true;
     else if (arg === '--json') args.json = true;
@@ -263,6 +264,13 @@ function runSessionCloseCheck(args) {
         ? { transcriptPath: checkTranscript }
         : {}),
     ...(args.sessionId ? { sessionId: args.sessionId } : {}),
+    // The P2 cwd close check (session-close attribution) applies to the GLOBAL gate only. Under
+    // --project the check is a project-scoped diagnostic, so a cwd blocker for a
+    // DIFFERENT project would muddy that scoped answer — pass sessionCwd only for
+    // the global form. process.cwd() is deliberately NOT a fallback: a check run
+    // after `cd ~/hypomnema` would map to the vault, not the session (authoritative
+    // enforcement lives in the PreCompact/Stop hooks, which carry payload.cwd).
+    ...(args.sessionCwd && !args.project ? { sessionCwd: args.sessionCwd } : {}),
   });
   const close = status.close;
 
@@ -643,6 +651,9 @@ function runMarkSessionClosed(args) {
     ...(args.project && !args.logOnly ? { closeScope: [args.project] } : {}),
     ...(closeTranscript ? { transcriptPath: closeTranscript } : {}),
     ...(args.logOnly ? { logOnly: true } : {}),
+    // P2 (session-close attribution): the marker gate must refuse to attest compact-ready while the
+    // session's cwd project has an unstarted close. logOnly exempts it in-gate.
+    ...(args.sessionCwd ? { sessionCwd: args.sessionCwd } : {}),
   });
   const status = gate.close;
   if (!gate.ok) {
@@ -685,21 +696,43 @@ function runMarkSessionClosed(args) {
     console.log(args.json ? JSON.stringify(result, null, 2) : `✗ ${reason}`);
     process.exit(1);
   }
-  // Marker attribution comes from the CLOSE SCOPE, never from the gate's
-  // global `primary`. The marker is what PreCompact later re-derives its own scope
-  // from, so attributing it to a project this session did not close hands PreCompact a
-  // scope the marker never cleared: `primary` can be a FOREIGN today-active project
-  // whose debt this gate demoted, and PreCompact would union it back in and re-block.
-  // Marker green, /compact red — the exact invariant PR #110 closed (codex design
-  // review, both workers). Explicit --project wins; else the scope's own project
-  // (preferring `primary` when it is itself in scope); else `primary`, which is only
-  // reachable when the scope was empty and the gate therefore stayed global anyway.
+  // Marker attribution comes from EVIDENCE, never from the gate's global
+  // `primary` (which is recency-derived, hypo-shared.mjs). The marker is what
+  // PreCompact later re-derives its own scope from, so attributing it to a project
+  // this session did not close hands PreCompact a scope the marker never cleared.
+  // The evidence set is the close scope — explicit --project ∪ the transcript's
+  // touched close files ∪ any prior marker for this session — all of which
+  // resolveCloseScope already unioned into status.scope. The recency primary is
+  // deliberately excluded: an empty scope means this session has no proof it closed
+  // any project (evidence-based close attribution), so we FAIL CLOSED rather than misattribute to recency.
   const closeScope = status.scope || [];
-  const scopeProject = closeScope.includes(status.project) ? status.project : closeScope[0];
-  const markerProject =
-    !args.logOnly && args.project ? args.project : (scopeProject ?? status.project);
+  const markerProjects = [
+    ...new Set([...(!args.logOnly && args.project ? [args.project] : []), ...closeScope]),
+  ];
+  if (!args.logOnly && markerProjects.length === 0) {
+    const err =
+      'cannot attribute this close to a project — no evidence (no --project, no transcript close-file edits, no prior marker). ' +
+      'Pass --project=<slug> for the project this session closed, or --log-only for a non-project (tooling/wiki-only) session.';
+    console.log(
+      args.json
+        ? JSON.stringify(
+            {
+              ok: false,
+              session_id: args.sessionId,
+              skipReason: 'no-attribution-evidence',
+              error: err,
+            },
+            null,
+            2,
+          )
+        : `✗ ${err}`,
+    );
+    process.exit(1);
+  }
+  const markerProject = !args.logOnly && args.project ? args.project : markerProjects[0];
   writeSessionClosedMarker(args.hypoDir, args.sessionId, {
     project: markerProject,
+    projects: args.logOnly ? [] : markerProjects,
     ...(args.logOnly ? { scope: 'log-only' } : {}),
   });
   // Marker writer swallows IO errors (best-effort, see hypo-shared.mjs). Verify
@@ -1641,7 +1674,9 @@ function applySessionClose(args) {
     });
     markerSkipReason = decision.skipReason;
     if (decision.write) {
-      writeSessionClosedMarker(args.hypoDir, args.sessionId, { project });
+      // apply KNOWS its authoritative payload.project — stamp it as the v4
+      // evidence set so PreCompact trusts this marker's scope directly (session-close attribution).
+      writeSessionClosedMarker(args.hypoDir, args.sessionId, { project, projects: [project] });
       // Codex CONCERN: the writer swallows IO errors (best-effort).
       // Verify the file actually landed — mirroring the standalone path — instead of
       // asserting markerWritten=true, so a .cache permission/disk problem surfaces

--- a/scripts/lib/wd-match.mjs
+++ b/scripts/lib/wd-match.mjs
@@ -72,7 +72,12 @@ function lastSegment(p) {
  * @returns {string|null} matched slug, or null when nothing matches.
  */
 export function pickProjectByCwd(projects, cwd, opts = {}) {
-  const { eligible = null, realpathCwd = null, caseInsensitive = isCaseInsensitiveFs() } = opts;
+  const {
+    eligible = null,
+    realpathCwd = null,
+    caseInsensitive = isCaseInsensitiveFs(),
+    rejectAmbiguous = false,
+  } = opts;
   if (!cwd && !realpathCwd) return null;
 
   const eligibleSet = eligible ? new Set(eligible) : null;
@@ -98,19 +103,32 @@ export function pickProjectByCwd(projects, cwd, opts = {}) {
   // ── Tier 1: longest absolute prefix (the original behavior) ────────────────
   // cwd === path or cwd under path/. Longest path wins so /repo/sub beats /repo.
   // The FIRST cwd variant that yields any prefix match wins (raw before realpath).
+  // With rejectAmbiguous (session-cwd close check), two DISTINCT projects sharing the same
+  // longest matching working_dir (a monorepo config) is a real tie we must not
+  // break arbitrarily — decline to null so the caller degrades to the
+  // unresolved-cwd path instead of attributing the close to the wrong project.
   for (const c of cwds) {
     const cf = casefold(c, caseInsensitive);
     let bestSlug = null;
     let bestLen = -1;
+    let bestTied = false;
     for (const e of entries) {
       if (!isEligible(e.slug)) continue;
       const pf = casefold(e.path, caseInsensitive);
-      if ((cf === pf || cf.startsWith(`${pf}/`)) && e.path.length > bestLen) {
-        bestLen = e.path.length;
-        bestSlug = e.slug;
+      if (cf === pf || cf.startsWith(`${pf}/`)) {
+        if (e.path.length > bestLen) {
+          bestLen = e.path.length;
+          bestSlug = e.slug;
+          bestTied = false;
+        } else if (e.path.length === bestLen && e.slug !== bestSlug) {
+          bestTied = true;
+        }
       }
     }
-    if (bestSlug) return bestSlug;
+    if (bestSlug) {
+      if (bestTied && rejectAmbiguous) return null;
+      return bestSlug;
+    }
   }
 
   // ── Tier 2: globally-unique basename of a cwd ancestor (cross-machine) ─────

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -1610,10 +1610,13 @@ test('--mark-session-closed with ok gate but dirty git → exit 1, no marker (AD
 test('--mark-session-closed with ok gate + clean git → exit 0, marker created', () => {
   withWiki(null, (dir) => {
     const cleanup = seedCloseTranscript('s-success');
+    // close attribution: attribution comes from evidence, never recency. A standalone
+    // mark whose transcript touched no close file must name the project it closed.
     const r = run('crystallize.mjs', [
       `--hypo-dir=${dir}`,
       '--mark-session-closed',
       '--session-id=s-success',
+      '--project=test-project',
       '--json',
     ]);
     cleanup();
@@ -1627,6 +1630,62 @@ test('--mark-session-closed with ok gate + clean git → exit 0, marker created'
     assert.equal(marker.session_id, 's-success');
     assert.equal(marker.verification, 'session-close-file-status:ok');
     assert.ok(marker.closed_at, 'marker must carry closed_at timestamp');
+  });
+});
+
+// session-close attribution P1: recency is no longer an attribution source. A
+// standalone mark whose transcript touched no close file and names no --project
+// has NO evidence of which project it closed, so it must FAIL CLOSED (exit 1, no
+// marker) instead of silently attributing to the recency project. Old behavior
+// wrote a marker attributed to test-project (recency); this pins the fix.
+test('--mark-session-closed with no attribution evidence → fail closed, no marker', () => {
+  withWiki(null, (dir) => {
+    const cleanup = seedCloseTranscript('s-noevidence');
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--mark-session-closed',
+      '--session-id=s-noevidence',
+      '--json',
+    ]);
+    cleanup();
+    assert.equal(r.status, 1, `no evidence must fail closed, got ${r.status}\n${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(out.skipReason, 'no-attribution-evidence');
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'session-closed-s-noevidence.marker')),
+      'no marker may be attributed to the recency project',
+    );
+  });
+});
+
+// The v4 marker discriminator: an evidence-attributed marker carries `projects`,
+// which resolveCloseScope trusts directly (a pre-v4 marker has only `project`).
+test('--mark-session-closed stamps the v4 projects discriminator', () => {
+  withWiki(null, (dir) => {
+    const cleanup = seedCloseTranscript('s-disc');
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--mark-session-closed',
+      '--session-id=s-disc',
+      '--project=test-project',
+      '--json',
+    ]);
+    cleanup();
+    assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
+    const marker = JSON.parse(
+      readFileSync(join(dir, '.cache', 'session-closed-s-disc.marker'), 'utf-8'),
+    );
+    assert.deepEqual(
+      marker.projects,
+      ['test-project'],
+      'projects discriminator is the evidence set',
+    );
+    assert.equal(
+      marker.project,
+      'test-project',
+      'flat project stays as projects[0] for back-compat',
+    );
   });
 });
 
@@ -2251,6 +2310,7 @@ test('--mark-session-closed writes the marker on PURE feedback drift and surface
         join(SCRIPTS, 'crystallize.mjs'),
         '--mark-session-closed',
         '--session-id=s-drift',
+        '--project=test-project',
         `--hypo-dir=${wiki}`,
         '--json',
       ],
@@ -2904,6 +2964,157 @@ test('IMPR-34: foreign incomplete close is a notice, not a blocker, when scope n
     // The actual win. Asserting only "no close blocker" would pass while the gate
     // stayed red for some other reason and the marker still never landed.
     assert.equal(gate.ok, true, `the gate is GREEN → the marker lands: ${JSON.stringify(gate)}`);
+  });
+});
+
+// ── session-cwd close check (session-close attribution, P2) ──────────────────
+// The false-green this closes: a secondary project whose close was NEVER STARTED
+// leaves no today close-activity trace, so the recency-based global status can't
+// see it. When the recency project was closed the same day, the gate goes green
+// while the session's own project stays open. The independent cwd check catches it.
+suite('session-cwd close check (P2)');
+
+// Give a project an index.md working_dir so pickProjectByCwd can resolve a cwd.
+function setWorkingDir(dir, slug, workingDir) {
+  const idx = join(dir, 'projects', slug, 'index.md');
+  writeFileSync(
+    idx,
+    `---\ntitle: ${slug}\ntype: index\nworking_dir: ${workingDir}\n---\n\n# ${slug}\n`,
+  );
+  // Commit so the gate's git axis stays clean (ahead-of-remote is only a notice).
+  spawnSync('git', ['-C', dir, 'add', '-A']);
+  spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'idx']);
+}
+
+test('P2: a never-started cwd project close is caught even when recency is green', () => {
+  const CWD = '/tmp/cwdproj-workdir';
+  withClosePartitionWiki(
+    [
+      // recency-proj: fully closed today → the only today-active project.
+      { slug: 'recency-proj', date: todayLocal() },
+      // cwd-proj: session-state fresh (a real project) but its close was never
+      // started — stale session-log, no today log entry, no today hot row → it is
+      // INVISIBLE to the today-active global status.
+      { slug: 'cwd-proj', date: todayLocal(), sessionLog: false, logEntry: false, hotRow: false },
+    ],
+    [],
+    (dir) => {
+      setWorkingDir(dir, 'cwd-proj', CWD);
+      // Without the cwd signal: the classic false-green. recency-proj is complete
+      // and cwd-proj is invisible, so the global gate is green.
+      const green = precompactGateStatus(dir, { claudeHome: join(dir, '.claude-none') });
+      assert.equal(
+        green.blockers.some((b) => b.type === 'close-cwd'),
+        false,
+        'no cwd signal → no cwd check (documents the pre-fix false-green surface)',
+      );
+      // The baseline must actually BE green — otherwise an unrelated blocker could
+      // make both runs red while this test still "passes" (codex pre-commit CONCERN).
+      assert.equal(
+        green.ok,
+        true,
+        `baseline must be the genuine false-green: ${JSON.stringify(green.blockers)}`,
+      );
+      // With the authoritative session cwd: the independent check evaluates
+      // cwd-proj's close, finds it incomplete, and blocks — no longer green.
+      const gated = precompactGateStatus(dir, {
+        claudeHome: join(dir, '.claude-none'),
+        sessionCwd: CWD,
+      });
+      const cwdBlocker = gated.blockers.find((b) => b.type === 'close-cwd');
+      assert.ok(
+        cwdBlocker,
+        `cwd-proj's unstarted close must block: ${JSON.stringify(gated.blockers)}`,
+      );
+      assert.equal(cwdBlocker.project, 'cwd-proj');
+      assert.equal(gated.ok, false, 'the gate is RED once the cwd project is checked');
+    },
+  );
+});
+
+test('P2: close-cwd is emitted even when the cwd project is also a normal close blocker', () => {
+  // The Stop hook keys its marker re-check on the close-cwd TYPE. If the cwd
+  // project is today-active AND incomplete it also shows up as an ordinary `close`
+  // blocker; the typed close-cwd must NOT be suppressed as a duplicate, or Stop
+  // would honor a stale marker (codex pre-commit BLOCKER).
+  const CWD = '/tmp/cwdproj-both';
+  withClosePartitionWiki(
+    // session-state stale → incomplete; session-log fresh → today-active.
+    [{ slug: 'cwd-proj', date: todayLocal(), sessionState: '2000-01-01' }],
+    [],
+    (dir) => {
+      setWorkingDir(dir, 'cwd-proj', CWD);
+      const gate = precompactGateStatus(dir, {
+        claudeHome: join(dir, '.claude-none'),
+        sessionCwd: CWD,
+      });
+      assert.ok(
+        gate.blockers.some((b) => b.type === 'close'),
+        'the today-active incomplete project is a normal close blocker',
+      );
+      assert.ok(
+        gate.blockers.some((b) => b.type === 'close-cwd' && b.project === 'cwd-proj'),
+        'the typed close-cwd blocker is retained so Stop can key on it',
+      );
+    },
+  );
+});
+
+test('P2: a complete cwd project close adds no blocker', () => {
+  const CWD = '/tmp/cwdproj-done';
+  withClosePartitionWiki([{ slug: 'cwd-proj', date: todayLocal() }], [], (dir) => {
+    setWorkingDir(dir, 'cwd-proj', CWD);
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      sessionCwd: CWD,
+    });
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close-cwd'),
+      false,
+      'a completed cwd project close gains no new blocker',
+    );
+  });
+});
+
+test('P2: log-only exempts the cwd check', () => {
+  const CWD = '/tmp/cwdproj-logonly';
+  withClosePartitionWiki(
+    [
+      { slug: 'recency-proj', date: todayLocal() },
+      { slug: 'cwd-proj', date: todayLocal(), sessionLog: false, logEntry: false, hotRow: false },
+    ],
+    [],
+    (dir) => {
+      setWorkingDir(dir, 'cwd-proj', CWD);
+      const gate = precompactGateStatus(dir, {
+        claudeHome: join(dir, '.claude-none'),
+        sessionCwd: CWD,
+        logOnly: true,
+      });
+      assert.equal(
+        gate.blockers.some((b) => b.type === 'close-cwd'),
+        false,
+        'a non-project (log-only) session has nothing to close → cwd check is skipped',
+      );
+    },
+  );
+});
+
+test('P2: an unmatched cwd is a notice, never a block', () => {
+  withClosePartitionWiki([{ slug: 'recency-proj', date: todayLocal() }], [], (dir) => {
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      sessionCwd: '/nowhere/unmatched/path',
+    });
+    assert.equal(
+      gate.blockers.some((b) => b.type === 'close-cwd'),
+      false,
+      'a cwd under no project working_dir must not hard-block',
+    );
+    assert.ok(
+      gate.notices.some((n) => n.type === 'close-cwd-unresolved'),
+      'the coverage gap surfaces as a best-effort notice',
+    );
   });
 });
 

--- a/tests/lib-core.test.mjs
+++ b/tests/lib-core.test.mjs
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { test, suite } from './harness.mjs';
 import {
   HOME,
+  HOOKS,
   SCRIPTS,
   SESSION_TMP_HOME,
   checkVaultOrExit,
@@ -292,6 +293,28 @@ test('valid vault via HYPO_DIR (marker present) → all 4 read CLIs behave as be
 // ── lib/wd-match.mjs (cross-machine project matcher) ─────────────────────────
 
 const { pickProjectByCwd, normalizeWorkingDir } = await import(`${SCRIPTS}/lib/wd-match.mjs`);
+const { resolveCloseScope } = await import(`${HOOKS}/hypo-shared.mjs`);
+
+suite('resolveCloseScope() — marker attribution (session-close attribution)');
+
+test('a v4 marker `projects` is trusted directly as scope', () => {
+  const scope = resolveCloseScope('/nonexistent-hypo', {}, { projects: ['alpha', 'beta'] });
+  assert.deepEqual([...scope].sort(), ['alpha', 'beta']);
+});
+
+test('an uncorroborated pre-v4 legacy marker.project is NOT partition-enabling scope', () => {
+  // Legacy marker carries only `project` (possibly recency-derived). With no
+  // direct signal corroborating the same slug, it must stay out of scope so a
+  // stale attribution cannot demote a real failure.
+  const scope = resolveCloseScope('/nonexistent-hypo', {}, { project: 'stale-recency' });
+  assert.equal(scope.has('stale-recency'), false, 'uncorroborated legacy project excluded');
+});
+
+test('explicit close scope is always honored regardless of marker shape', () => {
+  const scope = resolveCloseScope('/nonexistent-hypo', { closeScope: ['mine'] }, { project: 'x' });
+  assert.ok(scope.has('mine'));
+  assert.equal(scope.has('x'), false);
+});
 
 suite('normalizeWorkingDir()');
 
@@ -332,6 +355,28 @@ test('longest prefix wins (/repo/sub beats /repo)', () => {
 test('no false prefix match on sibling (Hypomnema vs Hypomnema-old)', () => {
   const sib = [{ slug: 'h', workingDir: '/Users/x/Hypomnema' }];
   assert.equal(pickProjectByCwd(sib, '/Users/x/Hypomnema-old'), null);
+});
+
+test('rejectAmbiguous declines a shared-working_dir tie (monorepo)', () => {
+  // Two DISTINCT projects mapped to the SAME working_dir: attributing a close to
+  // either would be a guess (session-close attribution P2). Default keeps the
+  // legacy first-match behavior; rejectAmbiguous declines to null.
+  const mono = [
+    { slug: 'api', workingDir: '/repo' },
+    { slug: 'web', workingDir: '/repo' },
+  ];
+  assert.ok(['api', 'web'].includes(pickProjectByCwd(mono, '/repo/src')), 'default breaks the tie');
+  assert.equal(
+    pickProjectByCwd(mono, '/repo/src', { rejectAmbiguous: true }),
+    null,
+    'rejectAmbiguous returns null on an equal-length tie',
+  );
+  // A unique longest match is still returned under rejectAmbiguous.
+  const uniq = [
+    { slug: 'api', workingDir: '/repo/api' },
+    { slug: 'web', workingDir: '/repo' },
+  ];
+  assert.equal(pickProjectByCwd(uniq, '/repo/api/src', { rejectAmbiguous: true }), 'api');
 });
 
 test('~ working_dir is expanded before compare', () => {


### PR DESCRIPTION
# English

## What changed

Two session-close correctness fixes.

1. The session-closed marker is now attributed from evidence, never from the recency project. The standalone mark path derives the project from an explicit `--project` or the transcript's touched close files, and fails closed (exit 1, no marker) when neither exists. Every marker now carries a `projects` discriminator; the scope resolver trusts it directly and treats a pre-upgrade marker's bare `project` as an uncorroborated hint (excluded from partition-enabling scope until a matching direct signal corroborates it).

2. The compact gate gained an independent session-cwd close check. The project that owns the session's cwd is verified for close-completeness after the partition and outside the scope set, so it cannot be demoted to foreign debt or spawn a design-history blocker. This catches a project whose close was never started, which the recency-based global status cannot see.

## Why

A session working in a secondary project (cwd elsewhere) closed while the wiki's high-traffic project dominated recency. The marker was stamped with the recency project, and later re-scoped under it, so the wrong project was recorded as closed. Separately, a project whose close was never started left no close-activity trace, so the global gate went green as soon as the recency project closed the same day, hiding the unfinished close.

## How

Attribution now flows from the close scope (explicit `--project` ∪ transcript close-file edits), never the recency alias; the marker records that evidence set. The session cwd is forwarded from the PreCompact and Stop hooks (the one verified cwd source) and via a new `--session-cwd` CLI flag; the Stop hook re-checks the cwd project before honoring an existing marker (a log-only marker is exempt). A monorepo tie (two projects sharing one working_dir) is declined rather than guessed, degrading to a best-effort notice. Apply's own gate stays cwd-free so a supported cross-project close is not blocked.

## Manual verification

Full suite green (`npm test`: 1650 passed). Added red-first regressions: the no-evidence mark fails closed; the marker carries `projects`; the session-cwd check turns a genuine false-green red while leaving a complete cwd close untouched; log-only exempts it; an unmatched cwd is a notice; a monorepo tie is declined; the typed `close-cwd` blocker survives even when the same project is also a normal close blocker (so the Stop hook can key on it). Live Stop/PreCompact hook behavior is worth confirming in a real session after release, since the deployed hook copies changed.

## Migration notes

None. Pre-upgrade markers (no `projects` field) expire on their normal 7-day TTL; during that window an uncorroborated legacy attribution is treated as a hint, erring toward over-block, never toward a false green.

---

# 한국어

## 변경 내용

세션 close 정확성 수정 두 가지.

1. session-closed 마커를 recency 프로젝트가 아니라 증거로 귀속한다. standalone mark 경로는 명시적 `--project`나 transcript가 건드린 close 파일에서 프로젝트를 도출하고, 둘 다 없으면 fail closed(exit 1, 마커 미기록)한다. 이제 모든 마커는 `projects` 판별자를 담고, scope 해소기는 이를 직접 신뢰하며, 업그레이드 이전 마커의 단일 `project`는 corroborate되기 전까지 (partition을 활성화하는) scope에서 제외되는 hint로만 취급한다.

2. compact 게이트에 독립적인 session-cwd close 검사를 추가했다. 세션 cwd가 속한 프로젝트를 partition 이후, scope 집합 밖에서 close 완료 여부로 검증하므로 foreign debt로 강등되거나 design-history 블로커를 만들지 않는다. recency 기반 전역 상태가 못 보는 "close를 아예 시작 안 한 프로젝트"를 잡는다.

## 이유

보조 프로젝트에서(cwd가 다른 곳) 작업하던 세션이 close될 때, 트래픽 많은 위키 프로젝트가 recency를 지배했다. 마커가 recency 프로젝트로 찍히고 이후 그 프로젝트로 재-scope돼 엉뚱한 프로젝트가 닫힌 것으로 기록됐다. 별개로, close를 시작조차 안 한 프로젝트는 close-activity 흔적을 안 남겨, 같은 날 recency 프로젝트가 닫히는 순간 전역 게이트가 green이 되며 미완 close를 숨겼다.

## 방법

귀속은 이제 close scope(명시 `--project` ∪ transcript close 파일 편집)에서 나오고 recency 별칭을 쓰지 않으며, 마커는 그 증거 집합을 기록한다. 세션 cwd는 PreCompact·Stop 훅(유일한 검증된 cwd 소스)과 신설 `--session-cwd` CLI 플래그로 전달되고, Stop 훅은 기존 마커를 인정하기 전에 cwd 프로젝트를 재검사한다(log-only 마커는 면제). monorepo tie(두 프로젝트가 같은 working_dir 공유)는 추측하지 않고 물러나 best-effort notice로 낮춘다. apply 자체 게이트는 cwd-free를 유지해 지원되는 cross-project close가 막히지 않는다.

## 수동 검증

전체 스위트 green(`npm test`: 1650 passed). red-first 회귀 추가: 증거 없는 mark는 fail closed, 마커에 `projects` 존재, session-cwd 검사가 진짜 false-green을 red로 바꾸되 완료된 cwd close는 그대로 둠, log-only 면제, 미매칭 cwd는 notice, monorepo tie는 물러남, 같은 프로젝트가 일반 close 블로커이기도 할 때 타입드 `close-cwd` 블로커가 살아남음(Stop 훅이 이를 key로 삼도록). 배포 훅 사본이 바뀌었으니 릴리스 후 실제 세션에서 Stop/PreCompact 훅 동작 확인 권장.

## 마이그레이션 노트

None. 업그레이드 이전 마커(`projects` 필드 없음)는 정상 7일 TTL로 만료되고, 그 기간 동안 corroborate 안 된 legacy 귀속은 hint로 취급돼 over-block 쪽으로 기울 뿐 false green으로는 절대 가지 않는다.

---

## Changelog

- EN: Fix the session-close marker being attributed to the recency project instead of the one the session closed, and catch a project whose close was never started that a same-day recency close would otherwise hide (#212).
- KO: 세션이 닫은 프로젝트가 아니라 recency 프로젝트로 찍히던 session-close 마커 귀속을 고치고, 같은 날 recency close가 가려버리던 "close를 시작조차 안 한 프로젝트"를 잡는다 (#212).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally (repo code; ambient-vault content warnings are unrelated)
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (internal gate/marker behavior; no doc surface)
- [x] Filled the `## Changelog` block above (EN + KO line)
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR
- [x] Commit messages follow Conventional Commits
