### PR TITLE
feat(ignore): add .hyposcanignore for scan-only exclusion separate from the privacy gate

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -280,6 +280,16 @@ function checkFiles(hypoDir) {
   }
 }
 
+// .hyposcanignore is optional (scan-only exclusions, not a privacy boundary),
+// so its absence is info-level — pass either way, never warn/fail.
+function checkScanIgnoreFile(hypoDir) {
+  const present = existsSync(join(hypoDir, '.hyposcanignore'));
+  pass(
+    'File: .hyposcanignore',
+    present ? 'present' : 'optional — not present, no scan-only exclusions configured',
+  );
+}
+
 function checkHooks(coreManagedByPlugin) {
   const claudeHooks = join(HOME, '.claude', 'hooks');
   const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
@@ -1479,6 +1489,7 @@ const rootOk = checkHypoRoot(args.hypoDir);
 if (rootOk) {
   checkDirectories(args.hypoDir);
   checkFiles(args.hypoDir);
+  checkScanIgnoreFile(args.hypoDir);
   checkBrokenLinks(args.hypoDir, ignorePatterns);
   checkVerifyBy(args.hypoDir, ignorePatterns);
 }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -291,6 +291,23 @@ function writeWikiignore(hypoDir, dryRun) {
   log('created', dest);
 }
 
+// ── .hyposcanignore ──────────────────────────────────────────────────────────
+// Scan-only exclusion sibling to .hypoignore. NOT a privacy boundary — see
+// templates/.hyposcanignore's header. Absence is fine: every scan-ignore
+// reader treats a missing file as an empty pattern list.
+
+function writeScanIgnore(hypoDir, dryRun) {
+  const dest = join(hypoDir, '.hyposcanignore');
+  if (existsSync(dest)) {
+    log('skipped', dest);
+    return;
+  }
+  const src = join(TEMPLATES, '.hyposcanignore');
+  const content = existsSync(src) ? readFileSync(src, 'utf-8') : '';
+  if (!dryRun) writeFileSync(dest, content);
+  log('created', dest);
+}
+
 // ── .gitignore ───────────────────────────────────────────────────────────────
 
 function writeGitignore(hypoDir, dryRun) {
@@ -1068,9 +1085,10 @@ if (args.fromRemote) {
     args.dryRun,
   );
 
-  // 3. hypo-config.md + .hypoignore + .gitignore
+  // 3. hypo-config.md + .hypoignore + .hyposcanignore + .gitignore
   writeHypoConfig(args.hypoDir, args.dryRun);
   writeWikiignore(args.hypoDir, args.dryRun);
+  writeScanIgnore(args.hypoDir, args.dryRun);
   writeGitignore(args.hypoDir, args.dryRun);
 }
 

--- a/scripts/lib/hypo-ignore.mjs
+++ b/scripts/lib/hypo-ignore.mjs
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'fs';
-import { join, relative, basename } from 'path';
+import { join, relative, basename, resolve } from 'path';
 
 export function loadHypoIgnore(hypoDir) {
   const ignorePath = join(hypoDir, '.hypoignore');
@@ -8,6 +8,46 @@ export function loadHypoIgnore(hypoDir) {
     .split('\n')
     .map((l) => l.trim())
     .filter((l) => l && !l.startsWith('#'));
+}
+
+// .hyposcanignore: scan-only exclusions (lint/graph/stats/query/verify/doctor
+// catalog scans). Deliberately NOT a privacy boundary: a match here is still
+// committed and still readable by hooks. Only isScanIgnored() below reads this
+// file. loadHypoIgnore()/isIgnored() must never see it, that is the whole
+// point of the split, so do not thread it into the pre-commit gate or
+// ingest --check.
+export function loadScanIgnore(hypoDir) {
+  const ignorePath = join(resolve(hypoDir), '.hyposcanignore');
+  if (!existsSync(ignorePath)) return [];
+  return readFileSync(ignorePath, 'utf-8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'));
+}
+
+// Parsed .hyposcanignore patterns, cached per vault for the process lifetime.
+// The shared walker (wikilink.mjs) calls isScanIgnored() once per directory
+// entry, so re-reading this file on every call would turn a vault scan into
+// O(files) filesystem reads for one small file. Nothing writes
+// .hyposcanignore mid-process, so a stale cache is not a real scenario.
+//
+// Keyed on path.resolve(hypoDir), NOT the raw argument: a raw-string key lets
+// two different relative spellings of the SAME vault ('.', './') miss each
+// other (harmless, just a wasted read), but it also lets a relative key like
+// '.' collide ACROSS vaults when the caller cd's between them between calls —
+// vault B would silently reuse vault A's scan patterns. Resolving to an
+// absolute path first makes the key vault-identity-stable regardless of cwd
+// or spelling.
+const scanIgnoreCache = new Map();
+
+function cachedScanIgnore(hypoDir) {
+  const key = resolve(hypoDir);
+  let patterns = scanIgnoreCache.get(key);
+  if (patterns === undefined) {
+    patterns = loadScanIgnore(key);
+    scanIgnoreCache.set(key, patterns);
+  }
+  return patterns;
 }
 
 function globToRegex(glob) {
@@ -39,12 +79,20 @@ export function isGeneratedArtifact(filePath, hypoDir) {
 }
 
 // Catalog/scan exclusion = privacy/.hypoignore patterns PLUS generated root
-// artifacts. Use this in tools that build the knowledge catalog (lint, graph,
-// stats, query, verify, crystallize, rename, doctor broken-links). Do NOT use it
-// in the pre-commit gate or ingest --check, which are privacy boundaries that
-// must stay on isIgnored()/.hypoignore alone.
+// artifacts PLUS scan-only/.hyposcanignore patterns (loaded and cached
+// internally, so callers keep passing only their privacy `patterns` array).
+// Use this in tools that build the knowledge catalog (lint, graph, stats,
+// query, verify, crystallize, rename, doctor broken-links). Do NOT use it in
+// the pre-commit gate or ingest --check, which are privacy boundaries that
+// must stay on isIgnored()/.hypoignore alone — OR-ing in .hyposcanignore here
+// only ever WIDENS what a scan skips, it can never make an .hypoignore match
+// committable, so that separation holds by construction.
 export function isScanIgnored(filePath, hypoDir, patterns) {
-  return isIgnored(filePath, hypoDir, patterns) || isGeneratedArtifact(filePath, hypoDir);
+  return (
+    isIgnored(filePath, hypoDir, patterns) ||
+    isGeneratedArtifact(filePath, hypoDir) ||
+    isIgnored(filePath, hypoDir, cachedScanIgnore(hypoDir))
+  );
 }
 
 export function isIgnored(filePath, hypoDir, patterns) {

--- a/scripts/stats.mjs
+++ b/scripts/stats.mjs
@@ -16,7 +16,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, extname } from 'path';
 import { resolveHypoRootInfo, checkVaultOrExit, expandHome } from './lib/hypo-root.mjs';
-import { loadHypoIgnore, isIgnored, isScanIgnored } from './lib/hypo-ignore.mjs';
+import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -73,11 +73,15 @@ function parseFrontmatter(content) {
   return fm;
 }
 
-function listDirs(dir) {
+// hypoDir/ignorePatterns are optional so callers that don't need scan-ignore
+// filtering (none left in this file) still work unchanged.
+function listDirs(dir, hypoDir = '', ignorePatterns = []) {
   if (!existsSync(dir)) return [];
   return readdirSync(dir).filter((e) => {
     if (e.startsWith('.')) return false;
-    return statSync(join(dir, e)).isDirectory();
+    const full = join(dir, e);
+    if (hypoDir && isScanIgnored(full, hypoDir, ignorePatterns)) return false;
+    return statSync(full).isDirectory();
   });
 }
 
@@ -98,12 +102,18 @@ if (args.hypoDirSource) checkVaultOrExit(args.hypoDir, args.hypoDirSource);
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const pageFiles = collectMdFiles(join(args.hypoDir, 'pages'), [], args.hypoDir, ignorePatterns);
-const projects = listDirs(join(args.hypoDir, 'projects'));
+// isScanIgnored (via listDirs' hypoDir arg): a .hyposcanignore-listed project
+// dir drops out of the project count too, same rationale as sources below.
+const projects = listDirs(join(args.hypoDir, 'projects'), args.hypoDir, ignorePatterns);
+// isScanIgnored (not isIgnored): sources counted here feed a scan-aggregation
+// report, not the commit/hook privacy gate, so a .hyposcanignore-only match
+// should drop out of the count too. Privacy semantics are preserved — an
+// .hypoignore match is still excluded, isScanIgnored only ever widens that.
 const sources = existsSync(join(args.hypoDir, 'sources'))
   ? readdirSync(join(args.hypoDir, 'sources')).filter(
       (e) =>
         !e.startsWith('.') &&
-        !isIgnored(join(args.hypoDir, 'sources', e), args.hypoDir, ignorePatterns),
+        !isScanIgnored(join(args.hypoDir, 'sources', e), args.hypoDir, ignorePatterns),
     )
   : [];
 
@@ -134,7 +144,10 @@ let adrCount = 0;
 for (const p of projects) {
   const decisionsDir = join(args.hypoDir, 'projects', p, 'decisions');
   if (existsSync(decisionsDir)) {
-    adrCount += readdirSync(decisionsDir).filter((f) => f.endsWith('.md')).length;
+    adrCount += readdirSync(decisionsDir).filter(
+      (f) =>
+        f.endsWith('.md') && !isScanIgnored(join(decisionsDir, f), args.hypoDir, ignorePatterns),
+    ).length;
   }
 }
 

--- a/templates/.hyposcanignore
+++ b/templates/.hyposcanignore
@@ -1,0 +1,10 @@
+# .hyposcanignore — patterns excluded from scan (lint/graph/stats/query/verify/doctor) only
+# One glob per line. Lines starting with # are comments.
+# Matched files are skipped by catalog scans but are still committed and still
+# readable by hooks. For secrets and anything that must never be committed or
+# surfaced by a hook, use .hypoignore instead — this file does NOT block commits.
+# Syntax follows .gitignore glob rules.
+
+# Draft / scratch (uncomment to hide from scans without blocking their commit)
+# drafts/
+# scratch/

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -76,6 +76,37 @@ test('doctor flags missing extensions baseline dir as failure', () => {
   });
 });
 
+// A안: .hyposcanignore is optional — presence/absence is info-level (pass
+// either way), never warn/fail.
+suite('doctor.mjs — .hyposcanignore info-level check (A안)');
+
+test('doctor passes File: .hyposcanignore when absent (optional file)', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+    rmSync(join(hypoDir, '.hyposcanignore'), { force: true });
+    const r = run('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json']);
+    const checks = JSON.parse(r.stdout);
+    const check = checks.find((c) => c.label === 'File: .hyposcanignore');
+    assert.ok(check, 'doctor should report a File: .hyposcanignore check');
+    assert.equal(check.status, 'pass', `absent .hyposcanignore must not warn/fail: ${r.stdout}`);
+  });
+});
+
+test('doctor passes File: .hyposcanignore when present', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+    assert.ok(existsSync(join(hypoDir, '.hyposcanignore')), 'init should scaffold it');
+    const r = run('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json']);
+    const checks = JSON.parse(r.stdout);
+    const check = checks.find((c) => c.label === 'File: .hyposcanignore');
+    assert.equal(check.status, 'pass');
+  });
+});
+
 // fix #6: doctor-checks-node-git-shell-npm
 suite('doctor.mjs — fix #6: external deps');
 

--- a/tests/fixtures/npm-pack.files.json
+++ b/tests/fixtures/npm-pack.files.json
@@ -428,6 +428,10 @@
     "exec": false
   },
   {
+    "path": "templates/.hyposcanignore",
+    "exec": false
+  },
+  {
     "path": "templates/Home.md",
     "exec": false
   },

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -89,6 +89,34 @@ test('init creates pages/observability/_index.md stub', () => {
   });
 });
 
+test('init creates .hyposcanignore scaffold (scan-only sibling of .hypoignore, A안)', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const dest = join(hypoDir, '.hyposcanignore');
+    assert.ok(existsSync(dest), '.hyposcanignore should be created');
+    const content = readFileSync(dest, 'utf8');
+    assert.ok(/scan/i.test(content), 'header should describe scan-only scope');
+    assert.ok(
+      /NOT a privacy boundary|does NOT block commit/i.test(content),
+      'header should make clear this is not a commit-blocking privacy file, unlike .hypoignore',
+    );
+  });
+});
+
+test('init does not overwrite an existing .hyposcanignore', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    writeFileSync(join(hypoDir, '.hyposcanignore'), 'custom-pattern/\n');
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const content = readFileSync(join(hypoDir, '.hyposcanignore'), 'utf8');
+    assert.equal(content, 'custom-pattern/\n');
+  });
+});
+
 test('--no-hooks succeeds without touching hook config', () => {
   withTmpDir((dir) => {
     const hypoDir = join(dir, 'wiki');

--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -1071,6 +1071,7 @@ const {
   isGeneratedArtifact,
   isScanIgnored,
   isIgnored: isHypoIgnored,
+  loadScanIgnore,
 } = await import(`${SCRIPTS}/lib/hypo-ignore.mjs`);
 
 const GA_ROOT = '/tmp/ga-vault';
@@ -1104,6 +1105,106 @@ test('isScanIgnored hides a generated root artifact but isIgnored does NOT', () 
 test('isScanIgnored still honors .hypoignore patterns (secret-block preserved)', () => {
   const secret = join(GA_ROOT, 'my-token.md');
   assert.equal(isScanIgnored(secret, GA_ROOT, ['*token*']), true);
+});
+
+suite('lib/hypo-ignore.mjs — .hyposcanignore scan-only exclusion (A안)');
+
+function withScanIgnoreVault(scanIgnoreContent, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-scanignore-'));
+  try {
+    if (scanIgnoreContent !== null) {
+      writeFileSync(join(dir, '.hyposcanignore'), scanIgnoreContent);
+    }
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('loadScanIgnore returns [] when .hyposcanignore is absent (today parity)', () => {
+  withScanIgnoreVault(null, (dir) => {
+    assert.deepEqual(loadScanIgnore(dir), []);
+  });
+});
+
+test('loadScanIgnore parses glob lines, skipping comments and blanks', () => {
+  withScanIgnoreVault('# comment\n\ndrafts/\nscratch/*.md\n', (dir) => {
+    assert.deepEqual(loadScanIgnore(dir), ['drafts/', 'scratch/*.md']);
+  });
+});
+
+test('isScanIgnored matches a .hyposcanignore-only path, but isIgnored (privacy) does not', () => {
+  withScanIgnoreVault('drafts/\n', (dir) => {
+    const target = join(dir, 'drafts', 'wip.md');
+    assert.equal(
+      isHypoIgnored(target, dir, []),
+      false,
+      'privacy check must not see .hyposcanignore — commit path stays open',
+    );
+    assert.equal(
+      isScanIgnored(target, dir, []),
+      true,
+      'scan check must skip a .hyposcanignore-listed path',
+    );
+  });
+});
+
+test('isScanIgnored with no .hyposcanignore behaves exactly like privacy+generated-artifact only (today parity)', () => {
+  withScanIgnoreVault(null, (dir) => {
+    const plain = join(dir, 'pages', 'note.md');
+    assert.equal(isScanIgnored(plain, dir, []), false);
+    const artifact = join(dir, 'GRAPH_REPORT.md');
+    assert.equal(isScanIgnored(artifact, dir, []), true);
+  });
+});
+
+// Cache-key regression (codex pre-commit BLOCKER): a raw, un-resolved hypoDir
+// string as the cache key lets a relative spelling like '.' collide ACROSS
+// vaults when the caller cd's between them — the cache must key on the
+// resolved absolute path, not the caller's spelling.
+test('cross-vault bleed: hypoDir="." scanning vault A does not leak A\'s patterns into vault B scanned as "."', () => {
+  const originalCwd = process.cwd();
+  const vaultA = mkdtempSync(join(tmpdir(), 'hypo-scanignore-vaultA-'));
+  const vaultB = mkdtempSync(join(tmpdir(), 'hypo-scanignore-vaultB-'));
+  try {
+    writeFileSync(join(vaultA, '.hyposcanignore'), 'drafts/\n');
+    // vaultB deliberately has NO .hyposcanignore — drafts/ must stay scannable.
+
+    process.chdir(vaultA);
+    const aTarget = join('.', 'drafts', 'wip.md');
+    assert.equal(
+      isScanIgnored(aTarget, '.', []),
+      true,
+      'vault A: drafts/ is .hyposcanignore-listed there',
+    );
+
+    process.chdir(vaultB);
+    const bTarget = join('.', 'drafts', 'wip.md');
+    assert.equal(
+      isScanIgnored(bTarget, '.', []),
+      false,
+      'vault B: must NOT reuse vault A\'s cached scan patterns just because both were addressed as "."',
+    );
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(vaultA, { recursive: true, force: true });
+    rmSync(vaultB, { recursive: true, force: true });
+  }
+});
+
+test('cache key normalizes "." and "./" to the same absolute vault (no duplicate cache entries, no bleed)', () => {
+  const originalCwd = process.cwd();
+  const vault = mkdtempSync(join(tmpdir(), 'hypo-scanignore-norm-'));
+  try {
+    writeFileSync(join(vault, '.hyposcanignore'), 'drafts/\n');
+    process.chdir(vault);
+    assert.equal(isScanIgnored(join('.', 'drafts', 'wip.md'), '.', []), true);
+    assert.equal(isScanIgnored(join('./', 'drafts', 'wip.md'), './', []), true);
+    assert.equal(isScanIgnored(join(vault, 'drafts', 'wip.md'), vault, []), true);
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(vault, { recursive: true, force: true });
+  }
 });
 
 suite('lint.mjs wikilink resolution (ISSUE-21)');

--- a/tests/notifier.test.mjs
+++ b/tests/notifier.test.mjs
@@ -300,6 +300,74 @@ test('stats: omits failureTypes key when no page is classified (OQ-4)', () => {
   );
 });
 
+// ── stats.mjs — .hyposcanignore scan-only exclusion (A안) ────────────────────
+suite('stats.mjs — .hyposcanignore scan-only exclusion');
+
+function withScanIgnoreStatsWiki(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-stats-scanignore-'));
+  try {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'sources'), { recursive: true });
+    mkdirSync(join(dir, 'projects', 'kept'), { recursive: true });
+    mkdirSync(join(dir, 'projects', 'hidden'), { recursive: true });
+    mkdirSync(join(dir, 'projects', 'kept', 'decisions'), { recursive: true });
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const fbPage = '---\ntitle: T\ntype: feedback\nstatus: active\nupdated: 2026-06-23\n---\nbody\n';
+
+test('stats: .hyposcanignore-listed source drops from the source count', () => {
+  withScanIgnoreStatsWiki((dir) => {
+    writeFileSync(join(dir, '.hyposcanignore'), 'sources/hidden.md\n');
+    writeFileSync(join(dir, 'sources', 'hidden.md'), 'x');
+    writeFileSync(join(dir, 'sources', 'kept.md'), 'x');
+    const r = run('stats.mjs', ['--json', `--hypo-dir=${dir}`]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.sources, 1, `expected only kept.md counted: ${r.stdout}`);
+  });
+});
+
+test('stats: .hyposcanignore-listed project dir drops from the project count and its ADRs', () => {
+  withScanIgnoreStatsWiki((dir) => {
+    writeFileSync(join(dir, '.hyposcanignore'), 'projects/hidden/\n');
+    mkdirSync(join(dir, 'projects', 'hidden', 'decisions'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'hidden', 'decisions', '0001-x.md'), 'x');
+    writeFileSync(join(dir, 'projects', 'kept', 'decisions', '0001-y.md'), 'x');
+    const r = run('stats.mjs', ['--json', `--hypo-dir=${dir}`]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.projects, 1, `expected hidden/ excluded: ${r.stdout}`);
+    assert.equal(out.adrs, 1, `expected only kept's ADR counted: ${r.stdout}`);
+  });
+});
+
+test('stats: a matching path stays in the count when only .hypoignore lists it not .hyposcanignore, and the same path is still committable (scope boundary)', () => {
+  withScanIgnoreStatsWiki((dir) => {
+    // No .hyposcanignore at all — parity with today when the file is absent.
+    writeFileSync(join(dir, 'sources', 'plain.md'), 'x');
+    const r = run('stats.mjs', ['--json', `--hypo-dir=${dir}`]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.sources,
+      1,
+      `expected plain.md counted (no .hyposcanignore present): ${r.stdout}`,
+    );
+  });
+});
+
+test('stats: privacy .hypoignore match is still excluded (isScanIgnored widens, never narrows privacy)', () => {
+  withScanIgnoreStatsWiki((dir) => {
+    writeFileSync(join(dir, '.hypoignore'), 'sources/secret.md\n');
+    writeFileSync(join(dir, 'sources', 'secret.md'), 'x');
+    writeFileSync(join(dir, 'sources', 'kept.md'), 'x');
+    const r = run('stats.mjs', ['--json', `--hypo-dir=${dir}`]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.sources, 1, `expected secret.md still excluded: ${r.stdout}`);
+  });
+});
+
 // ── stale-sibling detection (ADR 0038) ────────────────────────────────────────
 // Two Hypomnema installs coexist; an OLDER one owns the `hypomnema` bin on PATH
 // while a newer one owns the active hooks. P = init/upgrade downgrade-guard,

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -221,6 +221,95 @@ test('auto-stage skips .hypoignore-listed file_path', () => {
   });
 });
 
+suite('.hyposcanignore — scan-only exclusion does NOT block a commit (A안)');
+
+// Core regression: a .hyposcanignore match is a SCAN exclusion, not a privacy
+// boundary. It must still get committed by both commit loci — the auto-commit
+// Stop hook (commitWikiChanges) and the git pre-commit worker.
+test('auto-commit still commits a .hyposcanignore-only-listed path (not a privacy boundary)', () => {
+  withGrowthWiki((dir) => {
+    writeFileSync(join(dir, '.hyposcanignore'), 'drafts/\n');
+    mkdirSync(join(dir, 'drafts'), { recursive: true });
+    writeFileSync(join(dir, 'drafts', 'wip.md'), '# wip\n');
+    const r = runStop('hypo-auto-commit.mjs', dir);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'drafts'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(
+      tracked.includes('drafts/wip.md'),
+      `.hyposcanignore-only path must still be committed, got: ${tracked}`,
+    );
+  });
+});
+
+test('auto-commit still SKIPS a .hypoignore-listed path even when it also matches .hyposcanignore', () => {
+  withGrowthWiki((dir) => {
+    writeFileSync(join(dir, '.hypoignore'), 'secrets/\n');
+    writeFileSync(join(dir, '.hyposcanignore'), 'secrets/\n');
+    mkdirSync(join(dir, 'secrets'), { recursive: true });
+    writeFileSync(join(dir, 'secrets', 'token.md'), 'sk-leaked\n');
+    const r = runStop('hypo-auto-commit.mjs', dir);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'secrets'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.equal(
+      tracked.trim(),
+      '',
+      `privacy .hypoignore must still block commit, got: ${tracked}`,
+    );
+  });
+});
+
+test('commitWikiChanges() stages a .hyposcanignore-only path directly (privacy isolation)', () => {
+  withGrowthWiki((dir) => {
+    writeFileSync(join(dir, '.hyposcanignore'), 'notes.md\n');
+    writeFileSync(join(dir, 'notes.md'), '# notes\n');
+    const result = commitWikiChanges(dir);
+    assert.equal(result.committed, true, `stderr: ${JSON.stringify(result)}`);
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'notes.md'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(tracked.includes('notes.md'), `expected notes.md committed, got: ${tracked}`);
+  });
+});
+
+test('git pre-commit worker (hooks/hypo-pre-commit.mjs) does NOT block a staged .hyposcanignore-only path', () => {
+  withGrowthWiki((dir) => {
+    writeFileSync(join(dir, '.hyposcanignore'), 'drafts/\n');
+    mkdirSync(join(dir, 'drafts'), { recursive: true });
+    writeFileSync(join(dir, 'drafts', 'wip.md'), '# wip\n');
+    spawnSync('git', ['-C', dir, 'add', 'drafts/wip.md']);
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-pre-commit.mjs')], {
+      cwd: dir,
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: SESSION_TMP_HOME },
+    });
+    assert.equal(
+      r.status,
+      0,
+      `.hyposcanignore-only staged file must not block commit: ${r.stderr}`,
+    );
+  });
+});
+
+test('git pre-commit worker still blocks a staged .hypoignore-listed path (privacy preserved)', () => {
+  withGrowthWiki((dir) => {
+    writeFileSync(join(dir, '.hypoignore'), 'secrets/\n');
+    mkdirSync(join(dir, 'secrets'), { recursive: true });
+    writeFileSync(join(dir, 'secrets', 'token.md'), 'sk-leaked\n');
+    spawnSync('git', ['-C', dir, 'add', '-f', 'secrets/token.md']);
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-pre-commit.mjs')], {
+      cwd: dir,
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: SESSION_TMP_HOME },
+    });
+    assert.notEqual(r.status, 0, 'a staged .hypoignore-matched file must still block the commit');
+    assert.ok(/\.hypoignore/.test(r.stderr), `stderr should reference .hypoignore: ${r.stderr}`);
+  });
+});
+
 suite('hypo-file-watch.mjs — .hypoignore privacy guard (fix #48)');
 
 test('file-watch refuses to inject .hypoignore-matched file (e.g. .env)', () => {


### PR DESCRIPTION
# English

## What changed

A new optional `.hyposcanignore` file excludes paths from scanning tools (lint, graph, stats, query, verify, doctor) without touching the commit gate. It is scan-only: listing a path there hides it from scans but keeps it fully committable. Privacy exclusion stays with `.hypoignore` as before.

## Why

`.hypoignore` did two jobs at once: it was both the privacy commit gate (the pre-commit hook blocks committing a matching path) and the scan-exclusion list. So the only way to keep a path out of lint was to also make it permanently uncommittable. The single built-in scan-only escape hatch was a hardcoded constant a vault could not extend.

## How

`isScanIgnored()` now returns true for a privacy match, a generated-artifact match, or a `.hyposcanignore` match. Only `isScanIgnored()` reads `.hyposcanignore`; `loadHypoIgnore()` and `isIgnored()` do not, so the widened predicate is monotonic and can never make a `.hypoignore`-matched path committable. The privacy boundary (`.hypoignore`, `hooks/hypo-pre-commit.mjs`, and the inline copy in `hooks/hypo-shared.mjs` including the fresh page-usage check) is untouched. Scan patterns are parsed once and cached per absolute vault path. `stats` was routed through `isScanIgnored` at its source/project/ADR call sites; `graph` already reached it through the shared walker, so it is unchanged. `init` scaffolds an empty `.hyposcanignore`; `doctor` reports its presence at info level. An absent file yields an empty pattern set, so existing vaults behave exactly as today.

## Manual verification

Covered by the test suite across the changed areas (lint, notifier/stats, session-hooks, doctor, init): scan-only paths still commit; privacy paths are still blocked by both the pre-commit worker and `commitWikiChanges`; the same path listed only in `.hyposcanignore` drops from scans while staying committable; an empty vault matches today. The privacy-isolation and cross-vault cache-key regressions were proven red before the fix.

## Migration notes

None. `.hyposcanignore` is optional; existing vaults are unaffected until they add one (a fresh `init` scaffolds an empty one).

---

# 한국어

## 변경 내용

새 옵션 파일 `.hyposcanignore`가 스캔 도구(lint, graph, stats, query, verify, doctor)에서 경로를 제외하되 커밋 게이트는 건드리지 않는다. 스캔 전용이라, 여기 적은 경로는 스캔에서만 빠지고 커밋은 그대로 된다. 프라이버시 제외는 종전처럼 `.hypoignore`가 담당한다.

## 이유

`.hypoignore`가 두 일을 겸했다. 프라이버시 커밋 게이트(매치 경로의 커밋을 pre-commit 훅이 차단)이자 스캔 제외 목록이었다. 그래서 어떤 경로를 lint에서 빼려면 그 경로를 영구히 커밋 불가로 만들 수밖에 없었다. 유일한 스캔 전용 예외는 볼트가 확장할 수 없는 하드코딩 상수뿐이었다.

## 방법

`isScanIgnored()`는 이제 privacy 매치, generated-artifact 매치, `.hyposcanignore` 매치 중 하나면 true다. `.hyposcanignore`는 오직 `isScanIgnored()`만 읽고 `loadHypoIgnore()`·`isIgnored()`는 읽지 않아, 넓어진 술어가 monotonic이라 `.hypoignore` 매치 경로를 커밋 가능하게 만들 수 없다. 프라이버시 경계(`.hypoignore`, `hooks/hypo-pre-commit.mjs`, `hooks/hypo-shared.mjs`의 인라인 복제본과 page-usage fresh 검사)는 손대지 않았다. 스캔 패턴은 절대 vault 경로별로 1회 파싱·캐시한다. `stats`는 source/project/ADR call-site에서 `isScanIgnored`를 경유하게 했고, `graph`는 이미 공유 walker로 도달하므로 무변경이다. `init`은 빈 `.hyposcanignore`를 스캐폴드하고 `doctor`는 존재를 info 레벨로 보고한다. 파일이 없으면 빈 패턴이라 기존 볼트는 오늘과 동일하다.

## 수동 검증

변경 area(lint, notifier/stats, session-hooks, doctor, init) 테스트가 커버한다: scan-only 경로는 여전히 커밋되고, privacy 경로는 pre-commit worker와 `commitWikiChanges` 양쪽에서 여전히 차단되며, `.hyposcanignore`에만 있는 경로는 스캔에서 빠지되 커밋은 되고, 빈 볼트는 오늘과 일치한다. 프라이버시 격리와 cross-vault 캐시-키 회귀는 수정 전 red로 증명했다.

## 마이그레이션 노트

None. `.hyposcanignore`는 옵션이라 기존 볼트는 추가하기 전까지 영향 없다(fresh `init`은 빈 파일을 스캐폴드).

---

## Changelog

- EN: Add an optional `.hyposcanignore` that excludes paths from scanning tools (lint, graph, stats, query, verify, doctor) without blocking commits, separating scan exclusion from the `.hypoignore` privacy gate (#216).
- KO: 스캔 도구(lint, graph, stats, query, verify, doctor)에서 경로를 제외하되 커밋은 막지 않는 옵션 파일 `.hyposcanignore` 추가: 스캔 제외를 `.hypoignore` 프라이버시 게이트에서 분리 (#216).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
