### PR TITLE
fix(close): make the session-close gate a lease, not an existence check

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -3166,83 +3166,231 @@ export function resolveTranscriptBySessionId(
 }
 
 /**
- * Returns true iff the transcript carries a genuine USER session-close signal —
- * the hard gate for the session-closed marker writers. Scans the FULL
- * transcript: a close request can precede the marker write by the entire close
- * checklist, so the Stop hook's 30-line tail would miss it.
+ * Returns true iff the transcript's LATEST live user decision is to close — the
+ * hard gate for the session-closed marker writers. This is a state predicate, not
+ * an existence one: "is close still approved right now", not "did a
+ * close signal ever appear". Scans the FULL transcript in line order, classifies
+ * each record, and tracks the approval as a LEASE.
  *
- * Evidence (any one is sufficient):
- *   1. a de-polluted NL close phrase — isClosePattern over extractUserMessages,
- *      which already drops injected / tool / hook-feedback text;
- *   2. a `/compact` invocation (queue-operation). `/clear` is deliberately NOT
- *      counted: it abandons context, whereas a session-close PRESERVES the work
- *      to the wiki — a different intent;
- *   3. an AskUserQuestion answer whose SELECTED value names a close action (the
- *      canonical "offer [세션 마무리] → user picks it" flow).
+ * Classification (structural fields only — never content heuristics for producer):
+ *   • GRANT      a genuine user close: an NL close phrase in user text that
+ *                survives {@link eventUserText}'s exclusions; a `/compact`
+ *                queue-op; a remove-path queued_command attachment carrying a
+ *                close with an audited human producer (origin.kind "human"); a
+ *                correlated, non-error AskUserQuestion answer naming a close.
+ *   • INVALIDATE a fresh user intent that expires the lease: any other genuine
+ *                user text, `/clear`, `popAll`, a non-close queued_command, a
+ *                non-close AskUserQuestion selection.
+ *   • NEUTRAL    everything the model can produce or the harness injects: system/
+ *                sdk replay, isMeta bodies, sidechain, interruptedMessageId
+ *                companions, assistant, tool_result, task-notification.
+ *   • FATAL      an unparseable line — the transcript is being appended to or is
+ *                corrupt, so refuse rather than read a half-written record.
  *
- * A Stop-hook block is NOT evidence: it is the hook's own nudge to close, so
- * counting it would be circular (the incident's block told the model to write the
- * marker). extractUserMessages already strips it.
+ * The last grant wins and a later invalidate expires it, so a stale close (Defect
+ * B), a queued "keep working" after a close, and a non-close AskUserQuestion
+ * selection all correctly read as NOT closed. Abandoned-branch staleness is a
+ * known limit (no leaf pointer exists to resolve it — see the branch note on the
+ * function), mitigated by the lease.
  *
- * Fail-closed: any read error → false (caller refuses the marker).
+ * Threat model: an honest-but-drifting model that does not forge the
+ * transcript. This is a safety interlock, not an authorization boundary — a model
+ * that forges records is out of scope and documented so.
+ *
+ * Fail-closed: any read/parse error, or an unresolvable branch, → false.
  */
+// Genuine user text of a record, or null when the record is on a channel the
+// honest-but-drifting model can reach (so it is never user intent — NEUTRAL).
+// role:user is the boundary the model cannot cross: it authors role:assistant,
+// so a user record that survives every exclusion below is genuine user text.
+// The exclusions are exactly the model-reachable channels:
+//   • isMeta            slash-command / skill bodies and local-command caveats
+//   • promptSource system|sdk   queue replay of injected text, SDK prompts
+//   • isSidechain       subagent context (a subagent must not close the session)
+//   • interruptedMessageId  the harness cut the model off; user-SHAPED, not a
+//                       user decision (e.g. the [Request interrupted by user]
+//                       companion of a delivered /compact)
+//   • Stop-hook feedback  the hook's own close nudge — circular
+//   • tool_result blocks  tool output, not typed text
+// No promptSource allowlist is required: requiring `typed` would drop the
+// legacy absent-promptSource close the older gate has always honoured, while the
+// dangerous replay/injection paths carry system|sdk|isMeta|isSidechain and are
+// excluded here anyway.
+function eventUserText(obj) {
+  if (obj.isMeta === true) return null;
+  if (obj.promptSource === 'system' || obj.promptSource === 'sdk') return null;
+  if (obj.isSidechain === true) return null;
+  if (obj.interruptedMessageId) return null;
+  const msg = obj.message ?? obj;
+  const role = msg.role ?? obj.role ?? obj.type;
+  if (role !== 'user') return null;
+  const content = msg.content ?? obj.content;
+  if (typeof content === 'string') {
+    return content.startsWith('Stop hook feedback') ? null : content;
+  }
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text);
+    return texts.length ? texts.join('\n') : null;
+  }
+  return null;
+}
+
+// A record on a channel the honest-but-drifting model can reach, so it can never
+// be a user decision. Used to keep injected / replayed / subagent records out of
+// BOTH the user-text and the AskUserQuestion-answer classifiers.
+function isModelReachableRecord(obj) {
+  return (
+    obj.isMeta === true ||
+    obj.promptSource === 'system' ||
+    obj.promptSource === 'sdk' ||
+    obj.isSidechain === true
+  );
+}
+
 export function hasUserCloseSignal(transcriptPath) {
   if (!transcriptPath) return false;
-  let lines;
+  let raw;
   try {
-    lines = readFileSync(transcriptPath, 'utf-8').split('\n');
+    raw = readFileSync(transcriptPath, 'utf-8');
   } catch {
     return false;
   }
-  // (1) NL close over the full, de-polluted transcript.
-  if (isClosePattern(extractUserMessages(transcriptPath, Infinity))) return true;
-  // AskUserQuestion answers (3) must be correlated to a real AskUserQuestion
-  // tool_use by id — otherwise ANY tool_result string containing "have been
-  // answered" (e.g. a Read/Grep of this very file, or of a transcript) would
-  // satisfy the gate, reintroducing the tool_result pollution the de-pollution
-  // layer closes. First pass collects the genuine AskUserQuestion tool_use ids;
-  // the tool_use (assistant) always precedes its tool_result (user) in the log,
-  // so a single forward scan suffices.
-  const askIds = new Set();
-  for (const line of lines) {
+  // FATAL: a non-empty line that will not parse means the transcript is being
+  // appended to (a half-written record) or is corrupt. Skipping it would let a
+  // stale prior grant survive past an event we cannot read, so refuse. A line
+  // that parses to a non-object (a bare null / string / number) is valid JSON but
+  // not a record — noise, not corruption — so it is skipped, not fatal, and never
+  // reaches the field reads below.
+  const recs = [];
+  for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
-    let obj;
+    let o;
     try {
-      obj = JSON.parse(line);
+      o = JSON.parse(line);
     } catch {
-      continue;
+      return false;
     }
-    // (2) /compact (queue-operation). Not /clear — see doc above.
-    if (
-      obj.type === 'queue-operation' &&
-      typeof obj.content === 'string' &&
-      /^\/compact(?:\s|$)/.test(obj.content.trim())
-    ) {
-      return true;
-    }
-    const content = (obj.message ?? obj).content;
-    if (!Array.isArray(content)) continue;
-    for (const b of content) {
-      if (!b || typeof b !== 'object') continue;
-      // record AskUserQuestion tool_use ids
-      if (b.type === 'tool_use' && b.name === 'AskUserQuestion' && b.id) {
-        askIds.add(b.id);
+    if (o === null || typeof o !== 'object') continue;
+    recs.push(o);
+  }
+
+  // The approval is a LEASE, not an existence fact: walk the transcript in line
+  // order and track whether the LATEST user decision is a grant. Each grant sets
+  // it true, each invalidate sets it false, neutral leaves it — so at the end
+  // `granted` is "the most recent user decision was to close, and nothing has
+  // expired it since", which is how a stale close and a queued change-of-mind
+  // read as NOT closed.
+  //
+  // Branch note: line order mixes an abandoned branch's records with the live
+  // ones. A leaf-pointer ancestry filter was tried and withdrawn — the transcript
+  // carries no authoritative leaf pointer (measured: 0 leafUuid / summary
+  // records), so a heuristic leaf can skip the real invalidator and PRESERVE a
+  // stale grant (a fail-open, not a conservative filter). Until such a pointer
+  // exists, a close on a branch abandoned under a neutral tail is a known
+  // staleness limit, mitigated by the lease: any later live user intent, on any
+  // branch, still expires it.
+  const askIds = new Set();
+  let granted = false;
+
+  for (const o of recs) {
+    // Queue operations. The queue carries no correlation key (measured), so the
+    // ENQUEUE content is the decision — not a later contentless dequeue, which
+    // would need pairing we cannot do. Reading the enqueue also keeps the live
+    // PreCompact gate working (it sees the enqueue) and avoids double-counting the
+    // replay companion of an already-decided item (the /compact replay is not a
+    // fresh decision). popAll cancels the queue → invalidate. Delivery ops
+    // (dequeue, remove) carry no fresh decision here — a content-bearing remove of
+    // an NL queued command is handled by its queued_command attachment below.
+    if (o.type === 'queue-operation') {
+      if (o.operation === 'popAll') {
+        granted = false;
         continue;
       }
-      // (3) AskUserQuestion answer naming a close action — only when this
-      // tool_result actually answers a recorded AskUserQuestion. The answer lands
-      // in a role:user tool_result string: `… have been answered: "Q"="A". …`.
-      // Match the answer value(s) (the `="…"` side), never the question text, and
-      // run the SAME isClosePattern as the NL path so the two channels agree.
-      if (b.type === 'tool_result' && b.tool_use_id && askIds.has(b.tool_use_id)) {
+      if (o.operation !== 'enqueue') continue;
+      const c = typeof o.content === 'string' ? o.content.trim() : '';
+      if (/^\/compact(?:\s|$)/.test(c))
+        granted = true; // a user compaction preserves the work → grant
+      else if (/^\/clear(?:\s|$)/.test(c))
+        granted = false; // abandons context → invalidate
+      else if (!c || c.startsWith('<task-notification>')) {
+        /* model-caused / empty — neutral */
+      } else if (isClosePattern(c)) {
+        /* NL close via the queue — the open dequeue gap: the producer cannot be
+           attributed (a peer/model enqueue wears the same shape), so no grant */
+      } else granted = false; // a queued non-close user intent → invalidate (change of mind)
+      continue;
+    }
+
+    // remove-path delivery of a queued natural-language command (measured: the
+    // item leaves the queue as it is handed to the model, landing as an
+    // `attachment` of type queued_command with the prompt verbatim). A close here
+    // grants ONLY with an audited human producer — origin.kind "human", present
+    // on every 2.1.181+ user delivery (measured). A legacy origin-absent delivery
+    // cannot attest a producer, so it does not grant (fail-closed). A NON-close
+    // queued command (e.g. "keep working") is a fresh user intent and INVALIDATES
+    // a prior grant regardless of origin — that is what closes the re-close hole
+    // where a queued "continue" after a close leaves the stale lease live.
+    if (o.type === 'attachment' && o.attachment && o.attachment.type === 'queued_command') {
+      const prompt = typeof o.attachment.prompt === 'string' ? o.attachment.prompt : '';
+      const humanOrigin = !!(o.attachment.origin && o.attachment.origin.kind === 'human');
+      if (isClosePattern(prompt)) {
+        if (humanOrigin) granted = true;
+      } else if (prompt) {
+        granted = false;
+      }
+      continue;
+    }
+
+    // Record AskUserQuestion tool_use ids (assistant record, always precedes its
+    // answer in line order).
+    const content = (o.message ?? o).content;
+    if (Array.isArray(content)) {
+      for (const b of content) {
+        if (
+          b &&
+          typeof b === 'object' &&
+          b.type === 'tool_use' &&
+          b.name === 'AskUserQuestion' &&
+          b.id
+        )
+          askIds.add(b.id);
+      }
+    }
+
+    // Genuine user text → grant on a close phrase, invalidate on anything else.
+    const text = eventUserText(o);
+    if (text != null && text !== '') {
+      granted = isClosePattern(text);
+      continue;
+    }
+
+    // AskUserQuestion answer, correlated to a recorded AskUserQuestion, EXCLUDED
+    // and HARDENED. isModelReachableRecord keeps an injected / sdk / sidechain
+    // record from reaching the answer parser. is_error:false AND the host's
+    // success marker are required because a malformed AskUserQuestion echoes the
+    // raw input back in an is_error result, and the model authors the option
+    // labels. A close selection grants; any other real selection invalidates.
+    if (Array.isArray(content) && !isModelReachableRecord(o)) {
+      for (const b of content) {
+        if (!b || typeof b !== 'object') continue;
+        if (b.type !== 'tool_result' || !b.tool_use_id || !askIds.has(b.tool_use_id)) continue;
+        if (b.is_error === true) continue;
         const s = typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
+        if (!/have been answered/.test(s)) continue;
+        let sawAnswer = false;
+        let sawClose = false;
         for (const m of s.matchAll(/="([^"]*)"/g)) {
-          if (isClosePattern(m[1])) return true;
+          sawAnswer = true;
+          if (isClosePattern(m[1])) sawClose = true;
         }
+        if (sawClose) granted = true;
+        else if (sawAnswer) granted = false;
       }
     }
   }
-  return false;
+  return granted;
 }
 
 /** The literal the user must type to approve a parked-overwrite batch. */

--- a/tests/close-signals.test.mjs
+++ b/tests/close-signals.test.mjs
@@ -657,10 +657,10 @@ test('acceptance: /compact enqueue THEN remove → true (remove is delivery, so 
 // popAll carrying /compact grants anyway. popAll does carry content in the
 // corpus, so the shape is reachable — though this exact pairing, like the one
 // above, is composed rather than observed.
-test('acceptance: popAll carrying /compact → true (DEFECT: operation is never checked)', () => {
+test('acceptance: popAll carrying /compact → false (event model: popAll is a cancellation)', () => {
   withTmpDir((dir) => {
     const p = writeJsonl(dir, [QOP('popAll', '/compact')]);
-    assert.equal(hasUserCloseSignal(p), true);
+    assert.equal(hasUserCloseSignal(p), false);
   });
 });
 
@@ -725,7 +725,7 @@ const REMOVE_DELIVERY = (dir, { origin, version, removeContent, companions }) =>
 
 const HOOK_SUCCESS = { type: 'attachment', attachment: { type: 'hook_success' } };
 
-test('measured: NL close via the remove path, human origin (2.1.181+) → false (GAP: a real user close is invisible)', () => {
+test('measured: NL close via the remove path, human origin (2.1.181+) → true (event model reads the queued_command attachment)', () => {
   withTmpDir((dir) => {
     const p = REMOVE_DELIVERY(dir, {
       origin: { origin: { kind: 'human' } },
@@ -733,7 +733,7 @@ test('measured: NL close via the remove path, human origin (2.1.181+) → false 
       removeContent: true,
       companions: [HOOK_SUCCESS],
     });
-    assert.equal(hasUserCloseSignal(p), false);
+    assert.equal(hasUserCloseSignal(p), true);
   });
 });
 
@@ -986,24 +986,24 @@ const CLOSE_THEN_WORK = (dir, human) => {
   ]);
 };
 
-test('acceptance: close, then the user asks for more work → true (DEFECT: lease must expire)', () => {
+test('acceptance: close, then the user asks for more work → false (event model: lease expires)', () => {
   withTmpDir((dir) => {
-    assert.equal(hasUserCloseSignal(CLOSE_THEN_WORK(dir, true)), true);
+    assert.equal(hasUserCloseSignal(CLOSE_THEN_WORK(dir, true)), false);
   });
 });
 
-test('acceptance: close, then more work, both without origin → true (DEFECT: lease must expire here too)', () => {
+test('acceptance: close, then more work, both without origin → false (event model: lease expires here too)', () => {
   withTmpDir((dir) => {
-    assert.equal(hasUserCloseSignal(CLOSE_THEN_WORK(dir, false)), true);
+    assert.equal(hasUserCloseSignal(CLOSE_THEN_WORK(dir, false)), false);
   });
 });
 
 // INVALIDATE. /clear after a close abandons the context rather than preserving it.
 // It is a different intent, so it must retract the close rather than sit inert.
-test('acceptance: close, then /clear → true (DEFECT: /clear must invalidate the lease)', () => {
+test('acceptance: close, then /clear → false (event model: /clear invalidates the lease)', () => {
   withTmpDir((dir) => {
     const p = writeJsonl(dir, [USER(CLOSE), QOP('enqueue', '/clear')]);
-    assert.equal(hasUserCloseSignal(p), true);
+    assert.equal(hasUserCloseSignal(p), false);
   });
 });
 
@@ -1022,7 +1022,7 @@ test('acceptance: close, then /clear → true (DEFECT: /clear must invalidate th
 //
 // It must flip to false: this text is model-context, not a user decision, and a
 // subagent must never be able to close the session by quoting a close phrase.
-test('acceptance: sidechain mixed text+tool_result carrying a close → true (DEFECT: must never grant)', () => {
+test('acceptance: sidechain mixed text+tool_result carrying a close → false (event model excludes isSidechain)', () => {
   withTmpDir((dir) => {
     const p = writeJsonl(dir, [
       USER({
@@ -1041,7 +1041,158 @@ test('acceptance: sidechain mixed text+tool_result carrying a close → true (DE
         },
       }),
     ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// ── ADR 0075 event model: lease invalidation + robustness + AskUserQuestion hardening ──
+//
+// Coverage the merged measured-shapes suite does not carry, added after a
+// pre-commit review. The transcript has no authoritative leaf pointer (measured
+// 2026-07-19: 0 leafUuid / summary records), so a heuristic active-branch filter
+// was withdrawn — it could skip the real invalidator and PRESERVE a stale grant.
+// The gate is a pure line-order lease; these pin the invalidation edges, the
+// robustness edges, and the AskUserQuestion hardening.
+suite('hasUserCloseSignal() — lease invalidation + robustness + AskUserQuestion hardening');
+
+// LOAD-BEARING (invalidation via the queued non-close): the user closes, then
+// queues "keep working". The decision is read off the ENQUEUE content (the queue
+// has no correlation key), so the queued non-close expires the lease before the
+// dequeue+replay companions arrive. Without it the stale close would survive this
+// change-of-mind — the majority delivery path for queued text is the queue.
+test('close, then a queued non-close (read off the enqueue) → false', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      QOP('enqueue', '아 잠깐, 계속 작업하자'),
+      QOP('dequeue'),
+      USER({
+        message: { role: 'user', content: '아 잠깐, 계속 작업하자' },
+        isMeta: true,
+        promptSource: 'system',
+        queuePriority: 'later',
+      }),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// The negative twin: a task-notification replay wears promptSource:"system" too,
+// but carries origin.kind, so it is attributable as model-caused and stays
+// NEUTRAL — the user's close must survive the model's own background work.
+test('close, then a task-notification replay (origin.kind present) → true (stays granted)', () => {
+  withTmpDir((dir) => {
+    const notif =
+      '<task-notification>\n<task-id>x</task-id>\n<status>completed</status>\n</task-notification>';
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      QOP('enqueue', notif),
+      QOP('dequeue'),
+      USER({
+        message: { role: 'user', content: notif },
+        promptSource: 'system',
+        queuePriority: 'later',
+        origin: { kind: 'task-notification' },
+      }),
+    ]);
     assert.equal(hasUserCloseSignal(p), true);
+  });
+});
+
+// ROBUSTNESS: a line that parses to a bare `null` is valid JSON but not a record.
+// It must be skipped, not crash on a field read, and not change the verdict.
+test('a null JSONL line → skipped, not a crash, verdict unchanged', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [null, USER(CLOSE)]);
+    assert.equal(hasUserCloseSignal(p), true);
+  });
+});
+
+// EXCLUSION: an AskUserQuestion answer on an injected record (isMeta / sdk) must
+// not reach the answer parser — model-reachable channels are never a user click,
+// even when correlated to a real AskUserQuestion tool_use.
+test('AskUserQuestion answer on an isMeta record → false (exclusion applies)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'AskUserQuestion', id: 'q' }] },
+      },
+      {
+        type: 'user',
+        isMeta: true,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'q',
+              content: 'Your questions have been answered: "다음?"="세션 마무리 해줘"',
+            },
+          ],
+        },
+      },
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// Q7 hardening, LOAD-BEARING: the pre-event scanner matched any `="…"` in a
+// correlated tool_result and would grant on this. A malformed AskUserQuestion
+// yields a host is_error result that echoes the model's raw input; even with the
+// close phrase steered into it AND the success marker present, is_error:true must
+// refuse. A click is the signal, not an echo.
+test('AskUserQuestion is_error echo of a close phrase → false', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'AskUserQuestion', id: 'q' }] },
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'q',
+              is_error: true,
+              content: 'Your questions have been answered: "다음?"="세션 마무리 해줘"',
+            },
+          ],
+        },
+      },
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// A non-close AskUserQuestion selection after a close is a fresh user decision,
+// so it expires the lease (the "still continue" click retracts the close).
+test('close, then a non-close AskUserQuestion selection → false (lease expires)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'AskUserQuestion', id: 'q' }] },
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'q',
+              content: 'Your questions have been answered: "다음?"="아니 계속 작업하자"',
+            },
+          ],
+        },
+      },
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`hasUserCloseSignal`, the hard gate the session-close marker writers depend on, was an existence predicate: "did a close signal ever appear anywhere in the transcript". It is now a state predicate: "is the latest user decision still a close". It walks the transcript in line order and classifies each record as grant, invalidate, neutral, or fatal, tracking the approval as a lease.

## Why

The existence check is Defect B: a close signal that appeared once stays "somewhere in the transcript" forever, so a stale close, a queued change of mind, a `/clear`, and a model that closed the session on its own all still read as closed. Measured against 243 local transcripts, the old gate granted in 48 sessions where the user's real final intent was not to close (most were the model self-closing after the user's last message was ordinary work).

## How

- Producer is read from structural fields only, never content heuristics. Channels the drifting model can reach (promptSource system/sdk replay, isMeta bodies, sidechain records, interrupt companions) are neutral; a genuine user record that survives the exclusions is the grant/invalidate signal.
- The queue carries no correlation key (measured), so the decision is read off the enqueue: `/compact` grants, `/clear` and `popAll` invalidate, a queued non-close is a change of mind that invalidates, a queued NL close stays a gap (its producer cannot be attributed).
- A remove-path `queued_command` close grants only with an audited `origin.kind: "human"` (present on every 2.1.181+ delivery); a legacy origin-absent delivery does not grant.
- The AskUserQuestion answer path is hardened: `is_error` results (a malformed call echoes its raw input back) and injected records no longer reach the answer parser.
- A line that parses to a non-object (a bare `null`) is skipped rather than crashing on a field read.
- An earlier leaf-pointer branch guard was withdrawn: the transcript carries no authoritative leaf pointer (measured, 0 records), so a heuristic leaf could skip the real invalidator and preserve a stale grant. Abandoned-branch staleness is left as a documented limit, mitigated by the lease.

## Manual verification

Beyond the unit suite (`npm test`, 1656 passing, shard-independent), the rewritten function was run against all 243 local `~/.claude/projects` transcripts:

```
files: 243, crashes: 0
vs the previous gate:  new grants (old false, new true): 0
                       withdrawn (old true, new false): 48
```

Zero new grants means no new fail-open; the 48 withdrawals were all in the conservative direction. One was inspected end to end and is a textbook Defect B: the user's last message was ordinary work ("pane 안보인다"), and the model then wrote its own "세션 마무리 완료했습니다" assistant turn, which the old gate counted as a close and the new gate correctly refuses.

## Migration notes

None. The change is to the gate function body only; hook wiring, file layout, and the marker format are unchanged. The gate is strictly more conservative (it can refuse a real final close, which costs a re-type, but never opens where it did not before).

---

# 한국어

## 변경 내용

세션 종료 마커 기록의 하드 게이트인 `hasUserCloseSignal`이 존재 술어였습니다. "트랜스크립트 어딘가에 close 신호가 있었나". 이제 상태 술어입니다. "가장 최근 사용자 결정이 여전히 close인가". 트랜스크립트를 line order로 훑으며 각 레코드를 grant, invalidate, neutral, fatal로 분류하고 승인을 lease로 다룹니다.

## 이유

존재 검사는 Defect B입니다. 한 번 나온 close 신호는 영원히 "트랜스크립트 어딘가"에 남아서, stale close, 큐로 넣은 마음 바꿈, `/clear`, 그리고 모델이 스스로 종료한 경우까지 모두 여전히 close로 읽힙니다. 로컬 243개 트랜스크립트 실측에서, 옛 게이트는 사용자의 진짜 최종 의도가 종료가 아니었던 48개 세션에서 grant했습니다(대부분 사용자의 마지막 메시지가 평범한 작업인데 모델이 자기 판단으로 종료한 경우).

## 방법

- producer는 구조 필드로만 판단하고 내용 휴리스틱을 쓰지 않습니다. 드리프트하는 모델이 도달할 수 있는 채널(promptSource system/sdk 재생, isMeta 본문, sidechain, interrupt companion)은 neutral이고, 그 제외를 통과한 진짜 사용자 레코드가 grant/invalidate 신호입니다.
- 큐에는 상관 키가 없어서(실측) 결정을 enqueue에서 읽습니다. `/compact`는 grant, `/clear`와 `popAll`은 invalidate, 큐로 넣은 비-close는 마음 바꿈이라 invalidate, 큐로 넣은 자연어 close는 gap으로 둡니다(producer 귀속 불가).
- remove 경로의 `queued_command` close는 감사된 `origin.kind: "human"`(2.1.181+ 배달엔 예외 없이 존재)이 있을 때만 grant하고, origin 없는 레거시 배달은 grant하지 않습니다.
- AskUserQuestion answer 경로를 하드닝했습니다. `is_error` 결과(malformed 호출은 원입력을 그대로 echo)와 주입 레코드는 이제 answer parser에 닿지 않습니다.
- 비-object로 파싱되는 줄(예: `null`)은 필드 접근에서 크래시하지 않고 건너뜁니다.
- 초기의 leaf-pointer branch 가드는 철회했습니다. 트랜스크립트에 권위 있는 leaf 포인터가 없어서(실측 0건) 휴리스틱 leaf가 진짜 invalidator를 건너뛰고 stale grant를 보존할 수 있었습니다. 폐기 가지 staleness는 문서화된 한계로 두고 lease로 완화합니다.

## 수동 검증

유닛 스위트(`npm test`, 1656 통과, shard 독립) 외에, 재작성한 함수를 로컬 `~/.claude/projects`의 243개 트랜스크립트 전체에 실행했습니다.

```
파일: 243, 크래시: 0
이전 게이트 대비:  새 grant (old false, new true): 0
                   철회 (old true, new false): 48
```

새 grant 0은 새 fail-open이 없다는 뜻이고, 48개 철회는 전부 보수적 방향이었습니다. 한 건을 처음부터 끝까지 확인했는데 교과서적 Defect B였습니다. 사용자의 마지막 메시지는 평범한 작업("pane 안보인다")이었고 모델이 이어서 "세션 마무리 완료했습니다"라는 자기 assistant 턴을 썼는데, 옛 게이트는 이를 close로 셌고 새 게이트는 올바르게 거부합니다.

## 마이그레이션 노트

None. 변경은 게이트 함수 본문에만 있고 훅 배선, 파일 배치, 마커 포맷은 그대로입니다. 게이트는 순수하게 더 보수적입니다(진짜 최종 close를 거부해 재타이핑을 유발할 수는 있으나, 이전에 열지 않던 곳을 열지 않습니다).

---

## Changelog

- EN: Session-close gate now tracks the latest user decision as a lease instead of scanning the whole transcript for any close signal, so a stale close, a queued change of mind, a `/clear`, or a model self-close no longer counts as a user close (decisions/0075).
- KO: 세션 종료 게이트가 트랜스크립트 전체에서 close 신호를 찾는 대신 가장 최근 사용자 결정을 lease로 추적하도록 바뀌어, stale close나 큐로 넣은 마음 바꿈, `/clear`, 모델의 자기 종료가 더 이상 사용자 종료로 세어지지 않습니다 (decisions/0075).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
