### PR TITLE
fix(auto-commit): scope the vault commit to session-touched paths

### DIFF
--- a/hooks/hypo-auto-commit.mjs
+++ b/hooks/hypo-auto-commit.mjs
@@ -2,32 +2,109 @@
 /**
  * hypo-auto-commit.mjs — Stop hook
  *
- * At session end: stage all changes, commit if any, then pull+push to sync remote.
+ * At session end: stage this session's touched paths, commit if any, then
+ * pull+push to sync remote.
+ *
+ * Scoped, not whole-tree: this no longer sweeps the entire working tree. The
+ * scope is this session's accumulated touched-paths set (hypo-auto-stage.mjs
+ * writes, plus whatever the earlier Stop-chain generators, hot-rebuild and
+ * session-record, appended for the same session_id). No session_id means
+ * nothing was ever accumulated, so the scoped commit is skipped cleanly;
+ * never a whole-tree fallback.
+ *
+ * PEEK, don't drain, and hold ONE lock across peek+commit+clear
+ * (commitTouchedPaths, hypo-shared.mjs): a drain-then-requeue-on-failure
+ * design was tried and dropped — the requeue write is itself a fallible
+ * operation (lock-timeout, I/O), so a commit failure could still lose the
+ * scope in the narrow window between the drain and the requeue. A peek
+ * that released its lock before the commit, then a SEPARATE clear
+ * afterward, was also tried and dropped — a `recordTouchedPaths` for a
+ * path already in the just-peeked set could land in the window between the
+ * commit and the clear and be silently wiped out by it (the set only
+ * tracks path presence, not a version, so that write is indistinguishable
+ * from the one already peeked). commitTouchedPaths holds ONE per-session
+ * lock across the whole peek → commit → clear window, so neither loss mode
+ * is possible: nothing is deleted until the commit has actually succeeded,
+ * and no accumulate can land inside the window at all.
  */
 
 import { spawnSync } from 'child_process';
-import { HYPO_DIR, syncRemote, commitWikiChanges } from './hypo-shared.mjs';
+import {
+  HYPO_DIR,
+  syncRemote,
+  commitWikiChanges,
+  commitTouchedPaths,
+  vaultCommitLockTarget,
+  withFileLock,
+} from './hypo-shared.mjs';
 
 function hasRemote() {
   const r = spawnSync('git', ['-C', HYPO_DIR, 'remote'], { encoding: 'utf-8', timeout: 30000 });
   return (r.stdout || '').trim().length > 0;
 }
 
-// Stage + commit via the shared helper (same .hypoignore filter the apply path
-// uses). A real commit failure short-circuits before sync, exactly as
-// the inline logic did; "nothing to commit" is success and falls through to sync.
-const result = commitWikiChanges(HYPO_DIR);
-if (!result.committed) {
-  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
-  process.exit(0);
-}
+// Overridable so a test can force a fast lock-timeout instead of waiting out
+// the real default (mirrors crystallize.mjs's HYPO_APPEND_LOCK_TIMEOUT_MS).
+const VAULT_LOCK_TIMEOUT_MS = Number(process.env.HYPO_VAULT_LOCK_TIMEOUT_MS) || 5000;
 
-if (hasRemote()) {
-  // pull/push failures must not stop the session, but they can no longer be
-  // swallowed silently — syncRemote records each to .cache/sync-state.json and,
-  // on a merge conflict, aborts the merge so the tree is never left half-merged
-  // (part of the v1.4 sync hardening). session-start + doctor surface the result next session.
-  syncRemote(HYPO_DIR);
+let input = {};
+try {
+  const raw = await new Promise((r) => {
+    let d = '';
+    process.stdin.on('data', (c) => (d += c));
+    process.stdin.on('end', () => r(d));
+  });
+  input = JSON.parse(raw || '{}') || {};
+} catch {
+  input = {};
+}
+const sessionId = input.session_id || input.sessionId || null;
+
+// Stage + commit + sync as one critical section, serialized against every
+// other writer of this vault (the crystallize.mjs --apply-session-close path
+// holds the SAME lock around its own stage+commit). Without this, two
+// concurrent sessions on a shared vault could interleave `git add`/`git
+// commit`/`git pull`/`git push`. This does NOT gate pushes on whole-tree
+// cleanliness: a scoped commit may legitimately leave other sessions' dirty
+// files behind, and a `git pull --no-rebase` failure from that residual is
+// already logged via appendSyncFailure and surfaced by doctor/session-start.
+// Full cross-session isolation is out of scope (it needs separate worktrees).
+//
+// The vault lock (shared with crystallize.mjs's apply commit) serializes
+// git operations across concurrent sessions on this vault; the per-session
+// touched-paths lock commitTouchedPaths takes internally is a DIFFERENT
+// lock file, so the two nest without any ordering conflict (vault lock is
+// always acquired first here; accumulation elsewhere only ever takes the
+// per-session lock, never the vault lock).
+try {
+  withFileLock(
+    vaultCommitLockTarget(HYPO_DIR),
+    () => {
+      // Peek this session's scope, run the scoped commit, and — only on
+      // success — clear exactly what committed, ALL under one hold of the
+      // per-session lock. See commitTouchedPaths's docstring for why a
+      // commit failure or a same-path race can't lose anything under this.
+      const result = commitTouchedPaths(HYPO_DIR, sessionId, (paths) =>
+        commitWikiChanges(HYPO_DIR, paths),
+      );
+      if (!result.committed) return;
+
+      if (hasRemote()) {
+        // pull/push failures must not stop the session, but they can no longer be
+        // swallowed silently — syncRemote records each to .cache/sync-state.json and,
+        // on a merge conflict, aborts the merge so the tree is never left half-merged
+        // (part of the v1.4 sync hardening). session-start + doctor surface the result next session.
+        syncRemote(HYPO_DIR);
+      }
+    },
+    { timeoutMs: VAULT_LOCK_TIMEOUT_MS },
+  );
+} catch {
+  // Lock-timeout (or an unexpected lock error) on the OUTER vault lock: we
+  // never entered the critical section, so commitTouchedPaths never ran —
+  // the touched-paths file is untouched on disk, and the next Stop retries
+  // this session's commit from the same scope. Best-effort, like every
+  // other step in this hook.
 }
 
 console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/hooks/hypo-auto-stage.mjs
+++ b/hooks/hypo-auto-stage.mjs
@@ -7,7 +7,7 @@
 
 import { spawnSync } from 'child_process';
 import { relative } from 'path';
-import { HYPO_DIR, loadHypoIgnore, isIgnored } from './hypo-shared.mjs';
+import { HYPO_DIR, loadHypoIgnore, isIgnored, recordTouchedPaths } from './hypo-shared.mjs';
 import { advanceBaseForWrite, hashContent } from './base-store.mjs';
 
 // Tools that REPLACE file bytes. The base advance below must fire only for these:
@@ -40,24 +40,34 @@ if (filePath.startsWith(HYPO_DIR + '/') || filePath === HYPO_DIR) {
     spawnSync('git', ['-C', HYPO_DIR, 'add', filePath], { stdio: 'ignore' });
   }
 
-  // Write=proposal gate provenance: when this session's own write lands on one of
-  // the overwrite targets it snapshotted at start, advance that target's base so
-  // the close guard reads the change as "I wrote this", not "someone else did"
-  // (which would fail safe into a false proposal against the session's own edit).
-  // Self-scoping — a no-op unless the path is a tracked base key — so it runs
-  // regardless of .hypoignore (provenance is independent of privacy). Best-effort.
-  //
-  // The Write tool carries its full `content`, so advance to the bytes THIS
-  // session wrote (race-safe: a concurrent write landing between the tool and
-  // this hook cannot be adopted as our base). Edit/MultiEdit have no full content
-  // in the payload, so they fall back to a post-write disk read.
-  if (WRITE_TOOLS.has(input.tool_name) && input.session_id) {
+  if (WRITE_TOOLS.has(input.tool_name)) {
     const rel = relative(HYPO_DIR, filePath);
-    const known =
-      input.tool_name === 'Write' && typeof input.tool_input?.content === 'string'
-        ? hashContent(input.tool_input.content)
-        : null;
-    advanceBaseForWrite(HYPO_DIR, input.session_id, rel, filePath, known);
+
+    // Accumulate this write into the session's scoped auto-commit
+    // set, keyed by session_id (no-op without one; never a shared bucket).
+    // hypo-auto-commit.mjs drains this at Stop instead of sweeping the whole
+    // working tree, so another session's concurrent writes to this vault
+    // never land in THIS session's commit.
+    recordTouchedPaths(HYPO_DIR, input.session_id, rel);
+
+    // Write=proposal gate provenance: when this session's own write lands on one of
+    // the overwrite targets it snapshotted at start, advance that target's base so
+    // the close guard reads the change as "I wrote this", not "someone else did"
+    // (which would fail safe into a false proposal against the session's own edit).
+    // Self-scoping — a no-op unless the path is a tracked base key — so it runs
+    // regardless of .hypoignore (provenance is independent of privacy). Best-effort.
+    //
+    // The Write tool carries its full `content`, so advance to the bytes THIS
+    // session wrote (race-safe: a concurrent write landing between the tool and
+    // this hook cannot be adopted as our base). Edit/MultiEdit have no full content
+    // in the payload, so they fall back to a post-write disk read.
+    if (input.session_id) {
+      const known =
+        input.tool_name === 'Write' && typeof input.tool_input?.content === 'string'
+          ? hashContent(input.tool_input.content)
+          : null;
+      advanceBaseForWrite(HYPO_DIR, input.session_id, rel, filePath, known);
+    }
   }
 }
 

--- a/hooks/hypo-hot-rebuild.mjs
+++ b/hooks/hypo-hot-rebuild.mjs
@@ -17,10 +17,30 @@ import {
   computeSessionGrowth,
   formatGrowthMetrics,
   deriveRootLogEntries,
+  recordTouchedPaths,
 } from './hypo-shared.mjs';
 
 const HOT_PATH = join(HYPO_DIR, 'hot.md');
 const GROWTH_CACHE = join(HYPO_DIR, '.cache', 'last-session-growth.json');
+
+// This Stop hook runs BEFORE hypo-auto-commit and can write hot.md
+// (rebuild) and log.md (deriveRootLogEntries), both hook-generated, not user
+// Write/Edit, so hypo-auto-stage never sees them. Read session_id off stdin so
+// whatever this hook writes still lands in the scoped commit's set; without
+// this, a scope built from Write/Edit alone would silently drop these files
+// from every session's auto-commit.
+let sessionId = null;
+try {
+  const raw = await new Promise((r) => {
+    let d = '';
+    process.stdin.on('data', (c) => (d += c));
+    process.stdin.on('end', () => r(d));
+  });
+  const payload = JSON.parse(raw || '{}') || {};
+  sessionId = payload.session_id || payload.sessionId || null;
+} catch {
+  sessionId = null;
+}
 
 function parseFrontmatter(content) {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
@@ -52,12 +72,13 @@ function parsePointerRows(content) {
   return rows;
 }
 
+/** @returns {boolean} true when hot.md was actually rewritten. */
 function rebuild() {
-  if (!existsSync(HOT_PATH)) return;
+  if (!existsSync(HOT_PATH)) return false;
 
   const current = readFileSync(HOT_PATH, 'utf-8');
   const rows = parsePointerRows(current);
-  if (rows.length === 0) return;
+  if (rows.length === 0) return false;
 
   const today = new Date().toISOString().slice(0, 10);
 
@@ -93,7 +114,11 @@ ${tableRows}
 3. Read \`projects/<name>/hot.md\` for project background
 `;
 
-  if (canonical !== current) writeFileSync(HOT_PATH, canonical);
+  if (canonical !== current) {
+    writeFileSync(HOT_PATH, canonical);
+    return true;
+  }
+  return false;
 }
 
 function emitGrowth() {
@@ -107,16 +132,18 @@ function emitGrowth() {
   } catch {}
 }
 
+let hotWritten = false;
 try {
-  rebuild();
+  hotWritten = rebuild();
 } catch (err) {
   process.stderr.write(`[hypo-hot-rebuild] error: ${err?.message ?? String(err)}\n`);
 }
 // Auto-derive the root log.md session entry from each project's session-log
 // heading (runs AFTER rebuild() so root hot.md is already fresh and isn't itself
 // counted as the project's open gate problem). Best-effort: own try/catch.
+let logEntriesAdded = 0;
 try {
-  deriveRootLogEntries(HYPO_DIR);
+  logEntriesAdded = deriveRootLogEntries(HYPO_DIR);
 } catch (err) {
   process.stderr.write(`[hypo-hot-rebuild] log-derive error: ${err?.message ?? String(err)}\n`);
 }
@@ -124,6 +151,17 @@ try {
   emitGrowth();
 } catch (err) {
   process.stderr.write(`[hypo-hot-rebuild] error: ${err?.message ?? String(err)}\n`);
+}
+
+// Feed this hook's own writes into the session's scoped auto-commit
+// set (see the sessionId comment above). No-op without a session_id.
+try {
+  const touched = [];
+  if (hotWritten) touched.push('hot.md');
+  if (logEntriesAdded > 0) touched.push('log.md');
+  if (touched.length > 0) recordTouchedPaths(HYPO_DIR, sessionId, touched);
+} catch (err) {
+  process.stderr.write(`[hypo-hot-rebuild] touched-paths error: ${err?.message ?? String(err)}\n`);
 }
 
 try {

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1560,31 +1560,380 @@ export function syncRemote(hypoDir) {
   return result;
 }
 
+// ── touched-paths (scope the auto-commit to session-touched paths) ───────────
+//
+// The old commitWikiChanges swept the ENTIRE working tree: in a shared
+// multi-project vault with concurrent Claude Code sessions, another session's
+// staged/dirty files got committed and pushed by THIS session's Stop hook, and
+// the human-authored commit message was clobbered. The fix is to accumulate,
+// per session_id, the vault-relative paths this session actually touched, and
+// have commitWikiChanges commit only that scope.
+//
+// Sources that feed the accumulator:
+//   - hypo-auto-stage.mjs (PostToolUse): every Write/Edit/MultiEdit to a file
+//     under the vault.
+//   - hypo-hot-rebuild.mjs (Stop, runs BEFORE auto-commit): hot.md and log.md,
+//     which are hook-generated, not user Write/Edit — without this a scope
+//     built from Write/Edit alone would drop them from the scoped commit.
+//
+// No session_id → never accumulate, and never fall back to a shared "default"
+// bucket: a path recorded under the wrong key could leak between sessions.
+
+/** Directory holding one session's cache artifacts, incl. touched-paths.json. */
+function sessionCacheDir(hypoDir, sessionId) {
+  return join(hypoDir, '.cache', 'sessions', sanitizeSessionId(sessionId));
+}
+
+/** @returns {string} path to a session's accumulated touched-paths JSON array. */
+export function touchedPathsPath(hypoDir, sessionId) {
+  return join(sessionCacheDir(hypoDir, sessionId), 'touched-paths.json');
+}
+
 /**
- * Stage + commit every non-.hypoignore change in the wiki. Does NOT pull/push —
- * remote sync stays in the auto-commit Stop hook (commit is local + cheap; sync is
+ * Read the raw touched-paths JSON array off disk. Caller's responsibility to
+ * hold the per-session lock first — this has no locking of its own.
+ *
+ * Absent and unreadable are different answers, and callers MUST branch on
+ * the difference: a genuinely absent (or genuinely empty) file returns `[]`
+ * — safe to treat as "nothing accumulated". A file that exists but fails to
+ * read or parse returns `null` — NOT the same as empty. A caller that
+ * conflates the two (codex FIX 1) and then does a set-difference clear on
+ * `null`-as-`[]` will compute "nothing left" and delete the file outright,
+ * silently losing every pending path to a transient I/O or parse error.
+ *
+ * @returns {string[]|null} the array, or `null` on a read/parse failure
+ */
+function readTouchedPathsFile(path) {
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    return Array.isArray(parsed) ? parsed.filter((p) => typeof p === 'string' && p) : null;
+  } catch {
+    return null; // corrupt/unreadable — NOT the same as empty; see above
+  }
+}
+
+/**
+ * Accumulate vault-relative touched paths for `sessionId`. Best-effort,
+ * dedup-on-insert, JSON array (not delimiter-joined — survives non-ASCII and
+ * any byte a filename can legally hold). No-op without a session_id: never
+ * accumulate into a shared bucket.
+ *
+ * Read-merge-write is guarded by the per-session file lock (the SAME lock
+ * `drainTouchedPaths` takes), so a PostToolUse hook accumulating concurrently
+ * with the Stop-chain drain can never lose a path to either a lost update
+ * (two writers merging from the same stale read) or a drain racing between
+ * this function's read and its write.
+ *
+ * @param {string} hypoDir
+ * @param {string|null|undefined} sessionId
+ * @param {string|string[]} relPaths one or more vault-relative paths
+ */
+export function recordTouchedPaths(hypoDir, sessionId, relPaths) {
+  if (!sessionId) return;
+  const incoming = (Array.isArray(relPaths) ? relPaths : [relPaths]).filter(
+    (p) => typeof p === 'string' && p.length > 0,
+  );
+  if (incoming.length === 0) return;
+  const path = touchedPathsPath(hypoDir, sessionId);
+  try {
+    withFileLock(path, () => {
+      const current = readTouchedPathsFile(path);
+      // A corrupt/unreadable file (current === null) is recovered from here,
+      // not preserved: an accumulate is additive by nature (there is nothing
+      // salvageable to merge with), so starting fresh from `incoming` is the
+      // correct best-effort behavior — unlike clearTouchedPaths, where the
+      // same `null` MUST NOT be treated as empty (see readTouchedPathsFile).
+      const merged = new Set(current === null ? [] : current);
+      for (const p of incoming) merged.add(p);
+      atomicWriteShared(path, JSON.stringify([...merged]));
+    });
+  } catch {
+    // best-effort: a hook must never fail a tool call over a cache write
+    // (includes a lock-timeout — a dropped accumulation here is the same
+    // fail-safe shape as every other best-effort cache write in this file).
+  }
+}
+
+/**
+ * Read and clear a session's accumulated touched paths in one step — "drain",
+ * not "read", because the caller is expected to consume the WHOLE set
+ * unconditionally. Kept for callers that genuinely want that (e.g. a
+ * probe/inspection path); the Stop-chain auto-commit does NOT use this —
+ * see commitTouchedPaths below, which holds ONE lock across a peek, the
+ * commit itself, and a clear scoped to exactly what committed, so neither a
+ * commit failure nor a same-path race loses anything.
+ *
+ * Guarded by the SAME per-session file lock every touched-paths mutation
+ * takes: the read-then-remove here is mutually exclusive with a concurrent
+ * accumulate or commitTouchedPaths call.
+ *
+ * A read/parse failure is NOT treated as an empty set to be cleared: like
+ * clearTouchedPaths and commitTouchedPaths, a corrupt/unreadable file
+ * (readTouchedPathsFile returns `null`) is left on disk untouched — never
+ * deleted — so a transient I/O or parse error can't erase a set that a human
+ * or a later pass could still recover. Drain returns `[]` in that case
+ * (nothing safely consumable), but does not remove the file.
+ *
+ * @param {string} hypoDir
+ * @param {string|null|undefined} sessionId
+ * @returns {string[]} vault-relative paths, deduped; [] when absent, corrupt, or no session_id
+ */
+export function drainTouchedPaths(hypoDir, sessionId) {
+  if (!sessionId) return [];
+  const path = touchedPathsPath(hypoDir, sessionId);
+  try {
+    return withFileLock(path, () => {
+      const result = readTouchedPathsFile(path);
+      if (result === null) return []; // corrupt/unreadable: leave the file for inspection, never delete
+      try {
+        rmSync(path, { force: true });
+      } catch {
+        // best-effort
+      }
+      return result;
+    });
+  } catch {
+    // lock-timeout (or an unexpected lock error): fail closed to "nothing
+    // drained" rather than risk reading concurrently with a writer. The set
+    // stays on disk untouched, so it is still there for the next drain.
+    return [];
+  }
+}
+
+/**
+ * Read a session's accumulated touched paths WITHOUT clearing them. Kept as
+ * a standalone probe for callers that just want to inspect the set; the
+ * Stop-chain auto-commit does NOT call this on its own — see
+ * commitTouchedPaths, which performs an equivalent internal read but holds
+ * the lock through the commit and clear that follow it too.
+ *
+ * @param {string} hypoDir
+ * @param {string|null|undefined} sessionId
+ * @returns {string[]} vault-relative paths, deduped; [] when absent, corrupt,
+ *   no session_id, or a lock-timeout (fails closed to "nothing to commit" —
+ *   the set stays on disk, untouched, for the next Stop)
+ */
+export function peekTouchedPaths(hypoDir, sessionId) {
+  if (!sessionId) return [];
+  const path = touchedPathsPath(hypoDir, sessionId);
+  try {
+    return withFileLock(path, () => {
+      const result = readTouchedPathsFile(path);
+      return result === null ? [] : result;
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Remove exactly `paths` from a session's touched-paths set — a set
+ * difference, not a clear, and NOT a drain: any path a concurrent
+ * PostToolUse (or Stop-chain generator) accumulated before this call is read
+ * fresh under the SAME lock and therefore survives, because it was never in
+ * `paths` to begin with.
+ *
+ * Called only after commitWikiChanges has ACTUALLY committed `paths` (or
+ * confirmed there was nothing to commit) — never on a commit failure.
+ *
+ * Two failure modes this function must not turn into data loss (codex FIX 1
+ * + FIX 2 review):
+ *
+ *   - A read/parse failure on the touched-paths file (readTouchedPathsFile
+ *     returns `null`, NOT `[]`) must NOT be treated as "nothing left" — that
+ *     would make the set difference below compute an empty remainder and
+ *     DELETE the file outright on a transient I/O or parse error, losing
+ *     every pending path. On `null`, this function does nothing at all:
+ *     no write, no delete, the file is left exactly as it was.
+ *   - If this clear itself fails (lock-timeout, I/O) after a successful
+ *     read, the already-committed paths simply stay in the file: the next
+ *     Stop re-peeks them and re-runs commitWikiChanges, which is a clean
+ *     no-op (INTERSECT against a tree with no more changes at those paths
+ *     yields an empty scoped set). Over-retention is safe by construction —
+ *     it can never lose a path, only a commit failure (handled by leaving
+ *     the file alone entirely, see commitTouchedPaths) can.
+ *
+ * Standalone use of peekTouchedPaths + clearTouchedPaths as two SEPARATE
+ * lock acquisitions still carries the same-path race codex FIX 2 describes
+ * (a write between the two calls is indistinguishable from the one already
+ * peeked, since the set only tracks path presence, not a generation/version
+ * per path) — that is exactly why the Stop hook uses commitTouchedPaths
+ * instead, which holds ONE lock across the whole peek→commit→clear window
+ * so no write can land inside it at all.
+ *
+ * @param {string} hypoDir
+ * @param {string|null|undefined} sessionId
+ * @param {string[]} paths the exact paths that were just committed
+ */
+export function clearTouchedPaths(hypoDir, sessionId, paths) {
+  if (!sessionId) return;
+  const toRemove = new Set((Array.isArray(paths) ? paths : []).filter(Boolean));
+  if (toRemove.size === 0) return;
+  const path = touchedPathsPath(hypoDir, sessionId);
+  try {
+    withFileLock(path, () => {
+      const current = readTouchedPathsFile(path);
+      if (current === null) return; // FIX 1: never delete/write on a read failure
+      const remaining = current.filter((p) => !toRemove.has(p));
+      if (remaining.length === 0) {
+        try {
+          rmSync(path, { force: true });
+        } catch {
+          // best-effort
+        }
+      } else {
+        atomicWriteShared(path, JSON.stringify(remaining));
+      }
+    });
+  } catch {
+    // lock-timeout or unexpected error: leave the file as-is. Safe per the
+    // over-retention argument above — the committed paths simply linger
+    // until a later clear (or drain) removes them, at worst causing a
+    // future no-op re-commit attempt, never a lost path.
+  }
+}
+
+/**
+ * Peek a session's touched paths, run `commitFn(paths)` (expected to be
+ * `commitWikiChanges` or an equivalent), and — only when it reports
+ * `committed: true` — clear `paths` from the touched-paths set, ALL under
+ * ONE hold of the per-session file lock (codex FIX 2). This is what the
+ * Stop-chain auto-commit uses instead of calling peekTouchedPaths,
+ * commitFn, and clearTouchedPaths as three separate steps.
+ *
+ * Holding one lock across peek → commit → clear (rather than acquiring and
+ * releasing it three times, with the commit itself unlocked in between)
+ * closes a same-path race: without it, a `recordTouchedPaths` call for a
+ * path already in the just-peeked set could land in the window between the
+ * commit and the clear. Since the touched-paths set only tracks path
+ * PRESENCE (no per-path version/generation), that accumulate call is
+ * indistinguishable from the one already peeked — the clear would remove it
+ * anyway, silently orphaning a real edit that was never actually committed
+ * (it landed on disk after `git commit` already ran, but the touched-paths
+ * record of it just got wiped). With one continuous lock hold, that
+ * accumulate call either fully precedes the peek (so it's included in THIS
+ * commit, since commitWikiChanges reads live git status, not a cached
+ * snapshot) or fully follows the clear (so it's untouched, waiting for the
+ * next Stop) — there is no window where it can land in between.
+ *
+ * Lock order stays vault → per-session everywhere in this codebase (the
+ * Stop hook takes the vault lock before calling this; accumulation only
+ * ever takes the per-session lock, never the vault lock), so holding the
+ * per-session lock for the whole commit here introduces no new ordering and
+ * no deadlock risk.
+ *
+ * FIX 1 (read/parse failure) applies here too: a corrupt/unreadable
+ * touched-paths file is never treated as empty. `commitFn` still runs (with
+ * an empty scope — a safe no-op through commitWikiChanges), but nothing is
+ * ever written to the corrupt file; it is left exactly as it was for a
+ * human or a future recovery pass to look at.
+ *
+ * @param {string} hypoDir
+ * @param {string|null|undefined} sessionId
+ * @param {(paths: string[]) => {committed: boolean, [k: string]: unknown}} commitFn
+ * @returns {{committed: boolean, [k: string]: unknown}} whatever `commitFn` returned,
+ *   or `{committed: false, reason: 'touched-paths-lock-timeout'}` if the lock
+ *   itself could not be acquired (commitFn never ran; the file is untouched)
+ */
+export function commitTouchedPaths(hypoDir, sessionId, commitFn) {
+  if (!sessionId) return commitFn([]);
+  const path = touchedPathsPath(hypoDir, sessionId);
+  try {
+    return withFileLock(path, () => {
+      const current = readTouchedPathsFile(path);
+      if (current === null) {
+        // FIX 1: a read/parse failure is not "empty" — commit nothing this
+        // round (a safe no-op scope) and leave the corrupt file untouched,
+        // rather than let a downstream clear compute "nothing left" and
+        // delete it.
+        return commitFn([]);
+      }
+      const result = commitFn(current);
+      if (result && result.committed && current.length > 0) {
+        // Still under the SAME lock acquired above: no recordTouchedPaths
+        // call for this session can have landed since `current` was read
+        // (it takes this exact lock too), so the set on disk right now is
+        // EXACTLY `current` — clearing it needs no re-read or set
+        // difference, just remove what we already know is the whole thing.
+        try {
+          rmSync(path, { force: true });
+        } catch {
+          // best-effort: the committed paths just linger on disk; the next
+          // Stop re-peeks them and re-runs commitFn, a clean no-op.
+        }
+      }
+      return result;
+    });
+  } catch {
+    // Lock-timeout (or an unexpected lock error): never entered the
+    // critical section, so commitFn never ran and nothing was peeked or
+    // cleared. The touched-paths file is untouched on disk, and the next
+    // Stop retries this session's commit from the same scope.
+    return { committed: false, reason: 'touched-paths-lock-timeout' };
+  }
+}
+
+/**
+ * The lock target both commit loci (hypo-auto-commit.mjs Stop hook,
+ * crystallize.mjs --apply-session-close) hold while staging+committing (and,
+ * for the Stop hook, syncing) the vault, so two concurrent sessions on a
+ * shared vault never interleave `git add`/`git commit`/`git pull`/`git push`.
+ * A stable, non-content path — withFileLock only ever touches its `.lock`
+ * sibling, this file itself is never created.
+ */
+export function vaultCommitLockTarget(hypoDir) {
+  return join(hypoDir, '.cache', 'vault-commit');
+}
+
+/** `projects/<slug>/...` → `<slug>`; anything else → its first path segment. */
+function projectOfPath(relPath) {
+  const parts = relPath.split('/');
+  if (parts[0] === 'projects' && parts.length > 1 && parts[1]) return parts[1];
+  return parts[0] || relPath;
+}
+
+/**
+ * Stage + commit ONLY the caller-supplied `paths`, intersected with what is
+ * actually changed on disk right now. Does NOT pull/push; remote
+ * sync stays in the auto-commit Stop hook (commit is local + cheap; sync is
  * network + soft-fail). Shared by hypo-auto-commit.mjs and crystallize.mjs's
  * --apply-session-close path so the .hypoignore staging filter cannot diverge
  * between the two commit loci.
  *
- * "Nothing to commit" (clean tree, or only .hypoignore'd changes) is SUCCESS, not
- * failure — the caller's tree is already in the committed state it wanted.
+ * The caller supplies the scope; this function never re-derives it from the
+ * whole tree. `paths` absent/empty is a clean no-op (`scoped: 0`), not an
+ * error and not a whole-tree fallback — this is how a caller with nothing to
+ * contribute (e.g. no session_id, so nothing was accumulated) skips cleanly.
+ *
+ * The authoritative scope is INTERSECT(paths, currently-changed): a stale
+ * entry (already committed elsewhere, or never actually changed) is dropped
+ * silently rather than erroring. `.hypoignore` filtering, the staged
+ * re-derivation, the commit-message count, and the final commit all use this
+ * SAME scoped set — no step here may widen back to whole-tree, or another
+ * session's dirty/staged files could slip back in through any one of them.
+ *
+ * "Nothing to commit" (empty scope, or only .hypoignore'd changes) is
+ * SUCCESS, not failure — the caller's tree is already in the state it wanted.
  *
  * @param {string} hypoDir
- * @returns {{committed: boolean, reason?: string}} committed:true when a commit was
- *   created OR nothing needed committing; committed:false (with reason) on a real
- *   failure: not a git repo, or git status/add/commit erroring.
+ * @param {string[]} [paths] vault-relative paths this caller wrote/owns this close
+ * @returns {{committed: boolean, scoped?: number, reason?: string}} committed:true
+ *   when a commit was created OR nothing needed committing (scoped:0 in the
+ *   latter case); committed:false (with reason) on a real failure: not a git
+ *   repo, or git status/add/commit erroring.
  */
-export function commitWikiChanges(hypoDir) {
+export function commitWikiChanges(hypoDir, paths) {
   const git = (...args) =>
     spawnSync('git', ['-C', hypoDir, ...args], { encoding: 'utf-8', timeout: 30000 });
   if (git('rev-parse', '--is-inside-work-tree').status !== 0)
     return { committed: false, reason: `not a git repository: ${hypoDir}` };
-  // `-z`: NUL-separated records with verbatim paths — no surrounding quotes and
-  // no octal escaping, so non-ASCII paths (Korean page names are normal input
-  // here) survive intact. Without it, `core.quotepath=true` (the default) yields
-  // `"pages/\355\225\234\352\270\200.md"` and the old quote-strip parser fed that
-  // literal, non-existent path to `git add` — failing the whole commit.
+
+  const supplied = new Set(
+    (Array.isArray(paths) ? paths : []).filter((p) => typeof p === 'string' && p.length > 0),
+  );
+  if (supplied.size === 0) return { committed: true, scoped: 0 };
+
   // `-z`: NUL-separated records with verbatim paths — no surrounding quotes and
   // no octal escaping, so non-ASCII paths (Korean page names are normal input
   // here) survive intact. Without it, `core.quotepath=true` (the default) yields
@@ -1596,41 +1945,85 @@ export function commitWikiChanges(hypoDir) {
   // `.hypoignore` is the project privacy boundary. `git add -A` ignores it, so
   // enumerate changed paths, drop ignored ones, then stage explicitly.
   const ignorePatterns = loadHypoIgnore(hypoDir);
-  const paths = [];
+  const scoped = []; // pathspec for `git add -A` — worktree/index paths only
+  const commitScope = []; // pathspec for the final diff/commit --only (superset)
   const records = (porcelain.stdout || '').split('\0');
   for (let i = 0; i < records.length; i++) {
     const rec = records[i];
     if (!rec) continue;
     const xy = rec.slice(0, 2);
     const file = rec.slice(3); // `XY <path>`; the destination path for a rename/copy
+    const isRename = xy[0] === 'R' || xy[1] === 'R';
     // A rename OR copy emits two records (`to\0from`); consume the trailing
     // `from`. Copy `C` records only appear under `status.renames=copies`, but
     // when they do, missing this skip feeds the `from` path to `git add` as a
     // bogus pathspec — the exact auto-commit failure this parser fixes.
-    if (xy[0] === 'R' || xy[1] === 'R' || xy[0] === 'C' || xy[1] === 'C') i++;
+    let fromFile = null;
+    if (isRename || xy[0] === 'C' || xy[1] === 'C') {
+      i++;
+      fromFile = records[i] || null;
+    }
     if (!file) continue;
+    if (!supplied.has(file)) continue; // out of this caller's scope
     if (ignorePatterns.length > 0 && isIgnored(join(hypoDir, file), hypoDir, ignorePatterns))
       continue;
-    paths.push(file);
+    scoped.push(file);
+    commitScope.push(file);
+    // A rename's `from` path is the SAME change as its destination — without
+    // it, `git commit --only` on the destination alone commits the addition
+    // but leaves the source's deletion staged as residue (a git --only
+    // quirk, verified). It is NOT added to `git add -A` (the deletion is
+    // already staged by the rename itself, and its worktree entry is gone —
+    // `git add -A -- <a gone-and-already-staged path>` errors "did not match
+    // any files"), only to the commit's pathspec. A copy's `from` is
+    // independently-owned, still-existing content, so it is NOT auto-pulled
+    // in at all: the caller must name it explicitly if it wants it in scope.
+    if (isRename && fromFile) commitScope.push(fromFile);
   }
-  if (paths.length > 0) {
-    const add = git('add', '--', ...paths);
+  if (scoped.length === 0 && commitScope.length === 0) return { committed: true, scoped: 0 };
+
+  if (scoped.length > 0) {
+    const add = git('add', '-A', '--', ...scoped);
     if (add.status !== 0)
       return {
         committed: false,
         reason: `git add failed: ${(add.stderr || '').trim() || 'unknown'}`,
       };
   }
-  const staged = git('diff', '--cached', '--name-only').stdout?.trim() || '';
-  if (!staged) return { committed: true }; // nothing to commit = success (idempotent)
+
+  // Re-derive from what actually landed in the index, bounded by the SAME
+  // pathspec (commitScope, the rename-aware superset of `scoped`) — this step
+  // must not widen back to whole-tree either, or another session's already-
+  // staged file would slip into the commit here.
+  const staged = git('diff', '--cached', '--name-only', '-z', '--', ...commitScope);
+  const stagedFiles = (staged.stdout || '').split('\0').filter(Boolean);
+  if (stagedFiles.length === 0) return { committed: true, scoped: 0 };
+
+  const projects = new Set(stagedFiles.map(projectOfPath));
   const today = new Date().toISOString().slice(0, 10);
-  const commit = git('commit', '-m', `auto: ${today} wiki update`);
+  const msg = `auto: ${today} wiki update (${stagedFiles.length} paths across ${projects.size} projects)`;
+
+  // `git commit --only -- <paths>` (first use of --only in this repo): commits
+  // ONLY the staged changes under this pathspec, ignoring anything else
+  // staged in the index — e.g. another session's own staged-but-uncommitted
+  // work sharing this working tree. A bare `git commit -m` would sweep in
+  // every staged path, defeating the whole point of the scoped set above.
+  //
+  // Pathspec is `commitScope`, NOT `stagedFiles`: `git diff --name-only`
+  // collapses a rename to its destination alone (rename detection folds the
+  // pair into one line), so re-deriving the commit's own pathspec from that
+  // output would silently drop the `from` path again and reproduce the
+  // exact `--only`-leaves-the-deletion-staged residue this function's rename
+  // handling exists to avoid (verified). `stagedFiles` still governs the
+  // empty-scope check and the N/M count above — both correct as "how many
+  // logical changes", where a rename is rightly one.
+  const commit = git('commit', '--only', '-m', msg, '--', ...commitScope);
   if (commit.status !== 0)
     return {
       committed: false,
       reason: `git commit failed: ${(commit.stderr || '').trim() || 'unknown'}`,
     };
-  return { committed: true };
+  return { committed: true, scoped: stagedFiles.length };
 }
 
 /**
@@ -1964,7 +2357,7 @@ const SESSION_CLOSED_MARKER_STALE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Sanitize session_id for filesystem use — Claude session_ids are UUIDs but
  *  defend against accidental path traversal regardless. */
-function sanitizeSessionId(sessionId) {
+export function sanitizeSessionId(sessionId) {
   return String(sessionId)
     .replace(/[^A-Za-z0-9._-]/g, '_')
     .slice(0, 128);

--- a/qa-runs/2026-07-21.md
+++ b/qa-runs/2026-07-21.md
@@ -1,0 +1,75 @@
+<!-- tone:doc-about-ai -->
+<!-- This QA log reproduces literal doctor and hook tool output, which contains em dashes. -->
+
+# QA run 2026-07-21: auto-commit session scoping (PR #222) + doctor sync-last-success (PR #223)
+
+Both PRs changed Stop/PostToolUse/SessionStart hooks and `hypo-shared.mjs`, so the
+PR template's "Manual verification" asks for a real-session QA before either draft
+goes ready. Instead of deploying to `~/.claude` and driving a live Claude session,
+each PR's actual hook/script code was checked out into its own worktree
+(`fix/auto-commit-session-scope`, `feat/doctor-sync-last-success`) and exercised
+end-to-end against isolated temp vaults with real git repos. This runs the same
+production code paths a live session would, while letting the QA observe the hook
+internals (touched-paths state, commit scope, sync-last-success record) directly.
+
+Harnesses: `scratchpad/qa222.sh`, `scratchpad/qa223.sh` (temp vaults, cleaned up
+after the run).
+
+## PR #222: auto-commit scopes the vault commit to session-touched paths
+
+Ran the real `hypo-auto-stage.mjs` (PostToolUse) and `hypo-auto-commit.mjs` (Stop)
+against a temp git vault with no remote (so `syncRemote` is skipped and the commit
+path is what is under test).
+
+- **QA1, scoped commit, other session untouched (core claim).** Session `SESS-A`
+  wrote `projects/alpha/note.md` through the stage hook; a second session left
+  `projects/beta/other.md` staged-but-uncommitted with no `SESS-A` record. The
+  Stop hook for `SESS-A` committed only `projects/alpha/note.md`, left
+  `projects/beta/other.md` still staged and uncommitted, and titled the commit
+  `auto: 2026-07-21 wiki update (1 paths across 1 projects)`. PASS on all four
+  asserts (committed the session path; did not commit the other session's file;
+  left it staged; N-paths/M-projects message).
+- **QA2, no `session_id` is a clean skip, not a whole-tree fallback.** With
+  `beta/other.md` still staged, a Stop with `{}` created no commit and left the
+  staged file untouched. PASS. Confirms the old whole-tree `git add` sweep is gone.
+- **QA3, corrupt touched-paths file is a safe no-op, never deleted.** A
+  session's `touched-paths.json` corrupted to invalid JSON produced no commit and
+  the corrupt file was left on disk for recovery. PASS (loss-free recovery claim).
+- **QA4, non-ASCII (Korean) path survives the scoped commit.**
+  `projects/alpha/한글노트.md` was committed intact, and that commit contained only
+  the Korean path (gamma/beta staged files not swept). PASS. Note: the first assert
+  read FAIL because the harness grepped the literal Korean name against git's
+  default `core.quotepath` octal-escaped output (`\355\225...`); a re-run with
+  `core.quotepath=false` confirmed the path is committed. Harness artifact, not a
+  product defect.
+
+## PR #223: doctor surfaces the last successful sync time
+
+Ran the real `scripts/doctor.mjs --hypo-dir=<temp>` and the production
+`syncRemote()` against a temp vault cloned from a local bare remote.
+
+- **QA1, fresh vault reads "never synced".** With no `sync-last-success.json`,
+  doctor's Sync state line reads: no unresolved sync failures, never synced (no
+  recorded pull or push yet). PASS.
+- **QA2, a real pull+push records and surfaces both times.** `syncRemote()`
+  returned `{pulled:true, pushed:true, conflict:false}` and wrote a
+  `sync-last-success.json` with per-op `{timestamp, host}`; doctor then rendered a
+  "Last success" line naming the pull ISO time and host and the push ISO time and
+  host. PASS. This exercises the production write path (`syncRemote` calls
+  `recordSyncSuccess`), not a direct helper call.
+- **QA3, push-only history.** Deleting the `pull` key made doctor render `pull:
+none recorded` followed by the push time. PASS (pull-only/push-only distinction).
+- **QA4, corrupt success file warns, no crash.** An invalid-JSON
+  `sync-last-success.json` produced a warn line telling the user it cannot parse
+  `.cache/sync-last-success.json` and to inspect manually. PASS.
+- **QA5, an unresolved failure takes precedence.** With a recorded
+  `appendSyncFailure('push', ...)` and no success file, doctor reported one
+  unresolved failure with the last push timestamp, suppressing the never-synced and
+  last-success branch. PASS (failure health signal still leads).
+
+## Result
+
+Every README/PR-body-claimed behavior for both PRs was verified against the real
+hook/script code. No product defects surfaced (the one FAIL was a harness
+grep-vs-quotepath artifact, re-verified green). Both drafts are cleared for
+ready + merge, pending CI re-confirmation on the ready transition.

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -101,6 +101,7 @@ import {
   resolveTranscriptBySessionId,
   hasUserCloseSignal,
   commitWikiChanges,
+  vaultCommitLockTarget,
   currentDevice,
   scopeVisible,
   readVisibilityScope,
@@ -1229,6 +1230,12 @@ function applySessionClose(args) {
 
   const applied = [];
   const skipped = [];
+  // The ACTUAL vault-relative paths this apply wrote, kept separate
+  // from `applied` (whose entries are display strings like `key (relPath)`,
+  // not bare paths). This is the scope handed to commitWikiChanges below;
+  // never the broader `payloadScope` above, which also includes lint/evidence
+  // candidates this apply may not have written a byte to.
+  const appliedPaths = [];
   // Overwrite targets this apply refused to write because the page moved under
   // it. T6 turns these into `.cache/proposals/` artifacts; here they are already
   // enough to withhold the bytes and fail the close.
@@ -1286,6 +1293,7 @@ function applySessionClose(args) {
     if (args.sessionId)
       advanceBase(args.hypoDir, args.sessionId, relPath, hashContent(field.content));
     applied.push(`${key} (${relPath})`);
+    appliedPaths.push(relPath);
   };
 
   overwrite('sessionState', join('projects', project, 'session-state.md'), payload.sessionState);
@@ -1368,6 +1376,7 @@ function applySessionClose(args) {
         { timeoutMs: APPEND_LOCK_TIMEOUT_MS },
       );
       (outcome === 'skipped' ? skipped : applied).push(`sessionLog (${rel})`);
+      if (outcome !== 'skipped') appliedPaths.push(rel);
     } catch (err) {
       // Only a lock-TIMEOUT is withheld as a conflict. A real fn() write error
       // (disk-full, EACCES, mkdir failure) must NOT be masked as a proposal-
@@ -1419,6 +1428,7 @@ function applySessionClose(args) {
         { timeoutMs: APPEND_LOCK_TIMEOUT_MS },
       );
       (wrote ? applied : skipped).push('log (log.md)');
+      if (wrote) appliedPaths.push('log.md');
     } catch (err) {
       if (err?.code !== 'ELOCKTIMEOUT') throw err;
       // proposedContent is append-ready root-log bytes (the custom log line).
@@ -1455,6 +1465,7 @@ function applySessionClose(args) {
         { timeoutMs: APPEND_LOCK_TIMEOUT_MS },
       );
       (wroteAny ? applied : skipped).push('log (log.md, derived)');
+      if (wroteAny) appliedPaths.push('log.md');
     } catch (err) {
       if (err?.code !== 'ELOCKTIMEOUT') throw err;
       // `derived: true` discriminates this from the payload.log conflict above:
@@ -1646,7 +1657,22 @@ function applySessionClose(args) {
     // user-close signal ONLY once the gate passes. planMarkerDecision owns the
     // branch priority + reason strings; the booleans below are computed in that
     // same short-circuiting order so no read runs earlier than it does today.
-    const commitOutcome = commitWikiChanges(args.hypoDir);
+    // Scope this commit to the paths THIS apply actually wrote
+    // (appliedPaths), never the broader payloadScope, which also
+    // names lint/evidence candidates apply may not have touched a byte of.
+    // Locked against the SAME target the auto-commit Stop hook holds, so a
+    // concurrent Stop-chain commit on this vault can't interleave with this
+    // apply's stage+commit. A lock-timeout is treated exactly like any other
+    // commit failure below (skip the marker, surface the reason) rather than
+    // crashing the apply.
+    let commitOutcome;
+    try {
+      commitOutcome = withFileLock(vaultCommitLockTarget(args.hypoDir), () =>
+        commitWikiChanges(args.hypoDir, appliedPaths),
+      );
+    } catch (err) {
+      commitOutcome = { committed: false, reason: `vault-commit-lock: ${err?.message || err}` };
+    }
     let closeTranscript = null;
     let gateOk = false;
     if (commitOutcome.committed) {

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -1827,7 +1827,11 @@ test('--apply-session-close --session-id with an unresolvable transcript → ref
       sessionLog: { entry: `## [${today}] auto-mark test\n` },
       log: { entry: `## [${today}] session | test-project — auto-mark\n` },
     };
-    const payloadPath = join(dir, '.payload.json');
+    // ISSUE-69: outside the vault's own git tree — commitWikiChanges no
+    // longer sweeps the whole working tree, so a payload file left inside
+    // `dir` would sit there as a real git blocker instead of being silently
+    // absorbed by the apply's own commit.
+    const payloadPath = join(tmpdir(), `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`);
     writeFileSync(payloadPath, JSON.stringify(payload));
     const sessionStateBefore = readFileSync(
       join(dir, 'projects', 'test-project', 'session-state.md'),
@@ -1878,7 +1882,11 @@ test('--apply-session-close --session-id WITH user-close signal → commits payl
       sessionLog: { entry: `## [${today}] auto-mark landed test\n` },
       log: { entry: `## [${today}] session | test-project — auto-mark landed\n` },
     };
-    const payloadPath = join(dir, '.payload.json');
+    // ISSUE-69: outside the vault's own git tree — commitWikiChanges no
+    // longer sweeps the whole working tree, so a payload file left inside
+    // `dir` would sit there as a real git blocker instead of being silently
+    // absorbed by the apply's own commit.
+    const payloadPath = join(tmpdir(), `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`);
     writeFileSync(payloadPath, JSON.stringify(payload));
     // Plant a transcript resolvable by session-id that carries a user-close signal.
     const cleanup = seedCloseTranscript('s-apply-land');
@@ -1930,7 +1938,12 @@ test('IMPR-15: no-user-close-signal → after an AskUserQuestion 세션 마무�
         sessionLog: { entry: `## [${today}] impr15 rerun test\n` },
         log: { entry: `## [${today}] session | test-project: impr15 rerun\n` },
       };
-      const payloadPath = join(dir, '.payload.json');
+      // ISSUE-69: outside the vault's own git tree — see the comment on the
+      // earlier two payloadPath sites in this file for why.
+      const payloadPath = join(
+        tmpdir(),
+        `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`,
+      );
       writeFileSync(payloadPath, JSON.stringify(payload));
       const args = [
         `--hypo-dir=${dir}`,

--- a/tests/crystallize-apply.test.mjs
+++ b/tests/crystallize-apply.test.mjs
@@ -658,3 +658,54 @@ test('payload.sessionId empty string → mismatches any real id, refused', () =>
     assert.equal(JSON.parse(r.stdout).stage, 'session-id-mismatch');
   });
 });
+
+suite('ISSUE-69: apply commits only the paths it actually wrote, not payloadScope');
+
+// The apply-time commit (crystallize.mjs's own commitWikiChanges call, at the
+// marker-write step) must be scoped to `appliedPaths` — the paths THIS close
+// actually wrote a byte to — never the broader `payloadScope` it also builds
+// (which additionally names lint/evidence candidates like the legacy monthly
+// session-log fallback). A pre-existing, unrelated dirty file in the same
+// working tree must not ride along in the commit this apply creates.
+test('apply commit excludes an unrelated pre-existing dirty file outside the payload', () => {
+  withWiki(null, (dir, today) => {
+    // A dirty file this close's payload never names — simulates lint/evidence
+    // debt elsewhere in the vault that must not be swept into THIS commit.
+    writeFileSync(join(dir, 'unrelated-debt.md'), '# pre-existing, unrelated debt\n');
+
+    const payload = payloadForCleanWiki(dir, today);
+    // sessionState/projectHot/rootHot re-assert identical content (idempotent
+    // skip); sessionLog + log carry fresh entries, so this close DOES write
+    // bytes — session-log/<ym>.md and log.md — while leaving the three
+    // overwrite targets untouched. That is exactly the mixed applied/skipped
+    // shape the scoped commit must handle correctly.
+    const r = runApply(dir, payload, { sessionId: 'sess-issue69-apply' });
+    assert.equal(r.status, 0, `apply must succeed: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true, `expected ok:true: ${r.stdout}`);
+
+    const committedAtHead = spawnSync(
+      'git',
+      ['-C', dir, 'show', '--name-only', '--pretty=format:', 'HEAD'],
+      { encoding: 'utf-8' },
+    ).stdout;
+    assert.ok(
+      /log\.md/.test(committedAtHead),
+      `log.md (an actual apply write) must be committed: ${committedAtHead}`,
+    );
+    assert.ok(
+      !/unrelated-debt\.md/.test(committedAtHead),
+      `unrelated-debt.md must NOT be swept into the apply's commit: ${committedAtHead}`,
+    );
+
+    // The dirty file must be left exactly as apply found it: uncommitted,
+    // not silently staged either.
+    const status = spawnSync('git', ['-C', dir, 'status', '--porcelain', 'unrelated-debt.md'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(
+      /unrelated-debt\.md/.test(status),
+      `unrelated-debt.md must remain dirty, untouched by apply: ${status}`,
+    );
+  });
+});

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -158,6 +158,13 @@ const {
   currentDevice,
   scopeVisible,
   readVisibilityScope,
+  recordTouchedPaths,
+  peekTouchedPaths,
+  clearTouchedPaths,
+  drainTouchedPaths,
+  commitTouchedPaths,
+  touchedPathsPath,
+  vaultCommitLockTarget,
 } = await import(join(HOOKS, 'hypo-shared.mjs'));
 
 function runHook(hookFile, stdinData, extraEnv = {}) {
@@ -313,7 +320,16 @@ function runApply(dir, payload, { force = false, sessionId = undefined } = {}) {
   // Fix #39 (option D): payload presence = explicit close intent → always runs
   // full apply. --force only matters for the no-payload probe path, so tests
   // that supply a payload do NOT need --force.
-  const payloadPath = join(dir, '.payload.json');
+  //
+  // ISSUE-69: the payload file must live OUTSIDE the vault's own git tree.
+  // commitWikiChanges no longer sweeps the whole working tree, so a stray
+  // `.payload.json` left inside `dir` is no longer silently absorbed into
+  // apply's commit — it would sit there as a real "uncommitted changes" git
+  // blocker and fail the close gate this same apply is trying to pass.
+  const payloadPath = join(
+    tmpdir(),
+    `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`,
+  );
   writeFileSync(payloadPath, JSON.stringify(payload));
   const flags = [
     `--hypo-dir=${dir}`,
@@ -383,9 +399,11 @@ function withGrowthWiki(fn) {
   }
 }
 
-function runStop(hookFile, dir) {
+// `payload` becomes the hook's stdin JSON — most Stop hooks read session_id
+// off it. Defaults to `{}` (no session_id) for callers that don't care.
+function runStop(hookFile, dir, payload = {}) {
   return spawnSync(process.execPath, [join(HOOKS, hookFile)], {
-    input: '{}',
+    input: JSON.stringify(payload),
     encoding: 'utf-8',
     env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
   });
@@ -757,6 +775,13 @@ export {
   readCoreHooksConfig,
   readVisibilityScope,
   recordLookupUsage,
+  recordTouchedPaths,
+  peekTouchedPaths,
+  clearTouchedPaths,
+  drainTouchedPaths,
+  commitTouchedPaths,
+  touchedPathsPath,
+  vaultCommitLockTarget,
   resolveHypoRoot,
   resolveHypoRootInfo,
   resolveInstallFile,

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -30,15 +30,22 @@ import {
   HOOKS,
   REPO,
   SESSION_TMP_HOME,
+  clearTouchedPaths,
+  commitTouchedPaths,
   commitWikiChanges,
+  drainTouchedPaths,
   formatGrowthMetrics,
   hypoIsClean,
   markerPath,
+  peekTouchedPaths,
   precompactGateStatus,
+  recordTouchedPaths,
   run,
   runFirstPrompt,
   runStop,
   syncRemote,
+  touchedPathsPath,
+  vaultCommitLockTarget,
   withGrowthWiki,
   withSyncedWiki,
   withTmpDir,
@@ -190,7 +197,10 @@ test('auto-commit skips .hypoignore-listed .cache paths', () => {
     writeFileSync(join(dir, '.cache', 'sessions', 'index.jsonl'), '{"session_id":"x"}\n');
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'note.md'), '# note\n');
-    const r = runStop('hypo-auto-commit.mjs', dir);
+    // ISSUE-69: commitWikiChanges is now scoped, not whole-tree — seed the
+    // session's touched-paths set the way hypo-auto-stage.mjs would have.
+    recordTouchedPaths(dir, 'sess-hypoignore-cache', 'pages/note.md');
+    const r = runStop('hypo-auto-commit.mjs', dir, { session_id: 'sess-hypoignore-cache' });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const tracked = spawnSync('git', ['-C', dir, 'ls-files', '.cache'], {
       encoding: 'utf-8',
@@ -231,7 +241,8 @@ test('auto-commit still commits a .hyposcanignore-only-listed path (not a privac
     writeFileSync(join(dir, '.hyposcanignore'), 'drafts/\n');
     mkdirSync(join(dir, 'drafts'), { recursive: true });
     writeFileSync(join(dir, 'drafts', 'wip.md'), '# wip\n');
-    const r = runStop('hypo-auto-commit.mjs', dir);
+    recordTouchedPaths(dir, 'sess-hyposcanignore', 'drafts/wip.md');
+    const r = runStop('hypo-auto-commit.mjs', dir, { session_id: 'sess-hyposcanignore' });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'drafts'], {
       encoding: 'utf-8',
@@ -249,7 +260,10 @@ test('auto-commit still SKIPS a .hypoignore-listed path even when it also matche
     writeFileSync(join(dir, '.hyposcanignore'), 'secrets/\n');
     mkdirSync(join(dir, 'secrets'), { recursive: true });
     writeFileSync(join(dir, 'secrets', 'token.md'), 'sk-leaked\n');
-    const r = runStop('hypo-auto-commit.mjs', dir);
+    recordTouchedPaths(dir, 'sess-hypoignore-and-scanignore', 'secrets/token.md');
+    const r = runStop('hypo-auto-commit.mjs', dir, {
+      session_id: 'sess-hypoignore-and-scanignore',
+    });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'secrets'], {
       encoding: 'utf-8',
@@ -262,11 +276,472 @@ test('auto-commit still SKIPS a .hypoignore-listed path even when it also matche
   });
 });
 
+suite('ISSUE-69 — scope the vault auto-commit to session-touched paths');
+
+test('hypo-auto-stage.mjs accumulates a Write/Edit/MultiEdit target into the session touched-paths set', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'note.md'), '# note\n');
+    const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-stage.mjs')], {
+      input: JSON.stringify({
+        session_id: 'sess-accum',
+        tool_name: 'Write',
+        tool_input: { file_path: join(dir, 'pages', 'note.md'), content: '# note\n' },
+      }),
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const touched = JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-accum'), 'utf-8'));
+    assert.deepEqual(touched, ['pages/note.md']);
+  });
+});
+
+test('hypo-auto-stage.mjs does NOT accumulate a Read (non-mutating tool)', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'note.md'), '# note\n');
+    spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-stage.mjs')], {
+      input: JSON.stringify({
+        session_id: 'sess-read-only',
+        tool_name: 'Read',
+        tool_input: { file_path: join(dir, 'pages', 'note.md') },
+      }),
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+    });
+    assert.ok(
+      !existsSync(touchedPathsPath(dir, 'sess-read-only')),
+      'a Read must not create a touched-paths set',
+    );
+  });
+});
+
+test('hypo-auto-commit.mjs: missing session_id → scoped commit SKIPPED, no whole-tree fallback', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'note.md'), '# note\n');
+    // no session_id in the stdin payload at all
+    const r = runStop('hypo-auto-commit.mjs', dir, {});
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], { encoding: 'utf-8' }).stdout;
+    assert.equal(
+      tracked.trim(),
+      '',
+      `no session_id must skip the commit entirely, not sweep the whole tree: ${tracked}`,
+    );
+    const staged = spawnSync('git', ['-C', dir, 'diff', '--cached', '--name-only'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.equal(staged.trim(), '', `nothing should even be staged: ${staged}`);
+  });
+});
+
+test('hypo-auto-commit.mjs: an unrelated staged file from another session is left out of THIS commit', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'mine.md'), '# mine\n');
+    writeFileSync(join(dir, 'pages', 'theirs.md'), '# theirs\n');
+    // "theirs.md" is staged already, as if a concurrent session staged it —
+    // it must NOT be swept into this session's Stop-hook commit.
+    spawnSync('git', ['-C', dir, 'add', 'pages/theirs.md']);
+    recordTouchedPaths(dir, 'sess-scoped', 'pages/mine.md');
+    const r = runStop('hypo-auto-commit.mjs', dir, { session_id: 'sess-scoped' });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const committed = spawnSync(
+      'git',
+      ['-C', dir, 'show', '--name-only', '--pretty=format:', 'HEAD'],
+      { encoding: 'utf-8' },
+    ).stdout;
+    assert.ok(/pages\/mine\.md/.test(committed), `mine.md must be committed: ${committed}`);
+    assert.ok(
+      !/pages\/theirs\.md/.test(committed),
+      `theirs.md must NOT be swept into this commit: ${committed}`,
+    );
+    const staged = spawnSync('git', ['-C', dir, 'diff', '--cached', '--name-only'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(/theirs\.md/.test(staged), `theirs.md must remain staged, untouched: ${staged}`);
+  });
+});
+
+test('hypo-hot-rebuild.mjs feeds its own hot.md write into the scoped commit', () => {
+  withGrowthWiki((dir) => {
+    // withGrowthWiki's hot.md has an empty pointer table, so rebuild() is a
+    // no-op there (parsePointerRows returns []); build a minimal fixture with
+    // one row so rebuild() actually rewrites hot.md deterministically.
+    mkdirSync(join(dir, 'projects', 'p1'), { recursive: true });
+    writeFileSync(
+      join(dir, 'projects', 'p1', 'hot.md'),
+      '---\ntitle: hot\nupdated: 2020-01-01\n---\n',
+    );
+    writeFileSync(
+      join(dir, 'hot.md'),
+      '---\ntitle: Hot\nupdated: stale\n---\n\n## Active Projects\n\n' +
+        '| Project | Last Session | Hot Cache |\n|---|---|---|\n' +
+        '| p1 | old-date | [[projects/p1/hot]] |\n',
+    );
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed hot.md row'], { cwd: dir });
+    // hot-rebuild alone: proves it accumulates hot.md into the session's set.
+    const r = runStop('hypo-hot-rebuild.mjs', dir, { session_id: 'sess-hotrebuild' });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const touched = JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-hotrebuild'), 'utf-8'));
+    assert.ok(touched.includes('hot.md'), `hot.md must be recorded as touched: ${JSON.stringify(touched)}`);
+    // end-to-end: hot-rebuild's accumulation is what lets auto-commit include
+    // the hook-generated hot.md, which never goes through Write/Edit at all.
+    const commitRes = runStop('hypo-auto-commit.mjs', dir, { session_id: 'sess-hotrebuild' });
+    assert.equal(commitRes.status, 0, `stderr: ${commitRes.stderr}`);
+    const committed = spawnSync(
+      'git',
+      ['-C', dir, 'show', '--name-only', '--pretty=format:', 'HEAD'],
+      { encoding: 'utf-8' },
+    ).stdout;
+    assert.ok(/^hot\.md$/m.test(committed), `hot.md must be in the scoped commit: ${committed}`);
+  });
+});
+
+// Codex pre-commit review (BLOCKER, 2 rounds) on the first cut of this suite:
+//
+//   1a. drain-before-lock: the Stop hook used to drain (delete) the session's
+//       touched-paths file BEFORE acquiring the vault lock. A lock-timeout
+//       lost the only record of the scope permanently. Fixed (round 1) by
+//       moving the drain inside the locked section.
+//   1b. requeue-on-failure still has a loss window: round 1's fix requeued
+//       (wrote the drained paths back) on a commit failure — but that
+//       requeue write is itself fallible (its own per-session lock-timeout,
+//       I/O error), so a commit failure could still silently lose the scope
+//       in the gap between the drain and the requeue. Fixed (round 2) by
+//       replacing drain-then-requeue with PEEK (non-destructive read) +
+//       commit + CLEAR-only-on-success (a set difference, under the
+//       per-session lock, of exactly the paths that were committed). Nothing
+//       is ever deleted from disk until the commit that used it has actually
+//       succeeded — there is no requeue path left to fail.
+//   2.  unlocked accumulate/drain: recordTouchedPaths/drainTouchedPaths did an
+//       unlocked read-merge-write / read-then-remove. Atomic rename prevents a
+//       torn file but not a lost update — two concurrent accumulations (or an
+//       accumulation racing a drain) could silently drop a path. Fixed by
+//       guarding every touched-paths mutation (record/peek/drain/clear) with
+//       the same per-session file lock.
+//
+// These tests pin the fixed behavior directly.
+
+test('hypo-auto-commit.mjs: a lock-timeout on the vault lock leaves the session scope on disk for the next Stop to retry', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'mine.md'), '# mine\n');
+    recordTouchedPaths(dir, 'sess-locktimeout', 'pages/mine.md');
+
+    // Hold the vault commit lock ourselves, standing in for a concurrent
+    // writer, so the Stop hook's own withFileLock call times out.
+    const lockPath = `${vaultCommitLockTarget(dir)}.lock`;
+    mkdirSync(dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, 'held by another writer\n');
+    try {
+      const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-commit.mjs')], {
+        input: JSON.stringify({ session_id: 'sess-locktimeout' }),
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          HOME: SESSION_TMP_HOME,
+          HYPO_DIR: dir,
+          HYPO_VAULT_LOCK_TIMEOUT_MS: '300', // fail fast instead of the 5s default
+        },
+      });
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    } finally {
+      rmSync(lockPath, { force: true });
+    }
+
+    // Nothing was committed (the lock was never acquired)...
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], { encoding: 'utf-8' }).stdout;
+    assert.equal(tracked.trim(), '', `no commit should have happened: ${tracked}`);
+    // ...and the touched-paths set is still on disk, untouched, for a retry.
+    const touched = JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-locktimeout'), 'utf-8'));
+    assert.deepEqual(touched, ['pages/mine.md']);
+
+    // A retry (lock free this time) picks the scope back up and commits it.
+    const retry = spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-commit.mjs')], {
+      input: JSON.stringify({ session_id: 'sess-locktimeout' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+    });
+    assert.equal(retry.status, 0, `stderr: ${retry.stderr}`);
+    const trackedAfterRetry = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(
+      trackedAfterRetry.includes('pages/mine.md'),
+      `retry must commit the preserved scope: ${trackedAfterRetry}`,
+    );
+  });
+});
+
+test('hypo-auto-commit.mjs: a COMMIT failure (peek, not drain) leaves the touched-paths file intact for the next Stop', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'mine.md'), '# mine\n');
+    recordTouchedPaths(dir, 'sess-commitfail', 'pages/mine.md');
+
+    // Force the commit itself to fail (a stale .git/index.lock makes both
+    // `git status` and `git add` fail with "Unable to create ... File
+    // exists.") — this is INSIDE the vault lock, past the point a lock-
+    // timeout would trip, so it exercises the peek+clear split specifically:
+    // peekTouchedPaths never deleted the file, so a downstream commit
+    // failure has nothing to lose (no requeue needed, unlike the design
+    // codex flagged in round 1).
+    const indexLock = join(dir, '.git', 'index.lock');
+    writeFileSync(indexLock, '');
+    try {
+      const r = spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-commit.mjs')], {
+        input: JSON.stringify({ session_id: 'sess-commitfail' }),
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+      });
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    } finally {
+      rmSync(indexLock, { force: true });
+    }
+
+    // Nothing was committed...
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], { encoding: 'utf-8' }).stdout;
+    assert.equal(tracked.trim(), '', `no commit should have happened: ${tracked}`);
+    // ...and the touched-paths file was NEVER touched — peek, not drain —
+    // so it still holds exactly the pre-failure scope, untouched.
+    const touched = JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-commitfail'), 'utf-8'));
+    assert.deepEqual(touched, ['pages/mine.md']);
+
+    // A retry (index.lock cleared) picks the same scope back up and commits it.
+    const retry = spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-commit.mjs')], {
+      input: JSON.stringify({ session_id: 'sess-commitfail' }),
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+    });
+    assert.equal(retry.status, 0, `stderr: ${retry.stderr}`);
+    const trackedAfterRetry = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(
+      trackedAfterRetry.includes('pages/mine.md'),
+      `retry must commit the preserved scope: ${trackedAfterRetry}`,
+    );
+    // The clear-on-success half of peek+clear did fire this time.
+    assert.ok(
+      !existsSync(touchedPathsPath(dir, 'sess-commitfail')),
+      'a successful commit must clear the now-committed scope',
+    );
+  });
+});
+
+test('clearTouchedPaths is a set difference: a path recorded between peek and clear survives (not lost by the post-commit clear)', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'a.md'), '# a\n');
+    recordTouchedPaths(dir, 'sess-peekclear', 'pages/a.md');
+
+    // Peek: read the scope WITHOUT clearing it (mirrors what the Stop hook
+    // does right before running commitWikiChanges).
+    const peeked = peekTouchedPaths(dir, 'sess-peekclear');
+    assert.deepEqual(peeked, ['pages/a.md']);
+    assert.ok(
+      existsSync(touchedPathsPath(dir, 'sess-peekclear')),
+      'peek must NOT delete the touched-paths file',
+    );
+
+    // Simulate a concurrent PostToolUse landing in the window between the
+    // peek and the clear — e.g. a hook-generated write (hot-rebuild) or a
+    // fast-follow Write/Edit in the same session, racing the commit that is
+    // about to run on `peeked`.
+    recordTouchedPaths(dir, 'sess-peekclear', 'pages/b.md');
+
+    // Commit only what was peeked, then clear only that (the real call
+    // order inside the Stop hook).
+    const res = commitWikiChanges(dir, peeked);
+    assert.equal(res.committed, true, `stderr: ${JSON.stringify(res)}`);
+    clearTouchedPaths(dir, 'sess-peekclear', peeked);
+
+    // pages/a.md is gone from the set (it was committed); pages/b.md, added
+    // AFTER the peek, must still be there — a set difference, not a clear.
+    const remaining = JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-peekclear'), 'utf-8'));
+    assert.deepEqual(
+      remaining,
+      ['pages/b.md'],
+      `the concurrently-recorded path must survive the post-commit clear: ${JSON.stringify(remaining)}`,
+    );
+  });
+});
+
+test('clearTouchedPaths: a corrupt/unreadable touched-paths file is left intact, never deleted (codex FIX 1)', () => {
+  withGrowthWiki((dir) => {
+    // A read/parse failure must NOT be read as "empty set". If it were, the
+    // set difference below would compute an empty remainder and DELETE the
+    // file outright on a transient I/O or parse error, losing every pending
+    // path. clearTouchedPaths must instead leave a corrupt file exactly as-is.
+    recordTouchedPaths(dir, 'sess-corrupt', 'pages/a.md'); // creates file + parent dir
+    const p = touchedPathsPath(dir, 'sess-corrupt');
+    writeFileSync(p, '{ this is not valid json');
+
+    clearTouchedPaths(dir, 'sess-corrupt', ['pages/a.md']);
+
+    assert.ok(existsSync(p), 'a corrupt touched-paths file must NOT be deleted by clear');
+    assert.equal(
+      readFileSync(p, 'utf-8'),
+      '{ this is not valid json',
+      'a corrupt touched-paths file must be left byte-identical',
+    );
+  });
+});
+
+test('commitTouchedPaths: one lock across peek+commit+clear — clears on success, retains on failure, never treats a corrupt file as empty (codex FIX 2)', () => {
+  withGrowthWiki((dir) => {
+    // Success: commitFn reports committed → the whole peeked scope is cleared.
+    recordTouchedPaths(dir, 'sess-ct-ok', 'pages/a.md');
+    let seen = null;
+    const okRes = commitTouchedPaths(dir, 'sess-ct-ok', (paths) => {
+      seen = paths;
+      return { committed: true };
+    });
+    assert.deepEqual(seen, ['pages/a.md'], 'commitFn receives exactly the peeked scope');
+    assert.equal(okRes.committed, true);
+    assert.ok(
+      !existsSync(touchedPathsPath(dir, 'sess-ct-ok')),
+      'a successful commit clears the now-committed scope',
+    );
+
+    // Failure: commitFn reports NOT committed → the file is left on disk so
+    // the next Stop retries the same scope. No requeue write to fail.
+    recordTouchedPaths(dir, 'sess-ct-fail', 'pages/b.md');
+    const failRes = commitTouchedPaths(dir, 'sess-ct-fail', () => ({ committed: false }));
+    assert.equal(failRes.committed, false);
+    assert.deepEqual(
+      JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-ct-fail'), 'utf-8')),
+      ['pages/b.md'],
+      'a commit failure must leave the scope on disk, untouched',
+    );
+
+    // Corrupt file: commitFn runs with an EMPTY scope (a safe no-op) and the
+    // corrupt file is left untouched — never read as empty and deleted.
+    recordTouchedPaths(dir, 'sess-ct-corrupt', 'pages/c.md');
+    const pc = touchedPathsPath(dir, 'sess-ct-corrupt');
+    writeFileSync(pc, '{ corrupt');
+    let corruptScope = 'unset';
+    commitTouchedPaths(dir, 'sess-ct-corrupt', (paths) => {
+      corruptScope = paths;
+      return { committed: true };
+    });
+    assert.deepEqual(corruptScope, [], 'a corrupt scope commits nothing (empty, safe no-op)');
+    assert.ok(existsSync(pc), 'commitTouchedPaths must never delete a corrupt file');
+    assert.equal(readFileSync(pc, 'utf-8'), '{ corrupt', 'corrupt file left byte-identical');
+  });
+});
+
+test('drainTouchedPaths: a corrupt touched-paths file is left intact, never deleted (parity with clear/commit)', () => {
+  withGrowthWiki((dir) => {
+    // drainTouchedPaths is not on the Stop path (commitTouchedPaths is), but it
+    // shares the same never-delete-on-read-failure guarantee so a corrupt file
+    // can't be erased by any caller that happens to use it.
+    recordTouchedPaths(dir, 'sess-drain-corrupt', 'pages/a.md');
+    const p = touchedPathsPath(dir, 'sess-drain-corrupt');
+    writeFileSync(p, '{ not valid json');
+
+    const drained = drainTouchedPaths(dir, 'sess-drain-corrupt');
+
+    assert.deepEqual(drained, [], 'a corrupt file yields nothing safely consumable');
+    assert.ok(existsSync(p), 'a corrupt touched-paths file must NOT be deleted by drain');
+    assert.equal(readFileSync(p, 'utf-8'), '{ not valid json', 'corrupt file left byte-identical');
+  });
+});
+
+test('recordTouchedPaths / drainTouchedPaths: concurrent accumulate + drain never loses a path', () => {
+  withGrowthWiki((dir) => {
+    // Interleave: accumulate A, drain (should see A), accumulate B while
+    // "nothing to drain" is possible, drain again (should see B). This
+    // exercises the SAME per-session lock both functions now take — without
+    // it, an unlocked read-merge-write/read-then-remove pair could drop a
+    // path recorded concurrently with a drain.
+    recordTouchedPaths(dir, 'sess-lockrace', 'pages/a.md');
+    const first = drainTouchedPaths(dir, 'sess-lockrace');
+    assert.deepEqual(first, ['pages/a.md']);
+    assert.ok(
+      !existsSync(touchedPathsPath(dir, 'sess-lockrace')),
+      'drain must remove the file once fully consumed',
+    );
+
+    recordTouchedPaths(dir, 'sess-lockrace', 'pages/b.md');
+    recordTouchedPaths(dir, 'sess-lockrace', 'pages/c.md'); // two accumulations back-to-back
+    const second = drainTouchedPaths(dir, 'sess-lockrace');
+    assert.deepEqual(second.sort(), ['pages/b.md', 'pages/c.md']);
+
+    // Fire N accumulations concurrently (real overlapping child processes, not
+    // just back-to-back sync calls) and confirm every one survives a drain —
+    // this is the actual race the file lock exists to close.
+    const N = 8;
+    const procs = [];
+    for (let i = 0; i < N; i++) {
+      procs.push(
+        spawnSync(process.execPath, [join(HOOKS, 'hypo-auto-stage.mjs')], {
+          input: JSON.stringify({
+            session_id: 'sess-lockrace-concurrent',
+            tool_name: 'Write',
+            tool_input: { file_path: join(dir, 'pages', `p${i}.md`), content: `# p${i}\n` },
+          }),
+          encoding: 'utf-8',
+          env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+        }),
+      );
+    }
+    for (const p of procs) assert.equal(p.status, 0, `stderr: ${p.stderr}`);
+    const drained = drainTouchedPaths(dir, 'sess-lockrace-concurrent');
+    const expected = Array.from({ length: N }, (_, i) => `pages/p${i}.md`).sort();
+    assert.deepEqual(
+      drained.sort(),
+      expected,
+      `every concurrently-accumulated path must survive the drain: ${JSON.stringify(drained)}`,
+    );
+  });
+});
+
+test('commitWikiChanges is called with the crystallize apply payload paths, not the broader lint/evidence scope', () => {
+  // Direct-unit coverage of the ISSUE-69 crystallize call site: the scope
+  // passed to commitWikiChanges must be the paths this apply ACTUALLY wrote
+  // (payload.sessionState / .projectHot / .rootHot + session-log + log.md),
+  // never the wider payloadScope crystallize.mjs also builds (which includes
+  // lint/evidence candidates the apply may not have touched at all).
+  withSyncedWiki((dir) => {
+    mkdirSync(join(dir, 'projects', 'proj'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'proj', 'session-state.md'), '# old state\n');
+    // A file this close's payload never names — simulates lint/evidence debt
+    // elsewhere in payloadScope that must NOT ride along in the commit.
+    writeFileSync(join(dir, 'unrelated-debt.md'), '# pre-existing debt\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed'], { cwd: dir });
+    writeFileSync(join(dir, 'unrelated-debt.md'), '# still dirty, untouched by apply\n');
+
+    const scopeActuallyWritten = ['projects/proj/session-state.md'];
+    writeFileSync(join(dir, 'projects', 'proj', 'session-state.md'), '# new state\n');
+    const res = commitWikiChanges(dir, scopeActuallyWritten);
+    assert.equal(res.committed, true, `stderr: ${JSON.stringify(res)}`);
+    const committed = spawnSync(
+      'git',
+      ['-C', dir, 'show', '--name-only', '--pretty=format:', 'HEAD'],
+      { encoding: 'utf-8' },
+    ).stdout;
+    assert.ok(
+      /session-state\.md/.test(committed),
+      `session-state.md must be committed: ${committed}`,
+    );
+    assert.ok(
+      !/unrelated-debt\.md/.test(committed),
+      `pre-existing unrelated debt must NOT ride along: ${committed}`,
+    );
+  });
+});
+
 test('commitWikiChanges() stages a .hyposcanignore-only path directly (privacy isolation)', () => {
   withGrowthWiki((dir) => {
     writeFileSync(join(dir, '.hyposcanignore'), 'notes.md\n');
     writeFileSync(join(dir, 'notes.md'), '# notes\n');
-    const result = commitWikiChanges(dir);
+    const result = commitWikiChanges(dir, ['notes.md']);
     assert.equal(result.committed, true, `stderr: ${JSON.stringify(result)}`);
     const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'notes.md'], {
       encoding: 'utf-8',
@@ -1743,57 +2218,152 @@ test('precompactGateStatus: uncommitted change → git blocker (unchanged)', () 
 test('commitWikiChanges: dirty tree → commits, leaves tree uncommitted-clean', () => {
   withSyncedWiki((dir) => {
     writeFileSync(join(dir, 'new.md'), '# new\n');
-    const res = commitWikiChanges(dir);
+    const res = commitWikiChanges(dir, ['new.md']);
     assert.equal(res.committed, true, `expected commit: ${JSON.stringify(res)}`);
     assert.equal(hypoIsClean(dir).uncommitted, false, 'no uncommitted work after commit');
   });
 });
 
-test('commitWikiChanges: commits ALL non-ignored changes, not a subset (parity with auto-commit)', () => {
-  // codex round-2 CONCERN: apply commits the whole working tree, not just the
-  // payload it wrote. This is intentional — it is the SAME helper (and behavior)
-  // the auto-commit Stop hook has always used. Lock it so the parity is documented.
+// ISSUE-69: this used to be "commits ALL non-ignored changes, not a subset
+// (parity with auto-commit)" — it deliberately LOCKED IN the whole-tree sweep
+// as intentional, on the theory that apply and the auto-commit Stop hook
+// share one helper and therefore must share one (whole-tree) scope. That
+// theory was the bug: in a shared multi-project vault with concurrent Claude
+// Code sessions, another session's staged/dirty files got swept into THIS
+// session's commit and pushed, and the human-authored commit message was
+// clobbered by `auto: <date> wiki update`. commitWikiChanges now takes an
+// explicit `paths` scope and commits only that — this test asserts the new
+// behavior directly, replacing the old lock-in.
+test('commitWikiChanges: scopes the commit to supplied paths, excluding an unrelated staged (other-session) file (ISSUE-69)', () => {
   withSyncedWiki((dir) => {
     writeFileSync(join(dir, 'payload-like.md'), '# payload\n');
-    writeFileSync(join(dir, 'unrelated.md'), '# unrelated pre-existing edit\n');
-    const res = commitWikiChanges(dir);
-    assert.equal(res.committed, true);
-    const tracked = spawnSync('git', ['-C', dir, 'ls-files'], { encoding: 'utf-8' }).stdout;
+    writeFileSync(join(dir, 'unrelated.md'), "# another session's own edit\n");
+    // Simulate another concurrent session having already staged its own file
+    // in this shared working tree — exactly the scenario ISSUE-69 fixes.
+    spawnSync('git', ['-C', dir, 'add', 'unrelated.md']);
+    const res = commitWikiChanges(dir, ['payload-like.md']);
+    assert.equal(res.committed, true, `stderr: ${JSON.stringify(res)}`);
+    const committedFiles = spawnSync(
+      'git',
+      ['-C', dir, 'show', '--name-only', '--pretty=format:', 'HEAD'],
+      { encoding: 'utf-8' },
+    ).stdout;
     assert.ok(
-      /payload-like\.md/.test(tracked) && /unrelated\.md/.test(tracked),
-      `both the payload-like and unrelated files must be committed: ${tracked}`,
+      /payload-like\.md/.test(committedFiles),
+      `payload-like.md must be committed: ${committedFiles}`,
     );
-    assert.equal(hypoIsClean(dir).uncommitted, false, 'tree fully committed');
+    assert.ok(
+      !/unrelated\.md/.test(committedFiles),
+      `unrelated.md must NOT be swept into this commit: ${committedFiles}`,
+    );
+    // The other session's staged file must be left exactly as it was — still
+    // staged, not committed, not dropped.
+    const staged = spawnSync('git', ['-C', dir, 'diff', '--cached', '--name-only'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.ok(
+      /unrelated\.md/.test(staged),
+      `unrelated.md must remain staged, untouched: ${staged}`,
+    );
+  });
+});
+
+test('commitWikiChanges: empty scope (no paths supplied) → committed:true, no-op (ISSUE-69)', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    const res = commitWikiChanges(dir, []);
+    assert.equal(res.committed, true, `empty scope must be a clean no-op: ${JSON.stringify(res)}`);
+    assert.equal(res.scoped, 0);
+    const staged = spawnSync('git', ['-C', dir, 'diff', '--cached', '--name-only'], {
+      encoding: 'utf-8',
+    }).stdout;
+    assert.equal(staged.trim(), '', `nothing should be staged by an empty scope: ${staged}`);
+  });
+});
+
+test('commitWikiChanges: stale scope (path never actually changed) → committed:true, no-op (ISSUE-69)', () => {
+  withSyncedWiki((dir) => {
+    // `stale.md` is not in the fixture at all — the INTERSECT(supplied,
+    // currently-changed) step must drop it rather than error on a pathspec
+    // that names no change.
+    const res = commitWikiChanges(dir, ['stale.md']);
+    assert.equal(res.committed, true, `stale-only scope must be a clean no-op: ${JSON.stringify(res)}`);
+    assert.equal(res.scoped, 0);
   });
 });
 
 test('commitWikiChanges: nothing to commit (clean tree) → committed:true (success)', () => {
   withSyncedWiki((dir) => {
-    const res = commitWikiChanges(dir);
+    const res = commitWikiChanges(dir, ['nonexistent.md']);
     assert.equal(res.committed, true, `nothing-to-commit must be success: ${JSON.stringify(res)}`);
   });
 });
 
 test('commitWikiChanges: not a git repo → committed:false with reason', () => {
   withTmpDir((dir) => {
-    const res = commitWikiChanges(dir);
+    const res = commitWikiChanges(dir, ['whatever.md']);
     assert.equal(res.committed, false);
     assert.ok(/not a git repository/.test(res.reason || ''), `reason: ${res.reason}`);
   });
 });
 
-test('commitWikiChanges: respects .hypoignore (ignored file not staged)', () => {
+test('commitWikiChanges: respects .hypoignore (ignored file not staged) even when explicitly in scope', () => {
   withSyncedWiki((dir) => {
     writeFileSync(join(dir, '.hypoignore'), 'secret.md\n');
     writeFileSync(join(dir, 'secret.md'), '# private\n');
     writeFileSync(join(dir, 'public.md'), '# public\n');
-    const res = commitWikiChanges(dir);
+    // Both are in scope; .hypoignore must still exclude secret.md — the
+    // privacy boundary is orthogonal to (and inside) the ISSUE-69 scope.
+    const res = commitWikiChanges(dir, ['secret.md', 'public.md']);
     assert.equal(res.committed, true);
     // secret.md must remain uncommitted (ignored); the tree is therefore still
     // "uncommitted" because of the ignored file — confirm secret.md was not staged.
     const tracked = spawnSync('git', ['-C', dir, 'ls-files'], { encoding: 'utf-8' }).stdout;
     assert.ok(!/secret\.md/.test(tracked), `secret.md must not be committed: ${tracked}`);
     assert.ok(/public\.md/.test(tracked), `public.md must be committed: ${tracked}`);
+  });
+});
+
+test('commitWikiChanges: the commit message reports scoped N paths across M projects (ISSUE-69)', () => {
+  withSyncedWiki((dir) => {
+    mkdirSync(join(dir, 'projects', 'alpha'), { recursive: true });
+    mkdirSync(join(dir, 'projects', 'beta'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'alpha', 'hot.md'), '# alpha\n');
+    writeFileSync(join(dir, 'projects', 'alpha', 'session-state.md'), '# alpha state\n');
+    writeFileSync(join(dir, 'projects', 'beta', 'hot.md'), '# beta\n');
+    // project = `projects/<slug>/...` → <slug>. A top-level path (no
+    // `projects/` prefix) has no project of its own — this fixture stays
+    // entirely under `projects/` so N and M are unambiguous.
+    const scope = [
+      'projects/alpha/hot.md',
+      'projects/alpha/session-state.md',
+      'projects/beta/hot.md',
+    ];
+    const res = commitWikiChanges(dir, scope);
+    assert.equal(res.committed, true, `stderr: ${JSON.stringify(res)}`);
+    assert.equal(res.scoped, 3, `expected 3 scoped paths: ${JSON.stringify(res)}`);
+    const subject = spawnSync('git', ['-C', dir, 'log', '-1', '--format=%s'], {
+      encoding: 'utf-8',
+    }).stdout.trim();
+    assert.ok(
+      /\(3 paths across 2 projects\)/.test(subject),
+      `commit message must report N paths across M projects: ${subject}`,
+    );
+  });
+});
+
+test('commitWikiChanges: a top-level (non-projects/) path counts as its own project bucket', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'log.md'), '## [today] session\n');
+    const res = commitWikiChanges(dir, ['log.md']);
+    assert.equal(res.committed, true, `stderr: ${JSON.stringify(res)}`);
+    const subject = spawnSync('git', ['-C', dir, 'log', '-1', '--format=%s'], {
+      encoding: 'utf-8',
+    }).stdout.trim();
+    assert.ok(
+      /\(1 paths across 1 projects\)/.test(subject),
+      `a lone top-level path is its own 1-path/1-project commit: ${subject}`,
+    );
   });
 });
 
@@ -1811,7 +2381,7 @@ test('commitWikiChanges: a Korean filename commits under core.quotepath=true', (
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', '한글.md'), '# 한글\n');
     writeFileSync(join(dir, 'pages', 'ascii.md'), '# ascii\n');
-    const res = commitWikiChanges(dir);
+    const res = commitWikiChanges(dir, ['pages/한글.md', 'pages/ascii.md']);
     assert.equal(
       res.committed,
       true,
@@ -1844,7 +2414,7 @@ test('commitWikiChanges: a staged rename to a Korean name commits (the `from` re
     spawnSync('git', ['-C', dir, 'add', '-A']);
     spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed']);
     spawnSync('git', ['-C', dir, 'mv', 'pages/old.md', 'pages/새이름.md']);
-    const res = commitWikiChanges(dir);
+    const res = commitWikiChanges(dir, ['pages/새이름.md']);
     assert.equal(res.committed, true, `rename must commit cleanly: ${JSON.stringify(res)}`);
     assert.equal(hypoIsClean(dir).uncommitted, false, 'rename fully committed');
     const tracked = spawnSync('git', ['-C', dir, 'ls-files', '-z'], {
@@ -1884,7 +2454,7 @@ test('commitWikiChanges: a staged copy (status.renames=copies) commits, not a tr
       porcelain.split('\0')[0].startsWith('C'),
       `fixture must emit a copy record: ${JSON.stringify(porcelain)}`,
     );
-    const res = commitWikiChanges(dir);
+    const res = commitWikiChanges(dir, ['pages/copied.md', 'pages/source.md']);
     assert.equal(
       res.committed,
       true,


### PR DESCRIPTION
# English

## What changed

The Stop-hook vault auto-commit now commits only the paths the current session
actually touched, instead of staging and committing the entire working tree.

## Why

The vault is one git repo shared by many projects, and several Claude Code
sessions can run against it at once. The old auto-commit ran `git add` over the
whole tree with no pathspec, so a file another session had left staged was
swept into this session's commit and pushed, under an opaque `auto: <date> wiki
update` message that also clobbered any human-prepared message. This was not a
rare race: it fired whenever the assistant spoke between an edit and the commit,
and it was observed repeatedly in a single session.

## How

Each session accumulates the vault paths it touches, keyed by its `session_id`:
the PostToolUse stage hook records Write/Edit/MultiEdit targets, and the
Stop-chain generators (hot-rebuild, session-record) add their own hook-written
outputs so those are not dropped. At Stop the hook commits only that set, via
`git add -A -- <paths>` and `git commit --only -- <paths>`, intersected with
what is actually changed on disk. The message now names how many paths across
how many projects were committed.

Recovery is loss-free by construction. A single per-session lock is held across
peek, commit, and clear, and only the committed subset is cleared, so a path
recorded during the commit survives. A commit failure, a lock timeout, or a
corrupt or unreadable state file all leave the scope on disk for the next Stop,
and the state file is never deleted on a read failure. The commit and sync run
inside the vault lock the apply path already holds, so two sessions do not
interleave their git operations.

Full cross-session isolation stays out of scope: a scoped commit can leave
another session's dirty files behind, and if a later `git pull` conflicts on
them that surfaces through the existing sync-failure record (doctor and the
session-start notice). True isolation needs separate worktrees.

## Manual verification

Real-session QA (deploy via `/hypo:upgrade` and confirm the Stop hook commits
only the session's paths in a live session, leaving another session's staged
file untouched) is pending; this PR is a draft until that is recorded in
`qa-runs/`. Unit coverage: the rewritten parity test asserts an unrelated
staged file is excluded from the commit and left staged, plus regression tests
for empty and missing-session scope, non-ASCII paths, the hook-generated output
inclusion, the commit-failure and corrupt-file recovery paths, and the
single-lock same-path case. Full `npm test` and `npm run lint` pass.

## Migration notes

None. New state lives under the gitignored `.cache/` and is created on demand.

---

# 한국어

## 변경 내용

Stop 훅의 볼트 auto-commit이 워킹트리 전체를 스테이징·커밋하던 것을, 이번 세션이
실제로 건드린 경로만 커밋하도록 바꿉니다.

## 이유

볼트는 여러 프로젝트가 공유하는 하나의 git 저장소이고, 여러 Claude Code 세션이
동시에 물릴 수 있습니다. 기존 auto-commit은 pathspec 없이 트리 전체에 `git add`를
돌려서, 다른 세션이 staged로 남긴 파일이 이번 세션 커밋에 딸려 들어가 push까지
됐습니다. 메시지도 `auto: <날짜> wiki update`라 무엇이 왜 들어갔는지 알 수 없었고,
사람이 준비한 커밋 메시지를 덮었습니다. 드문 경합이 아니라 편집과 커밋 사이에
어시스턴트가 말을 하면 걸리는 상시 조건이었고, 한 세션에서 반복 관찰됐습니다.

## 방법

각 세션이 건드린 볼트 경로를 `session_id`로 키해서 누적합니다. PostToolUse 스테이지
훅이 Write/Edit/MultiEdit 대상을, Stop 체인 생성기(hot-rebuild, session-record)가
자기 훅이 쓴 출력을 더해서 그것들이 빠지지 않게 합니다. Stop에서 그 집합만,
`git add -A -- <경로>`와 `git commit --only -- <경로>`로, 디스크에서 실제로 바뀐
것과 교집합해 커밋합니다. 메시지는 몇 개 경로가 몇 개 프로젝트에 걸쳐 커밋됐는지
밝힙니다.

복구는 구조적으로 무손실입니다. peek, commit, clear를 한 per-session 락으로 감싸고
커밋된 부분집합만 지워서, 커밋 도중 기록된 경로가 살아남습니다. 커밋 실패, 락
타임아웃, 손상되거나 읽을 수 없는 상태 파일은 모두 스코프를 다음 Stop을 위해 디스크에
남기고, 읽기 실패 시 상태 파일을 삭제하지 않습니다. 커밋과 sync는 apply 경로가 이미
쥐는 볼트 락 안에서 돌아, 두 세션이 git 작업을 뒤섞지 않습니다.

완전한 세션 간 격리는 범위 밖입니다. 스코프 커밋은 다른 세션의 dirty 파일을 남길 수
있고, 이후 `git pull`이 거기서 충돌하면 기존 sync 실패 기록(doctor와 session-start
알림)으로 드러납니다. 진짜 격리는 별도 worktree가 필요합니다.

## 수동 검증

실세션 QA(`/hypo:upgrade`로 배포 후, 라이브 세션에서 Stop 훅이 세션 경로만 커밋하고
다른 세션의 staged 파일은 건드리지 않는지 확인)는 대기 중이고, `qa-runs/`에 기록될
때까지 이 PR은 draft입니다. 유닛 커버리지: 재작성한 parity 테스트가 무관한 staged
파일이 커밋에서 빠지고 staged로 남는지 단언하고, 빈/세션없음 스코프, 비ASCII 경로,
훅 생성 출력 포함, 커밋 실패·손상 파일 복구, 단일 락 same-path 케이스 회귀 테스트를
더했습니다. 전체 `npm test`와 `npm run lint` 통과.

## 마이그레이션 노트

없음. 새 상태는 gitignore되는 `.cache/` 아래에 필요 시 생성됩니다.

---

## Changelog

- EN: Vault auto-commit now commits only the current session's touched paths, so a concurrent session's staged files are no longer swept into an unrelated commit.
- KO: 볼트 auto-commit이 이번 세션이 건드린 경로만 커밋해, 동시에 도는 다른 세션의 staged 파일이 무관한 커밋에 섞이지 않습니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
