### PR TITLE
fix(check-tracker-ids): skip --commit-range when the head commit is gone after a branch delete

### DIFF
--- a/scripts/check-tracker-ids.mjs
+++ b/scripts/check-tracker-ids.mjs
@@ -417,7 +417,62 @@ function runCommitMsg(file, json) {
 // itself stripped any editor template / --verbose scissors diff at commit time,
 // so unlike --commit-msg (which reads a live COMMIT_EDITMSG file) no
 // messageHasGitTemplate/stripScissors preprocessing applies or is needed here.
+// Parse a two-dot `base..head` shape without touching a three-dot
+// (symmetric-difference) range or anything else this checker never emits
+// itself — every caller in this file builds a two-dot range, so a `...` or a
+// dot-free string here is a shape this checker did not produce and the
+// existence pre-check below must not apply to it. Returns null for anything
+// that is not cleanly `<non-empty>..<non-empty>`, which sends the caller
+// straight to the original git-log path (and its original exit-2 behavior).
+function parseCommitRange(range) {
+  if (range.includes('...')) return null;
+  const idx = range.indexOf('..');
+  if (idx < 0) return null;
+  const base = range.slice(0, idx);
+  const head = range.slice(idx + 2);
+  if (!base || !head || base.includes('..') || head.includes('..')) return null;
+  return { base, head };
+}
+
+// True only if `ref` resolves to a commit this checkout can actually see.
+function commitExists(ref) {
+  return git(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`]).status === 0;
+}
+
 function runCommitRange(range, json) {
+  // A squash-merge + --delete-branch (or a force-push) can leave `head`
+  // resolving to nothing once the branch is gone, so a CI re-run on the
+  // merged PR fails `git log a..b` with "Invalid revision range" — not
+  // because anything is wrong with the content, but because the ref this
+  // checker is asked to scan no longer exists anywhere. That is a procedural
+  // side effect of the merge, not a violation, so it must SKIP (exit 0), not
+  // FAIL (exit 2) and leave an already-merged, already-reviewed PR red for a
+  // reason nobody can act on.
+  //
+  // The pre-check only fires for a clean two-dot `base..head` shape
+  // (parseCommitRange), and ONLY skips when `base` resolves AND `head` does
+  // not — never on `base` alone missing, never on both missing. This is
+  // load-bearing, not cosmetic: `base` is where the real content lives (every
+  // commit in the range is `base`'s descendant), so an attacker (or a broken
+  // caller) could pair a bogus, unresolvable base with a real, violating head
+  // — `deadbeefdead..<violating-head>` — and if that were allowed to skip, it
+  // would walk straight past the gate with a genuine violation sitting right
+  // there. Requiring base to resolve means the "content anchor" of the range
+  // is always verified live; only the deleted-branch symptom (head vanished,
+  // base intact on a surviving branch like main) takes the skip path. A
+  // genuinely malformed range (three dots, missing side, garbage token, base
+  // missing, or both missing) skips this branch and falls straight into the
+  // original git-log call below, so it still fails exit 2 exactly as before.
+  const parsed = parseCommitRange(range);
+  if (parsed && commitExists(parsed.base) && !commitExists(parsed.head)) {
+    process.stdout.write(
+      `[check-tracker-ids] --commit-range: skipping "${range}" — head commit not found in this ` +
+        `checkout: ${parsed.head} (base ${parsed.base} resolves fine; likely a deleted branch ` +
+        `after merge, not a content violation; the pr-surface job already scanned this range ` +
+        `before the merge).\n`,
+    );
+    process.exit(0);
+  }
   const listRes = git(['log', '--format=%H', range, '--']);
   if (listRes.status !== 0) {
     process.stderr.write(

--- a/tests/pr-pack-surface.test.mjs
+++ b/tests/pr-pack-surface.test.mjs
@@ -744,12 +744,107 @@ test('--commit-msg and --commit-range agree on the SAME message (one judgment, A
   });
 });
 
-test('CLI --commit-range: an unresolvable range exits 2 (git error), not a crash', () => {
+test('CLI --commit-range: BOTH endpoints missing (bogus base too) does NOT skip — still fails exit 2', () => {
+  // Skip requires the base to resolve. Two syntactically plausible but
+  // nonexistent shas is not the deleted-branch symptom (there the base is a
+  // real commit still reachable from a surviving branch like main); it is
+  // indistinguishable from a broken/garbage range, so it must keep failing
+  // loudly rather than silently pass.
   withTmpDir((dir) => {
     gitRepo(dir);
     writeFileSync(join(dir, 'a.txt'), 'one\n');
     commitIn(dir, 'chore: base');
     const r = runChecker(['--commit-range', 'deadbeefdead..cafebabecafe'], {
+      CHECK_TRACKER_ROOT: dir,
+    });
+    assert.equal(r.status, 2);
+  });
+});
+
+test('CLI --commit-range: a REAL base with a genuinely missing head skips (exit 0), and still reports the missing sha', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const base = commitIn(dir, 'chore: base');
+    // A syntactically plausible sha that was never committed here — stands in
+    // for a PR head that existed on GitHub but whose branch is now deleted.
+    const ghostHead = 'fa74adefa74adefa74adefa74adefa74adefa74';
+    const r = runChecker(['--commit-range', `${base}..${ghostHead}`], {
+      CHECK_TRACKER_ROOT: dir,
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /skipping/i);
+    assert.match(r.stdout, new RegExp(ghostHead));
+  });
+});
+
+test('CLI --commit-range: BLOCKER regression — a bogus base paired with a REAL violating head must NOT skip past the gate', () => {
+  // This is the exact bypass codex reproduced: a caller (or an attacker) pairs
+  // an unresolvable base with a real, violating head. If skip fired here, a
+  // genuine attribution trailer would walk straight past the CI gate. Skip
+  // must require the BASE to resolve, so this has to hit the original git-log
+  // path and fail exit 2 — never a silent pass.
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const violatingHead = commitIn(
+      dir,
+      'feat: thing\n\nCo-Authored-By: Claude <noreply@anthropic.com>',
+    );
+    const r = runChecker(['--commit-range', `deadbeefdead..${violatingHead}`], {
+      CHECK_TRACKER_ROOT: dir,
+    });
+    assert.equal(r.status, 2);
+    assert.doesNotMatch(r.stdout || '', /skipping/i);
+  });
+});
+
+test('CLI --commit-range: an empty head ("base..") is native git shorthand for HEAD, not our skip path', () => {
+  // `base..` is valid git rev-range syntax (git fills in HEAD for the empty
+  // side), so parseCommitRange rejects the shape (empty head) and this falls
+  // straight into the ORIGINAL git-log call — the same as before this fix.
+  // It is not our new skip branch: no "skipping" message, and it resolves
+  // via git's own defaulting rather than commitExists.
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const base = commitIn(dir, 'chore: base');
+    const r = runChecker(['--commit-range', `${base}..`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 0, r.stderr); // base == HEAD here, so an empty (clean) range
+    assert.doesNotMatch(r.stdout || '', /skipping/i);
+  });
+});
+
+test('CLI --commit-range: an empty base ("..head") is native git shorthand for HEAD, not our skip path', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    const head = commitIn(dir, 'chore: base');
+    const r = runChecker(['--commit-range', `..${head}`], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 0, r.stderr); // head == HEAD here, so an empty (clean) range
+    assert.doesNotMatch(r.stdout || '', /skipping/i);
+  });
+});
+
+test('CLI --commit-range: a genuinely malformed range (no two-dot shape) still fails exit 2', () => {
+  // The exact gap this fix must NOT open: an unparseable range is not the
+  // "branch deleted after merge" case, so it must keep failing loudly rather
+  // than silently skip past a broken CI wiring.
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    commitIn(dir, 'chore: base');
+    const r = runChecker(['--commit-range', 'not-a-range-at-all'], { CHECK_TRACKER_ROOT: dir });
+    assert.equal(r.status, 2);
+  });
+});
+
+test('CLI --commit-range: a three-dot range with unresolvable endpoints still fails exit 2 (not the two-dot skip path)', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    commitIn(dir, 'chore: base');
+    const r = runChecker(['--commit-range', 'deadbeefdead...cafebabecafe'], {
       CHECK_TRACKER_ROOT: dir,
     });
     assert.equal(r.status, 2);


### PR DESCRIPTION
# English

## What changed

`check-tracker-ids --commit-range base..head` no longer exits 2 when the head commit is gone because the PR branch was deleted after a squash-merge. In that specific case it now skips the scan (exit 0) and logs the reason. Malformed or otherwise-unresolvable ranges still exit 2.

## Why

When a PR is merged with `--squash --delete-branch` and its CI is later re-run (for example after editing the PR body), the head sha no longer exists on the remote. The gate's second step, `check-tracker-ids --commit-range`, could not resolve the range and exited 2. That left a merged PR showing a red check indistinguishable from a real failure, and in practice caused exactly that confusion.

## How

Before calling `git log`, the checker parses a two-dot `base..head` shape and verifies each endpoint with `git rev-parse --verify <ref>^{commit}`. It skips only when the base resolves and the head does not, which is precisely the deleted-branch shape. Every other shape (missing base, both missing, three-dot, no dots) falls straight through to the original `git log` path and its exit 2, so a scan cannot be bypassed by pairing an unresolvable base with a real violation in the head.

## Manual verification

Covered by the test suite: `node tests/runner.mjs --grep=commit-range` (12 passed). The bypass regression was proven red by reverting the skip condition to "either endpoint missing" and observing the bogus-base + real-violating-head case exit 0 instead of 2.

## Migration notes

None.

---

# 한국어

## 변경 내용

`check-tracker-ids --commit-range base..head`가, 스쿼시 머지 후 브랜치가 삭제되어 head 커밋이 사라진 경우에는 더 이상 exit 2로 죽지 않는다. 그 경우에만 스캔을 건너뛰고(exit 0) 사유를 로그로 남긴다. 형식이 잘못됐거나 그 밖에 해석 불가한 range는 종전대로 exit 2다.

## 이유

`--squash --delete-branch`로 머지한 PR의 CI가 나중에 다시 돌면(예: PR 본문 수정 후) head sha가 원격에 없다. 게이트의 두 번째 스텝 `check-tracker-ids --commit-range`가 range를 해석하지 못해 exit 2로 실패했고, 머지된 PR이 진짜 실패와 구별되지 않는 red로 남았다. 실제로 이 혼동이 발생했다.

## 방법

`git log` 호출 전에 two-dot `base..head` 형태를 파싱하고 `git rev-parse --verify <ref>^{commit}`로 양 끝 커밋의 존재를 확인한다. base는 해석되고 head는 해석되지 않을 때만 skip하는데, 이게 정확히 브랜치 삭제 형태다. 그 외 모든 형태(base 없음, 둘 다 없음, three-dot, 점 없음)는 원래의 `git log` 경로로 가서 exit 2를 유지하므로, 해석 불가한 base에 실제 위반이 담긴 head를 붙여 스캔을 우회하는 길이 없다.

## 수동 검증

테스트 스위트가 커버한다: `node tests/runner.mjs --grep=commit-range` (12 통과). 우회 회귀는 skip 조건을 "둘 중 하나라도 없으면"으로 되돌려, bogus-base + 실제 위반 head 케이스가 exit 2가 아니라 exit 0으로 통과하는 것을 관찰해 red로 증명했다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: Fix the PR surface gate leaving a red check on merged PRs whose branch was deleted: `check-tracker-ids --commit-range` now skips a range whose head commit no longer exists, while still failing on malformed ranges (#214).
- KO: 브랜치가 삭제된 머지 PR에서 PR 표면 게이트가 red로 남던 문제 수정: `check-tracker-ids --commit-range`가 head 커밋이 사라진 range는 건너뛰되, 형식이 잘못된 range는 여전히 실패한다 (#214).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
