### PR TITLE
feat(init): add an opt-in --lint-strict wiki pre-commit gate

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -32,7 +32,7 @@ import {
   renameSync,
   unlinkSync,
 } from 'fs';
-import { join, basename, dirname, isAbsolute } from 'path';
+import { join, basename, dirname, isAbsolute, resolve } from 'path';
 import { homedir } from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -121,6 +121,7 @@ function parseArgs(argv) {
     shellSetup: true,
     shellConfig: null,
     allowDowngrade: false,
+    lintStrict: false,
   };
   for (const arg of argv.slice(2)) {
     if (arg === '--help' || arg === '-h') {
@@ -154,6 +155,10 @@ Init options:
   --shell-config=<path>  Shell config file path (default: auto-detect)
   --allow-downgrade      Override the guard that refuses to overwrite NEWER active
                          hooks with an older package (stale-PATH-CLI footgun)
+  --lint-strict          Opt-in: also gate the wiki pre-commit hook on
+                         \`lint --strict\` (promotes STRICT_PROMOTE_IDS warnings
+                         to a blocking error), sequenced after the .hypoignore
+                         guard. Off by default; re-run init to add or drop it.
   --dry-run              Show what would be done without making changes
   --help, -h             Show this help message
 
@@ -179,6 +184,7 @@ docstring at the top of scripts/<command>.mjs; capture also accepts \`--help\`.`
     else if (arg === '--no-shell') args.shellSetup = false;
     else if (arg.startsWith('--shell-config=')) args.shellConfig = expandHome(arg.slice(15));
     else if (arg === '--allow-downgrade') args.allowDowngrade = true;
+    else if (arg === '--lint-strict') args.lintStrict = true;
   }
   return args;
 }
@@ -700,26 +706,56 @@ function installPkgGitHook(dryRun) {
 const WIKI_PRE_COMMIT_MARKER_START = '# hypo-managed:pre-commit:start';
 const WIKI_PRE_COMMIT_MARKER_END = '# hypo-managed:pre-commit:end';
 
-// `root` is the DURABLE install root the hook should resolve hypo-pre-commit.mjs
-// through — not necessarily PKG_ROOT. In a dual install (a manual/npm init while
-// the plugin is enabled) PKG_ROOT is the manual/npm checkout the dual-install
-// notice tells the user to uninstall; embedding it here would leave the vault's
-// git hook dangling the moment they do, breaking every wiki commit. The caller
-// passes the preserved plugin-owned root instead (see `durableRoot`), so the hook
-// points at the install that actually persists.
-function wikiPreCommitContent(root) {
-  const worker = join(root, 'hooks', 'hypo-pre-commit.mjs');
-  // Single-quote escaping prevents shell expansion of special chars (e.g. $HOME, backticks) in path
-  const escaped = worker.replace(/'/g, "'\\''");
-  return `#!/bin/sh\n${WIKI_PRE_COMMIT_MARKER_START}\nnode '${escaped}'\nexit $?\n${WIKI_PRE_COMMIT_MARKER_END}\n`;
+// Single-quote escaping prevents shell expansion of special chars (e.g. $HOME, backticks) in path
+function shellSingleQuote(p) {
+  return `'${p.replace(/'/g, "'\\''")}'`;
 }
 
-function installWikiPreCommitHook(hypoDir, dryRun, force, root) {
+// `root` is the DURABLE install root the hook should resolve hypo-pre-commit.mjs
+// (and, when opted in, lint.mjs) through — not necessarily PKG_ROOT. In a dual
+// install (a manual/npm init while the plugin is enabled) PKG_ROOT is the
+// manual/npm checkout the dual-install notice tells the user to uninstall;
+// embedding it here would leave the vault's git hook dangling the moment they
+// do, breaking every wiki commit. The caller passes the preserved plugin-owned
+// root instead (see `durableRoot`), so the hook points at the install that
+// actually persists.
+//
+// The block runs its steps sequentially rather than tail-calling `exit $?` on
+// the first one, so a second step (the opt-in --lint-strict gate below) can
+// run after the .hypoignore guard instead of being unreachable dead code.
+// `lintStrict` is baked into the generated shim at install time — the same
+// pattern already used for HYPOMNEMA_ROOT/HYPOMNEMA_GIT_DIR in
+// install-git-hooks.mjs — so toggling it means re-running init with/without
+// `--lint-strict`, not editing the hook by hand.
+//
+// `hypoDir` MUST be absolutized before it is baked in. Git runs a pre-commit
+// hook with cwd set to the wiki's own working-tree root, so a relative
+// `--hypo-dir` (e.g. from `hypo init --hypo-dir=wiki` run from its parent) is
+// re-resolved AT COMMIT TIME against that root instead of the directory the
+// caller meant — `wiki` becomes `<wiki-root>/wiki`, a path that doesn't exist,
+// and lint.mjs falls through to its own default resolution (HYPO_DIR/
+// hypo-config.md scan) and may silently lint an unrelated vault. `worker`
+// needs no such treatment: `root` is already realpath'd upstream (see
+// `durableRoot` / PKG_ROOT resolution), so it's absolute at every call site.
+function wikiPreCommitContent(root, hypoDir, lintStrict) {
+  const absHypoDir = resolve(hypoDir);
+  const worker = join(root, 'hooks', 'hypo-pre-commit.mjs');
+  const steps = [`node ${shellSingleQuote(worker)} || exit 1`];
+  if (lintStrict) {
+    const lintScript = join(root, 'scripts', 'lint.mjs');
+    steps.push(
+      `node ${shellSingleQuote(lintScript)} --hypo-dir=${shellSingleQuote(absHypoDir)} --strict || exit 1`,
+    );
+  }
+  return `#!/bin/sh\n${WIKI_PRE_COMMIT_MARKER_START}\n${steps.join('\n')}\nexit 0\n${WIKI_PRE_COMMIT_MARKER_END}\n`;
+}
+
+function installWikiPreCommitHook(hypoDir, dryRun, force, root, lintStrict) {
   const gitDir = join(hypoDir, '.git');
   if (!existsSync(gitDir)) return; // no git repo — silently skip
   const hooksDir = join(gitDir, 'hooks');
   const hookPath = join(hooksDir, 'pre-commit');
-  const newContent = wikiPreCommitContent(root);
+  const newContent = wikiPreCommitContent(root, hypoDir, lintStrict);
 
   if (existsSync(hookPath)) {
     const existing = readFileSync(hookPath, 'utf-8');
@@ -1202,7 +1238,13 @@ if (args.hooks) {
 // 8b. wiki pre-commit hook (.hypoignore last-line-of-defence guard — §6.8).
 // Point it at the durable install root, not PKG_ROOT, so a dual install does not
 // embed a manual/npm path that dangles once the user uninstalls it.
-installWikiPreCommitHook(args.hypoDir, args.dryRun, args.forceCommands, durableRoot);
+installWikiPreCommitHook(
+  args.hypoDir,
+  args.dryRun,
+  args.forceCommands,
+  durableRoot,
+  args.lintStrict,
+);
 
 // 9. first commit + push (skip when cloned from remote — already has commits)
 if (args.gitInit && !args.fromRemote) {

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -243,6 +243,207 @@ test('pre-commit hook blocks staged .env file via git commit', () => {
   });
 });
 
+suite('init.mjs --lint-strict opt-in gate (ISSUE-59)');
+
+test('default init: wiki pre-commit hook does not wire lint --strict', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const content = readFileSync(join(hypoDir, '.git', 'hooks', 'pre-commit'), 'utf8');
+    assert.ok(
+      !content.includes('lint.mjs'),
+      `--lint-strict was not requested; hook must not reference lint.mjs: ${content}`,
+    );
+  });
+});
+
+test('--lint-strict init: wiki pre-commit hook sequences lint --strict after the .hypoignore guard', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+    const r = run('init.mjs', [
+      `--hypo-dir=${hypoDir}`,
+      '--no-hooks',
+      '--no-git-init',
+      '--lint-strict',
+    ]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const content = readFileSync(join(hypoDir, '.git', 'hooks', 'pre-commit'), 'utf8');
+    assert.ok(content.includes('lint.mjs'), `hook should reference lint.mjs: ${content}`);
+    assert.ok(content.includes('--strict'), `hook should pass --strict: ${content}`);
+    // Sequential, not the old "exit $?" tail-call that made a second step
+    // unreachable dead code.
+    assert.ok(!content.includes('exit $?'), `hook must not tail-call exit $?: ${content}`);
+    const workerIdx = content.indexOf('hypo-pre-commit.mjs');
+    const lintIdx = content.indexOf('lint.mjs');
+    assert.ok(
+      workerIdx !== -1 && lintIdx !== -1 && workerIdx < lintIdx,
+      `.hypoignore guard must run before the lint --strict gate: ${content}`,
+    );
+  });
+});
+
+test('--lint-strict init: commit is blocked when a staged page fails lint --strict (W1 no-frontmatter)', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+    spawnSync('git', ['-C', hypoDir, 'config', 'user.email', 'test@hypo.test'], {
+      stdio: 'ignore',
+    });
+    spawnSync('git', ['-C', hypoDir, 'config', 'user.name', 'Hypo Test'], { stdio: 'ignore' });
+    const r = run('init.mjs', [
+      `--hypo-dir=${hypoDir}`,
+      '--no-hooks',
+      '--no-git-init',
+      '--lint-strict',
+    ]);
+    assert.equal(r.status, 0, `init failed: ${r.stderr}`);
+
+    spawnSync('git', ['-C', hypoDir, 'add', '.'], { stdio: 'ignore' });
+    spawnSync('git', ['-C', hypoDir, 'commit', '-m', 'init'], { stdio: 'ignore' });
+
+    writeFileSync(join(hypoDir, 'pages', 'broken.md'), 'no frontmatter here\n');
+    spawnSync('git', ['-C', hypoDir, 'add', 'pages/broken.md'], { stdio: 'ignore' });
+
+    const commitR = spawnSync(
+      'git',
+      ['-C', hypoDir, 'commit', '-m', 'add page missing frontmatter'],
+      { encoding: 'utf-8' },
+    );
+    assert.notEqual(
+      commitR.status,
+      0,
+      `git commit should be blocked by lint --strict: ${commitR.stdout}${commitR.stderr}`,
+    );
+  });
+});
+
+test('default init (no --lint-strict): the same lint violation does NOT block the commit', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+    spawnSync('git', ['-C', hypoDir, 'config', 'user.email', 'test@hypo.test'], {
+      stdio: 'ignore',
+    });
+    spawnSync('git', ['-C', hypoDir, 'config', 'user.name', 'Hypo Test'], { stdio: 'ignore' });
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(r.status, 0, `init failed: ${r.stderr}`);
+
+    spawnSync('git', ['-C', hypoDir, 'add', '.'], { stdio: 'ignore' });
+    spawnSync('git', ['-C', hypoDir, 'commit', '-m', 'init'], { stdio: 'ignore' });
+
+    writeFileSync(join(hypoDir, 'pages', 'broken.md'), 'no frontmatter here\n');
+    spawnSync('git', ['-C', hypoDir, 'add', 'pages/broken.md'], { stdio: 'ignore' });
+
+    const commitR = spawnSync(
+      'git',
+      ['-C', hypoDir, 'commit', '-m', 'add page missing frontmatter'],
+      { encoding: 'utf-8' },
+    );
+    assert.equal(
+      commitR.status,
+      0,
+      `--lint-strict was not opted in; commit must not be blocked: ${commitR.stdout}${commitR.stderr}`,
+    );
+  });
+});
+
+test('--lint-strict init with a RELATIVE --hypo-dir bakes an absolute path into the hook (codex BLOCKER)', () => {
+  withTmpDir((parentDir) => {
+    const hypoDir = join(parentDir, 'wiki');
+    spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'init.mjs'),
+        '--hypo-dir=wiki',
+        '--no-hooks',
+        '--no-git-init',
+        '--lint-strict',
+      ],
+      {
+        cwd: parentDir,
+        encoding: 'utf-8',
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const content = readFileSync(join(hypoDir, '.git', 'hooks', 'pre-commit'), 'utf8');
+    // Git runs the hook with cwd = the wiki's own working-tree root. A
+    // relative --hypo-dir baked in verbatim re-resolves at commit time
+    // against THAT root, not the directory the caller meant — 'wiki' would
+    // become '<hypoDir>/wiki', a path that does not exist.
+    //
+    // Compare against the realpath, not the mkdtempSync path verbatim: macOS
+    // TMPDIR is itself a symlink (/var/folders/... -> /private/var/...), and
+    // a child process's process.cwd() resolves it, so `resolve()` inside
+    // init.mjs bakes in the physical path — that's still correct and
+    // absolute, just not byte-identical to the pre-realpath string.
+    const realHypoDir = realpathSync(hypoDir);
+    assert.ok(
+      content.includes(`--hypo-dir=${shellSingleQuoteForTest(realHypoDir)}`),
+      `--hypo-dir must be baked in absolute (${realHypoDir}): ${content}`,
+    );
+    assert.ok(
+      !content.includes(`--hypo-dir='wiki'`) && !content.includes('wiki/wiki'),
+      `--hypo-dir must not stay relative or double up against cwd: ${content}`,
+    );
+  });
+});
+
+function shellSingleQuoteForTest(p) {
+  return `'${p.replace(/'/g, "'\\''")}'`;
+}
+
+test('--lint-strict init with a RELATIVE --hypo-dir still blocks a real lint violation at commit time', () => {
+  withTmpDir((parentDir) => {
+    const hypoDir = join(parentDir, 'wiki');
+    spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+    spawnSync('git', ['-C', hypoDir, 'config', 'user.email', 'test@hypo.test'], {
+      stdio: 'ignore',
+    });
+    spawnSync('git', ['-C', hypoDir, 'config', 'user.name', 'Hypo Test'], { stdio: 'ignore' });
+    const r = spawnSync(
+      process.execPath,
+      [
+        join(SCRIPTS, 'init.mjs'),
+        '--hypo-dir=wiki',
+        '--no-hooks',
+        '--no-git-init',
+        '--lint-strict',
+      ],
+      {
+        cwd: parentDir,
+        encoding: 'utf-8',
+        env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+      },
+    );
+    assert.equal(r.status, 0, `init failed: ${r.stderr}`);
+
+    spawnSync('git', ['-C', hypoDir, 'add', '.'], { stdio: 'ignore' });
+    spawnSync('git', ['-C', hypoDir, 'commit', '-m', 'init'], { stdio: 'ignore' });
+
+    writeFileSync(join(hypoDir, 'pages', 'broken.md'), 'no frontmatter here\n');
+    spawnSync('git', ['-C', hypoDir, 'add', 'pages/broken.md'], { stdio: 'ignore' });
+
+    // git invokes the hook with cwd = hypoDir (the wiki's own toplevel) —
+    // exactly the case a relative --hypo-dir at init time gets re-resolved
+    // against wrong.
+    const commitR = spawnSync(
+      'git',
+      ['-C', hypoDir, 'commit', '-m', 'add page missing frontmatter'],
+      { encoding: 'utf-8' },
+    );
+    assert.notEqual(
+      commitR.status,
+      0,
+      `relative --hypo-dir at init must not defeat --lint-strict at commit time: ${commitR.stdout}${commitR.stderr}`,
+    );
+  });
+});
+
 // Write a hooks.json into a temp package root and return that root.
 function withPkgHooksJson(content, fn) {
   withTmpDir((dir) => {


### PR DESCRIPTION
# English

## What changed

`hypo init` gains an opt-in `--lint-strict` flag. When set, the generated wiki pre-commit hook runs `lint --strict` after the existing `.hypoignore` guard, so frontmatter and broken-wikilink warnings block the commit. Off by default; re-run init with or without the flag to toggle it.

## Why

`lint --strict` already existed but nothing invoked it, so a vault cleaned to zero errors had no wiring to keep it clean. The gate had to live in the product, not as a hand-written hook copied into the vault (which is the drift anti-pattern this project avoids).

## How

The generated hook previously ended with `node <worker>` then `exit $?`, which made any following step unreachable. It now runs its steps sequentially (`node <worker> || exit 1`, then optionally `node <lint.mjs> --hypo-dir=<dir> --strict || exit 1`, then `exit 0`), with `--lint-strict` baked into the shim at install time. The wiki directory is resolved to an absolute path before being embedded, because git runs the pre-commit hook with the wiki toplevel as its working directory; a relative `--hypo-dir` would otherwise re-resolve against the wrong path and let violations through.

## Manual verification

Covered by the test suite: `node tests/runner.mjs --file=init` (the new opt-in suite plus end-to-end commit-blocked / not-blocked cases). The absolute-path regression was proven red by reverting the `resolve()` call and observing a relative `--hypo-dir` bake in literally and the commit pass despite a real violation. One unrelated hermeticity test fails only inside a git worktree (its `.git` is a file, not a directory), and passes on a normal checkout and in CI.

## Migration notes

None. Existing installs are unaffected until they re-run init with `--lint-strict`.

---

# 한국어

## 변경 내용

`hypo init`에 opt-in `--lint-strict` 플래그가 생겼다. 켜면 생성된 위키 pre-commit 훅이 기존 `.hypoignore` 가드 뒤에 `lint --strict`를 실행해, frontmatter·깨진 wikilink 경고가 커밋을 막는다. 기본은 off이고, 플래그를 붙이거나 빼고 init을 다시 돌리면 토글된다.

## 이유

`lint --strict`는 이미 있었지만 그것을 부르는 배선이 없어서, 볼트를 error 0으로 청소해도 그 상태를 유지할 게이트가 없었다. 배선은 제품이 제공해야 한다. 볼트에 손으로 훅을 두는 방식은 이 프로젝트가 피하는 drift 안티패턴이다.

## 방법

생성된 훅은 이전에 `node <worker>` 뒤 `exit $?`로 끝나 다음 스텝이 도달 불가였다. 이제 스텝을 순차 실행하고(`node <worker> || exit 1`, 옵션으로 `node <lint.mjs> --hypo-dir=<dir> --strict || exit 1`, 그다음 `exit 0`), `--lint-strict`를 설치 시점에 shim에 굽는다. 위키 디렉터리는 임베드 전에 절대경로로 해석하는데, git이 pre-commit 훅을 위키 toplevel을 작업 디렉터리로 실행하기 때문이다. 상대 `--hypo-dir`는 엉뚱한 경로로 다시 풀려 위반을 통과시킨다.

## 수동 검증

테스트 스위트가 커버한다: `node tests/runner.mjs --file=init` (새 opt-in 스위트 + 커밋 차단/비차단 end-to-end). 절대경로 회귀는 `resolve()` 호출을 되돌려 상대 `--hypo-dir`가 리터럴로 박히고 실제 위반에도 커밋이 통과하는 것을 관찰해 red로 증명했다. 무관한 hermeticity 테스트 1건은 git worktree 안에서만 실패하며(그 `.git`이 디렉터리가 아니라 파일), 정상 체크아웃과 CI에서는 통과한다.

## 마이그레이션 노트

None. 기존 설치는 `--lint-strict`로 init을 다시 돌리기 전까지 영향 없다.

---

## Changelog

- EN: Add an opt-in `hypo init --lint-strict` flag that gates the wiki pre-commit hook on `lint --strict`, so frontmatter and broken-wikilink warnings block commits (#215).
- KO: 위키 pre-commit 훅을 `lint --strict`로 게이트하는 opt-in `hypo init --lint-strict` 플래그 추가: frontmatter·깨진 wikilink 경고가 커밋을 막는다 (#215).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
