### PR TITLE
fix(cli): fail loud on unknown flags, and stop reporting a clean scan with no vault

### DIFF
--- a/scripts/graph.mjs
+++ b/scripts/graph.mjs
@@ -91,7 +91,7 @@ function escapeDot(s) {
 
 // ── formatters ────────────────────────────────────────────────────────────────
 
-function formatJson(pages, graph, minEdges) {
+function formatJson(pages, graph, minEdges, vaultFound) {
   const nodes = pages
     .map((p) => ({
       slug: p.slug,
@@ -107,7 +107,9 @@ function formatJson(pages, graph, minEdges) {
     return fn && tn;
   });
 
-  return JSON.stringify({ nodes, edges }, null, 2);
+  // vaultFound: same reasoning as lint.mjs/stats.mjs — an empty graph from a
+  // vault that was never found must not read the same as a real, linkless one.
+  return JSON.stringify({ nodes, edges, vaultFound }, null, 2);
 }
 
 function formatMermaid(pages, graph, minEdges) {
@@ -156,7 +158,11 @@ function formatDot(pages, graph, minEdges) {
 const args = parseArgs(process.argv);
 // Only validate the auto-resolved path (env/marker/default). An explicit
 // --hypo-dir=<path> (tests, other tooling) is trusted as-is, valid or not.
-if (args.hypoDirSource) checkVaultOrExit(args.hypoDir, args.hypoDirSource);
+// See lint.mjs's matching comment: source 'default'/stale-'marker' stays
+// exit-0 (CI-safe).
+const vaultMissing = args.hypoDirSource
+  ? checkVaultOrExit(args.hypoDir, args.hypoDirSource)
+  : false;
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects'].map((d) => join(args.hypoDir, d));
@@ -164,13 +170,22 @@ const pages = scanDirs.flatMap((d) => collectPagesGraph(d, args.hypoDir, ignoreP
 const slugIndex = buildSlugIndex(pages);
 const graph = buildGraph(pages, slugIndex);
 
-switch (args.format) {
-  case 'mermaid':
-    console.log(formatMermaid(pages, graph, args.minEdges));
-    break;
-  case 'dot':
-    console.log(formatDot(pages, graph, args.minEdges));
-    break;
-  default:
-    console.log(formatJson(pages, graph, args.minEdges));
+if (vaultMissing && (args.format === 'mermaid' || args.format === 'dot')) {
+  // Same reasoning as lint.mjs/stats.mjs: mermaid/dot render straight to a
+  // diagram tool with no JSON envelope to carry `vaultFound`, so a valid but
+  // linkless diagram from a real (empty) vault and "no vault was found at
+  // all" would otherwise render identically. checkVaultOrExit already put the
+  // "No Hypomnema vault found" notice on stderr; suppress the stdout diagram
+  // rather than hand the renderer an empty-but-"real"-looking graph.
+} else {
+  switch (args.format) {
+    case 'mermaid':
+      console.log(formatMermaid(pages, graph, args.minEdges));
+      break;
+    case 'dot':
+      console.log(formatDot(pages, graph, args.minEdges));
+      break;
+    default:
+      console.log(formatJson(pages, graph, args.minEdges, !vaultMissing));
+  }
 }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -143,6 +143,9 @@ Commands:
   capture                 Reverse-capture ~/.claude/{commands,agents} extensions and
                           settings.json hooks into the wiki for cross-machine sync
                           (pass names or --all; --dry-run to preview)
+  proposal                Manage staged crystallize proposals: list, apply, or
+                          discard a parked write (also challenge/resolve for the
+                          no-TTY agent approval channel)
 
   Running \`hypomnema\` with no command is equivalent to \`hypomnema init\`.
 
@@ -165,10 +168,14 @@ Init options:
                          to a blocking error), sequenced after the .hypoignore
                          guard. Off by default; re-run init to add or drop it.
   --dry-run              Show what would be done without making changes
+  --version              Print the installed package version and exit
   --help, -h             Show this help message
 
 Subcommand-specific flags (upgrade/doctor/uninstall/capture) live in the
 docstring at the top of scripts/<command>.mjs; capture also accepts \`--help\`.`);
+      process.exit(0);
+    } else if (arg === '--version') {
+      console.log(PKG_VERSION ?? 'unknown');
       process.exit(0);
     } else if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
     else if (arg === '--no-hooks') args.hooks = false;
@@ -190,6 +197,18 @@ docstring at the top of scripts/<command>.mjs; capture also accepts \`--help\`.`
     else if (arg.startsWith('--shell-config=')) args.shellConfig = expandHome(arg.slice(15));
     else if (arg === '--allow-downgrade') args.allowDowngrade = true;
     else if (arg === '--lint-strict') args.lintStrict = true;
+    else {
+      // An unrecognized argument used to fall through silently and run the
+      // default init flow (scaffold + hook install + settings.json merge) —
+      // a destructive write triggered by what looked like a query. `--version`
+      // was the concrete case that bit a user: it reads like an inspection
+      // flag, was never implemented, and its typo/mistake landed on a live
+      // wiki's pre-commit hook instead of printing anything. Fail loud and
+      // do nothing, rather than guess what the caller meant.
+      console.error(`Unknown option: ${arg}`);
+      console.error('Run `hypomnema --help` for usage.');
+      process.exit(2);
+    }
   }
   return args;
 }

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -489,7 +489,16 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs, validTypes) {
 const args = parseArgs(process.argv);
 // Only validate the auto-resolved path (env/marker/default). An explicit
 // --hypo-dir=<path> (tests, other tooling) is trusted as-is, valid or not.
-if (args.hypoDirSource) checkVaultOrExit(args.hypoDir, args.hypoDirSource);
+// `vaultMissing` stays on the CI-safe exit-0 path (source 'default'/stale-
+// 'marker' — see checkVaultOrExit's doc comment and its pinned test coverage):
+// this repo's own `npm run lint` runs with no vault at all and must keep
+// passing. What was actually missing is that a vault-less run still printed
+// "no lint issues found" — indistinguishable, on stdout or in --json, from a
+// real empty vault that was actually scanned. Suppress that false-positive-
+// looking output below instead of changing the exit code.
+const vaultMissing = args.hypoDirSource
+  ? checkVaultOrExit(args.hypoDir, args.hypoDirSource)
+  : false;
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const scanDirs = ['pages', 'projects', 'journal'].map((d) => join(args.hypoDir, d));
@@ -597,6 +606,11 @@ if (args.json) {
     JSON.stringify(
       {
         ok: errors.length === 0,
+        // A machine consumer piping `--json` (the exact CI-scripting case that
+        // motivated this field) can tell "scanned and clean" apart from
+        // "nothing to scan" without needing stderr. `ok` keeps its existing
+        // errors-only meaning so nothing that already reads it breaks.
+        vaultFound: !vaultMissing,
         errors: errors.map(toOut),
         warns: warns.map(toOut),
         total: issues.length,
@@ -605,6 +619,11 @@ if (args.json) {
       2,
     ),
   );
+} else if (vaultMissing) {
+  // checkVaultOrExit already put the "No Hypomnema vault found" notice on
+  // stderr. Printing "✓ No lint issues found" here as well would claim a scan
+  // that never happened — the exact false-green shape a piped/redirected
+  // caller cannot tell apart from a real, clean vault.
 } else {
   if (issues.length === 0) {
     console.log('✓ No lint issues found');

--- a/scripts/stats.mjs
+++ b/scripts/stats.mjs
@@ -98,7 +98,12 @@ function getLastActivity(hypoDir) {
 const args = parseArgs(process.argv);
 // Only validate the auto-resolved path (env/marker/default). An explicit
 // --hypo-dir=<path> (tests, other tooling) is trusted as-is, valid or not.
-if (args.hypoDirSource) checkVaultOrExit(args.hypoDir, args.hypoDirSource);
+// See lint.mjs's matching comment: source 'default'/stale-'marker' stays
+// exit-0 (CI-safe), but the all-zero counts below must not be printed as if a
+// real (empty) vault had been scanned.
+const vaultMissing = args.hypoDirSource
+  ? checkVaultOrExit(args.hypoDir, args.hypoDirSource)
+  : false;
 
 const ignorePatterns = loadHypoIgnore(args.hypoDir);
 const pageFiles = collectMdFiles(join(args.hypoDir, 'pages'), [], args.hypoDir, ignorePatterns);
@@ -165,7 +170,14 @@ const stats = {
 };
 
 if (args.json) {
-  console.log(JSON.stringify(stats, null, 2));
+  // vaultFound lets a machine consumer of `--json` tell "scanned, genuinely
+  // empty" apart from "nothing was scanned" without needing stderr — the
+  // same reasoning as lint.mjs's matching field.
+  console.log(JSON.stringify({ ...stats, vaultFound: !vaultMissing }, null, 2));
+} else if (vaultMissing) {
+  // checkVaultOrExit already printed the "No Hypomnema vault found" notice on
+  // stderr. An all-zero stats block here would read as "scanned an empty
+  // vault", which never happened.
 } else {
   console.log(`Pages:    ${pageFiles.length} total`);
   const typeEntries = Object.entries(typeCounts).sort((a, b) => b[1] - a[1]);

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -1244,3 +1244,113 @@ test('dual install points the wiki pre-commit hook at the durable plugin root', 
     }
   });
 });
+
+// ── CLI surface: unknown args / --version / help-dispatch consistency ───────
+//
+// An unrecognized argument used to fall through the parseArgs loop silently
+// and run the default init flow (scaffold + hook install + settings.json
+// merge) — a destructive write triggered by what read like a query. `--version`
+// was the concrete case: never implemented, looks like an inspection flag, and
+// a typo landed on a live wiki's pre-commit hook instead of printing anything.
+
+suite('init.mjs — unknown args / --version / help-dispatch consistency');
+
+test('an unrecognized flag exits 2 with a usage hint and does not run init', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--version-typo']);
+    assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stdout: ${r.stdout}`);
+    assert.ok(
+      r.stderr.includes('Unknown option: --version-typo'),
+      `stderr should name the bad flag: ${r.stderr}`,
+    );
+    assert.ok(r.stderr.includes('--help'), `stderr should point at --help: ${r.stderr}`);
+    assert.ok(!existsSync(hypoDir), 'an unknown flag must not scaffold a wiki');
+  });
+});
+
+test('--version prints the package version and exits 0 without scaffolding', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const pkgVersion = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf-8')).version;
+    const r = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--version']);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.stdout.trim(), pkgVersion, `stdout: ${r.stdout}`);
+    assert.ok(!existsSync(hypoDir), '--version must not scaffold a wiki');
+  });
+});
+
+test('--help lists exactly the dispatchable subcommand set (regression for the missing "proposal" entry)', () => {
+  const r = run('init.mjs', ['--help']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+
+  const src = readFileSync(join(SCRIPTS, 'init.mjs'), 'utf-8');
+  const known = src.match(/const KNOWN_SUBCOMMANDS = new Set\(\[([\s\S]*?)\]\)/);
+  assert.ok(known, 'could not locate KNOWN_SUBCOMMANDS in scripts/init.mjs source');
+  const dispatched = new Set(
+    known[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean),
+  );
+
+  // Command names in the printed help: exactly 2 leading spaces, a lowercase
+  // (hyphenated) word, then 2+ spaces before the description. Continuation
+  // lines are indented past column 2 and the "Running ..." prose line starts
+  // uppercase, so both are excluded by construction rather than by an
+  // explicit denylist.
+  const listed = new Set([...r.stdout.matchAll(/^ {2}([a-z][a-z-]+)\s{2,}\S/gm)].map((m) => m[1]));
+
+  assert.ok(dispatched.size > 0, 'KNOWN_SUBCOMMANDS parsed as empty — regex likely stale');
+  assert.ok(listed.size > 0, 'help text parsed as empty — regex likely stale');
+  assert.deepEqual(
+    [...listed].sort(),
+    [...dispatched].sort(),
+    `help-listed commands must exactly match the dispatch set.\nlisted:     ${JSON.stringify([...listed].sort())}\ndispatched: ${JSON.stringify([...dispatched].sort())}`,
+  );
+  assert.ok(listed.has('proposal'), 'help must list the proposal subcommand (PR #185)');
+});
+
+// codex review finding (post-merge cross-check): --version was implemented
+// but never added to --help's own option list — the same shape of gap as the
+// "proposal" subcommand fix above, just one level down (an option instead of
+// a command). Same fix, same kind of drift test.
+
+test('--help lists --version among the Init options', () => {
+  const r = run('init.mjs', ['--help']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.ok(/^ {2}--version(?:\s|,)/m.test(r.stdout), `--help should list --version: ${r.stdout}`);
+});
+
+test('--help option list matches every flag parseArgs actually recognizes', () => {
+  const r = run('init.mjs', ['--help']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+
+  const src = readFileSync(join(SCRIPTS, 'init.mjs'), 'utf-8');
+  // Exact-match flags: `arg === '--word'` (picks up --help, --version,
+  // --no-hooks, etc; the bare '-h' alias is intentionally not a member of
+  // this set — it is documented as ", -h" alongside --help, not as its own
+  // line). Prefix flags: `arg.startsWith('--word=')`, normalized by dropping
+  // the trailing '='.
+  const exact = [...src.matchAll(/arg\s*===\s*'(--[a-zA-Z-]+)'/g)].map((m) => m[1]);
+  const prefixed = [...src.matchAll(/arg\.startsWith\('(--[a-zA-Z-]+)='\)/g)].map((m) => m[1]);
+  const recognized = new Set([...exact, ...prefixed]);
+
+  // Flag names in the printed "Init options:" block: 2 leading spaces, the
+  // flag, an optional `=<placeholder>` or `, -h` alias, then 2+ spaces before
+  // the description. Continuation lines (indented past column 2) don't match.
+  const listed = new Set(
+    [...r.stdout.matchAll(/^ {2}(--[a-zA-Z-]+)(?:=\S+)?(?:,\s*-h)?\s{2,}\S/gm)].map((m) => m[1]),
+  );
+
+  assert.ok(
+    recognized.size > 0,
+    'no recognized flags parsed from init.mjs source — regex likely stale',
+  );
+  assert.ok(listed.size > 0, 'no flags parsed from --help output — regex likely stale');
+  assert.deepEqual(
+    [...listed].sort(),
+    [...recognized].sort(),
+    `--help's option list must exactly match the flags parseArgs recognizes.\nlisted:     ${JSON.stringify([...listed].sort())}\nrecognized: ${JSON.stringify([...recognized].sort())}`,
+  );
+});

--- a/tests/lib-core.test.mjs
+++ b/tests/lib-core.test.mjs
@@ -290,6 +290,126 @@ test('valid vault via HYPO_DIR (marker present) → all 4 read CLIs behave as be
   }
 });
 
+// ── ISSUE-51 follow-up: vault-missing must not look like a real, clean scan ──
+//
+// checkVaultOrExit's exit-0 "default"/stale-"marker" path stays exit-0 (this
+// repo's own `npm run lint` in CI relies on it, pinned above) — but the
+// callers used to print their normal success shape regardless, so a piped
+// `--json` consumer (or a plain stdout read) could not tell "genuinely
+// scanned and empty" apart from "found no vault at all". Prove both halves:
+// the human-facing success line is suppressed, and the machine-facing `--json`
+// payload carries an explicit `vaultFound: false`.
+
+test('lint.mjs: no vault → stdout does NOT claim "No lint issues found"', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-lint-'));
+  try {
+    const r = spawnCli('lint.mjs', [], { HOME: noVaultHome, HYPO_DIR: '' });
+    assert.equal(r.status, 0, `expected exit 0 (CI-safe), got ${r.status}. stderr: ${r.stderr}`);
+    assert.ok(
+      !r.stdout.includes('No lint issues found'),
+      `no-vault run must not claim a clean scan that never happened: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+test('lint.mjs --json: no vault → vaultFound:false; real (empty) vault → vaultFound:true', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-lint-json-'));
+  const validDir = mkdtempSync(join(tmpdir(), 'hypo-valid-vault-lint-json-'));
+  try {
+    const missing = spawnCli('lint.mjs', ['--json'], { HOME: noVaultHome, HYPO_DIR: '' });
+    assert.equal(missing.status, 0, `stderr: ${missing.stderr}`);
+    assert.equal(JSON.parse(missing.stdout).vaultFound, false, `stdout: ${missing.stdout}`);
+
+    writeFileSync(join(validDir, 'hypo-config.md'), '# marker\n');
+    const found = spawnCli('lint.mjs', ['--json'], { HOME: SESSION_TMP_HOME, HYPO_DIR: validDir });
+    assert.equal(found.status, 0, `stderr: ${found.stderr}`);
+    assert.equal(JSON.parse(found.stdout).vaultFound, true, `stdout: ${found.stdout}`);
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+    rmSync(validDir, { recursive: true, force: true });
+  }
+});
+
+test('stats.mjs: no vault → stdout stays empty, not an all-zero stats block', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-stats-'));
+  try {
+    const r = spawnCli('stats.mjs', [], { HOME: noVaultHome, HYPO_DIR: '' });
+    assert.equal(r.status, 0, `expected exit 0 (CI-safe), got ${r.status}. stderr: ${r.stderr}`);
+    assert.equal(
+      r.stdout.trim(),
+      '',
+      `no-vault run must not print stats as if scanned: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+test('stats.mjs --json: no vault → vaultFound:false', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-stats-json-'));
+  try {
+    const r = spawnCli('stats.mjs', ['--json'], { HOME: noVaultHome, HYPO_DIR: '' });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(JSON.parse(r.stdout).vaultFound, false, `stdout: ${r.stdout}`);
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+test('graph.mjs (default json format): no vault → vaultFound:false', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-graph-'));
+  try {
+    const r = spawnCli('graph.mjs', [], { HOME: noVaultHome, HYPO_DIR: '' });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(JSON.parse(r.stdout).vaultFound, false, `stdout: ${r.stdout}`);
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+// mermaid/dot have no JSON envelope to carry vaultFound, so a vault-missing
+// run must suppress the diagram outright rather than hand a renderer an
+// empty-but-"real"-looking graph (codex review finding, following the
+// --format=json fix above).
+test('graph.mjs --format=mermaid: no vault → stdout stays empty, not an empty-but-valid diagram', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-graph-mermaid-'));
+  try {
+    const r = spawnCli('graph.mjs', ['--format=mermaid'], { HOME: noVaultHome, HYPO_DIR: '' });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.stdout.trim(), '', `no-vault run must not render a diagram: ${r.stdout}`);
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+test('graph.mjs --format=dot: no vault → stdout stays empty, not an empty-but-valid diagram', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-default-novault-graph-dot-'));
+  try {
+    const r = spawnCli('graph.mjs', ['--format=dot'], { HOME: noVaultHome, HYPO_DIR: '' });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.stdout.trim(), '', `no-vault run must not render a diagram: ${r.stdout}`);
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+  }
+});
+
+test('graph.mjs --format=mermaid: real (empty) vault still renders the normal diagram', () => {
+  const validDir = mkdtempSync(join(tmpdir(), 'hypo-valid-vault-graph-mermaid-'));
+  try {
+    writeFileSync(join(validDir, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('graph.mjs', ['--format=mermaid'], {
+      HOME: SESSION_TMP_HOME,
+      HYPO_DIR: validDir,
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.stdout.trim(), 'graph TD', `stdout: ${r.stdout}`);
+  } finally {
+    rmSync(validDir, { recursive: true, force: true });
+  }
+});
+
 // ── lib/wd-match.mjs (cross-machine project matcher) ─────────────────────────
 
 const { pickProjectByCwd, normalizeWorkingDir } = await import(`${SCRIPTS}/lib/wd-match.mjs`);


### PR DESCRIPTION
# English

## What changed

Three fixes on the CLI surface.

1. `hypomnema <unknown-flag>` exits 2 with a usage pointer instead of silently running the default init flow. `--version` is implemented and documented.
2. `hypomnema --help` lists the `proposal` subcommand, which has dispatched since it was added.
3. `lint`, `stats` and `graph` no longer report a successful scan when no vault was found. Their JSON payloads gain a `vaultFound` boolean.

## Why

All three share one shape: an invocation that reads like a query behaved like something else.

The unknown-flag case is the sharpest. `init.mjs`'s parse loop had no branch for an unrecognized argument, so it was ignored and execution continued into the default init flow: scaffolding, hook installation, a `settings.json` merge. `--version` made that concrete. It is a flag a user is likely to try first, it was never implemented, and the result was a destructive write. It overwrote a live wiki's pre-commit hook.

The help omission has a smaller blast radius but the same effect on a user whose only discovery path is `--help`: a command absent from the list does not exist.

The vault case is the one that reaches CI. `HOME=$(mktemp -d) node scripts/lint.mjs 2>/dev/null` printed `✓ No lint issues found` and exited 0. The notice explaining that no vault was found goes to stderr, so a piped or redirected caller sees a clean pass. Earlier work stopped an unfound vault from being reported as an empty success for an interactive user; this closes the same failure on the path nobody watches.

## How

The vault fix deliberately does not change any exit code, which is a departure from what the original report proposed.

`checkVaultOrExit` already returned "the vault is missing, suppress your own summary" and documented that contract, but only `query.mjs` honored it. `lint`, `stats` and `graph` discarded the return value. Restoring the contract in those three is the actual fix, and it turned out to be the smaller change as well.

Flipping the exit code was rejected on evidence: this package's own `ci.yml` and `release.yml` lint jobs run `npm run lint` on a runner with no vault at all and depend on exit 0, and three existing tests pin that path by name. Making a vault-less run fail would have required rewriting those assertions and would have broken the gate this PR has to keep green.

`graph`'s mermaid and dot formats suppress their output entirely rather than carry a flag, since neither has an envelope to put one in and an empty diagram is otherwise indistinguishable from a valid one.

Two drift tests are new and are the durable part of this PR: one diffs the printed command list against the dispatch table, the other diffs the printed option list against the flags the parser actually recognizes. The `proposal` omission is exactly the kind of drift they now catch.

## Manual verification

No hook, shared module, template or init flow behavior changed, so the suite covers this. Commands run:

```
npm test        # 1753 passed, 0 failed
npm run lint    # 0 errors, 130 pre-existing warnings
```

Each new test was proven red by reverting the corresponding fix and observing the failure, then restored.

## Migration notes

`lint --json`, `stats --json` and `graph` (default JSON format) gain a `vaultFound` field. The addition is additive and `ok` keeps its existing meaning, so an existing consumer that ignores unknown keys is unaffected. A consumer that parsed `graph --format=mermaid` or `--format=dot` output while no vault was resolvable will now receive empty output instead of an empty diagram; that case previously produced a misleading result.

---

# 한국어

## 변경 내용

CLI 표면 결함 세 건을 고쳤습니다.

1. `hypomnema <알-수-없는-플래그>`가 조용히 init 기본 동작을 실행하는 대신 usage를 띄우고 exit 2로 끝납니다. `--version`을 구현하고 문서화했습니다.
2. `hypomnema --help`가 `proposal` 서브커맨드를 나열합니다. 이 명령은 추가된 이래 정상 동작해 왔습니다.
3. `lint`, `stats`, `graph`가 볼트를 찾지 못했을 때 스캔에 성공한 것처럼 보고하지 않습니다. JSON 출력에 `vaultFound` 불리언이 붙습니다.

## 이유

셋 다 같은 모양입니다. 조회처럼 읽히는 입력이 다른 일을 했습니다.

unknown 플래그가 가장 날카롭습니다. `init.mjs`의 인자 루프에 인식 못 한 인자를 처리하는 분기가 없어서, 그런 인자를 무시하고 init 기본 동작으로 흘렀습니다. 스캐폴딩, 훅 설치, `settings.json` 병합입니다. `--version`이 그걸 실제로 드러냈습니다. 사용자가 가장 먼저 쳐볼 법한 플래그인데 구현조차 안 돼 있었고, 결과는 파괴적 쓰기였습니다. 실제로 돌아가던 위키의 pre-commit 훅을 덮어썼습니다.

help 누락은 파급이 작지만, 발견 경로가 `--help`뿐인 사용자에게는 효과가 같습니다. 목록에 없는 명령은 없는 명령입니다.

볼트 건은 CI까지 닿습니다. `HOME=$(mktemp -d) node scripts/lint.mjs 2>/dev/null`이 `✓ No lint issues found`를 출력하고 exit 0으로 끝났습니다. 볼트를 못 찾았다는 안내는 stderr로 나가니, 파이프나 리다이렉트를 거친 호출자에게는 그냥 통과로 보입니다. 이전 작업이 대화형 사용자에게는 이 빈 성공을 막았는데, 아무도 안 보는 경로에 같은 실패가 남아 있었습니다.

## 방법

볼트 수정은 exit code를 하나도 바꾸지 않습니다. 원래 제안과 다른 선택이라 근거를 남깁니다.

`checkVaultOrExit`은 원래부터 "볼트가 없으니 호출자는 자기 요약을 억제하라"를 반환하고 그 계약을 doc comment에 적어두고 있었는데, 이를 지키는 건 `query.mjs` 하나뿐이었습니다. `lint`, `stats`, `graph`는 반환값을 버렸습니다. 그 셋에서 계약을 되살리는 게 실제 수정이고, 결과적으로 더 작은 변경이기도 했습니다.

exit code를 바꾸는 안은 근거를 확인해 기각했습니다. 이 패키지 자신의 `ci.yml`과 `release.yml` lint job이 볼트가 아예 없는 러너에서 `npm run lint`를 돌리고 exit 0에 의존하며, 기존 테스트 셋이 그 경로를 이름으로 못박고 있습니다. 볼트 없는 실행을 실패로 만들면 그 단언들을 다시 써야 하고, 이 PR이 green으로 유지해야 하는 게이트 자체가 깨집니다.

`graph`의 mermaid, dot 형식은 플래그를 싣는 대신 출력을 통째로 억제합니다. 두 형식에는 플래그를 담을 봉투가 없고, 빈 다이어그램은 유효한 다이어그램과 구별되지 않기 때문입니다.

드리프트 테스트 두 개가 이 PR에서 오래 남을 부분입니다. 하나는 출력된 명령 목록을 디스패치 표와 대조하고, 다른 하나는 출력된 옵션 목록을 파서가 실제로 인식하는 플래그 집합과 대조합니다. 이번에 고친 `proposal` 누락이 바로 이 테스트가 잡는 종류의 드리프트입니다.

## 수동 검증

훅, 공유 모듈, 템플릿, init 흐름의 동작은 바뀌지 않아 테스트 스위트가 커버합니다. 실행한 명령입니다.

```
npm test        # 1753 passed, 0 failed
npm run lint    # 0 errors, 130 pre-existing warnings
```

새 테스트는 각각 해당 수정을 되돌려 실패를 확인한 뒤 복구했습니다.

## 마이그레이션 노트

`lint --json`, `stats --json`, `graph`(기본 JSON 형식)에 `vaultFound` 필드가 추가됩니다. 추가만 하는 변경이고 `ok`의 기존 의미도 그대로라, 모르는 키를 무시하는 기존 소비자는 영향을 받지 않습니다. 볼트를 찾을 수 없는 상태에서 `graph --format=mermaid`나 `--format=dot` 출력을 파싱하던 소비자는 이제 빈 다이어그램 대신 빈 출력을 받습니다. 그 경우 이전 결과가 오해를 부르는 값이었습니다.

---

## Changelog

- EN: `hypomnema` now rejects an unknown flag with exit 2 instead of silently running init, implements and documents `--version`, lists the `proposal` subcommand in `--help`, and stops `lint`, `stats` and `graph` from reporting a clean scan when no vault was found.
- KO: `hypomnema`가 알 수 없는 플래그를 조용히 init으로 흘리는 대신 exit 2로 거부하고, `--version`을 구현해 문서화했으며, `--help`에 `proposal` 서브커맨드를 싣고, `lint`, `stats`, `graph`가 볼트를 찾지 못했을 때 정상 스캔인 것처럼 보고하지 않습니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
