### PR TITLE
test(hypo-ignore): guard the scan-only/privacy split at the call sites

### DIFF
--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -13,6 +13,7 @@ import { parseFrontmatter as libParseFrontmatter } from '../scripts/lib/frontmat
 import { test, suite } from './harness.mjs';
 import {
   HOME,
+  REPO,
   SCRIPTS,
   SESSION_TMP_HOME,
   findDesignHistoryStale,
@@ -1204,6 +1205,48 @@ test('cache key normalizes "." and "./" to the same absolute vault (no duplicate
   } finally {
     process.chdir(originalCwd);
     rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+// The A안 split only holds if privacy-relevant callers never reach for the
+// scan-only functions. The hole this guards is a gate loading .hyposcanignore
+// patterns IN PLACE OF .hypoignore ones, which would let a user-authored scan
+// pattern punch through the secret gate. (Using isScanIgnored in a reject-style
+// gate would over-block, not leak — annoying, but not a privacy failure.)
+//
+// Most hooks are structurally immune: hooks cannot import scripts/ (one-way
+// dependency direction), so hooks/hypo-shared.mjs carries its own
+// isIgnored/loadHypoIgnore with no scan variant. hooks/hypo-pre-commit.mjs is
+// the one hook that imports scripts/lib/hypo-ignore.mjs directly. installHooks
+// does copy it into ~/.claude/hooks/ along with every other hooks/*.mjs, but
+// that copy is never the one that runs: the wiki's git pre-commit shim executes
+// the package-root worker (scripts/init.mjs, wikiPreCommitContent), where
+// scripts/ sits alongside and the import resolves. So it can reach
+// isScanIgnored and has to be checked here. scripts/ingest.mjs,
+// scripts/capture.mjs, and scripts/lib/extensions.mjs are the other places a
+// privacy decision gets made; none of the four may touch the scan-only pair.
+const SCAN_IGNORE_CALLER_GUARD_FILES = [
+  'hooks/hypo-pre-commit.mjs',
+  'scripts/ingest.mjs',
+  'scripts/capture.mjs',
+  'scripts/lib/extensions.mjs',
+];
+
+test('privacy-relevant files never reference isScanIgnored/loadScanIgnore (scan-only stays scan-only)', () => {
+  for (const rel of SCAN_IGNORE_CALLER_GUARD_FILES) {
+    const code = readFileSync(join(REPO, rel), 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
+    // Match the bare identifier, not `name(`: an aliased import
+    // (`import { isScanIgnored as si }`) or a passed reference
+    // (`someFilter(isScanIgnored)`) reaches the same file and a call-shaped
+    // regex would wave both through. Comments are stripped above, so a doc
+    // comment naming the function stays legal.
+    assert.equal(
+      /\b(isScanIgnored|loadScanIgnore)\b/.test(code),
+      false,
+      `${rel} must not reference the scan-only .hyposcanignore functions`,
+    );
   }
 });
 


### PR DESCRIPTION
# English

## What changed

Adds one test that scans the four files where a privacy decision is made and fails if any of them references `isScanIgnored` or `loadScanIgnore`.

Guarded: `hooks/hypo-pre-commit.mjs`, `scripts/ingest.mjs`, `scripts/capture.mjs`, `scripts/lib/extensions.mjs`. Test only, no production code touched.

## Why

`.hyposcanignore` and `.hypoignore` do deliberately different jobs. The scan-only list widens what a catalog scan skips (lint, graph, stats, query, verify, doctor); the privacy list drives the wiki pre-commit secret gate and `ingest --check`. The dangerous direction is a gate loading scan-only patterns in place of privacy ones, because a user-authored scan pattern would then punch a hole in the secret gate.

That invariant was held by three code comments in `scripts/lib/hypo-ignore.mjs` and one behavioral test comparing `isIgnored` against `isScanIgnored`. Nothing checked the call sites. Someone adding a gate later and reaching for the wrong ignore loader would have shipped green, and the comments only reach whoever happens to open that one module.

## How

Follows the existing apply-path hook scan in `tests/proposal-base.test.mjs`: strip block and line comments, then assert the forbidden identifiers do not appear in the executable text. Naming a function in prose stays legal.

Two details worth calling out:

The regex matches the bare identifier (`\bisScanIgnored\b`), not a call shape. A call-shaped pattern would wave through an aliased import (`import { isScanIgnored as si }`) and a passed reference (`someFilter(isScanIgnored)`), both of which reach the same file. Comments are already stripped, so widening it costs no false positives across these four files.

The guard list is four files because the rest of the hooks are structurally immune. Hooks cannot import from `scripts/` (one-way dependency direction), so `hooks/hypo-shared.mjs` carries its own `isIgnored` and `loadHypoIgnore` with no scan variant at all. `hooks/hypo-pre-commit.mjs` is the one hook importing `scripts/lib/hypo-ignore.mjs` directly: `installHooks` does copy it into `~/.claude/hooks/` with every other hook file, but that copy never runs. The wiki's git pre-commit shim executes the package-root worker, where `scripts/` sits alongside and the import resolves. `scripts/crystallize.mjs`, `rename.mjs`, and `graph.mjs` are excluded on purpose: they consume `loadHypoIgnore` as the privacy half of a catalog scan, not as an admit-or-reject decision.

## Manual verification

No hook, `hooks/hypo-shared.mjs`, template, or init flow was changed, so no real-session run is required. The new test was proven red in both forms it is meant to catch, and reverted clean each time:

```
# direct call (caught by the old call-shaped regex too)
$ printf '\nconst _probe = isScanIgnored(1);\n' >> scripts/ingest.mjs
$ node tests/runner.mjs --grep="scan-only stays scan-only"
  ✗ scripts/ingest.mjs must not reference the scan-only .hyposcanignore functions

# aliased import (the old regex passed this; the widened one does not)
$ printf '\nimport { isScanIgnored as si } from "./lib/hypo-ignore.mjs";\n' >> scripts/capture.mjs
$ node tests/runner.mjs --grep="scan-only stays scan-only"
  ✗ scripts/capture.mjs must not reference the scan-only .hyposcanignore functions

# a comment naming the function does not trip it
$ node tests/runner.mjs --file=lint
  123 passed, 0 failed
```

Full suite: `1699 passed, 0 failed (70.6s)`. `npm run lint`: 0 errors.

## Migration notes

None.

---

# 한국어

## 변경 내용

프라이버시 판단이 일어나는 4개 파일을 스캔해 `isScanIgnored`나 `loadScanIgnore`를 참조하면 실패하는 테스트 1개를 추가한다.

대상: `hooks/hypo-pre-commit.mjs`, `scripts/ingest.mjs`, `scripts/capture.mjs`, `scripts/lib/extensions.mjs`. 테스트만 추가하고 제품 코드는 건드리지 않는다.

## 이유

`.hyposcanignore`와 `.hypoignore`는 일부러 다른 일을 한다. 스캔 전용 목록은 카탈로그 스캔이 건너뛸 범위를 넓히고(lint, graph, stats, query, verify, doctor), 프라이버시 목록은 위키 pre-commit 시크릿 게이트와 `ingest --check`를 움직인다. 위험한 방향은 게이트가 프라이버시 패턴 대신 스캔 전용 패턴을 로드하는 쪽이다. 그러면 사용자가 적어 넣은 스캔 패턴이 시크릿 게이트에 구멍을 낸다.

이 불변식을 지키던 건 `scripts/lib/hypo-ignore.mjs`의 주석 3곳과, `isIgnored`와 `isScanIgnored`의 동작을 비교하는 테스트 1개뿐이었다. 호출부를 검사하는 것은 없었다. 나중에 게이트를 만들며 잘못된 ignore 로더를 집어도 테스트는 전부 통과했을 것이고, 주석은 그 모듈을 열어본 사람에게만 닿는다.

## 방법

`tests/proposal-base.test.mjs`에 이미 있는 apply 경로 훅 스캔을 그대로 따른다. 블록 주석과 라인 주석을 벗겨낸 뒤 실행 코드에 금지 식별자가 없는지 확인한다. 문서 주석에서 함수 이름을 언급하는 것은 그대로 허용된다.

짚어둘 게 두 가지다.

정규식은 호출 형태가 아니라 식별자 자체(`\bisScanIgnored\b`)를 본다. 호출 형태로 잡으면 별칭 import(`import { isScanIgnored as si }`)와 참조 전달(`someFilter(isScanIgnored)`)이 빠져나가는데, 둘 다 같은 파일에 손이 닿는다. 주석은 이미 제거한 뒤라 이 4개 파일에서 범위를 넓혀도 오탐이 생기지 않는다.

대상이 4개인 건 나머지 훅이 구조적으로 이미 면역이기 때문이다. 훅은 `scripts/`를 import할 수 없어서(단방향 의존) `hooks/hypo-shared.mjs`가 `isIgnored`와 `loadHypoIgnore`를 자체 구현으로 갖고 있고 거기엔 스캔 변종이 아예 없다. `hooks/hypo-pre-commit.mjs`만 `scripts/lib/hypo-ignore.mjs`를 직접 import한다. `installHooks`가 다른 훅 파일과 함께 이 파일도 `~/.claude/hooks/`로 복사하기는 하지만 그 사본은 실행되지 않는다. 위키의 git pre-commit shim은 패키지 루트의 워커를 실행하고, 거기에는 `scripts/`가 옆에 있어 import가 풀린다. `scripts/crystallize.mjs`, `rename.mjs`, `graph.mjs`는 의도적으로 제외했다. 이들은 `loadHypoIgnore`를 카탈로그 스캔의 프라이버시 쪽 절반으로 쓸 뿐, 허용/거부를 판단하지 않는다.

## 수동 검증

훅, `hooks/hypo-shared.mjs`, 템플릿, init 흐름을 바꾸지 않았으므로 실제 세션 실행은 필요 없다. 새 테스트는 잡아야 할 두 형태 모두에서 red임을 증명했고, 매번 원복해 확인했다.

```
# 직접 호출 (구 정규식으로도 잡히던 형태)
$ printf '\nconst _probe = isScanIgnored(1);\n' >> scripts/ingest.mjs
$ node tests/runner.mjs --grep="scan-only stays scan-only"
  ✗ scripts/ingest.mjs must not reference the scan-only .hyposcanignore functions

# 별칭 import (구 정규식은 통과시켰고, 넓힌 쪽은 잡는다)
$ printf '\nimport { isScanIgnored as si } from "./lib/hypo-ignore.mjs";\n' >> scripts/capture.mjs
$ node tests/runner.mjs --grep="scan-only stays scan-only"
  ✗ scripts/capture.mjs must not reference the scan-only .hyposcanignore functions

# 함수 이름을 언급하는 주석은 걸리지 않는다
$ node tests/runner.mjs --file=lint
  123 passed, 0 failed
```

전체 스위트: `1699 passed, 0 failed (70.6s)`. `npm run lint`: 0 error.

## 마이그레이션 노트

None.

---

## Changelog

- EN: None (test-only change, no user-visible effect)
- KO: None (테스트 전용 변경, 사용자에게 보이는 변화 없음)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
