### PR TITLE
fix(upgrade): re-resolve the dual-install plugin root from the registry in the dualSkip path

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -32,7 +32,7 @@ import {
   renameSync,
   unlinkSync,
 } from 'fs';
-import { join, basename, dirname, isAbsolute, resolve } from 'path';
+import { join, basename, dirname, resolve } from 'path';
 import { homedir } from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -49,7 +49,11 @@ import {
 import { syncExtensions } from './lib/extensions.mjs';
 import { templateSchemaVersion } from './lib/template-schema-version.mjs';
 import { classifyInstall, downgradeGuardMessage } from '../hooks/version-check.mjs';
-import { isHypomnemaPluginEnabled, enabledHypomnemaPluginKey } from './lib/plugin-detect.mjs';
+import {
+  isHypomnemaPluginEnabled,
+  resolveEnabledPluginRoot as resolveEnabledPluginRootShared,
+  usablePkgRoot,
+} from './lib/plugin-detect.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -535,22 +539,8 @@ function readPkgVersionAt(root) {
   }
 }
 
-// A pkgRoot is "usable" as a DURABLE install root only if it is an ABSOLUTE path to
-// a real package directory whose package.json carries a version. A relative path
-// (e.g. installPath ".") would be resolved against the caller's cwd and break the
-// vault git hook from any other directory; a version-less package.json cannot be
-// attributed a version without lying (see writePkgJson). A bare path that merely
-// exists is a pointer the runtime cannot resolve scripts through. Shared by the
-// registry resolution and the durable-root fallback so they agree on what is real.
-function usablePkgRoot(pkgRoot) {
-  return (
-    typeof pkgRoot === 'string' &&
-    pkgRoot.length > 0 &&
-    isAbsolute(pkgRoot) &&
-    existsSync(join(pkgRoot, 'package.json')) &&
-    readPkgVersionAt(pkgRoot) !== null
-  );
-}
+// usablePkgRoot now lives in ./lib/plugin-detect.mjs (imported above), shared with
+// upgrade.mjs's dualSkip provenance correction so both agree on what is real.
 
 function writePkgJson(dryRun, extraFields = {}, root = PKG_ROOT) {
   const dest = pkgJsonPath();
@@ -976,37 +966,15 @@ const hypomnemaPluginEnabled =
   !pluginMode && isHypomnemaPluginEnabled(join(HOME, '.claude', 'settings.json'));
 const coreManagedByPlugin = pluginMode || hypomnemaPluginEnabled;
 
-// Resolve the enabled Hypomnema plugin's REAL install root from the plugin
-// registry (~/.claude/plugins/installed_plugins.json). POSITIVE attribution: it
-// looks up the EXACT key that settings.json marks enabled (via
-// enabledHypomnemaPluginKey), not just any hypo-named entry — a disabled legacy or
-// other-marketplace entry must never be selected. Among that key's registry
-// entries it prefers the user-scope install (the one a plugin-enabled user runs),
-// falling back to any usable entry. Returns a usable absolute install root, or
-// null when the registry is absent/unreadable, names no entry for the enabled key,
-// or that entry is not a usable package dir.
+// resolveEnabledPluginRoot lives in ./lib/plugin-detect.mjs (shared with
+// upgrade.mjs's dualSkip provenance correction, imported above as
+// resolveEnabledPluginRootShared). This wrapper binds it to init's own HOME-derived
+// settings/registry paths so callers below read the same as before the move.
 function resolveEnabledPluginRoot(settingsPath) {
-  const key = enabledHypomnemaPluginKey(settingsPath);
-  if (!key) return null;
-  let reg;
-  try {
-    reg = JSON.parse(
-      readFileSync(join(HOME, '.claude', 'plugins', 'installed_plugins.json'), 'utf-8'),
-    );
-  } catch {
-    return null;
-  }
-  const plugins =
-    reg && typeof reg.plugins === 'object' && !Array.isArray(reg.plugins) ? reg.plugins : null;
-  const entries = plugins && Array.isArray(plugins[key]) ? plugins[key] : null;
-  if (!entries) return null;
-  const paths = (scope) =>
-    entries
-      .filter((e) => e && (scope === undefined || e.scope === scope))
-      .map((e) => (typeof e.installPath === 'string' ? e.installPath : null))
-      .filter((p) => usablePkgRoot(p));
-  // Prefer the user-scope install, then any usable entry for this exact key.
-  return paths('user')[0] ?? paths(undefined)[0] ?? null;
+  return resolveEnabledPluginRootShared(
+    settingsPath,
+    join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
+  );
 }
 
 // Non-mutating read of the recorded pkgRoot. resolveDurableRoot runs before init's

--- a/scripts/lib/pkg-json.mjs
+++ b/scripts/lib/pkg-json.mjs
@@ -75,3 +75,43 @@ export function writePkgJsonAtomic(pkgJsonPath, data) {
     throw err;
   }
 }
+
+// Non-mutating read of the version a candidate install root's own package.json
+// carries, or null. Shared by writeDualSkipProvenance (what to stamp) and
+// upgrade.mjs's read-only report (what to preview/display) so both agree.
+export function readVersionAtRoot(root) {
+  try {
+    const v = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')).version;
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// Dual-install self-heal: writes a NARROW provenance correction to
+// pkgJsonPath, pointing pkgRoot/pkgVersion at the plugin registry's own
+// resolved root/version, while preserving every other existing field
+// (including a prior `commands` map — that map reflects the PLUGIN's own
+// install, not the caller's own run, so unlike a full plugin-mode metadata
+// write it must NOT be dropped or touched here).
+//
+// TOCTOU guard: the caller (upgrade.mjs) resolves `registryRoot` as usable via
+// a SEPARATE earlier read (resolveEnabledPluginRoot / usablePkgRoot) — that
+// root's own package.json can vanish or corrupt between that resolution and
+// this write. Re-reads the version HERE and refuses the correction outright if
+// it cannot, rather than stamp a NEW pkgRoot with a STALE version (the old
+// recorded one, or none): a wrong root+version pairing is worse than no
+// correction. Returns false without writing anything when refused — the
+// existing metadata is left exactly as it was, and the caller must not report
+// this as "corrected".
+export function writeDualSkipProvenance(pkgJsonPath, registryRoot) {
+  const registryVersion = readVersionAtRoot(registryRoot);
+  if (!registryVersion) return false;
+  const existing = readPkgJson(pkgJsonPath);
+  writePkgJsonAtomic(pkgJsonPath, {
+    ...existing,
+    pkgRoot: registryRoot,
+    pkgVersion: registryVersion,
+  });
+  return true;
+}

--- a/scripts/lib/plugin-detect.mjs
+++ b/scripts/lib/plugin-detect.mjs
@@ -15,7 +15,8 @@
 // legacy `hypomnema@<marketplace>` key in `enabledPlugins` until they reinstall
 // as `hypo@<marketplace>`, and the guard must hold across that gap.
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
 
 /**
  * @param {string} settingsPath  path to a Claude Code settings.json (e.g. ~/.claude/settings.json)
@@ -86,4 +87,64 @@ export function enabledHypomnemaPluginKey(settingsPath) {
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
   return enabledKeyFrom(parsed.enabledPlugins);
+}
+
+function readPkgVersionAt(root) {
+  try {
+    const v = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')).version;
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// A pkgRoot is "usable" as a DURABLE install root only if it is an ABSOLUTE path to
+// a real package directory whose package.json carries a version. A relative path
+// (e.g. installPath ".") would be resolved against the caller's cwd and break the
+// vault git hook from any other directory; a version-less package.json cannot be
+// attributed a version without lying. A bare path that merely exists is a pointer
+// the runtime cannot resolve scripts through. Shared by init's registry resolution,
+// its durable-root fallback, and upgrade's dualSkip provenance correction so they
+// all agree on what is real.
+export function usablePkgRoot(pkgRoot) {
+  return (
+    typeof pkgRoot === 'string' &&
+    pkgRoot.length > 0 &&
+    isAbsolute(pkgRoot) &&
+    existsSync(join(pkgRoot, 'package.json')) &&
+    readPkgVersionAt(pkgRoot) !== null
+  );
+}
+
+// Resolve the enabled Hypomnema plugin's REAL install root from the plugin
+// registry (~/.claude/plugins/installed_plugins.json). POSITIVE attribution: it
+// looks up the EXACT key that settingsPath marks enabled (via
+// enabledHypomnemaPluginKey), not just any hypo-named entry — a disabled legacy or
+// other-marketplace entry must never be selected. Among that key's registry
+// entries it prefers the user-scope install (the one a plugin-enabled user runs),
+// falling back to any usable entry. Returns a usable absolute install root, or
+// null when the registry is absent/unreadable, names no entry for the enabled key,
+// or that entry is not a usable package dir. Fails open (null) on every
+// uncertainty — callers must treat null as "cannot positively resolve", never as
+// "resolved to nothing usable exists".
+export function resolveEnabledPluginRoot(settingsPath, registryPath) {
+  const key = enabledHypomnemaPluginKey(settingsPath);
+  if (!key) return null;
+  let reg;
+  try {
+    reg = JSON.parse(readFileSync(registryPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+  const plugins =
+    reg && typeof reg.plugins === 'object' && !Array.isArray(reg.plugins) ? reg.plugins : null;
+  const entries = plugins && Array.isArray(plugins[key]) ? plugins[key] : null;
+  if (!entries) return null;
+  const paths = (scope) =>
+    entries
+      .filter((e) => e && (scope === undefined || e.scope === scope))
+      .map((e) => (typeof e.installPath === 'string' ? e.installPath : null))
+      .filter((p) => usablePkgRoot(p));
+  // Prefer the user-scope install, then any usable entry for this exact key.
+  return paths('user')[0] ?? paths(undefined)[0] ?? null;
 }

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -49,9 +49,11 @@ import {
   sha256 as sha256Buf,
   isRegularFile,
   readFileIfRegular,
+  readVersionAtRoot,
+  writeDualSkipProvenance,
 } from './lib/pkg-json.mjs';
 import { syncExtensions } from './lib/extensions.mjs';
-import { isHypomnemaPluginEnabled } from './lib/plugin-detect.mjs';
+import { isHypomnemaPluginEnabled, resolveEnabledPluginRoot } from './lib/plugin-detect.mjs';
 import { classifyInstall, downgradeGuardMessage } from '../hooks/version-check.mjs';
 
 const HOME = homedir();
@@ -873,6 +875,15 @@ function writePluginModeMetadata() {
   return true;
 }
 
+// readVersionAtRoot and writeDualSkipProvenance now live in ./lib/pkg-json.mjs
+// (imported above) — writeDualSkipProvenance is deliberately not
+// writePluginModeMetadata(): that function hardcodes THIS npm run's
+// PKG_ROOT/PKG_VERSION and always drops `commands` — both correct for true
+// plugin mode, both wrong for a dualSkip correction, where the identity being
+// written is the OTHER install's. Moving both into lib/pkg-json.mjs (alongside
+// the other pkgJsonPath-taking helpers already there) also makes the writer's
+// TOCTOU refusal directly unit-testable without spawning the whole script.
+
 // ── main ─────────────────────────────────────────────────────────────────────
 
 const args = parseArgs(process.argv);
@@ -927,6 +938,37 @@ const guide = checkGuideVersion(args.hypoDir);
 const hooks = checkHookFiles(claudeHooksDir);
 const settings = checkSettingsJson(claudeSettingsPath, claudeHooksDir);
 const pkgJson = checkPkgJson();
+// dualSkip provenance self-heal: the registry root the enabled plugin key
+// POSITIVELY resolves to (same lookup init.mjs's resolveDurableRoot uses), or
+// null when the registry is absent/unreadable/corrupt or names no usable entry
+// for the enabled key. Computed unconditionally (fail-open on any uncertainty —
+// see lib/plugin-detect.mjs) so both the --apply write below and the read-only
+// report can agree on the same positively-resolved identity without a second
+// registry read racing the first.
+const dualSkipRegistryRoot = dualSkip
+  ? resolveEnabledPluginRoot(
+      claudeSettingsPath,
+      join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
+    )
+  : null;
+// The recorded pkgRoot currently on disk, read non-mutatingly (readPkgJsonSafe
+// would rename aside a corrupt file — a write — before this script has decided
+// whether to touch anything).
+const dualSkipRecordedRoot = (() => {
+  try {
+    const v = JSON.parse(readFileSync(pkgJsonPath(), 'utf-8')).pkgRoot;
+    return typeof v === 'string' ? v : null;
+  } catch {
+    return null;
+  }
+})();
+// A CONDITIONAL self-heal, never an unconditional rewrite: correct only when the
+// registry positively resolves a usable root that DIFFERS from what's already
+// recorded. An unresolvable registry (null) must PRESERVE the existing pointer,
+// not blank it or fall back to this npm PKG_ROOT — a null here is "cannot prove
+// a correction is needed", not "there is nothing to preserve".
+const dualSkipWouldCorrect =
+  dualSkip && dualSkipRegistryRoot !== null && dualSkipRegistryRoot !== dualSkipRecordedRoot;
 const commands = checkCommands();
 const oldHookRefs = checkOldHookNames(claudeSettingsPath);
 const hypoignore = checkHypoignore(args.hypoDir);
@@ -999,14 +1041,28 @@ const schemaDrift =
 // an already-installed pre-versioning vault, the population this change targets.
 // Excluding it (as the old unknown-only check did) is the bug this fixes.
 const guideDrift = guide.bump !== 'none' && guide.bump !== 'unknown' && guide.bump !== 'ahead';
-// Dual-install: when core is skipped, hypo-pkg.json is deliberately left
-// pointing at the PLUGIN's package root (preserved identity), so checkPkgJson()
-// reports it 'stale' relative to this npm/manual PKG_ROOT. That mismatch is
-// INTENTIONAL — `--apply` will not (and must not) rewrite it — so it must not
-// count as actionable drift, or the user would be nagged to run --apply forever.
-// A genuinely missing/corrupt file (status 'missing') is still surfaced (warning
+// Dual-install: when core is skipped, hypo-pkg.json is normally left pointing
+// at the PLUGIN's package root (preserved identity), so checkPkgJson() reports
+// it 'stale' relative to this npm/manual PKG_ROOT. That mismatch is USUALLY
+// intentional — `--apply` will not rewrite an already-correct plugin pointer
+// — so it must not count as actionable drift by default, or the user would be
+// nagged to run --apply forever. The one exception is dualSkipWouldCorrect: an
+// npm-first divergence where the recorded pointer differs from what the plugin
+// registry POSITIVELY resolves (e.g. `npm init`, enable the plugin, `npm init`
+// again — the npm root stays recorded forever otherwise). THAT case IS
+// actionable — `--apply` corrects it via writeDualSkipProvenance — so it must
+// count as drift, or the user has no signal to ever run --apply. dualSkipWouldCorrect
+// is checked FIRST and unconditionally (not gated behind `pkgJson.status !==
+// 'up-to-date'`): checkPkgJson() compares the recorded pointer only against
+// THIS run's own PKG_ROOT, so an npm-first divergence where the recorded
+// pointer happens to equal PKG_ROOT (but the registry resolves a DIFFERENT
+// plugin root) would read 'up-to-date' and slip past that status check
+// entirely — leaving a correctable divergence permanently unreported. A
+// genuinely missing/corrupt file (status 'missing') is still surfaced (warning
 // below), because the runtime then cannot resolve its package root at all.
-const pkgJsonDrift = pkgJson.status !== 'up-to-date' && !(dualSkip && pkgJson.status === 'stale');
+const pkgJsonDrift =
+  dualSkipWouldCorrect ||
+  (pkgJson.status !== 'up-to-date' && !(dualSkip && pkgJson.status === 'stale'));
 const staleCommands = commands.filter((c) => c.status === 'stale' || c.status === 'missing');
 const userModifiedCommands = commands.filter((c) => c.status === 'user-modified');
 const orphanedCommands = commands.filter((c) => c.status === 'orphaned');
@@ -1018,6 +1074,11 @@ let migrationPath = null;
 let appliedHooks = [];
 let appliedSettings = [];
 let appliedPkgJson = false;
+// True only once the dualSkip provenance self-heal actually WROTE a correction
+// this run (a positively-resolved registry root that differed from the
+// recorded one). Distinct from dualSkipWouldCorrect (a pre-apply preview
+// computed above), which stays true even in a dry run.
+let dualSkipCorrected = false;
 let appliedHookNameRenames = [];
 let appliedHooksCodex = [];
 let appliedSettingsCodex = [];
@@ -1104,6 +1165,20 @@ if (args.apply) {
     // user to resolve the dual install.
     if (pkgJson.status === 'missing') {
       appliedPkgJson = writePluginModeMetadata();
+    } else if (dualSkipWouldCorrect) {
+      // npm-first correction: a usable pkgRoot IS already recorded (status
+      // 'stale' or 'up-to-date'), but the registry positively resolves a
+      // DIFFERENT usable root — e.g. `npm init`, then enable the plugin, then
+      // `npm init` again, leaving the npm root recorded forever. Correct the
+      // provenance to the registry's own root/version. When the registry
+      // cannot positively resolve one (dualSkipWouldCorrect is false — null
+      // registry lookup, or it already matches what's recorded), fall through
+      // to preserving the existing pointer untouched; never blank it.
+      // writeDualSkipProvenance can still refuse here (TOCTOU: the registry
+      // root's own package.json became unreadable between resolution and this
+      // write) — dualSkipCorrected only follows an ACTUAL write, never assume it.
+      appliedPkgJson = writeDualSkipProvenance(pkgJsonPath(), dualSkipRegistryRoot);
+      dualSkipCorrected = appliedPkgJson;
     } else {
       appliedPkgJson = false;
     }
@@ -1403,7 +1478,28 @@ if (managesClaudeCore) {
 if (settingsCodex) pushSettingsSummary(settingsCodex, ' (codex)', invalidSettingsCodex);
 
 // Package metadata
-if (dualSkip && pkgJson.status === 'stale') {
+if (dualSkip && dualSkipCorrected) {
+  // npm-first correction actually WROTE this run: the pre-apply pkgJson
+  // classification above was computed against the running npm PKG_ROOT, so
+  // without this branch a corrected pointer would still be reported as
+  // "preserved — not rewritten" (or "up to date"/"stale") below, contradicting
+  // what --apply just did. Report the explicit outcome instead, with the
+  // registry package's own version — the identity now on disk.
+  const correctedVersion = readVersionAtRoot(dualSkipRegistryRoot);
+  lines.push(
+    `✓ Package metadata  hypo-pkg.json corrected to enabled plugin registry root` +
+      (correctedVersion ? ` (v${correctedVersion})` : ''),
+  );
+} else if (dualSkip && dualSkipWouldCorrect) {
+  // Same divergence, but this was a dry run (no --apply): preview what
+  // --apply would do rather than claiming the identity is already preserved.
+  const previewVersion = readVersionAtRoot(dualSkipRegistryRoot);
+  lines.push(
+    `⚠ Package metadata  hypo-pkg.json points at a stale npm/manual root — \`--apply\` will` +
+      ` correct it to the enabled plugin registry root` +
+      (previewVersion ? ` (v${previewVersion})` : ''),
+  );
+} else if (dualSkip && pkgJson.status === 'stale') {
   // Dual-install: the 'stale' here is the preserved plugin identity (pkgRoot points at
   // the plugin, not this npm/manual copy). That is intentional — not actionable.
   lines.push(

--- a/tests/upgrade.test.mjs
+++ b/tests/upgrade.test.mjs
@@ -19,6 +19,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { parseSchemaVocab } from '../scripts/lib/schema-vocab.mjs';
 import { isHypomnemaPluginEnabled } from '../scripts/lib/plugin-detect.mjs';
+import { writeDualSkipProvenance } from '../scripts/lib/pkg-json.mjs';
 import { test, suite } from './harness.mjs';
 import {
   HOME,
@@ -1124,4 +1125,410 @@ test('manual install, plugin NOT enabled → normal core management (no false po
       'npm-only --apply must still copy core hooks (no regression)',
     );
   });
+});
+
+// ── dualSkip provenance self-heal (upgrade.mjs + lib/plugin-detect.mjs) ─────
+// npm-first counter-example: `npm init`, then enable the plugin, then `npm init`
+// again leaves hypo-pkg.json pointing at the npm root FOREVER — the old dualSkip
+// branch only ever preserved whatever was already recorded, never positively
+// checked it against the plugin registry. resolveEnabledPluginRoot (shared with
+// init.mjs's resolveDurableRoot) lets dualSkip self-heal that ONE case while
+// still refusing to touch an already-correct or unresolvable pointer.
+
+suite('upgrade.mjs — dualSkip provenance self-heal (registry root)');
+
+// A second fake install root standing in for "the plugin's real cache root" —
+// distinct from the npm root withDualInstall/withFakeUpgradeInstall builds, with
+// a DISTINGUISHABLE package.json version so a test can prove which root's
+// identity ended up recorded. Package.json only: usablePkgRoot/resolveEnabledPluginRoot
+// need nothing else, and these tests never invoke the registry root's own scripts.
+function withRegistryRoot(version, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-registry-'));
+  try {
+    const root = join(dir, 'plugins', 'cache', 'hypomnema', 'hypomnema', version);
+    mkdirSync(root, { recursive: true });
+    const pkg = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf-8'));
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ ...pkg, version }));
+    fn(root);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// Writes ~/.claude/plugins/installed_plugins.json with a single entry for `key`
+// pointing at `installPath` (user scope — resolveEnabledPluginRoot prefers it).
+function writeRegistry(home, key, installPath) {
+  const dir = join(home, '.claude', 'plugins');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'installed_plugins.json'),
+    JSON.stringify({ plugins: { [key]: [{ installPath, scope: 'user' }] } }),
+  );
+}
+
+const DUAL_INSTALL_KEY = 'hypomnema@hypomnema'; // matches withDualInstall's settings.json fixture
+
+test('npm-first correction: stale npm pkgRoot + a real registry entry → dualSkip corrects to the registry root', () => {
+  withDualInstall(true, ({ upgrade, home, wiki }) => {
+    withRegistryRoot('9.9.9', (registryRoot) => {
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      // Simulate the npm-first sequence: a stale/npm-shaped pointer already
+      // recorded, predating the plugin's registration.
+      writeFileSync(
+        pkgPath,
+        JSON.stringify({ pkgRoot: '/old/npm/root', pkgVersion: '1.0.0', schemaVersion: '2.0' }),
+      );
+      writeRegistry(home, DUAL_INSTALL_KEY, registryRoot);
+      const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+      assert.equal(
+        r.status,
+        0,
+        `npm-first correction --apply should exit 0: ${r.stderr}\n${r.stdout}`,
+      );
+      const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      assert.equal(
+        realpathSync(meta.pkgRoot),
+        realpathSync(registryRoot),
+        'dualSkip must correct pkgRoot to the positively-resolved registry root',
+      );
+      assert.equal(
+        meta.pkgVersion,
+        '9.9.9',
+        'pkgVersion must come from the registry root, not npm',
+      );
+      assert.match(
+        r.stdout,
+        /corrected to enabled plugin registry root/,
+        'report must surface an explicit corrected outcome, not "preserved"/"stale"',
+      );
+    });
+  });
+});
+
+test('npm-first correction (dry run): reports the pending correction and does not write', () => {
+  withDualInstall(true, ({ upgrade, home, wiki }) => {
+    withRegistryRoot('9.9.9', (registryRoot) => {
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      writeFileSync(
+        pkgPath,
+        JSON.stringify({ pkgRoot: '/old/npm/root', pkgVersion: '1.0.0', schemaVersion: '2.0' }),
+      );
+      writeRegistry(home, DUAL_INSTALL_KEY, registryRoot);
+      const before = readFileSync(pkgPath, 'utf-8');
+      const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`], home);
+      assert.equal(
+        r.status,
+        1,
+        'a genuinely correctable npm-first divergence must count as drift (exit 1) so --apply is discoverable',
+      );
+      assert.match(
+        r.stdout,
+        /will correct it to the enabled plugin registry root/,
+        'dry run must preview the pending correction',
+      );
+      assert.equal(
+        readFileSync(pkgPath, 'utf-8'),
+        before,
+        'a dry run (no --apply) must never write',
+      );
+    });
+  });
+});
+
+test("npm-first correction (recorded already equals this run's PKG_ROOT): dry run still flags drift", () => {
+  // checkPkgJson()'s own status only ever compares the recorded pointer against
+  // THIS run's PKG_ROOT — so if the recorded pointer happens to equal PKG_ROOT,
+  // status reads 'up-to-date' even when the registry positively resolves a
+  // DIFFERENT, real plugin root. pkgJsonDrift must not let that 'up-to-date'
+  // status suppress the divergence: dualSkipWouldCorrect has to win regardless
+  // of status, or this exact npm-first shape goes unreported forever.
+  withDualInstall(true, ({ upgrade, root, home, wiki }) => {
+    withRegistryRoot('9.9.9', (registryRoot) => {
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      // checkPkgJson() compares the recorded string byte-for-byte against
+      // PKG_ROOT as the running upgrade.mjs computes it — which, via
+      // import.meta.url, is the REALPATH of `root` (macOS resolves the
+      // /var -> /private/var symlink at module-URL resolution time). Record
+      // the realpath so status is genuinely 'up-to-date', not merely 'stale'
+      // (which the pre-BLOCKER-1-fix formula already handled correctly).
+      writeFileSync(
+        pkgPath,
+        JSON.stringify({ pkgRoot: realpathSync(root), pkgVersion: '1.0.0', schemaVersion: '2.0' }),
+      );
+      writeRegistry(home, DUAL_INSTALL_KEY, registryRoot);
+      const before = readFileSync(pkgPath, 'utf-8');
+      const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`], home);
+      const check = JSON.parse(runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--json'], home).stdout);
+      assert.equal(
+        check.pkgJson.status,
+        'up-to-date',
+        'precondition: the recorded pointer must byte-match PKG_ROOT (status up-to-date), or this is not exercising the bug',
+      );
+      assert.equal(
+        r.status,
+        1,
+        `a registry divergence must count as drift even when recorded == PKG_ROOT (status up-to-date): ${r.stdout}`,
+      );
+      assert.match(
+        r.stdout,
+        /will correct it to the enabled plugin registry root/,
+        'dry run must preview the pending correction even when pkgJson.status is up-to-date',
+      );
+      assert.equal(
+        readFileSync(pkgPath, 'utf-8'),
+        before,
+        'a dry run (no --apply) must never write',
+      );
+    });
+  });
+});
+
+test('already-correct: registry root matches what is recorded → no rewrite (no churn)', () => {
+  withDualInstall(true, ({ upgrade, home, wiki }) => {
+    // Same version as the npm root's own package.json (REPO's) — an already-
+    // correct registry pointer must not itself look like a "newer active
+    // install" and trip the unrelated downgrade guard.
+    const repoVersion = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf-8')).version;
+    withRegistryRoot(repoVersion, (registryRoot) => {
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      const seeded = JSON.stringify({
+        pkgRoot: registryRoot,
+        pkgVersion: repoVersion,
+        schemaVersion: '2.0',
+      });
+      writeFileSync(pkgPath, seeded);
+      writeRegistry(home, DUAL_INSTALL_KEY, registryRoot);
+      const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+      assert.equal(r.status, 0, `already-correct --apply should exit 0: ${r.stderr}`);
+      // syncExtensions runs unconditionally in --apply and re-pretty-prints the
+      // file with an `extensions` field regardless of dualSkip — orthogonal to
+      // this correction logic — so compare the identity fields, not raw bytes.
+      const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      assert.equal(
+        meta.pkgRoot,
+        registryRoot,
+        'an already-correct dualSkip pointer must not be repointed',
+      );
+      assert.equal(
+        meta.pkgVersion,
+        repoVersion,
+        'an already-correct pkgVersion must not be rewritten',
+      );
+      assert.doesNotMatch(
+        r.stdout,
+        /corrected to enabled plugin registry root/,
+        'an unchanged identity must not be reported as corrected',
+      );
+    });
+  });
+});
+
+test('corrupt registry: usable recorded pointer is preserved, apply does not abort', () => {
+  withDualInstall(true, ({ upgrade, home, wiki }) => {
+    const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+    const pluginRoot = '/some/.claude/plugins/cache/mp/hypomnema/1.3.0';
+    writeFileSync(
+      pkgPath,
+      JSON.stringify({ pkgRoot: pluginRoot, pkgVersion: '1.3.0', schemaVersion: '2.0' }),
+    );
+    // Corrupt registry: unreadable as JSON. resolveEnabledPluginRoot must fail
+    // open (null) — never abort a normal upgrade over a damaged registry file.
+    mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'plugins', 'installed_plugins.json'), '{ not valid json');
+    const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+    assert.equal(
+      r.status,
+      0,
+      `--apply must not abort on a corrupt registry: ${r.stderr}\n${r.stdout}`,
+    );
+    const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    assert.equal(
+      meta.pkgRoot,
+      pluginRoot,
+      'a corrupt registry must preserve the existing usable pointer untouched',
+    );
+    assert.equal(meta.pkgVersion, '1.3.0');
+    assert.match(
+      r.stdout,
+      /plugin-owned \(preserved/,
+      'corrupt registry must report preserved, not corrected',
+    );
+  });
+});
+
+test('partial registry: enabled key absent from installed_plugins.json → preserved, no abort', () => {
+  withDualInstall(true, ({ upgrade, home, wiki }) => {
+    const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+    const pluginRoot = '/some/.claude/plugins/cache/mp/hypomnema/1.3.0';
+    writeFileSync(
+      pkgPath,
+      JSON.stringify({ pkgRoot: pluginRoot, pkgVersion: '1.3.0', schemaVersion: '2.0' }),
+    );
+    // Well-formed registry, but no entry for the enabled key (a different
+    // marketplace/name is installed) — must not be treated as a positive match.
+    writeRegistry(home, 'some-other-plugin@mp', '/irrelevant/root');
+    const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+    assert.equal(
+      r.status,
+      0,
+      `--apply must not abort on a registry with no matching entry: ${r.stderr}`,
+    );
+    const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    assert.equal(
+      meta.pkgRoot,
+      pluginRoot,
+      'no usable entry for the enabled key must preserve the existing pointer untouched',
+    );
+  });
+});
+
+test('correction preserves unrelated existing metadata (commands map, extensions)', () => {
+  withDualInstall(true, ({ upgrade, home, wiki }) => {
+    withRegistryRoot('9.9.9', (registryRoot) => {
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      writeFileSync(
+        pkgPath,
+        JSON.stringify({
+          pkgRoot: '/old/npm/root',
+          pkgVersion: '1.0.0',
+          schemaVersion: '2.0',
+          commands: { 'resume.md': 'deadbeef' },
+          extensions: { claude: { 'x.mjs': 'cafe' } },
+        }),
+      );
+      writeRegistry(home, DUAL_INSTALL_KEY, registryRoot);
+      const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+      assert.equal(r.status, 0, `--apply should exit 0: ${r.stderr}`);
+      const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      assert.equal(realpathSync(meta.pkgRoot), realpathSync(registryRoot));
+      assert.equal(meta.pkgVersion, '9.9.9');
+      // Unlike writePluginModeMetadata (true plugin mode), a dualSkip provenance
+      // correction is NOT plugin-mode cleanup — it must not drop the commands map
+      // or touch unrelated fields, since the identity being written is the OTHER
+      // (plugin) install's, not this npm run's.
+      assert.deepEqual(
+        meta.commands,
+        { 'resume.md': 'deadbeef' },
+        'a dualSkip correction must preserve an existing commands map, unlike plugin-mode metadata writes',
+      );
+      assert.deepEqual(
+        meta.extensions,
+        { claude: { 'x.mjs': 'cafe' } },
+        'extensions must be preserved',
+      );
+    });
+  });
+});
+
+// ── writeDualSkipProvenance TOCTOU refusal (lib/pkg-json.mjs) ───────────────
+// resolveEnabledPluginRoot proves registryRoot usable via a SEPARATE, earlier
+// read; the writer re-reads registryRoot's package.json at write time and must
+// refuse (not stamp a new pkgRoot with a stale/missing version) if that root
+// stops being usable by the time the write actually happens. Unit-tested
+// directly against the shared lib function — deterministic, no timing race
+// needed — since upgrade.mjs itself has no exported surface to spawn this
+// exact boundary condition end-to-end.
+
+suite('lib/pkg-json.mjs — writeDualSkipProvenance TOCTOU refusal');
+
+function withPkgJsonFixture(seeded, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-pkgjson-'));
+  try {
+    const pkgPath = join(dir, 'hypo-pkg.json');
+    if (seeded !== null) writeFileSync(pkgPath, JSON.stringify(seeded));
+    fn(pkgPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('registry root unreadable at write time: refuses, preserves existing metadata, returns false', () => {
+  withPkgJsonFixture(
+    { pkgRoot: '/old/npm/root', pkgVersion: '1.0.0', schemaVersion: '2.0' },
+    (pkgPath) => {
+      const before = readFileSync(pkgPath, 'utf-8');
+      // A registryRoot whose package.json cannot be read at write time — the
+      // exact TOCTOU shape: something resolved this root as usable earlier,
+      // but by the time the writer re-reads it, it no longer is.
+      const result = writeDualSkipProvenance(pkgPath, '/nonexistent/registry/root');
+      assert.equal(
+        result,
+        false,
+        'must refuse (return false), not write a stale-version correction',
+      );
+      assert.equal(
+        readFileSync(pkgPath, 'utf-8'),
+        before,
+        'a refused correction must leave the existing metadata byte-identical',
+      );
+    },
+  );
+});
+
+test('registry root package.json is corrupt JSON at write time: refuses, preserves existing metadata', () => {
+  const registryDir = mkdtempSync(join(tmpdir(), 'hypo-registry-corrupt-'));
+  try {
+    writeFileSync(join(registryDir, 'package.json'), '{ not valid json');
+    withPkgJsonFixture(
+      { pkgRoot: '/old/npm/root', pkgVersion: '1.0.0', schemaVersion: '2.0' },
+      (pkgPath) => {
+        const before = readFileSync(pkgPath, 'utf-8');
+        const result = writeDualSkipProvenance(pkgPath, registryDir);
+        assert.equal(
+          result,
+          false,
+          'corrupt package.json at the registry root must refuse the correction',
+        );
+        assert.equal(readFileSync(pkgPath, 'utf-8'), before, 'existing metadata must be untouched');
+      },
+    );
+  } finally {
+    rmSync(registryDir, { recursive: true, force: true });
+  }
+});
+
+test('registry root package.json has no usable version at write time: refuses', () => {
+  const registryDir = mkdtempSync(join(tmpdir(), 'hypo-registry-noversion-'));
+  try {
+    writeFileSync(join(registryDir, 'package.json'), JSON.stringify({ name: 'hypomnema' }));
+    withPkgJsonFixture(
+      { pkgRoot: '/old/npm/root', pkgVersion: '1.0.0', schemaVersion: '2.0' },
+      (pkgPath) => {
+        const before = readFileSync(pkgPath, 'utf-8');
+        const result = writeDualSkipProvenance(pkgPath, registryDir);
+        assert.equal(result, false, 'a version-less package.json must refuse the correction');
+        assert.equal(readFileSync(pkgPath, 'utf-8'), before);
+      },
+    );
+  } finally {
+    rmSync(registryDir, { recursive: true, force: true });
+  }
+});
+
+test('registry root usable at write time: writes the correction and returns true', () => {
+  const registryDir = mkdtempSync(join(tmpdir(), 'hypo-registry-ok-'));
+  try {
+    writeFileSync(
+      join(registryDir, 'package.json'),
+      JSON.stringify({ name: 'hypomnema', version: '9.9.9' }),
+    );
+    withPkgJsonFixture(
+      {
+        pkgRoot: '/old/npm/root',
+        pkgVersion: '1.0.0',
+        schemaVersion: '2.0',
+        extensions: { claude: {} },
+      },
+      (pkgPath) => {
+        const result = writeDualSkipProvenance(pkgPath, registryDir);
+        assert.equal(result, true, 'a usable registry root must be written');
+        const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        assert.equal(meta.pkgRoot, registryDir);
+        assert.equal(meta.pkgVersion, '9.9.9');
+        assert.deepEqual(meta.extensions, { claude: {} }, 'unrelated fields must be preserved');
+      },
+    );
+  } finally {
+    rmSync(registryDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
# English

## What changed

In a dual install, `hypo upgrade` now re-resolves the durable plugin root from the plugin registry (the same positive lookup `init` uses) instead of trusting the recorded pointer unconditionally. When the registry resolves a usable root that differs from what is recorded, the dualSkip path corrects `hypo-pkg.json`; when the registry is unavailable or corrupt, it preserves the recorded pointer and never aborts.

## Why

A dual install happens when someone runs a manual or npm `init` while the Hypomnema plugin is enabled. If the npm install came first, `hypo-pkg.json` recorded the npm root. The dualSkip path then preserved that pointer on every upgrade, so the runtime hooks kept resolving through the npm root the dual-install notice explicitly tells the user to uninstall. `init` already defeats this by re-resolving from the registry; `upgrade` did not, so the two disagreed on the same fact.

## How

`resolveEnabledPluginRoot` (and its `usablePkgRoot` helper) moved into `scripts/lib/plugin-detect.mjs`, already shared by `init` and `upgrade`; `init` imports it and its `registry → recorded → PKG_ROOT` fallback chain is unchanged. The dualSkip apply path corrects only when the registry positively resolves a usable root that differs from the recorded one; a null lookup preserves the recorded pointer and never falls back to `PKG_ROOT` or aborts. Correction goes through a narrow provenance writer that overwrites only `pkgRoot`/`pkgVersion` and preserves every other field. That writer re-reads the registry root's own `package.json` version at write time and refuses the correction (writing nothing) if it cannot, so a report never claims "corrected" with a mismatched or missing version. The drift check surfaces a correctable divergence even when the recorded pointer happens to match this run's own root, instead of misreporting it as up to date.

## Manual verification

Covered by the test suite (`node tests/runner.mjs --file=upgrade,init`): npm-first correction (including the dry-run preview and the case where the recorded pointer equals this run's own root), no-churn when already correct, corrupt or partial registry preserving the pointer without aborting, `PKG_ROOT` fallback, and preservation of unrelated metadata across a correction. A dedicated `lib/pkg-json.mjs` suite exercises the write-time version-refusal path directly. Both blocking regressions (the suppressed-drift case and the write-time TOCTOU) were proven red before the fix. The 15 failing tests in that run are a pre-existing worktree-only artifact (`.git` is a file, not a directory) and pass on a normal checkout and in CI.

## Migration notes

None for correct installs. On the next `hypo upgrade`, an npm-first dual install whose recorded root diverges from the enabled plugin root is reported as correctable and fixed on `--apply`.

---

# 한국어

## 변경 내용

dual install에서 `hypo upgrade`가 이제 기록된 포인터를 무조건 신뢰하지 않고, 플러그인 registry에서 durable plugin root를 다시 resolve한다(`init`이 쓰는 것과 같은 positive 조회). registry가 기록과 다른 usable root를 resolve하면 dualSkip 경로가 `hypo-pkg.json`을 정정하고, registry가 없거나 손상됐으면 기록된 포인터를 보존하며 abort하지 않는다.

## 이유

dual install은 Hypomnema 플러그인이 켜진 상태에서 수동/npm `init`을 돌릴 때 생긴다. npm 설치가 먼저였다면 `hypo-pkg.json`이 npm root를 기록한다. 그러면 dualSkip 경로가 매 upgrade마다 그 포인터를 보존해서, 런타임 훅이 dual-install 안내가 "uninstall하라"고 명시한 npm root를 계속 가리켰다. `init`은 registry 재resolve로 이미 이걸 막는데 `upgrade`는 안 막아, 같은 사실을 두 경로가 다르게 판단했다.

## 방법

`resolveEnabledPluginRoot`(와 `usablePkgRoot` 헬퍼)를 이미 `init`·`upgrade`가 공유하는 `scripts/lib/plugin-detect.mjs`로 옮겼다. `init`은 이를 import하고 `registry → recorded → PKG_ROOT` fallback 체인은 그대로다. dualSkip apply 경로는 registry가 기록과 다른 usable root를 positively resolve할 때만 정정하고, null 조회면 기록된 포인터를 보존하며 `PKG_ROOT` fallback도 abort도 하지 않는다. 정정은 `pkgRoot`/`pkgVersion`만 덮고 나머지 필드는 보존하는 좁은 provenance writer를 거친다. 이 writer는 write 시점에 registry root 자신의 `package.json` 버전을 재읽기하고, 못 하면 정정을 거절(아무것도 안 씀)해서, 어긋나거나 없는 버전으로 "corrected"를 보고하는 일이 없다. drift 검사는 기록된 포인터가 이번 실행의 root와 우연히 같아도 정정 가능한 divergence를 up-to-date로 오보고하지 않고 드러낸다.

## 수동 검증

테스트 스위트가 커버한다(`node tests/runner.mjs --file=upgrade,init`): npm-first 정정(dry-run 프리뷰와 기록 포인터가 이번 실행 root와 같은 케이스 포함), 이미 맞으면 no-churn, corrupt/partial registry에서 포인터 보존·미abort, `PKG_ROOT` fallback, 정정 시 무관 metadata 보존. 별도 `lib/pkg-json.mjs` 스위트가 write 시점 버전-거절 경로를 직접 검증한다. 두 blocking 회귀(억제된 drift, write 시점 TOCTOU)는 수정 전 red로 증명했다. 그 실행의 실패 15건은 worktree 전용 아티팩트(`.git`이 디렉터리가 아니라 파일)이고 정상 체크아웃·CI에서는 통과한다.

## 마이그레이션 노트

정상 설치는 없음. 다음 `hypo upgrade`에서, 기록된 root가 활성 플러그인 root와 어긋난 npm-first dual install은 정정 가능으로 보고되고 `--apply` 시 고쳐진다.

---

## Changelog

- EN: Fix `hypo upgrade` in a dual install preserving a stale npm-first `pkgRoot`: the dualSkip path now re-resolves the plugin root from the registry and corrects `hypo-pkg.json` when it diverges, preserving it when the registry is unavailable (#217).
- KO: dual install에서 `hypo upgrade`가 오래된 npm-first `pkgRoot`를 보존하던 문제 수정: dualSkip 경로가 registry에서 플러그인 root를 다시 resolve해 어긋나면 `hypo-pkg.json`을 정정하고, registry가 없으면 보존한다 (#217).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
