### PR TITLE
feat(doctor): surface the last successful sync time

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -19,6 +19,7 @@ import {
   formatGrowthMetrics,
   readSyncState,
   clearSyncState,
+  recordSyncSuccess,
   readClearMarker,
   clearClearMarker,
   loadHypoIgnore,
@@ -253,14 +254,22 @@ function buildClearRecoveryLine(source) {
   );
 }
 
-/** Pull the wiki repo. Returns true only when the pull actually succeeded. */
+/**
+ * Pull the wiki repo. Returns true only when the pull actually succeeded. On
+ * success, also records the last-success timestamp (silently — no notice; the
+ * existing failure notice below is unchanged) so doctor never reports "never
+ * synced" right after a healthy startup pull, even when no auto-commit Stop
+ * hook has run yet this session.
+ */
 function gitPull(dir) {
   if (!existsSync(join(dir, '.git'))) return false;
   const r = spawnSync('git', ['-C', dir, 'pull', '--ff-only', '--quiet'], {
     stdio: 'pipe',
     timeout: 10000,
   });
-  return r.status === 0;
+  const ok = r.status === 0;
+  if (ok) recordSyncSuccess(dir, 'pull');
+  return ok;
 }
 
 /**

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1528,6 +1528,7 @@ export function syncRemote(hypoDir) {
     const pull = git('pull', '--no-rebase', '-q');
     if (pull.status === 0) {
       result.pulled = true;
+      recordSyncSuccess(hypoDir, 'pull');
     } else {
       // A merge conflict leaves unmerged index entries; a network/auth failure
       // leaves none. Only the former must be aborted to keep the tree clean.
@@ -1552,8 +1553,10 @@ export function syncRemote(hypoDir) {
       appendSyncFailure(hypoDir, 'pull', pull.stderr || pull.stdout);
     }
     const push = git('push');
-    if (push.status === 0) result.pushed = true;
-    else appendSyncFailure(hypoDir, 'push', push.stderr || push.stdout);
+    if (push.status === 0) {
+      result.pushed = true;
+      recordSyncSuccess(hypoDir, 'push');
+    } else appendSyncFailure(hypoDir, 'push', push.stderr || push.stdout);
   } catch {
     // best-effort — never break the Stop hook
   }
@@ -1658,6 +1661,134 @@ export function clearSyncState(hypoDir) {
     rmSync(syncStatePath(hypoDir), { force: true });
   } catch {
     // best-effort
+  }
+}
+
+// ── sync-last-success ────────────────────────────────────────
+// `.cache/sync-last-success.json` is a single JSON object, PER-OPERATION:
+//   { "pull": {"timestamp": "<ISO>", "host": "<os.hostname()>"},
+//     "push": {"timestamp": "<ISO>", "host": "<...>"} }
+// Either key may be absent (pull-only or push-only history). Deliberately
+// separate from sync-state.json: that file is failure-only and gets wiped
+// wholesale on recovery (clearSyncState), so a success record living there
+// would be erased by the very thing it is meant to survive. syncRemote()
+// records here on a successful pull/push; session-start's independent
+// `git pull --ff-only` records a pull here too, so doctor never reports
+// "never synced" right after a healthy startup pull. doctor reads it via
+// readSyncLastSuccess; schema + parsing live here only.
+//
+// Scope: `.cache/` is gitignored (templates/gitignore), same as
+// sync-state.json — this file never syncs across machines, so there is no
+// cross-machine merge to protect. The lock below only has to cover the
+// same-machine case: two concurrent processes on one machine (a pull-writer
+// and a push-writer, or two overlapping sessions). `host` is kept per record
+// purely for provenance (which machine last recorded the op), not because a
+// remote write could ever land here.
+
+/** @returns {string} path to the sync-last-success JSON file for a wiki root. */
+function syncLastSuccessPath(hypoDir) {
+  return join(hypoDir, '.cache', 'sync-last-success.json');
+}
+
+/**
+ * A valid last-success record: `{timestamp: string, host: string}`. Anything
+ * else (wrong type, missing field, non-object) is malformed.
+ * @param {unknown} v
+ * @returns {boolean}
+ */
+function isValidSyncSuccessRecord(v) {
+  return (
+    v !== null &&
+    typeof v === 'object' &&
+    !Array.isArray(v) &&
+    typeof v.timestamp === 'string' &&
+    v.timestamp.trim().length > 0 &&
+    typeof v.host === 'string' &&
+    v.host.trim().length > 0
+  );
+}
+
+/**
+ * Read last-success records. A missing file means "never synced" (not an
+ * error) — the caller distinguishes that from a parse failure via
+ * `parseError`. A present `pull`/`push` field that does not match the
+ * `{timestamp, host}` shape (including an empty/whitespace-only timestamp or
+ * host — a technically-typed but content-free record) is dropped from `data`
+ * (never surfaced as if it were a real record) AND flags `parseError: true`,
+ * so the caller warns ("cannot parse ... inspect manually") instead of
+ * silently rendering `undefined` or an empty value — same corrupt-file
+ * handling as sync-state.json. An unrecognized top-level key (anything other
+ * than `pull`/`push`) likewise flags the whole file as corrupt: this schema
+ * has exactly two legal keys, so a third one is evidence of a hand-edit or a
+ * future/foreign writer, not a shape this reader should quietly tolerate.
+ *
+ * @param {string} hypoDir
+ * @returns {{data: {pull?: {timestamp: string, host: string}, push?: {timestamp: string, host: string}}, parseError: boolean}}
+ */
+export function readSyncLastSuccess(hypoDir) {
+  const path = syncLastSuccessPath(hypoDir);
+  if (!existsSync(path)) return { data: {}, parseError: false };
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed))
+      return { data: {}, parseError: true };
+    let malformed = Object.keys(parsed).some((k) => k !== 'pull' && k !== 'push');
+    const data = {};
+    for (const op of ['pull', 'push']) {
+      if (parsed[op] === undefined) continue;
+      if (isValidSyncSuccessRecord(parsed[op])) data[op] = parsed[op];
+      else malformed = true; // drop the bad field; flag the file as corrupt
+    }
+    return { data, parseError: malformed };
+  } catch {
+    return { data: {}, parseError: true };
+  }
+}
+
+/**
+ * Record a successful pull or push. Concurrency-safe on the same machine:
+ * takes the vault file lock on the target path, re-reads the CURRENT file
+ * under the lock, updates only the given op's field (the other op's existing
+ * value survives — a same-machine concurrent pull-writer and push-writer must
+ * not erase each other), then commits via temp-write + rename so a crash or a
+ * concurrent read never sees a half-written file. `.cache/` is gitignored, so
+ * this file never syncs across machines — there is no cross-machine case to
+ * protect here. A pre-existing but unparseable file, or a sibling field that
+ * does not match `{timestamp, host}` (including an empty/whitespace-only
+ * value) or that carries an unrecognized key, is dropped rather than carried
+ * forward (never preserve garbage into a freshly-written record) — the same
+ * `isValidSyncSuccessRecord` predicate readSyncLastSuccess uses.
+ *
+ * Lock acquisition is best-effort — a timeout (or any other failure) is
+ * swallowed, same as appendSyncFailure, since a failed success-log must never
+ * break the caller (Stop hook / SessionStart).
+ *
+ * @param {string} hypoDir
+ * @param {'pull'|'push'} op
+ */
+export function recordSyncSuccess(hypoDir, op) {
+  try {
+    const path = syncLastSuccessPath(hypoDir);
+    withFileLock(path, () => {
+      let current = {};
+      try {
+        if (existsSync(path)) {
+          const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            for (const k of ['pull', 'push']) {
+              if (isValidSyncSuccessRecord(parsed[k])) current[k] = parsed[k];
+            }
+          }
+        }
+      } catch {
+        // corrupt existing file: overwrite with a fresh object rather than
+        // carry the corruption forward.
+      }
+      current[op] = { timestamp: new Date().toISOString(), host: hostname() };
+      atomicWriteShared(path, JSON.stringify(current, null, 2) + '\n');
+    });
+  } catch {
+    // best-effort: lock timeout or write failure must never break the caller
   }
 }
 

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -23,6 +23,7 @@ import { resolveGitHooksDir } from './lib/git-hooks-dir.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import {
   readSyncState,
+  readSyncLastSuccess,
   projectSuggestionsPath,
   collectProjectWorkingDirs,
 } from '../hooks/hypo-shared.mjs';
@@ -683,6 +684,21 @@ function checkProjectIndexAnchors(hypoDir) {
   }
 }
 
+/**
+ * Render a `.cache/sync-last-success.json` record as an absolute-time note.
+ * Deliberately no "recent"/staleness verdict — the failure-state check above
+ * already carries the health signal; this only says what and when.
+ */
+function formatLastSuccess(lastSuccess) {
+  const pull = lastSuccess.pull
+    ? `pull ${lastSuccess.pull.timestamp} (${lastSuccess.pull.host})`
+    : 'pull: none recorded';
+  const push = lastSuccess.push
+    ? `push ${lastSuccess.push.timestamp} (${lastSuccess.push.host})`
+    : 'push: none recorded';
+  return `${pull}; ${push}`;
+}
+
 function checkSyncState(hypoDir) {
   // "open" = file exists with ≥1 entries; session-start clears once
   // sync is healthy again. Schema + parsing live in hooks/hypo-shared.mjs.
@@ -694,7 +710,27 @@ function checkSyncState(hypoDir) {
   }
 
   if (entries.length === 0) {
-    pass('Sync state', 'No unresolved sync failures');
+    // No unresolved failure — but that alone does not mean sync ever ran.
+    // Read the separate, additive last-success record to tell "never synced"
+    // apart from "healthy" and, when present, from a pull-only/push-only
+    // history. A corrupt success file warns rather than crashing, same as the
+    // sync-state parse-error handling above.
+    const { data: lastSuccess, parseError: successParseError } = readSyncLastSuccess(hypoDir);
+    if (successParseError) {
+      warn('Sync state', 'Cannot parse .cache/sync-last-success.json — inspect manually');
+    } else if (!lastSuccess.pull && !lastSuccess.push) {
+      pass(
+        'Sync state',
+        'No unresolved sync failures — never synced (no recorded pull or push yet)',
+      );
+    } else {
+      // Distinguishes pull-only / push-only / both, since formatLastSuccess
+      // reports "none recorded" for whichever op is absent.
+      pass(
+        'Sync state',
+        `No unresolved sync failures. Last success — ${formatLastSuccess(lastSuccess)}`,
+      );
+    }
   } else {
     const last = entries[entries.length - 1];
     // A merge conflict needs a real manual merge, not a plain push/pull — give

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -278,6 +278,203 @@ test('doctor-sync-state-warn: conflict entry → manual-merge guidance, not gene
   });
 });
 
+// FEAT-34: last-success timestamp visibility in the sync-state check.
+suite('doctor.mjs — FEAT-34: sync-last-success visibility');
+
+function syncFixtureWiki(dir) {
+  writeFileSync(join(dir, 'hypo-config.md'), '# config');
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  mkdirSync(join(dir, 'projects'), { recursive: true });
+  mkdirSync(join(dir, 'sources'), { recursive: true });
+}
+
+test('doctor-sync-last-success: no success file, no failures → never synced (not unqualified healthy)', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'pass', `expected pass: ${check.detail}`);
+    assert.ok(
+      /never synced/.test(check.detail),
+      `absent success record must say "never synced", not an unqualified healthy message: ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-last-success: pull-only record → reports pull time, notes push missing', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: { timestamp: '2026-07-20T00:00:00.000Z', host: 'test-host' } }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'pass', `expected pass: ${check.detail}`);
+    assert.ok(
+      check.detail.includes('2026-07-20T00:00:00.000Z') && check.detail.includes('test-host'),
+      `pull success time/host must be reported: ${check.detail}`,
+    );
+    assert.ok(
+      /push: none recorded/.test(check.detail),
+      `push-absent must be called out distinctly, not implied: ${check.detail}`,
+    );
+    assert.ok(
+      !/never synced/.test(check.detail),
+      `a pull-only record is not "never synced": ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-last-success: push-only record → reports push time, notes pull missing', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ push: { timestamp: '2026-07-19T12:00:00.000Z', host: 'other-host' } }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'pass', `expected pass: ${check.detail}`);
+    assert.ok(
+      check.detail.includes('2026-07-19T12:00:00.000Z') && check.detail.includes('other-host'),
+      `push success time/host must be reported: ${check.detail}`,
+    );
+    assert.ok(
+      /pull: none recorded/.test(check.detail),
+      `pull-absent must be called out distinctly: ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-last-success: corrupt sync-last-success.json → warn, not crash', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, '.cache', 'sync-last-success.json'), 'not-json{{{');
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    assert.ok(r.status !== null && r.status <= 1, `doctor must not crash: exit ${r.status}`);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `corrupt success file must warn: ${check.detail}`);
+    assert.ok(
+      /sync-last-success\.json/.test(check.detail),
+      `warn must name the offending file: ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-last-success: malformed pull/push record (schema-valid JSON, wrong shape) → warn, not "undefined (undefined)"', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    // Parseable JSON, but `pull` is a string instead of {timestamp, host} —
+    // must not render as `pull undefined (undefined)`.
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: 'not-a-record' }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `malformed success record must warn: ${check.detail}`);
+    assert.ok(
+      !/undefined/.test(check.detail),
+      `malformed record must never render "undefined": ${check.detail}`,
+    );
+    assert.ok(
+      /sync-last-success\.json/.test(check.detail),
+      `warn must name the offending file: ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-last-success: empty-string timestamp/host → warn, not a false "pull ()" pass', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    // typeof === 'string' is true for '', so a naive check would accept this
+    // and render "pull  ()" as a healthy pass.
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: { timestamp: '', host: '' } }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `empty timestamp/host must warn, not pass: ${check.detail}`);
+    assert.ok(
+      !/pull \(\)|pull\s*$/.test(check.detail),
+      `must not render an empty "pull ()" as if it were a real record: ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-last-success: unrecognized top-level key → warn, not silently ignored', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({
+        pull: { timestamp: '2026-07-20T00:00:00.000Z', host: 'test-host' },
+        unexpectedKey: 'hand-edit or foreign writer',
+      }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(
+      check.status,
+      'warn',
+      `an unrecognized top-level key must warn, not be silently ignored: ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-last-success: unresolved failure still reported unchanged, even with a success record present', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: { timestamp: '2026-07-20T00:00:00.000Z', host: 'test-host' } }),
+    );
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-07-20T01:00:00Z',
+        op: 'push',
+        error: 'network timeout',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    // The failure-reporting branch is unchanged by FEAT-34: same message shape
+    // as the pre-existing "open sync-state.json entries → warn" test.
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+    assert.ok(
+      /unresolved failure\(s\) — last: push at 2026-07-20T01:00:00Z/.test(check.detail),
+      `unresolved-failure detail must be unchanged: ${check.detail}`,
+    );
+  });
+});
+
 suite('doctor.mjs — per-project index.md working_dir anchor coverage');
 
 function doctorAnchorCheck(dir) {

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -23,6 +23,8 @@ import {
   findBackfillCandidate,
   buildBackfillSuggestionLine,
   computeSessionGrowth,
+  recordSyncSuccess,
+  readSyncLastSuccess,
 } from '../hooks/hypo-shared.mjs';
 import { test, suite } from './harness.mjs';
 import {
@@ -1682,6 +1684,228 @@ test('session-start surfaces a conflict entry with manual-merge guidance', () =>
     const ctx = JSON.parse(r.stdout).additionalContext || '';
     assert.ok(ctx.includes('remote diverged'), `conflict notice missing: ${ctx}`);
     assert.ok(ctx.includes('pull --no-rebase'), `manual-merge guidance missing: ${ctx}`);
+  });
+});
+
+// ── FEAT-34: last-success timestamp visibility ──────────────────────────────
+//
+// recordSyncSuccess writes `.cache/sync-last-success.json`, a separate,
+// PER-OPERATION file (sync-state.json is failure-only and gets wiped on
+// recovery, so a success record living there would be erased). The
+// concurrency contract under test: a pull-write and a push-write must not
+// erase each other's field — proving that requires actually writing pull
+// then push and checking both survive, not just checking the latest write.
+
+function readSyncLastSuccessFile(dir) {
+  return JSON.parse(readFileSync(join(dir, '.cache', 'sync-last-success.json'), 'utf-8'));
+}
+
+suite('FEAT-34 — recordSyncSuccess concurrency-safe merge');
+
+test('recordSyncSuccess: pull then push preserves both fields (no last-writer-wins erasure)', () => {
+  withGrowthWiki((dir) => {
+    recordSyncSuccess(dir, 'pull');
+    const afterPull = readSyncLastSuccessFile(dir);
+    assert.ok(
+      afterPull.pull?.timestamp && afterPull.pull?.host,
+      `pull field missing: ${JSON.stringify(afterPull)}`,
+    );
+    assert.ok(
+      !afterPull.push,
+      `push must be absent before it is recorded: ${JSON.stringify(afterPull)}`,
+    );
+
+    recordSyncSuccess(dir, 'push');
+    const afterPush = readSyncLastSuccessFile(dir);
+    // The proof: the push write did NOT clobber the pull field recorded above.
+    assert.ok(
+      afterPush.pull?.timestamp === afterPull.pull.timestamp &&
+        afterPush.pull?.host === afterPull.pull.host,
+      `push write must not erase the existing pull field (merge, not overwrite): ${JSON.stringify(afterPush)}`,
+    );
+    assert.ok(
+      afterPush.push?.timestamp && afterPush.push?.host,
+      `push field missing: ${JSON.stringify(afterPush)}`,
+    );
+  });
+});
+
+test('recordSyncSuccess: re-recording the same op overwrites only that op, with a fresh timestamp/host', () => {
+  withGrowthWiki((dir) => {
+    recordSyncSuccess(dir, 'pull');
+    const first = readSyncLastSuccessFile(dir).pull;
+    recordSyncSuccess(dir, 'pull');
+    const second = readSyncLastSuccessFile(dir).pull;
+    assert.equal(second.host, first.host, 'host should be stable within one test process');
+    assert.ok(second.timestamp, 'the re-recorded entry must still carry a timestamp');
+  });
+});
+
+test('recordSyncSuccess: never throws on a corrupt existing file — overwrites with a fresh record', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, '.cache', 'sync-last-success.json'), 'not-json{{{');
+    assert.doesNotThrow(() => recordSyncSuccess(dir, 'push'));
+    const data = readSyncLastSuccessFile(dir);
+    assert.ok(
+      data.push?.timestamp,
+      `push must be recorded despite prior corruption: ${JSON.stringify(data)}`,
+    );
+  });
+});
+
+test('recordSyncSuccess: a malformed sibling field is dropped on write, not preserved as garbage', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    // pull is schema-valid JSON but the wrong shape (not {timestamp, host})
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: 'not-a-record' }),
+    );
+    recordSyncSuccess(dir, 'push');
+    const data = readSyncLastSuccessFile(dir);
+    assert.ok(
+      data.push?.timestamp && data.push?.host,
+      `push must be recorded: ${JSON.stringify(data)}`,
+    );
+    assert.ok(
+      !('pull' in data) ||
+        (typeof data.pull === 'object' && typeof data.pull.timestamp === 'string'),
+      `a malformed sibling must be dropped, never carried forward as garbage: ${JSON.stringify(data)}`,
+    );
+    assert.notEqual(data.pull, 'not-a-record', 'the malformed string must not survive the write');
+  });
+});
+
+test('recordSyncSuccess: an empty-string sibling ({timestamp:"",host:""}) is dropped on write, not preserved', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: { timestamp: '', host: '' } }),
+    );
+    recordSyncSuccess(dir, 'push');
+    const data = readSyncLastSuccessFile(dir);
+    assert.ok(
+      data.push?.timestamp && data.push?.host,
+      `push must be recorded: ${JSON.stringify(data)}`,
+    );
+    assert.ok(
+      !data.pull,
+      `an empty-string sibling must be dropped, not carried forward: ${JSON.stringify(data)}`,
+    );
+  });
+});
+
+test('readSyncLastSuccess: empty-string timestamp/host is rejected (not merely typeof-checked)', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: { timestamp: '', host: '' } }),
+    );
+    const { data, parseError } = readSyncLastSuccess(dir);
+    assert.equal(
+      parseError,
+      true,
+      'an empty-string record must flag parseError, not pass as valid',
+    );
+    assert.ok(!data.pull, 'the empty-string record must be dropped, never surfaced as real data');
+  });
+});
+
+test('readSyncLastSuccess: an unrecognized top-level key flags the file as corrupt', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({
+        pull: { timestamp: '2026-07-20T00:00:00.000Z', host: 'test-host' },
+        unexpectedKey: 'hand-edit',
+      }),
+    );
+    const { data, parseError } = readSyncLastSuccess(dir);
+    assert.equal(parseError, true, 'an unrecognized top-level key must be treated as corrupt');
+    assert.ok(data.pull, 'a genuinely valid sibling field is still surfaced even under parseError');
+  });
+});
+
+test('readSyncLastSuccess: a genuinely valid populated pull and push record is preserved (regression guard)', () => {
+  withGrowthWiki((dir) => {
+    recordSyncSuccess(dir, 'pull');
+    recordSyncSuccess(dir, 'push');
+    const { data, parseError } = readSyncLastSuccess(dir);
+    assert.equal(parseError, false);
+    assert.ok(
+      data.pull?.timestamp && data.pull?.host,
+      `pull must survive: ${JSON.stringify(data)}`,
+    );
+    assert.ok(
+      data.push?.timestamp && data.push?.host,
+      `push must survive: ${JSON.stringify(data)}`,
+    );
+  });
+});
+
+test('readSyncLastSuccess: a malformed pull/push record is dropped from data and flags parseError', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-last-success.json'),
+      JSON.stringify({ pull: 'not-a-record' }),
+    );
+    const { data, parseError } = readSyncLastSuccess(dir);
+    assert.equal(parseError, true, 'a malformed record must flag parseError so the caller warns');
+    assert.ok(!data.pull, 'the malformed field must be dropped, never rendered as pull:undefined');
+  });
+});
+
+suite(
+  'FEAT-34 — doctor never-synced vs healthy distinction (proved red without the success record)',
+);
+
+test('proved red: without any recorded success, the sync-state check cannot distinguish never-synced from healthy', () => {
+  withGrowthWiki((dir) => {
+    // No sync-state.json failures, and — the point of this test — no
+    // sync-last-success.json either, simulating the pre-FEAT-34 world where
+    // readSyncLastSuccess did not exist and checkSyncState had nothing to
+    // read. readSyncLastSuccess on a missing file returns {} (never synced),
+    // which is the fixture this suite's doctor tests rely on to tell "never
+    // synced" apart from "healthy" — assert that distinguishing signal is
+    // present so a regression that silently stops writing/reading the file
+    // is caught here too, not only in doctor.test.mjs.
+    const { data, parseError } = readSyncLastSuccess(dir);
+    assert.equal(parseError, false);
+    assert.deepEqual(data, {}, 'an unrecorded wiki must read back as "no success recorded"');
+
+    recordSyncSuccess(dir, 'pull');
+    const { data: afterRecord } = readSyncLastSuccess(dir);
+    assert.ok(
+      afterRecord.pull,
+      'after a recorded pull, the same read must show it — the distinguishing signal',
+    );
+  });
+});
+
+suite('FEAT-34 — session-start independent pull records success silently');
+
+test('session-start: a successful startup pull records sync-last-success without a new notice line', () => {
+  withSyncedWiki((dir) => {
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'sync-last-success.json')),
+      'no prior success record',
+    );
+    const r = runStart(dir);
+    assert.equal(r.status, 0, `session-start must exit 0: ${r.stderr}`);
+    const data = readSyncLastSuccessFile(dir);
+    assert.ok(
+      data.pull?.timestamp && data.pull?.host,
+      `startup pull must record success: ${JSON.stringify(data)}`,
+    );
+    // Silent: the existing failure-notice contract is unchanged — no new
+    // success line is injected into additionalContext.
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(!ctx.includes('sync-last-success'), `startup pull success must stay silent: ${ctx}`);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`hypo:doctor` now reports the last successful sync (pull and push) time, so a
vault that has synced cleanly is no longer indistinguishable from one that has
never synced at all.

## Why

Sync failures and unresolved conflicts already surface through doctor and the
session-start notice, but a successful pull or push left no trace anywhere. So
doctor printed "no unresolved sync failures" identically whether sync had just
succeeded a second ago or had literally never run. There was no way to answer
"is this vault actually syncing?"

## How

Success is recorded in a separate `.cache/sync-last-success.json`, holding a
per-operation `{timestamp, host}` for pull and for push. It is written on the
`syncRemote` pull and push success paths and on the session-start
`pull --ff-only` success path, under the existing vault file lock with a
read, merge, atomic-rename so a pull writer and a push writer cannot erase each
other's field. doctor reads it and distinguishes never-synced, pull-only,
push-only, healthy, and a corrupt record, and rejects a technically-typed but
empty or unknown-keyed record rather than rendering a blank value.

The failure-only `sync-state.json` and its existing reporting are untouched;
this is purely additive. The success record is per-machine (like the failure
record, `.cache/` is gitignored), so the lock only needs to serialize
concurrent writers on the same machine.

## Manual verification

Real-session QA (deploy via `/hypo:upgrade`, force a successful sync, and
confirm `hypo:doctor` shows the last pull/push time; then a fresh vault shows
never-synced) is pending; this PR is a draft until recorded in `qa-runs/`. Unit
coverage: doctor tests for never-synced, pull-only, push-only, corrupt, empty,
and unknown-key records, plus the concurrency-merge test that a push write
preserves an existing pull field. Full `npm test` and `npm run lint` pass.

## Migration notes

None. The new record lives under the gitignored `.cache/` and is created on the
next successful sync.

---

# 한국어

## 변경 내용

`hypo:doctor`가 마지막 성공 동기화(pull과 push) 시각을 보고합니다. 그래서 깨끗이
동기화된 볼트와 한 번도 동기화 안 된 볼트가 더는 똑같아 보이지 않습니다.

## 이유

동기화 실패와 미해결 충돌은 이미 doctor와 session-start 알림으로 드러났지만, pull이나
push 성공은 어디에도 흔적을 안 남겼습니다. 그래서 doctor는 방금 성공했든 한 번도 안
돌았든 "미해결 동기화 실패 없음"을 똑같이 찍었습니다. "이 볼트가 실제로 동기화되고
있나?"에 답할 방법이 없었습니다.

## 방법

성공은 별도 `.cache/sync-last-success.json`에 pull과 push 각각의 `{timestamp, host}`로
기록합니다. `syncRemote`의 pull·push 성공 경로와 session-start의 `pull --ff-only`
성공 경로에서, 기존 볼트 파일 락 아래 read, merge, atomic-rename로 써서 pull 기록자와
push 기록자가 서로의 필드를 지우지 못하게 합니다. doctor가 이걸 읽어 never-synced,
pull-only, push-only, healthy, 손상 record를 구분하고, 형식만 맞고 비었거나 미인식 키가
있는 record는 빈 값 렌더 대신 거부합니다.

실패 전용 `sync-state.json`과 기존 보고는 그대로입니다. 순수 추가입니다. 성공 record는
머신 로컬입니다(실패 record처럼 `.cache/`는 gitignore됨). 그래서 락은 같은 머신의 동시
기록자만 직렬화하면 됩니다.

## 수동 검증

실세션 QA(`/hypo:upgrade`로 배포, 성공 동기화를 유발해 `hypo:doctor`가 마지막 pull/push
시각을 보이는지, 새 볼트에선 never-synced가 뜨는지 확인)는 대기 중이고, `qa-runs/`에
기록될 때까지 이 PR은 draft입니다. 유닛 커버리지: never-synced, pull-only, push-only,
손상, 빈, 미인식 키 record에 대한 doctor 테스트와, push 쓰기가 기존 pull 필드를
보존하는 동시성 merge 테스트. 전체 `npm test`와 `npm run lint` 통과.

## 마이그레이션 노트

없음. 새 record는 gitignore되는 `.cache/` 아래에 다음 성공 동기화 때 생성됩니다.

---

## Changelog

- EN: `hypo:doctor` now shows the last successful pull and push time, distinguishing a healthy vault from one that has never synced.
- KO: `hypo:doctor`가 마지막 pull·push 성공 시각을 보여줘, 정상 볼트와 한 번도 동기화 안 된 볼트를 구분합니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
