### PR TITLE
fix(init,doctor): resolve the git hooks dir from git instead of guessing .git/hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "scripts/lib/failure-type.mjs",
     "scripts/lib/feedback-scope.mjs",
     "scripts/lib/frontmatter.mjs",
+    "scripts/lib/git-hooks-dir.mjs",
     "scripts/lib/hypo-ignore.mjs",
     "scripts/lib/hypo-root.mjs",
     "scripts/lib/page-usage.mjs",

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -19,6 +19,7 @@ import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
+import { resolveGitHooksDir } from './lib/git-hooks-dir.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import {
   readSyncState,
@@ -450,19 +451,57 @@ function checkGit(hypoDir) {
     warn('Git remote origin', 'No remote configured — wiki will not sync/backup automatically');
   }
 
-  const preCommitPath = join(hypoDir, '.git', 'hooks', 'pre-commit');
+  // Ask git for the ACTIVE hooks dir rather than assuming <repo>/.git/hooks —
+  // that guess is wrong in a linked worktree (`.git` is a file) and whenever
+  // core.hooksPath is set, and reporting "not installed" for either would be a
+  // false negative. Read-side policy differs from the installer's: doctor
+  // reports a hooks dir it would refuse to WRITE into, so the user can see it.
+  const resolved = resolveGitHooksDir(hypoDir);
+  if (!resolved.ok) {
+    const detail =
+      resolved.reason === 'hooks-disabled'
+        ? `Hooks path is not a directory (${resolved.path}) — git runs no hooks, so the .hypoignore guard cannot run`
+        : `Could not resolve the git hooks directory (${resolved.detail || resolved.reason})`;
+    warn('git hooks/pre-commit', detail);
+    return;
+  }
+
+  const preCommitPath = join(resolved.path, 'pre-commit');
+  const label = resolved.owned ? 'git hooks/pre-commit' : `pre-commit (${resolved.path})`;
+  let content = null;
+  let unreadable = null;
   if (existsSync(preCommitPath)) {
-    const content = readFileSync(preCommitPath, 'utf-8');
-    if (content.includes('# hypo-managed:pre-commit:start')) {
-      pass('.git/hooks/pre-commit', 'Hypomnema .hypoignore guard installed');
-    } else {
-      warn(
-        '.git/hooks/pre-commit',
-        'Exists but not managed by Hypomnema — manual git add can bypass .hypoignore',
-      );
+    try {
+      content = readFileSync(preCommitPath, 'utf-8');
+    } catch (e) {
+      unreadable = e.code || e.message;
     }
+  }
+
+  if (unreadable) {
+    warn(label, `Exists but could not be read (${unreadable})`);
+  } else if (content === null) {
+    // Telling the user to run /hypo:init here would contradict the ownership
+    // warning below, which says it will refuse this very path.
+    warn(
+      label,
+      resolved.owned
+        ? 'Not installed — run /hypo:init to install .hypoignore guard'
+        : 'Not installed, and /hypo:init will not install into this path — point core.hooksPath back inside the repository, or install the guard yourself',
+    );
+  } else if (content.includes('# hypo-managed:pre-commit:start')) {
+    pass(label, 'Hypomnema .hypoignore guard installed');
   } else {
-    warn('.git/hooks/pre-commit', 'Not installed — run /hypo:init to install .hypoignore guard');
+    warn(label, 'Exists but not managed by Hypomnema — manual git add can bypass .hypoignore');
+  }
+
+  // Reported even when the hook above was unreadable — an unreadable hook is
+  // exactly when knowing WHERE git looks matters most.
+  if (!resolved.owned) {
+    warn(
+      'core.hooksPath',
+      `Points outside this repository (${resolved.path}) — /hypo:init will not install there`,
+    );
   }
 }
 

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -38,6 +38,7 @@ import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { expandHome, resolveHypoRoot } from './lib/hypo-root.mjs';
+import { hooksDirForInstall, unsafeHookTargetReason } from './lib/git-hooks-dir.mjs';
 import { readCoreHooksConfig } from './lib/core-hooks.mjs';
 import {
   readPkgJson as readPkgJsonSafe,
@@ -693,10 +694,19 @@ function installCommands(targetDir, dryRun, force) {
 }
 
 function installPkgGitHook(dryRun) {
-  const gitDir = join(PKG_ROOT, '.git');
-  if (!existsSync(gitDir)) return;
-  const hooksDir = join(gitDir, 'hooks');
+  const { dir: hooksDir, skip } = hooksDirForInstall(PKG_ROOT);
+  if (!hooksDir) {
+    if (skip) log('skipped', `${PKG_ROOT} post-commit (${skip})`);
+    return;
+  }
   const hookPath = join(hooksDir, 'post-commit');
+  // Checked before existsSync: a dangling symlink reads as absent there, and
+  // writing would create its external target.
+  const unsafe = unsafeHookTargetReason(hookPath);
+  if (unsafe) {
+    log('skipped', `${hookPath} (${unsafe})`);
+    return;
+  }
   if (existsSync(hookPath)) {
     log('skipped', hookPath);
     return;
@@ -758,11 +768,22 @@ function wikiPreCommitContent(root, hypoDir, lintStrict) {
 }
 
 function installWikiPreCommitHook(hypoDir, dryRun, force, root, lintStrict) {
-  const gitDir = join(hypoDir, '.git');
-  if (!existsSync(gitDir)) return; // no git repo — silently skip
-  const hooksDir = join(gitDir, 'hooks');
+  const { dir: hooksDir, skip } = hooksDirForInstall(hypoDir);
+  if (!hooksDir) {
+    // no git repo — silently skip, as before; anything else is worth surfacing
+    if (skip) log('skipped', `${hypoDir} pre-commit (${skip})`);
+    return;
+  }
   const hookPath = join(hooksDir, 'pre-commit');
   const newContent = wikiPreCommitContent(root, hypoDir, lintStrict);
+
+  // Before every branch below, including --force: a symlink here would send the
+  // write through to an arbitrary external file.
+  const unsafe = unsafeHookTargetReason(hookPath);
+  if (unsafe) {
+    log('skipped', `${hookPath} (${unsafe})`);
+    return;
+  }
 
   if (existsSync(hookPath)) {
     const existing = readFileSync(hookPath, 'utf-8');
@@ -777,8 +798,18 @@ function installWikiPreCommitHook(hypoDir, dryRun, force, root, lintStrict) {
       }
       log('merged', `${hookPath} (pre-commit updated)`);
     } else if (force) {
+      // The .bak is a SECOND write to a DIFFERENT path, so the guard on
+      // hookPath above says nothing about it. Left unchecked, a pre-commit.bak
+      // symlink turns --force-commands into an overwrite of whatever it points
+      // at — deterministically, not as a race.
+      const bakPath = hookPath + '.bak';
+      const unsafeBak = unsafeHookTargetReason(bakPath);
+      if (unsafeBak) {
+        log('skipped', `${bakPath} (${unsafeBak}) — not force-overwriting without a safe backup`);
+        return;
+      }
       if (!dryRun) {
-        writeFileSync(hookPath + '.bak', existing);
+        writeFileSync(bakPath, existing);
         writeFileSync(hookPath, newContent);
         chmodSync(hookPath, 0o755);
       }

--- a/scripts/lib/git-hooks-dir.mjs
+++ b/scripts/lib/git-hooks-dir.mjs
@@ -1,0 +1,229 @@
+/**
+ * Resolve a repository's active git hooks directory by asking git, never by
+ * assuming the on-disk layout.
+ *
+ * The layout assumption this replaces (`join(root, '.git', 'hooks')`) is wrong
+ * in two ways that both showed up in practice:
+ *
+ *   1. In a linked worktree `.git` is a regular FILE holding `gitdir: <path>`,
+ *      so `existsSync` passes and `mkdirSync` dies with ENOTDIR.
+ *   2. When `core.hooksPath` is set, git does not read `.git/hooks` at all, so
+ *      a hook written there is inert.
+ *
+ * `git rev-parse --git-path hooks` handles both: it follows the worktree's
+ * gitdir pointer AND substitutes `core.hooksPath` (verified on git 2.50.1 —
+ * `/dev/null` stays `/dev/null`, a relative value stays relative, and `~` is
+ * expanded). That makes rev-parse the single authority here; reading
+ * `core.hooksPath` out of the config ourselves would be strictly worse, since
+ * it would leave `~` unexpanded and could not tell an empty-but-set value from
+ * an unset one.
+ *
+ * Two things rev-parse does NOT give us, so we add them:
+ *
+ *   - `git -C <root>` does not neutralize ambient git environment variables.
+ *     `GIT_DIR` + `GIT_WORK_TREE` redirect the probe at a foreign repository,
+ *     and `GIT_CONFIG_COUNT`/`GIT_CONFIG_PARAMETERS` redirect it at an
+ *     arbitrary hooks path. Every probe therefore runs under a scrubbed env,
+ *     with the scrub list taken from git's own `--local-env-vars` when
+ *     available.
+ *   - `core.hooksPath` may point at a directory SHARED by many repositories
+ *     (the documented centralized-hooks pattern). Auto-installing there would
+ *     put our hook in front of unrelated repositories' commits, and our
+ *     post-commit executes `$REPO_ROOT/scripts/upgrade.mjs` dynamically. So the
+ *     result carries an `owned` flag, and callers that WRITE must refuse when
+ *     it is false. Callers that only READ (doctor) may report the path.
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, lstatSync, realpathSync, statSync } from 'fs';
+import { basename, dirname, isAbsolute, join, resolve, sep } from 'path';
+
+// Fallback scrub list for git versions without `rev-parse --local-env-vars`.
+// Mirrors scripts/install-git-hooks.mjs, which established this trust model.
+const STATIC_LOCAL_ENV_VARS = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
+  'GIT_CONFIG',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_PREFIX',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_GRAFT_FILE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_SHALLOW_FILE',
+];
+
+function buildScrubbedEnv(localEnvList) {
+  const scrub = new Set([
+    ...(localEnvList || STATIC_LOCAL_ENV_VARS),
+    'GIT_NAMESPACE',
+    'GIT_CEILING_DIRECTORIES',
+    // GIT_CONFIG_COUNT / GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n inject config
+    // wholesale and are not always listed by --local-env-vars.
+    ...Object.keys(process.env).filter((k) => /^GIT_CONFIG_/.test(k)),
+  ]);
+  return Object.fromEntries(Object.entries(process.env).filter(([k]) => !scrub.has(k)));
+}
+
+// Canonicalize a path that may not exist yet: realpath the deepest existing
+// ancestor and re-append the rest. Without this, a hooks dir git will create
+// lazily could evade the containment check via an unresolved symlinked parent.
+function canonicalize(p) {
+  let cur = resolve(p);
+  const tail = [];
+  for (;;) {
+    try {
+      return join(realpathSync(cur), ...tail);
+    } catch {
+      const parent = dirname(cur);
+      if (parent === cur) return resolve(p); // hit the root; nothing to resolve
+      // basename, not a slice: when the parent IS the root it already ends in a
+      // separator, so `parent.length + 1` would eat the first real character
+      // ("/Nope/x" -> "ope/x") and could rewrite an external path into one that
+      // looks repository-owned.
+      tail.unshift(basename(cur));
+      cur = parent;
+    }
+  }
+}
+
+function isInside(child, parent) {
+  return child === parent || child.startsWith(parent + sep);
+}
+
+/**
+ * @param {string} repoRoot        working tree root to probe
+ * @param {{timeoutMs?: number}} [opts]
+ * @returns {{ok: true, path: string, owned: boolean, gitDir: string, commonDir: string}
+ *          |{ok: false, reason: string, detail?: string, path?: string}}
+ *
+ * Failure reasons are deliberately distinct so callers can react differently:
+ *   not-a-repo        no `.git` entry (also the case for a bare repo — matches
+ *                     the pre-existing behavior of every call site)
+ *   git-unavailable   git is not on PATH / not executable
+ *   probe-failed      git ran but could not resolve the repo (stale `.git`
+ *                     pointer, dubious ownership, timeout, ...)
+ *   hooks-disabled    the active hooks path is `/dev/null` or an existing
+ *                     non-directory — git's documented way to disable hooks
+ */
+export function resolveGitHooksDir(repoRoot, { timeoutMs = 5000 } = {}) {
+  if (!existsSync(join(repoRoot, '.git'))) return { ok: false, reason: 'not-a-repo' };
+
+  let env = buildScrubbedEnv(null);
+  const run = (args) =>
+    execFileSync('git', args, {
+      encoding: 'utf-8',
+      env,
+      cwd: repoRoot,
+      timeout: timeoutMs,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 1024 * 1024,
+    }).trim();
+
+  try {
+    // Enrich the scrub list from git's own truth when this git supports it.
+    try {
+      env = buildScrubbedEnv(run(['rev-parse', '--local-env-vars']).split(/\r?\n/).filter(Boolean));
+    } catch {
+      // Old git without --local-env-vars; the static list already applied.
+    }
+
+    const gitDir = canonicalize(run(['rev-parse', '--absolute-git-dir']));
+    const rawCommon = run(['rev-parse', '--git-common-dir']);
+    // A relative --git-common-dir is relative to the command's cwd, which we
+    // pinned to repoRoot.
+    const commonDir = canonicalize(isAbsolute(rawCommon) ? rawCommon : join(repoRoot, rawCommon));
+    const topLevel = canonicalize(run(['rev-parse', '--show-toplevel']));
+
+    // --path-format is git 2.31+. Fall back to the plain form, whose output is
+    // relative to cwd (= repoRoot) when core.hooksPath is relative.
+    let raw;
+    try {
+      raw = run(['rev-parse', '--path-format=absolute', '--git-path', 'hooks']);
+    } catch {
+      raw = run(['rev-parse', '--git-path', 'hooks']);
+    }
+    if (!raw) return { ok: false, reason: 'probe-failed', detail: 'empty hooks path' };
+
+    const hooksPath = canonicalize(isAbsolute(raw) ? raw : join(repoRoot, raw));
+
+    // git documents core.hooksPath=/dev/null as "disable all hooks". Treat any
+    // existing non-directory the same way rather than failing on mkdir later.
+    if (existsSync(hooksPath) && !statSync(hooksPath).isDirectory()) {
+      return { ok: false, reason: 'hooks-disabled', path: hooksPath };
+    }
+
+    // Repository-owned means: inside this repo's git directory (the normal
+    // `.git/hooks`, and in a linked worktree the shared common dir) or inside
+    // the working tree itself (the `core.hooksPath=.githooks` convention).
+    // Anything else is a location we do not own and must not write into.
+    const owned =
+      isInside(hooksPath, commonDir) ||
+      isInside(hooksPath, gitDir) ||
+      isInside(hooksPath, topLevel);
+
+    return { ok: true, path: hooksPath, owned, gitDir, commonDir };
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return { ok: false, reason: 'git-unavailable' };
+    return { ok: false, reason: 'probe-failed', detail: e && (e.code || e.message) };
+  }
+}
+
+/**
+ * Guard the final hook ENTRY, not just the directory it lives in.
+ *
+ * An owned hooks directory can still contain a symlink pointing anywhere, and
+ * `writeFileSync` follows symlinks. Three ways that escapes the boundary the
+ * directory check appears to establish:
+ *   - a live symlink to an external file gets its TARGET overwritten;
+ *   - if that target happens to carry our managed marker, it is rewritten even
+ *     without --force-commands;
+ *   - a DANGLING symlink reads as absent through `existsSync`, so the "not
+ *     installed yet" path creates the external target outright.
+ * So refuse to write through any symlink, and refuse anything that is not a
+ * regular file. Callers log the reason and move on.
+ *
+ * @returns {null | string} null when writing is safe, else a reason to log
+ */
+export function unsafeHookTargetReason(hookPath) {
+  let st;
+  try {
+    st = lstatSync(hookPath);
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return null; // genuinely absent — safe to create
+    return `cannot stat (${e.code || e.message})`;
+  }
+  if (st.isSymbolicLink()) return 'is a symlink — refusing to write through it';
+  if (!st.isFile()) return 'exists but is not a regular file';
+  return null;
+}
+
+/**
+ * Write-side wrapper: the hooks directory only if it is safe to install into.
+ * Returns `{dir}` when installing is allowed, otherwise `{skip}` carrying a
+ * human-readable reason for the caller to log.
+ */
+export function hooksDirForInstall(repoRoot, opts) {
+  const r = resolveGitHooksDir(repoRoot, opts);
+  if (!r.ok) {
+    if (r.reason === 'not-a-repo') return { skip: null }; // silent, as before
+    if (r.reason === 'hooks-disabled') {
+      // Do not name core.hooksPath here: the same branch fires for a plain
+      // .git/hooks that happens to be a regular file, where no such setting
+      // exists and naming it would send the user hunting for a phantom config.
+      return { skip: `hooks path is not a directory, so git runs no hooks (${r.path})` };
+    }
+    if (r.reason === 'git-unavailable') return { skip: 'git not available on PATH' };
+    return { skip: `could not resolve hooks dir (${r.detail || r.reason})` };
+  }
+  if (!r.owned) {
+    return {
+      skip: `core.hooksPath points outside this repository (${r.path}) — refusing to install into a shared hooks directory`,
+    };
+  }
+  return { dir: r.path };
+}

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -28,6 +28,7 @@ import {
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { resolveGitHooksDir } from './lib/git-hooks-dir.mjs';
 
 const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 const KEEP = process.argv.includes('--keep');
@@ -78,7 +79,13 @@ try {
   // `npm pack` didn't mutate it. The `prepare` lifecycle script runs during
   // `npm pack` and could theoretically touch .git/hooks/pre-commit; the
   // installer's CI/lifecycle guards must prevent that.
-  const preCommitPath = join(REPO, '.git', 'hooks', 'pre-commit');
+  // Resolve the ACTIVE hooks dir. Guessing `.git/hooks` snapshots the wrong
+  // file in a linked worktree (or under core.hooksPath), which would make the
+  // "pack didn't mutate the hook" assertion below vacuously pass.
+  const hooksProbe = resolveGitHooksDir(REPO);
+  const preCommitPath = hooksProbe.ok
+    ? join(hooksProbe.path, 'pre-commit')
+    : join(REPO, '.git', 'hooks', 'pre-commit');
   const preCommitBefore = existsSync(preCommitPath) ? readFileSync(preCommitPath, 'utf-8') : null;
 
   step('npm pack');

--- a/tests/fixtures/npm-pack.files.json
+++ b/tests/fixtures/npm-pack.files.json
@@ -300,6 +300,10 @@
     "exec": false
   },
   {
+    "path": "scripts/lib/git-hooks-dir.mjs",
+    "exec": false
+  },
+  {
     "path": "scripts/lib/hypo-ignore.mjs",
     "exec": false
   },

--- a/tests/git-hooks-dir.test.mjs
+++ b/tests/git-hooks-dir.test.mjs
@@ -1,0 +1,362 @@
+// tests/git-hooks-dir.test.mjs
+//
+// Pins the hooks-directory resolution against the layouts that broke the old
+// `join(root, '.git', 'hooks')` guess: linked worktrees, core.hooksPath in all
+// of its documented forms, and a hostile ambient git environment.
+
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { test, suite } from './harness.mjs';
+import {
+  resolveGitHooksDir,
+  hooksDirForInstall,
+  unsafeHookTargetReason,
+} from '../scripts/lib/git-hooks-dir.mjs';
+import { runWithHome, withTmpHome } from './helpers.mjs';
+
+const git = (cwd, args) => execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+
+// A developer whose own ~/.gitconfig sets core.hooksPath would flip the
+// default-layout expectations below into the external-path case. The resolver
+// deliberately scrubs GIT_CONFIG_* (that injection is the attack it blocks), so
+// hermeticity cannot be forced through the environment. Detect the ambient
+// value instead and assert the layout only when there is none. The ownership
+// and worktree assertions run either way.
+const AMBIENT_HOOKS_PATH = (() => {
+  try {
+    return execFileSync('git', ['config', '--global', '--get', 'core.hooksPath'], {
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    return ''; // exit 1 = key not set
+  }
+})();
+
+function newRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-hooksdir-'));
+  git(dir, ['init', '-q', '.']);
+  git(dir, ['config', 'user.email', 't@example.com']);
+  git(dir, ['config', 'user.name', 'T']);
+  writeFileSync(join(dir, 'f.txt'), 'x\n');
+  git(dir, ['add', 'f.txt']);
+  // --no-verify: building the fixture must not execute a developer's global
+  // hooks. The local core.hooksPath below is set AFTER this commit by the tests
+  // that need it, so it cannot suppress them here.
+  git(dir, ['commit', '-q', '--no-verify', '-m', 'init']);
+  return dir;
+}
+
+suite('git-hooks-dir: layout resolution');
+
+test('plain checkout resolves to the repo .git/hooks and is repo-owned', () => {
+  const repo = newRepo();
+  try {
+    const r = resolveGitHooksDir(repo);
+    assert.equal(r.ok, true);
+    if (!AMBIENT_HOOKS_PATH) {
+      assert.equal(r.owned, true);
+      assert.equal(r.path, join(realpathSync(repo), '.git', 'hooks'));
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// The original defect: in a linked worktree `.git` is a FILE, so the old
+// `join(root,'.git','hooks')` guess produced a path under a regular file and
+// mkdir died with ENOTDIR.
+test('linked worktree resolves to the shared common dir, not <worktree>/.git/hooks', () => {
+  const repo = newRepo();
+  const wt = `${repo}-wt`;
+  try {
+    git(repo, ['worktree', 'add', '-q', '-b', 'wt', wt]);
+    assert.equal(statSync(join(wt, '.git')).isFile(), true, '.git must be a file here');
+
+    const r = resolveGitHooksDir(wt);
+    assert.equal(r.ok, true);
+    assert.equal(r.owned, true);
+    if (!AMBIENT_HOOKS_PATH) assert.equal(r.path, join(r.commonDir, 'hooks'));
+    assert.ok(!r.path.startsWith(join(wt, '.git') + '/'), 'must not point under the .git file');
+
+    // The whole point: the install-side path is usable, i.e. mkdir succeeds.
+    const { dir } = hooksDirForInstall(wt);
+    mkdirSync(dir, { recursive: true });
+    assert.equal(existsSync(dir), true);
+  } finally {
+    rmSync(wt, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('non-repo yields not-a-repo and a silent install skip', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-norepo-'));
+  try {
+    assert.equal(resolveGitHooksDir(dir).reason, 'not-a-repo');
+    const r = hooksDirForInstall(dir);
+    assert.equal(r.dir, undefined);
+    assert.equal(r.skip, null, 'not-a-repo stays silent, as it was before');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+suite('git-hooks-dir: core.hooksPath');
+
+test('relative core.hooksPath resolves inside the worktree and stays owned', () => {
+  const repo = newRepo();
+  try {
+    git(repo, ['config', 'core.hooksPath', '.githooks']);
+    const r = resolveGitHooksDir(repo);
+    assert.equal(r.ok, true);
+    assert.equal(r.owned, true);
+    assert.equal(r.path, join(realpathSync(repo), '.githooks'));
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// git documents core.hooksPath=/dev/null as "disable every hook". The old
+// code would have tried to mkdir under it and thrown a second ENOTDIR.
+test('core.hooksPath=/dev/null reports hooks-disabled instead of throwing', () => {
+  const repo = newRepo();
+  try {
+    git(repo, ['config', 'core.hooksPath', '/dev/null']);
+    const r = resolveGitHooksDir(repo);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'hooks-disabled');
+    const { skip } = hooksDirForInstall(repo);
+    assert.match(skip, /not a directory/);
+    // The same branch fires for a plain .git/hooks that is a regular file, so
+    // the message must not blame a setting that may not exist.
+    assert.doesNotMatch(skip, /core\.hooksPath/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// A hooks dir shared across repositories is a documented pattern, and our
+// post-commit executes $REPO_ROOT/scripts/upgrade.mjs — installing there
+// would run one repo's script from another repo's commit.
+test('core.hooksPath outside the repo resolves but refuses installation', () => {
+  const repo = newRepo();
+  const shared = mkdtempSync(join(tmpdir(), 'hypo-shared-hooks-'));
+  try {
+    git(repo, ['config', 'core.hooksPath', shared]);
+    const r = resolveGitHooksDir(repo);
+    assert.equal(r.ok, true, 'still resolvable — doctor needs to report it');
+    assert.equal(r.owned, false);
+
+    const inst = hooksDirForInstall(repo);
+    assert.equal(inst.dir, undefined, 'must not hand back a shared dir to write into');
+    assert.match(inst.skip, /outside this repository/);
+  } finally {
+    rmSync(shared, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+suite('git-hooks-dir: ambient environment cannot redirect the probe');
+
+// `git -C <root>` does NOT neutralize these; without scrubbing, a stray
+// GIT_DIR/GIT_WORK_TREE in the environment silently retargets resolution at
+// a foreign repository, and GIT_CONFIG_* injects an arbitrary hooks path.
+test('GIT_DIR/GIT_WORK_TREE pointing elsewhere do not move the result', () => {
+  const repo = newRepo();
+  const foreign = newRepo();
+  const saved = { ...process.env };
+  try {
+    process.env.GIT_DIR = join(foreign, '.git');
+    process.env.GIT_WORK_TREE = foreign;
+    const r = resolveGitHooksDir(repo);
+    assert.equal(r.ok, true);
+    assert.ok(!r.path.startsWith(foreign), `resolution leaked into the foreign repo: ${r.path}`);
+    if (!AMBIENT_HOOKS_PATH) assert.equal(r.path, join(r.commonDir, 'hooks'));
+  } finally {
+    for (const k of ['GIT_DIR', 'GIT_WORK_TREE']) delete process.env[k];
+    Object.assign(process.env, saved);
+    rmSync(foreign, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('GIT_CONFIG_COUNT injection cannot set core.hooksPath', () => {
+  const repo = newRepo();
+  const evil = mkdtempSync(join(tmpdir(), 'hypo-evil-hooks-'));
+  const saved = { ...process.env };
+  try {
+    process.env.GIT_CONFIG_COUNT = '1';
+    process.env.GIT_CONFIG_KEY_0 = 'core.hooksPath';
+    process.env.GIT_CONFIG_VALUE_0 = evil;
+    const r = resolveGitHooksDir(repo);
+    assert.equal(r.ok, true);
+    assert.ok(!r.path.startsWith(evil), `injected hooks path was honored: ${r.path}`);
+    if (!AMBIENT_HOOKS_PATH) assert.equal(r.owned, true);
+  } finally {
+    for (const k of ['GIT_CONFIG_COUNT', 'GIT_CONFIG_KEY_0', 'GIT_CONFIG_VALUE_0']) {
+      delete process.env[k];
+    }
+    Object.assign(process.env, saved);
+    rmSync(evil, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+suite('git-hooks-dir: the hook entry itself is guarded, not just its directory');
+
+// writeFileSync follows symlinks, so an owned hooks dir containing a symlinked
+// hook entry would still write to wherever that link points.
+test('a symlinked hook entry is refused', () => {
+  const repo = newRepo();
+  const outside = mkdtempSync(join(tmpdir(), 'hypo-outside-'));
+  const target = join(outside, 'victim.sh');
+  try {
+    writeFileSync(target, 'original\n');
+    const hooks = join(repo, '.git', 'hooks');
+    mkdirSync(hooks, { recursive: true });
+    const link = join(hooks, 'pre-commit');
+    symlinkSync(target, link);
+
+    assert.match(unsafeHookTargetReason(link), /symlink/);
+    assert.equal(readFileSync(target, 'utf-8'), 'original\n', 'target must be untouched');
+  } finally {
+    rmSync(outside, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// A dangling symlink reads as absent through existsSync, so the "not installed
+// yet" branch would have created the external target outright.
+test('a dangling symlink is refused rather than read as absent', () => {
+  const repo = newRepo();
+  const outside = mkdtempSync(join(tmpdir(), 'hypo-outside-'));
+  const target = join(outside, 'not-yet-there.sh');
+  try {
+    const hooks = join(repo, '.git', 'hooks');
+    mkdirSync(hooks, { recursive: true });
+    const link = join(hooks, 'post-commit');
+    symlinkSync(target, link);
+
+    assert.equal(existsSync(link), false, 'existsSync alone would say "absent"');
+    assert.match(unsafeHookTargetReason(link), /symlink/);
+    assert.equal(existsSync(target), false, 'must not have created the external target');
+  } finally {
+    rmSync(outside, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('an absent hook entry is writable, a directory in its place is not', () => {
+  const repo = newRepo();
+  try {
+    const hooks = join(repo, '.git', 'hooks');
+    mkdirSync(hooks, { recursive: true });
+    assert.equal(unsafeHookTargetReason(join(hooks, 'pre-commit')), null);
+
+    mkdirSync(join(hooks, 'post-commit'));
+    assert.match(unsafeHookTargetReason(join(hooks, 'post-commit')), /not a regular file/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// canonicalize() walks up to the deepest existing ancestor. When that ancestor
+// is the filesystem root, a length-based slice ate the first character and
+// could turn an external path into one that looks repository-owned.
+test('a path whose deepest existing ancestor is the root survives canonicalization', () => {
+  const repo = newRepo();
+  try {
+    git(repo, ['config', 'core.hooksPath', '/Nonexistent-hypo-probe-1234/hooks']);
+    const r = resolveGitHooksDir(repo);
+    assert.equal(r.ok, true);
+    assert.equal(r.path, '/Nonexistent-hypo-probe-1234/hooks', 'no character may be dropped');
+    assert.equal(r.owned, false);
+    assert.equal(hooksDirForInstall(repo).dir, undefined);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+suite('git-hooks-dir: init.mjs actually installs into a linked worktree');
+
+// The end-to-end case the module tests cannot prove: reverting the init.mjs
+// integration while keeping the module would leave every other test green.
+//
+// The VAULT is the linked worktree here, deliberately. Pointing this at the
+// package root instead would only exercise the worktree path when the suite
+// itself happens to be running from a worktree, and would prove nothing on a
+// normal CI checkout.
+test('init installs the vault pre-commit hook when the vault is a linked worktree', () => {
+  const repo = newRepo();
+  const wt = `${repo}-wt`;
+  try {
+    git(repo, ['worktree', 'add', '-q', '-b', 'wt', wt]);
+    assert.equal(statSync(join(wt, '.git')).isFile(), true, 'vault .git must be a file');
+
+    withTmpHome((home) => {
+      const r = runWithHome('init.mjs', [`--hypo-dir=${wt}`, '--no-commands'], home);
+      const out = `${r.stdout || ''}${r.stderr || ''}`;
+      assert.ok(!/ENOTDIR/.test(out), `init crashed with ENOTDIR:\n${out}`);
+      assert.equal(r.status, 0, `init exited ${r.status}:\n${out}`);
+
+      // It must land in the shared common dir, which is the whole point.
+      const hookPath = join(repo, '.git', 'hooks', 'pre-commit');
+      assert.equal(existsSync(hookPath), true, `hook not installed at ${hookPath}:\n${out}`);
+      assert.match(readFileSync(hookPath, 'utf-8'), /hypo-managed:pre-commit:start/);
+      assert.equal(existsSync(join(wt, '.git', 'hooks')), false, 'nothing under the .git file');
+    });
+  } finally {
+    rmSync(wt, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+// The .bak is a second write to a different path, so guarding the hook entry
+// says nothing about it. Unguarded, --force-commands overwrote whatever the
+// pre-commit.bak symlink pointed at.
+test('--force-commands does not write the backup through a symlinked .bak', () => {
+  const repo = newRepo();
+  const outside = mkdtempSync(join(tmpdir(), 'hypo-outside-'));
+  const victim = join(outside, 'victim.txt');
+  try {
+    writeFileSync(victim, 'PRECIOUS\n');
+    const hooks = join(repo, '.git', 'hooks');
+    mkdirSync(hooks, { recursive: true });
+    // A real, unmanaged pre-commit: the case that takes the force branch.
+    writeFileSync(join(hooks, 'pre-commit'), '#!/bin/sh\necho mine\n', { mode: 0o755 });
+    symlinkSync(victim, join(hooks, 'pre-commit.bak'));
+
+    withTmpHome((home) => {
+      const r = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${repo}`, '--no-commands', '--force-commands'],
+        home,
+      );
+      const out = `${r.stdout || ''}${r.stderr || ''}`;
+      assert.equal(readFileSync(victim, 'utf-8'), 'PRECIOUS\n', `backup escaped:\n${out}`);
+      // Also pin that the refusal happens BEFORE the hook write. Without this,
+      // moving the guard between the two writes would still pass above while
+      // leaving the unmanaged hook overwritten and its only backup lost.
+      assert.equal(
+        readFileSync(join(hooks, 'pre-commit'), 'utf-8'),
+        '#!/bin/sh\necho mine\n',
+        `the unmanaged hook was overwritten with no usable backup:\n${out}`,
+      );
+    });
+  } finally {
+    rmSync(outside, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## What changed

Hook installation and inspection now ask git where hooks live instead of assuming `<repo>/.git/hooks`. A new `scripts/lib/git-hooks-dir.mjs` resolves the active hooks directory and is used by `init.mjs` (package post-commit and vault pre-commit), `doctor.mjs`, and `smoke-pack.mjs`.

## Why

In a linked worktree `.git` is a regular file holding `gitdir: <path>`, not a directory. `existsSync` passed on it and `mkdirSync` then failed with `ENOTDIR`, so `npm test` failed 185 tests in any worktree checkout while the main checkout stayed green. Anyone using `git worktree` to run parallel branches hit this immediately.

The same guess was wrong a second way: when `core.hooksPath` is set, git does not read `.git/hooks` at all, so doctor reported "not installed" for a hook that was simply somewhere else.

## How

`git rev-parse --git-path hooks` answers both cases. It follows the worktree's gitdir pointer and it substitutes `core.hooksPath`, including tilde expansion and `/dev/null`. Reading the config directly would be worse: no tilde expansion, and an empty-but-set value is indistinguishable from an unset one.

Two things rev-parse does not provide, added here:

Ambient git environment variables survive `git -C`. `GIT_DIR` plus `GIT_WORK_TREE` point the probe at a foreign repository and `GIT_CONFIG_*` points it at an arbitrary hooks path, so every probe runs under an environment scrubbed from git's own `--local-env-vars`.

`core.hooksPath` may point at a directory shared across repositories, which is a documented centralized-hooks pattern. Our post-commit executes `$REPO_ROOT/scripts/upgrade.mjs`, so installing into a shared directory would run one repository's script from another repository's commit. The resolver returns an `owned` flag: writers refuse when it is false, readers still report the path.

The hook entry itself is guarded, not only its directory. `writeFileSync` follows symlinks, a dangling symlink reads as absent through `existsSync`, and the `--force-commands` backup is a second write to a different path. All three are refused rather than followed.

## Manual verification

Reproduced and fixed in a real linked worktree (`git worktree add ../Hypomnema-v1.7.1`):

```
before: npm test -> exit 1, Error: ENOTDIR: not a directory,
        mkdir '.../Hypomnema-v1.7.1/.git/hooks' at installPkgGitHook (init.mjs:692)
after:  npm test -> 1664 passed, 0 failed, exit 0
```

`core.hooksPath` behavior verified directly against git 2.50.1 rather than assumed:

```
unset      -> <repo>/.git/hooks
/dev/null  -> /dev/null
.githooks  -> .githooks
~/shared   -> /Users/<me>/shared
```

Gates: `npm test`, `lint`, `format:check`, `check:pack-surface`, `check:tracker-ids`, `check:versions`, `smoke-pack`, `smoke:plugin` all pass.

Each new guard was mutation-checked so the tests are not vacuous. Removing the ownership refusal, reverting the `init.mjs` integration, removing the `.bak` guard, and moving the `.bak` guard between the two writes each turn exactly one test red.

## Migration notes

None. Existing installs keep resolving to the same `.git/hooks` they used before. Two behavior changes are worth knowing: installation is skipped with a logged reason when `core.hooksPath` points outside the repository or when git is unavailable on PATH, where the old code would have written directly.

---

# 한국어

## 변경 내용

훅을 설치하고 점검할 때 `<repo>/.git/hooks`를 가정하지 않고 git에 직접 묻습니다. 활성 훅 디렉터리를 해석하는 `scripts/lib/git-hooks-dir.mjs`를 추가했고, `init.mjs`(패키지 post-commit, 볼트 pre-commit), `doctor.mjs`, `smoke-pack.mjs`가 이를 씁니다.

## 이유

linked worktree에서 `.git`은 디렉터리가 아니라 `gitdir: <path>`를 담은 일반 파일입니다. `existsSync`는 통과하고 이어지는 `mkdirSync`가 `ENOTDIR`로 죽어서, worktree 체크아웃에서는 `npm test`가 185건 실패하고 메인 체크아웃만 green이었습니다. `git worktree`로 브랜치를 병렬로 돌리면 바로 걸립니다.

같은 가정이 다른 방향으로도 틀렸습니다. `core.hooksPath`가 설정되면 git은 `.git/hooks`를 아예 읽지 않으므로, 훅이 다른 곳에 멀쩡히 있는데도 doctor가 "미설치"라고 보고했습니다.

## 방법

`git rev-parse --git-path hooks`가 두 경우를 모두 답합니다. worktree의 gitdir 포인터를 따라가고, `core.hooksPath`도 반영합니다(물결표 확장과 `/dev/null` 포함). 설정값을 직접 읽는 쪽이 오히려 나쁩니다. 물결표를 확장하지 못하고, 값이 빈 문자열인 경우와 미설정을 구분할 수 없습니다.

rev-parse가 주지 않아 따로 넣은 것이 둘입니다.

주변 git 환경변수는 `git -C`로 막히지 않습니다. `GIT_DIR`과 `GIT_WORK_TREE`는 탐색을 남의 저장소로, `GIT_CONFIG_*`는 임의의 훅 경로로 돌립니다. 그래서 모든 탐색은 git 자신의 `--local-env-vars`로 세척한 환경에서 실행합니다.

`core.hooksPath`는 여러 저장소가 공유하는 디렉터리를 가리킬 수 있고, 이는 git이 문서화한 중앙 집중식 훅 방식입니다. 우리 post-commit은 `$REPO_ROOT/scripts/upgrade.mjs`를 실행하므로, 공유 디렉터리에 설치하면 다른 저장소의 커밋에서 이 저장소의 스크립트가 돕니다. 해석 결과에 `owned` 플래그를 두어, 쓰는 쪽은 거부하고 읽는 쪽은 경로를 그대로 보고합니다.

훅 디렉터리뿐 아니라 훅 파일 자체도 검사합니다. `writeFileSync`는 심링크를 따라가고, 끊어진 심링크는 `existsSync`에 "없음"으로 읽히며, `--force-commands`의 백업은 다른 경로로 가는 두 번째 쓰기입니다. 셋 다 따라가지 않고 거부합니다.

## 수동 검증

실제 linked worktree(`git worktree add ../Hypomnema-v1.7.1`)에서 재현하고 고쳤습니다.

```
수정 전: npm test -> exit 1, Error: ENOTDIR: not a directory,
         mkdir '.../Hypomnema-v1.7.1/.git/hooks' at installPkgGitHook (init.mjs:692)
수정 후: npm test -> 1664 passed, 0 failed, exit 0
```

`core.hooksPath` 동작은 추정하지 않고 git 2.50.1에 직접 물어 확인했습니다.

```
미설정     -> <repo>/.git/hooks
/dev/null  -> /dev/null
.githooks  -> .githooks
~/shared   -> /Users/<me>/shared
```

게이트: `npm test`, `lint`, `format:check`, `check:pack-surface`, `check:tracker-ids`, `check:versions`, `smoke-pack`, `smoke:plugin` 모두 통과합니다.

테스트가 헛돌지 않는지 각 가드마다 변이로 확인했습니다. 소유권 거부 제거, `init.mjs` 통합 되돌리기, `.bak` 가드 제거, `.bak` 가드를 두 쓰기 사이로 이동. 각각 정확히 한 테스트만 빨개집니다.

## 마이그레이션 노트

없습니다. 기존 설치는 전과 같은 `.git/hooks`로 해석됩니다. 다만 동작이 달라지는 지점이 둘 있습니다. `core.hooksPath`가 저장소 밖을 가리키거나 git이 PATH에 없으면 이유를 로그로 남기고 설치를 건너뜁니다. 이전 코드는 그대로 파일에 썼습니다.

---

## Changelog

- EN: Hook installation and `hypo:doctor` now resolve the git hooks directory from git, fixing an `ENOTDIR` crash in linked worktrees and a false "not installed" report when `core.hooksPath` is set (#221).
- KO: 훅 설치와 `hypo:doctor`가 훅 디렉터리를 git에서 해석합니다. linked worktree에서 나던 `ENOTDIR` 크래시와 `core.hooksPath` 설정 시의 잘못된 "미설치" 보고를 고쳤습니다 (#221).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
