### PR TITLE
fix(sync): give a failed merge-abort its own guidance, and stop hiding sync history

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -283,7 +283,9 @@ function gitPull(dir) {
  * fresh `hypo init` wiki does not git-ignore `.cache/`, so a broader cleanliness
  * check would see the sync-state file itself and never clear.
  *
- * @returns {string} a `[WIKI: last sync failed: ...]` line, or '' when clear.
+ * @returns {string} a `[WIKI: last sync failed: ...]` (or, for a conflict/
+ *   conflict-unresolved entry, dedicated manual-merge guidance) line, or ''
+ *   when clear.
  */
 function syncStateNotice(pullOk) {
   const { entries, parseError } = readSyncState(HYPO_DIR);
@@ -304,7 +306,29 @@ function syncStateNotice(pullOk) {
     return '';
   }
   const last = entries[entries.length - 1];
-  if (last.op === 'conflict') {
+  // 'conflict-unresolved' (the merge --abort itself failed, syncRemote) is the
+  // more dangerous of the two conflict ops: the tree may still be half-merged
+  // (unmerged index entries, or an in-progress MERGE_HEAD), so the plain
+  // "pull --no-rebase" advice below is not enough and would be actively wrong
+  // — it tells the user their local work is safely committed when it may not
+  // be. Check this BEFORE the generic startsWith('conflict') branch so it gets
+  // its own guidance rather than being swallowed by the 'conflict' wording.
+  if (last.op === 'conflict-unresolved') {
+    return (
+      `[WIKI: remote diverged AND the automatic merge-abort failed — the working ` +
+      `tree may still be half-merged (unmerged paths or an in-progress merge). ` +
+      `Do NOT commit or push yet. Inspect \`git -C ${HYPO_DIR} status\` first: if a ` +
+      `merge is in progress, resolve the conflicts, then \`git -C ${HYPO_DIR} add <resolved paths>\` ` +
+      `and \`git -C ${HYPO_DIR} commit\` (git refuses a commit while unmerged entries remain staged) ` +
+      `— or run \`git -C ${HYPO_DIR} merge --abort\` to discard it instead, before continuing.]`
+    );
+  }
+  // startsWith, not ===: matches doctor.mjs's checkSyncState, which already
+  // treats every 'conflict*' op the same way. An exact-match check here used
+  // to miss 'conflict-unresolved' — the MORE dangerous op — and fall through
+  // to the generic "last sync failed" line below, which carries no manual-
+  // merge guidance at all.
+  if (String(last.op || '').startsWith('conflict')) {
     return (
       `[WIKI: remote diverged — auto-merge was aborted to protect your edits ` +
       `(your local work is committed and safe; the other machine's version is on the remote). ` +

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -733,17 +733,60 @@ function checkSyncState(hypoDir) {
     }
   } else {
     const last = entries[entries.length - 1];
-    // A merge conflict needs a real manual merge, not a plain push/pull — give
-    // the same explicit guidance session-start does instead of the generic hint.
-    if (String(last.op || '').startsWith('conflict')) {
+    // An unresolved failure does not mean the OTHER operation never
+    // succeeded — a push failure can sit right next to a healthy pull, and
+    // the last-success record above used to only wire into the healthy/
+    // never-synced branch, leaving this branch silent about it. Append it
+    // here too, best-effort, same as the healthy branch — a corrupt success
+    // file still warns, never crashes.
+    const { data: lastSuccess, parseError: successParseError } = readSyncLastSuccess(hypoDir);
+    // Not "unreadable": readSyncLastSuccess also sets parseError for a file
+    // that reads fine and parses as valid JSON but has the wrong shape (a
+    // malformed pull/push field, or an unrecognized key) — "unreadable" would
+    // misdescribe that case.
+    const successSuffix = successParseError
+      ? ' (.cache/sync-last-success.json is invalid or unreadable — inspect manually)'
+      : lastSuccess.pull || lastSuccess.push
+        ? ` Last success — ${formatLastSuccess(lastSuccess)}.`
+        : '';
+    // More than one open entry means the vault has been failing across
+    // multiple sync attempts without clearing — name each one (op@timestamp),
+    // not just the last, so the user isn't left to open sync-state.json
+    // themselves to see the pattern. Capped like checkBrokenLinks/checkVerifyBy.
+    const unresolvedList =
+      entries.length > 1
+        ? ` Unresolved: ${entries
+            .slice(-5)
+            .map((e) => `${e.op || '?'}@${e.timestamp || '?'}`)
+            .join(', ')}${entries.length > 5 ? ` (+${entries.length - 5} more)` : ''}.`
+        : '';
+    // 'conflict-unresolved' (the merge --abort itself failed, syncRemote) is
+    // the more dangerous of the two conflict ops: the tree may still be
+    // half-merged (unmerged index entries, or an in-progress MERGE_HEAD).
+    // Checked BEFORE the generic startsWith('conflict') branch below — that
+    // branch used to swallow this op too and claim "your local work is
+    // committed", which is not true when the abort itself failed, and its
+    // `git pull --no-rebase` advice would simply be refused by git while a
+    // merge is still in progress. Wording mirrors hypo-session-start.mjs's
+    // syncStateNotice so the two surfaces never contradict each other.
+    if (last.op === 'conflict-unresolved') {
       warn(
         'Sync state',
-        `${entries.length} unresolved sync issue(s) — last: remote diverged (merge conflict). Your local work is committed; the other machine's version is on the remote. Resolve with \`git pull --no-rebase\`, fix conflicts, then push.`,
+        `${entries.length} unresolved sync issue(s) — last: remote diverged AND the automatic merge-abort failed; the working tree may still be half-merged (unmerged paths or an in-progress merge). Do NOT commit or push yet. Run \`git status\` first: if a merge is in progress, resolve the conflicts, then \`git add <resolved paths>\` and \`git commit\` (git refuses a commit while unmerged entries remain staged) — or run \`git merge --abort\` to discard it instead, before continuing.${unresolvedList}${successSuffix}`,
+      );
+    } else if (String(last.op || '').startsWith('conflict')) {
+      // A merge conflict needs a real manual merge, not a plain push/pull —
+      // give the same explicit guidance session-start does instead of the
+      // generic hint. This branch is unmerged-index-free by construction (the
+      // abort succeeded), so "committed and safe" is an accurate claim here.
+      warn(
+        'Sync state',
+        `${entries.length} unresolved sync issue(s) — last: remote diverged (merge conflict). Your local work is committed; the other machine's version is on the remote. Resolve with \`git pull --no-rebase\`, fix conflicts, \`git add\` them, then commit and push.${unresolvedList}${successSuffix}`,
       );
     } else {
       warn(
         'Sync state',
-        `${entries.length} unresolved failure(s) — last: ${last.op || '?'} at ${last.timestamp || '?'}. Inspect .cache/sync-state.json or push/pull manually to clear.`,
+        `${entries.length} unresolved failure(s) — last: ${last.op || '?'} at ${last.timestamp || '?'}. Inspect .cache/sync-state.json or push/pull manually to clear.${unresolvedList}${successSuffix}`,
       );
     }
   }

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -278,6 +278,53 @@ test('doctor-sync-state-warn: conflict entry → manual-merge guidance, not gene
   });
 });
 
+// A merge --abort that itself fails ('conflict-unresolved', syncRemote) is the
+// MORE dangerous of the two conflict ops: the tree may still be half-merged
+// (unmerged index entries / an in-progress MERGE_HEAD). It must NOT get the
+// plain-conflict wording, which (a) claims "your local work is committed" —
+// untrue when the abort itself failed — and (b) tells the user to run
+// `git pull --no-rebase`, which git would simply refuse mid-merge. Distinct,
+// dedicated guidance is required, matching hypo-session-start.mjs's
+// syncStateNotice so the two surfaces never contradict each other.
+test('doctor-sync-state-warn: conflict-unresolved entry → dedicated half-merged-tree guidance, distinct from a clean conflict', () => {
+  withTmpDir((dir) => {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'projects'), { recursive: true });
+    mkdirSync(join(dir, 'sources'), { recursive: true });
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-06-19T00:00:00Z',
+        op: 'conflict-unresolved',
+        error: 'fatal: merge --abort failed',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+    assert.ok(
+      /diverged/.test(check.detail) && /half-merged/.test(check.detail),
+      `conflict-unresolved must warn about a possibly half-merged tree, not the plain-conflict wording: ${check.detail}`,
+    );
+    assert.ok(
+      // /i: doctor.mjs capitalizes the sentence ("Your local work is
+      // committed"), so a case-sensitive negative match here would pass
+      // unconditionally and catch nothing if the swallow were reintroduced.
+      !/your local work is committed/i.test(check.detail),
+      `conflict-unresolved must NOT reuse the clean-conflict "committed and safe" claim (the abort itself failed): ${check.detail}`,
+    );
+    assert.ok(
+      !/pull --no-rebase/.test(check.detail),
+      `conflict-unresolved must not advise a plain \`git pull --no-rebase\` — git would refuse it mid-merge: ${check.detail}`,
+    );
+  });
+});
+
 // FEAT-34: last-success timestamp visibility in the sync-state check.
 suite('doctor.mjs — FEAT-34: sync-last-success visibility');
 
@@ -444,7 +491,7 @@ test('doctor-sync-last-success: unrecognized top-level key → warn, not silentl
   });
 });
 
-test('doctor-sync-last-success: unresolved failure still reported unchanged, even with a success record present', () => {
+test('doctor-sync-last-success: unresolved failure keeps its core message and now also names the last success', () => {
   withTmpDir((dir) => {
     syncFixtureWiki(dir);
     mkdirSync(join(dir, '.cache'), { recursive: true });
@@ -465,12 +512,44 @@ test('doctor-sync-last-success: unresolved failure still reported unchanged, eve
     const out = JSON.parse(r.stdout);
     const check = out.find((c) => c.label === 'Sync state');
     assert.ok(check, 'Sync state check not found');
-    // The failure-reporting branch is unchanged by FEAT-34: same message shape
-    // as the pre-existing "open sync-state.json entries → warn" test.
+    // FEAT-34 originally left this branch silent about last-success (a push
+    // failure hid an otherwise-healthy pull). The core message shape from the
+    // pre-existing "open sync-state.json entries → warn" test still holds —
+    // this only asserts the ADDITION, not a replacement.
     assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
     assert.ok(
       /unresolved failure\(s\) — last: push at 2026-07-20T01:00:00Z/.test(check.detail),
-      `unresolved-failure detail must be unchanged: ${check.detail}`,
+      `unresolved-failure core message must survive unchanged: ${check.detail}`,
+    );
+    assert.ok(
+      check.detail.includes('Last success') &&
+        check.detail.includes('2026-07-20T00:00:00.000Z') &&
+        check.detail.includes('test-host'),
+      `a failing op must not hide that the OTHER op last succeeded: ${check.detail}`,
+    );
+  });
+});
+
+test('doctor-sync-state-warn: multiple unresolved entries are listed, not just the last one', () => {
+  withTmpDir((dir) => {
+    syncFixtureWiki(dir);
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const lines = [
+      { timestamp: '2026-07-20T01:00:00Z', op: 'push', error: 'network timeout', host: 'test' },
+      { timestamp: '2026-07-20T02:00:00Z', op: 'pull', error: 'connection refused', host: 'test' },
+    ]
+      .map((e) => JSON.stringify(e))
+      .join('\n');
+    writeFileSync(join(dir, '.cache', 'sync-state.json'), lines + '\n');
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+    assert.ok(
+      check.detail.includes('push@2026-07-20T01:00:00Z') &&
+        check.detail.includes('pull@2026-07-20T02:00:00Z'),
+      `both unresolved entries must be named, not just the last: ${check.detail}`,
     );
   });
 });

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -326,7 +326,9 @@ test('hypo-auto-commit.mjs: missing session_id → scoped commit SKIPPED, no who
     // no session_id in the stdin payload at all
     const r = runStop('hypo-auto-commit.mjs', dir, {});
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], { encoding: 'utf-8' }).stdout;
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], {
+      encoding: 'utf-8',
+    }).stdout;
     assert.equal(
       tracked.trim(),
       '',
@@ -389,7 +391,10 @@ test('hypo-hot-rebuild.mjs feeds its own hot.md write into the scoped commit', (
     const r = runStop('hypo-hot-rebuild.mjs', dir, { session_id: 'sess-hotrebuild' });
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const touched = JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-hotrebuild'), 'utf-8'));
-    assert.ok(touched.includes('hot.md'), `hot.md must be recorded as touched: ${JSON.stringify(touched)}`);
+    assert.ok(
+      touched.includes('hot.md'),
+      `hot.md must be recorded as touched: ${JSON.stringify(touched)}`,
+    );
     // end-to-end: hot-rebuild's accumulation is what lets auto-commit include
     // the hook-generated hot.md, which never goes through Write/Edit at all.
     const commitRes = runStop('hypo-auto-commit.mjs', dir, { session_id: 'sess-hotrebuild' });
@@ -456,7 +461,9 @@ test('hypo-auto-commit.mjs: a lock-timeout on the vault lock leaves the session 
     }
 
     // Nothing was committed (the lock was never acquired)...
-    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], { encoding: 'utf-8' }).stdout;
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], {
+      encoding: 'utf-8',
+    }).stdout;
     assert.equal(tracked.trim(), '', `no commit should have happened: ${tracked}`);
     // ...and the touched-paths set is still on disk, untouched, for a retry.
     const touched = JSON.parse(readFileSync(touchedPathsPath(dir, 'sess-locktimeout'), 'utf-8'));
@@ -506,7 +513,9 @@ test('hypo-auto-commit.mjs: a COMMIT failure (peek, not drain) leaves the touche
     }
 
     // Nothing was committed...
-    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], { encoding: 'utf-8' }).stdout;
+    const tracked = spawnSync('git', ['-C', dir, 'ls-files', 'pages'], {
+      encoding: 'utf-8',
+    }).stdout;
     assert.equal(tracked.trim(), '', `no commit should have happened: ${tracked}`);
     // ...and the touched-paths file was NEVER touched — peek, not drain —
     // so it still holds exactly the pre-failure scope, untouched.
@@ -2162,6 +2171,38 @@ test('session-start surfaces a conflict entry with manual-merge guidance', () =>
   });
 });
 
+// A merge --abort that itself fails is recorded as 'conflict-unresolved'
+// (syncRemote, hypo-shared.mjs) — the MORE dangerous of the two conflict ops,
+// since the tree may still be half-merged. Before this fix, syncStateNotice's
+// exact `last.op === 'conflict'` check missed it entirely and fell through to
+// the generic "last sync failed" line, which carries no manual-merge guidance
+// and (worse) doesn't warn against committing/pushing into a half-merged tree.
+test('session-start surfaces a conflict-unresolved entry with half-merged-tree guidance (distinct from a clean conflict)', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-07-28T00:00:00Z',
+        op: 'conflict-unresolved',
+        error: 'fatal: merge --abort failed',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = runStart(dir);
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(ctx.includes('remote diverged'), `conflict-unresolved notice missing: ${ctx}`);
+    assert.ok(
+      /half-merged/.test(ctx),
+      `conflict-unresolved must warn about a possibly half-merged tree, not the plain conflict wording: ${ctx}`,
+    );
+    assert.ok(
+      !ctx.includes('your local work is committed and safe'),
+      `conflict-unresolved must NOT reuse the clean-conflict "committed and safe" claim (the abort itself failed): ${ctx}`,
+    );
+  });
+});
+
 // ── FEAT-34: last-success timestamp visibility ──────────────────────────────
 //
 // recordSyncSuccess writes `.cache/sync-last-success.json`, a separate,
@@ -2511,7 +2552,11 @@ test('commitWikiChanges: stale scope (path never actually changed) → committed
     // currently-changed) step must drop it rather than error on a pathspec
     // that names no change.
     const res = commitWikiChanges(dir, ['stale.md']);
-    assert.equal(res.committed, true, `stale-only scope must be a clean no-op: ${JSON.stringify(res)}`);
+    assert.equal(
+      res.committed,
+      true,
+      `stale-only scope must be a clean no-op: ${JSON.stringify(res)}`,
+    );
     assert.equal(res.scoped, 0);
   });
 });


### PR DESCRIPTION
# English

## What changed

`conflict-unresolved` now gets its own guidance on both surfaces that report sync trouble, and `doctor`'s sync-state check reports more of what it already knows.

- The session-start notice and `doctor` both branch on `conflict-unresolved` before the generic conflict case, and say the same thing about a possibly half-merged tree.
- Both recovery messages now name the staging step.
- `doctor` lists up to five recent unresolved entries instead of only the last one, and names the last successful sync alongside a failure.

## Why

`syncRemote` records two different conflict outcomes. `conflict` means it aborted a conflicted merge and the tree came back clean. `conflict-unresolved` means the abort itself failed, so the tree may still hold unmerged index entries or an in-progress merge. The second is the dangerous one, and both surfaces got it wrong in opposite directions.

The session-start notice matched `op === 'conflict'` exactly, so `conflict-unresolved` fell through to a generic "last sync failed" line with no recovery guidance at all.

`doctor` matched `startsWith('conflict')`, which looks correct and is worse in effect. It handed the dangerous op the clean-conflict message, which asserts that local work is committed and safe (not true when the abort failed) and advises `git pull --no-rebase` (which git refuses outright while a merge is in progress). A user following that advice hits a wall, having been told their work is safe on no evidence.

Separately, `doctor`'s failure branch under-reported. It named only the last entry, so a vault failing across many sessions looked like one incident, and it never read the last-success record, so a single failing push hid an otherwise-healthy pull.

## How

Both messages are worded to mirror each other on purpose. The two surfaces are reachable in the same session, and a user who sees both must not have to decide which one to believe.

The recovery sequence names `git add` explicitly. Resolving conflict content is not enough: git refuses a commit while unmerged entries remain in the index, and the previous wording walked the user straight into that refusal. The clean-conflict message was corrected the same way.

The entry list is capped at five with a count of the remainder, matching how the broken-link and verify-by checks already cap their output.

No new state file. `sync-state.json` and `sync-last-success.json` already carry everything needed and are already written under the vault lock.

## Manual verification

```
npm test        # 1743 passed, 0 failed
npm run lint    # 0 errors, 130 pre-existing warnings
```

Every new and rewritten test was proven red by reverting the corresponding fix and observing the failure, then restored. The `doctor` conflict-unresolved test was re-proven after being rewritten, since it previously pinned the wrong behavior: it asserted that `conflict-unresolved` should receive the *same* guidance as a clean conflict, which is the defect this PR fixes. It now asserts the distinct wording and asserts the absence of both the "committed and safe" claim and the `pull --no-rebase` advice.

**Done 2026-08-03.** A live two-machine conflict was induced end to end and the deployed hook was driven against the resulting state. See `qa-runs/2026-08-03.md` (committed on #226 branch, which covers both PRs). A bare remote plus two clones produced a real merge conflict; a `PATH` shim failed the `merge --abort`, so `syncRemote()` recorded `conflict-unresolved` through its own code path, and `git ls-files -u` confirmed the tree was left half-merged. The deployed `hypo-session-start.mjs` then exited 0 and emitted the half-merged guidance, and `doctor` gave the distinct wording, the five-entry cap with a remainder count, and the last successful sync. 19 checks, 19 PASS. Previously: The suite drives `hypo-session-start.mjs` as a child process against fixture state files, which exercises the same code path, but it does not prove the notice reaches a live session banner. A live two-machine conflict has not been induced.

## Migration notes

None. No state file format changed and no new file is written. Existing vaults with a recorded `conflict-unresolved` entry will simply start receiving the correct guidance.

---

# 한국어

## 변경 내용

sync 문제를 알리는 두 표면 모두 `conflict-unresolved`에 전용 안내를 주고, `doctor`의 sync-state 검사가 이미 알고 있던 것을 더 많이 보여줍니다.

- session-start 안내와 `doctor` 둘 다 일반 충돌 분기보다 앞에서 `conflict-unresolved`를 가르고, half-merged 가능성에 대해 같은 말을 합니다.
- 두 복구 안내 모두 staging 단계를 명시합니다.
- `doctor`가 마지막 항목 하나 대신 최근 미해결 항목을 최대 다섯 개까지 나열하고, 실패와 함께 마지막 성공 sync를 같이 보여줍니다.

## 이유

`syncRemote`는 충돌 결과를 두 가지로 기록합니다. `conflict`는 충돌한 머지를 abort했고 트리가 깨끗하게 돌아왔다는 뜻입니다. `conflict-unresolved`는 abort 자체가 실패해서 트리에 unmerged index 항목이나 진행 중인 머지가 남아 있을 수 있다는 뜻입니다. 위험한 쪽은 후자인데, 두 표면이 서로 반대 방향으로 틀렸습니다.

session-start 안내는 `op === 'conflict'` 정확 일치를 봐서, `conflict-unresolved`가 복구 안내라고는 하나도 없는 일반 "last sync failed" 줄로 떨어졌습니다.

`doctor`는 `startsWith('conflict')`를 썼는데, 맞아 보이지만 효과는 더 나쁩니다. 위험한 쪽에 일반 충돌 문구를 줬거든요. 그 문구는 로컬 작업이 커밋돼 안전하다고 단정하고(abort가 실패했으면 사실이 아닙니다) `git pull --no-rebase`를 지시합니다(머지가 진행 중이면 git이 그냥 거절합니다). 그 안내를 따른 사용자는 벽에 부딪히는데, 그전에 근거 없이 "당신 작업은 안전하다"는 말을 들은 상태입니다.

별개로 `doctor`의 실패 분기가 적게 보고했습니다. 마지막 항목만 이름을 불러서 여러 세션에 걸쳐 실패해온 볼트가 단발 사고처럼 보였고, 마지막 성공 기록은 아예 안 읽어서 push 실패 하나가 멀쩡한 pull을 가렸습니다.

## 방법

두 문구를 일부러 서로 미러링했습니다. 두 표면은 한 세션에서 같이 마주칠 수 있고, 둘 다 본 사용자가 어느 쪽을 믿을지 고민하게 만들면 안 됩니다.

복구 순서에 `git add`를 명시했습니다. 충돌 내용을 해결하는 것만으로는 부족합니다. index에 unmerged 항목이 남아 있으면 git이 커밋을 거절하는데, 이전 문구는 사용자를 그 거절로 곧장 몰고 갔습니다. 일반 충돌 문구도 같은 방식으로 고쳤습니다.

항목 목록은 다섯 개로 자르고 나머지 개수를 붙입니다. 깨진 링크 검사와 verify-by 검사가 이미 쓰는 방식과 같습니다.

새 상태 파일은 만들지 않았습니다. `sync-state.json`과 `sync-last-success.json`이 필요한 걸 이미 다 담고 있고, 이미 볼트 락 아래에서 쓰입니다.

## 수동 검증

```
npm test        # 1743 passed, 0 failed
npm run lint    # 0 errors, 130 pre-existing warnings
```

새로 쓰거나 다시 쓴 테스트는 각각 해당 수정을 되돌려 실패를 확인한 뒤 복구했습니다. `doctor`의 conflict-unresolved 테스트는 다시 쓴 뒤 red를 재확인했습니다. 이 테스트가 원래 틀린 동작을 못박고 있었기 때문입니다. `conflict-unresolved`가 일반 충돌과 *같은* 안내를 받아야 한다고 단언하고 있었는데, 그게 바로 이 PR이 고치는 결함입니다. 지금은 전용 문구를 단언하고, "커밋돼 안전하다"는 주장과 `pull --no-rebase` 지시가 둘 다 없음을 단언합니다.

**완료(2026-08-03).** 2머신 충돌을 실제로 일으켜 끝까지 태웠고, 그 상태에 대고 배포된 훅을 돌렸습니다. 기록은 `qa-runs/2026-08-03.md`(두 PR을 함께 다루며 #226 브랜치에 커밋)에 있습니다. bare 원격과 클론 두 개로 진짜 충돌을 만들고, `PATH` shim으로 `merge --abort`를 실패시켜 `syncRemote()`가 자기 코드 경로로 `conflict-unresolved`를 기록하게 했으며, `git ls-files -u`로 트리가 half-merged로 남은 것을 확인했습니다. 배포된 `hypo-session-start.mjs`는 0으로 끝나며 half-merged 안내를 냈고, `doctor`는 전용 문구와 5개 상한 + 나머지 개수, 마지막 성공 sync를 모두 보여줬습니다. 19개 검사 전부 통과. 이전 서술: 테스트 스위트가 `hypo-session-start.mjs`를 픽스처 상태 파일에 대고 자식 프로세스로 돌려 같은 코드 경로를 태우지만, 그 안내가 실제 세션 배너까지 도달하는지는 증명하지 못합니다. 2머신 충돌을 실제로 일으켜보지 않았습니다.

## 마이그레이션 노트

None. 상태 파일 형식이 바뀌지 않았고 새로 쓰는 파일도 없습니다. `conflict-unresolved` 항목이 기록된 기존 볼트는 그냥 올바른 안내를 받기 시작합니다.

---

## Changelog

- EN: A failed merge-abort (`conflict-unresolved`) now gets its own recovery guidance in both `doctor` and the session-start notice, instead of the clean-conflict wording that wrongly claimed local work was committed and safe; `doctor` also names the last successful sync and lists several unresolved failures rather than only the most recent one.
- KO: merge abort가 실패한 상태(`conflict-unresolved`)가 `doctor`와 session-start 안내 양쪽에서 전용 복구 안내를 받습니다. 로컬 작업이 커밋돼 안전하다고 잘못 단정하던 일반 충돌 문구를 쓰지 않습니다. `doctor`는 마지막 성공 sync를 함께 보여주고, 가장 최근 하나가 아니라 여러 미해결 실패를 나열합니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)

