### PR TITLE
feat(crystallize,lint): seed a project index on close, surface a missing one

### DIFF
--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -73,6 +73,9 @@ import {
   mkdirSync,
   renameSync,
   realpathSync,
+  openSync,
+  writeSync,
+  closeSync,
 } from 'fs';
 import { join, dirname } from 'path';
 import { spawnSync } from 'child_process';
@@ -81,7 +84,7 @@ import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
 import { collectPagesCrystallize, extractWikilinks } from './lib/wikilink.mjs';
 import { aggregateColdCandidates } from './lib/page-usage.mjs';
-import { isValidProjectName } from './lib/project-create.mjs';
+import { isValidProjectName, substituteTokens, TEMPLATE_DIR } from './lib/project-create.mjs';
 import { appendPendingTags, checkForbidden } from './lib/schema-vocab.mjs';
 import {
   sessionCloseFileStatus,
@@ -906,6 +909,70 @@ function verifyCloseAuthority(sessionId) {
   return { ok: true };
 }
 
+// A-1 (project index lifecycle): seed projects/<project>/index.md from the
+// template the first time this project closes without one. SCHEMA.md declares
+// project-index at projects/*/index.md and templates/projects/_template/ ships
+// one, but createProject (the auto-project-offer path) is the only writer of
+// it today — a project directory created any other way (a manual mkdir, an
+// older vault, direct Write tool calls) never gets one. Idempotent: an
+// existing index.md is left untouched; this only fills the gap, and only the
+// three tokens the template defines are substituted — the rest (one-line
+// description, Progress checklist) stays human-authored prose exactly as
+// createProject already leaves it.
+//
+// `working_dir` has no authoritative source in this flow: apply never
+// receives the session's cwd (see hooks/hypo-shared.mjs's precompactGateStatus
+// doc — process.cwd() is explicitly non-authoritative here, since it reflects
+// this script's own launch directory, not the session's). It is left EMPTY,
+// not filled with a placeholder string: hooks/hypo-shared.mjs's collector
+// (collectProjectWorkingDirs) and findBackfillCandidate both treat any truthy
+// `working_dir` as "already anchored" and stop offering to backfill the real
+// cwd — a fake placeholder is truthy, so it would silently and permanently
+// swallow the exact anchor-recovery path a human would otherwise get. Empty
+// stays falsy there, so the project surfaces as a genuine backfill candidate
+// until a person (or the auto-project-offer flow) fills in a real path. The
+// key itself stays present in the frontmatter (substituted to an empty value,
+// not omitted) so the shape matches every other index.md and a human sees
+// exactly where to type the answer.
+// "Never overwrite an existing index" is this feature's explicit contract, so
+// creation uses an EXCLUSIVE create (`wx`), not the existsSync-then-atomicWrite
+// shape every other target in this file uses. atomicWrite's tmp+rename
+// replaces whatever sits at `dest` the instant rename fires — existing or not —
+// so a plain `if (existsSync(dest)) return null` beforehand only narrows the
+// race, it does not close it: another writer (a human, or a concurrent close)
+// can land real bytes at `dest` between that check and this function's rename.
+// `wx` makes the OS do the check-and-create atomically, mirroring
+// hooks/base-store.mjs's snapshotBase (`openSync(path, 'wx')` + EEXIST ==
+// "someone already got there, leave it"). No tmp+rename is needed here: unlike
+// atomicWrite's use case (replacing bytes a reader might already be mid-read
+// of), a `wx` create can never observably tear — the file either doesn't
+// exist yet (nothing to tear) or the open fails outright.
+export function ensureProjectIndex(hypoDir, project, relPath, today) {
+  const dest = join(hypoDir, relPath);
+  const src = join(TEMPLATE_DIR, 'index.md');
+  if (!existsSync(src)) return null; // template missing — nothing to scaffold from
+  const content = substituteTokens(readFileSync(src, 'utf-8'), {
+    name: project,
+    started: today,
+    workingDir: '',
+    today,
+  });
+  mkdirSync(dirname(dest), { recursive: true });
+  let fd;
+  try {
+    fd = openSync(dest, 'wx');
+  } catch (e) {
+    if (e && e.code === 'EEXIST') return null; // another writer already created it
+    throw e;
+  }
+  try {
+    writeSync(fd, content);
+  } finally {
+    closeSync(fd);
+  }
+  return relPath;
+}
+
 function applySessionClose(args) {
   // Option D: early-exit fires only when NO payload was supplied.
   // Rationale: payload presence is explicit close intent and must always run
@@ -1186,6 +1253,11 @@ function applySessionClose(args) {
   // normalization, so it must use the OS-native separator the sibling entries use.
   const sessionLogWriteTarget = join('projects', project, 'session-log', `${date}.md`);
   const sessionLogEvidence = join(...sessionLogScopePath(args.hypoDir, project, date).split('/'));
+  // A-1: known here (read-only check, no write yet) so a freshly-scaffolded
+  // index.md is scoped to THIS close's own payloadScope below, rather than
+  // showing up as an unrelated pre-existing-content notice.
+  const indexRelPath = join('projects', project, 'index.md');
+  const indexMissing = !existsSync(join(args.hypoDir, indexRelPath));
   const payloadScope = new Set([
     join('projects', project, 'session-state.md'),
     join('projects', project, 'hot.md'),
@@ -1194,6 +1266,7 @@ function applySessionClose(args) {
     sessionLogEvidence, // == write target, except a hybrid-month monthly fallback
     'log.md',
     ...(payload.openQuestions ? [join('pages', 'open-questions.md')] : []),
+    ...(indexMissing ? [indexRelPath] : []),
   ]);
 
   let preflightLint;
@@ -1300,6 +1373,17 @@ function applySessionClose(args) {
   overwrite('projectHot', join('projects', project, 'hot.md'), payload.projectHot);
   overwrite('rootHot', 'hot.md', payload.rootHot);
   overwrite('openQuestions', join('pages', 'open-questions.md'), payload.openQuestions);
+
+  // A-1: fill a missing project index as part of this close's writes (after
+  // preflight passed, so an aborted close never leaves a half-applied side
+  // effect on disk).
+  if (indexMissing) {
+    const createdIndex = ensureProjectIndex(args.hypoDir, project, indexRelPath, date);
+    if (createdIndex) {
+      applied.push(`projectIndex (${createdIndex})`);
+      appliedPaths.push(createdIndex);
+    }
+  }
 
   // Append idempotency: dedup by exact-entry presence, not by "any heading
   // dated today". The freshness gate (sessionCloseFileStatus) is what answers

--- a/scripts/lib/project-create.mjs
+++ b/scripts/lib/project-create.mjs
@@ -28,7 +28,11 @@ import { resolveHypoRoot, expandHome } from './hypo-root.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = join(SCRIPT_DIR, '..', '..');
-const TEMPLATE_DIR = join(PKG_ROOT, 'templates', 'projects', '_template');
+// Exported so other project-scaffolding call sites (crystallize.mjs's
+// session-close apply, which fills a MISSING index.md on a project that
+// bypassed createProject entirely) resolve the same template dir instead of
+// re-deriving the path.
+export const TEMPLATE_DIR = join(PKG_ROOT, 'templates', 'projects', '_template');
 
 const TEMPLATE_FILES = ['index.md', 'prd.md', 'hot.md', 'session-state.md'];
 

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -112,10 +112,19 @@ function parseTagsField(rawValue) {
 }
 
 // type-conditional required fields (spec §6.3, SCHEMA.md §2)
+// `project-index` deliberately does NOT list `working_dir` here. An index
+// existing at all is required (W12 above); the cwd anchor inside it is not —
+// crystallize.mjs's auto-created index has no session cwd to fill it with, and
+// requiring it would force a fake, non-empty placeholder into the field. A
+// placeholder value is truthy, and hooks/hypo-shared.mjs's collector +
+// findBackfillCandidate both read "has a truthy working_dir" as "already
+// anchored, do not offer to backfill" — so a fake value permanently poisons
+// the exact recovery path it should trigger. `status`/`started` stay required:
+// they always have a real value to substitute (`active` / the close date).
 const TYPE_CONDITIONAL_FIELDS = {
   prd: ['status', 'started'],
   adr: ['source', 'status', 'date'],
-  'project-index': ['working_dir', 'status', 'started'],
+  'project-index': ['status', 'started'],
   'tool-eval': ['status'],
   postmortem: ['outcome'],
   learning: ['source'],
@@ -397,6 +406,26 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs, validTypes) {
     }
   }
 
+  // W13: project-index with no working_dir anchor. Deliberately NOT in
+  // TYPE_CONDITIONAL_FIELDS (see the comment there) — an auto-created index has
+  // no cwd to put here, and that close must not block on its own output, so
+  // this stays warn-only and out of STRICT_PROMOTE_IDS, exactly like W12. The
+  // gap this closes: cwd-first backfill (hooks/hypo-shared.mjs's
+  // findBackfillCandidate) only fires when the cwd's leaf directory name
+  // matches the project's slug — a project whose real working dir has a
+  // DIFFERENT basename than its slug never becomes a backfill candidate, so an
+  // emptied/never-filled anchor can otherwise sit invisible except in
+  // `doctor`'s manual report.
+  if (fm.type === 'project-index' && !fm.working_dir) {
+    issue(
+      'warn',
+      rel,
+      `project-index has no working_dir anchor (cwd-first resume can't match this project)`,
+      null,
+      'W13',
+    );
+  }
+
   // type-conditional forbidden fields (W11): a field valid only on a
   // DIFFERENT type planted here by an unvalidated writer. Object.hasOwn
   // (not `fm[field]`) so a present-but-empty `working_dir:` still flags —
@@ -538,6 +567,40 @@ for (const s of findDesignHistoryStale(args.hypoDir)) {
     null,
     'W8',
   );
+}
+
+// W12: project directory missing index.md. SCHEMA.md declares project-index
+// at projects/*/index.md and templates/projects/_template/ ships one, so a
+// project without it is a tooling/vault drift, not a legitimate shape — but
+// warn-only: promoting this to an error would hard-block a close for every
+// pre-existing project that predates the create-on-close path (crystallize.mjs
+// A-1), and a missing index is never this close's fault to fix. `_`-prefixed
+// directories are excluded (not just `_template`), matching the markdown
+// collector's own convention (scripts/lib/wikilink.mjs's skipUnderscoreDir —
+// `_scratch`, `_drafts`, etc. are scaffold, not a project).
+if (existsSync(join(args.hypoDir, 'projects'))) {
+  for (const slug of readdirSync(join(args.hypoDir, 'projects'))) {
+    if (slug.startsWith('_')) continue;
+    const projectDir = join(args.hypoDir, 'projects', slug);
+    // A dangling symlink (or any other stat failure) must not crash the whole
+    // lint run — skip it exactly as doctor.mjs's own project-anchor scan does.
+    let st;
+    try {
+      st = statSync(projectDir);
+    } catch {
+      continue;
+    }
+    if (!st.isDirectory()) continue;
+    if (!existsSync(join(projectDir, 'index.md'))) {
+      issue(
+        'warn',
+        `projects/${slug}/index.md`,
+        `Missing project index: projects/${slug}/ has no index.md (SCHEMA.md declares project-index at projects/*/index.md)`,
+        null,
+        'W12',
+      );
+    }
+  }
 }
 
 if (args.fix) {

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -2864,7 +2864,10 @@ test('importing crystallize.mjs runs no CLI and exposes exactly the pure exports
   // The pure close-pipeline exports are usable only because the CLI dispatch is
   // guarded behind isMain(). A regressed guard that let the CLI run on import
   // would either crash (process.exit) or leak crystallize output here — assert
-  // the import is silent and yields exactly the two exported names.
+  // the import is silent and yields exactly the three exported names.
+  // ensureProjectIndex (A-1 project-index lifecycle) joined the list so
+  // tests/crystallize-apply.test.mjs can exercise its no-replace create
+  // directly, the same reason the other two are exported.
   const script = join(REPO, 'scripts', 'crystallize.mjs');
   const r = spawnSync(
     process.execPath,
@@ -2878,7 +2881,7 @@ test('importing crystallize.mjs runs no CLI and exposes exactly the pure exports
   assert.equal(r.status, 0, `import must exit 0, got ${r.status}: ${r.stderr}`);
   assert.equal(
     r.stdout,
-    'closeResultContradiction,planMarkerDecision',
+    'closeResultContradiction,ensureProjectIndex,planMarkerDecision',
     `import must print only the pure exports (no CLI output): ${JSON.stringify(r.stdout)}`,
   );
 });

--- a/tests/crystallize-apply.test.mjs
+++ b/tests/crystallize-apply.test.mjs
@@ -8,6 +8,8 @@ import { spawnSync } from 'node:child_process';
 import { mkdirSync, writeFileSync, readFileSync, existsSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { snapshotBase, overwriteTargets } from '../hooks/base-store.mjs';
+import { findBackfillCandidate } from '../hooks/hypo-shared.mjs';
+import { ensureProjectIndex } from '../scripts/crystallize.mjs';
 import { test, suite } from './harness.mjs';
 import {
   HOME,
@@ -708,4 +710,161 @@ test('apply commit excludes an unrelated pre-existing dirty file outside the pay
       `unrelated-debt.md must remain dirty, untouched by apply: ${status}`,
     );
   });
+});
+
+suite('A-1 (project index lifecycle): apply creates a missing index.md');
+
+// SCHEMA.md declares project-index at projects/*/index.md and
+// templates/projects/_template/ ships one, but nothing wrote it for a project
+// created outside createProject (buildCleanWikiTree's test-project has no
+// index.md, mirroring that gap). apply now fills it on the project's first
+// close, substituting only the three tokens the template defines.
+test('apply on a project with no index.md creates one from the template, tokens substituted', () => {
+  withWiki(null, (dir, today) => {
+    const indexPath = join(dir, 'projects', 'test-project', 'index.md');
+    assert.ok(!existsSync(indexPath), 'fixture must start without an index.md');
+
+    const payload = payloadForCleanWiki(dir, today);
+    const r = runApply(dir, payload, { sessionId: 'sess-index-create' });
+    assert.equal(r.status, 0, `apply must succeed: ${r.stdout}`);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true, `expected ok:true: ${r.stdout}`);
+    assert.ok(
+      out.applied.some((a) => a.startsWith('projectIndex (')),
+      `applied must record the created index: ${JSON.stringify(out.applied)}`,
+    );
+
+    assert.ok(existsSync(indexPath), 'index.md must now exist');
+    const content = readFileSync(indexPath, 'utf-8');
+    assert.ok(
+      content.includes('title: test-project — Index'),
+      `slug not substituted into title: ${content}`,
+    );
+    assert.ok(content.includes('# test-project'), `slug not substituted into heading: ${content}`);
+    assert.ok(content.includes(`started: ${today}`), `started not substituted: ${content}`);
+    assert.ok(content.includes(`updated: ${today}`), `updated not substituted: ${content}`);
+    assert.ok(
+      !content.includes('<project-name>') &&
+        !content.includes('<started>') &&
+        !content.includes('<working_dir>'),
+      `unsubstituted template token leaked: ${content}`,
+    );
+    // working_dir must be EMPTY, not a placeholder string. A truthy placeholder
+    // reads as "already anchored" to the collector/backfill logic below and
+    // would permanently swallow the real anchor-recovery path (the bug this
+    // pins — a prior version filled this with prose text).
+    assert.match(
+      content,
+      /^working_dir:\s*$/m,
+      `working_dir must be empty, not a fake placeholder: ${content}`,
+    );
+
+    // BLOCKER regression (a): the auto-created index must be lint-clean on its
+    // own merits, independent of apply's internal post-apply-lint scoping.
+    const lintOut = JSON.parse(run('lint.mjs', [`--hypo-dir=${dir}`, '--json']).stdout);
+    const indexErrors = (lintOut.errors || []).filter(
+      (e) => e.file === 'projects/test-project/index.md',
+    );
+    assert.deepEqual(
+      indexErrors,
+      [],
+      `auto-created index must not trip lint errors: ${JSON.stringify(indexErrors)}`,
+    );
+    // CONCERN 1 (2nd round): a missing anchor is expected to surface as a
+    // visible W13 WARNING (not silence, not an error) so it doesn't sit
+    // invisible until a manual `doctor` run. Matched by message (not `id`):
+    // non-W8/non-strict --json deliberately omits the `id` field on every
+    // other warning class (lint.mjs's byte-identical-default guarantee).
+    assert.ok(
+      (lintOut.warns || []).some(
+        (w) =>
+          w.file === 'projects/test-project/index.md' && w.message.includes('working_dir anchor'),
+      ),
+      `auto-created index with an empty anchor must surface a working_dir-anchor warning: ${JSON.stringify(lintOut.warns)}`,
+    );
+
+    // BLOCKER regression (b): the empty working_dir must NOT read as
+    // "already anchored" — findBackfillCandidate must still offer to backfill
+    // this project's real cwd.
+    const candidate = findBackfillCandidate('/Users/dev/test-project', dir);
+    assert.ok(
+      candidate,
+      'an auto-created index with an empty working_dir must still be a backfill candidate',
+    );
+    assert.equal(candidate.slug, 'test-project');
+    assert.equal(candidate.hasIndex, true);
+  });
+});
+
+test('apply aborted at preflight-lint never creates the index (no side effect on a failed close)', () => {
+  withWiki(null, (dir, today) => {
+    // Reuses the proven "corrupt APPEND target still blocks" preflight-abort
+    // shape: a session-log daily shard with an unclosed frontmatter fence is an
+    // in-scope, non-overwrite append target preflight cannot filter out — here
+    // to prove the SAME abort leaves the index untouched.
+    writeFileSync(
+      join(dir, 'projects', 'test-project', 'session-log', `${today}.md`),
+      '---\ntitle: sl\ntype: session-log\n\nbody (frontmatter never closes)\n',
+    );
+    const indexPath = join(dir, 'projects', 'test-project', 'index.md');
+    assert.ok(!existsSync(indexPath), 'fixture must start without an index.md');
+    const payload = payloadForCleanWiki(dir, today);
+    const r = runApply(dir, payload, { sessionId: 'sess-index-preflight-abort' });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false, `expected preflight to abort: ${r.stdout}`);
+    assert.equal(out.stage, 'preflight-lint', `expected preflight-lint stage: ${r.stdout}`);
+    assert.ok(!existsSync(indexPath), 'a preflight abort must not create the index as a side effect');
+  });
+});
+
+// CONCERN 2 (TOCTOU): the caller's `indexMissing` flag is snapshotted early
+// (before preflight lint), then acted on later. Reproduce the race directly at
+// ensureProjectIndex's own boundary — a file lands at the destination between
+// when a caller last observed "missing" and this call — and assert the
+// winner's bytes survive. A plain existsSync-then-atomicWrite (tmp+rename)
+// would clobber it: rename replaces whatever sits at the destination the
+// instant it fires, existing or not.
+test('ensureProjectIndex: a file created after the caller\'s missing-check survives untouched (no-replace create)', () => {
+  withTmpDir((dir) => {
+    const relPath = join('projects', 'race-project', 'index.md');
+    const dest = join(dir, relPath);
+    mkdirSync(dirname(dest), { recursive: true });
+    const winnerContent =
+      '---\ntitle: race — Index\ntype: project-index\nstatus: active\nstarted: 2026-01-01\nupdated: 2026-01-01\nworking_dir: /real/path\n---\n\nwinner bytes, written after the caller believed this was missing\n';
+    // Simulates: caller checked indexMissing (got true), THEN another writer
+    // (human or a concurrent close) created the file, THEN this call runs.
+    writeFileSync(dest, winnerContent);
+    const result = ensureProjectIndex(dir, 'race-project', relPath, '2026-06-01');
+    assert.equal(result, null, 'ensureProjectIndex must report a no-op, not a create, on this race');
+    assert.equal(
+      readFileSync(dest, 'utf-8'),
+      winnerContent,
+      "the winner's bytes must survive byte-for-byte, never clobbered by the losing create",
+    );
+  });
+});
+
+test('apply on a project that already has an index.md leaves it byte-for-byte untouched', () => {
+  const existingIndex =
+    '---\ntitle: test-project — Index\ntype: project-index\nstatus: active\nstarted: 2026-01-01\nupdated: 2026-01-01\nworking_dir: /real/path\n---\n\n# test-project\n\nhand-written content\n';
+  withWiki(
+    (dir) => writeFileSync(join(dir, 'projects', 'test-project', 'index.md'), existingIndex),
+    (dir, today) => {
+      const indexPath = join(dir, 'projects', 'test-project', 'index.md');
+      const payload = payloadForCleanWiki(dir, today);
+      const r = runApply(dir, payload, { sessionId: 'sess-index-keep' });
+      assert.equal(r.status, 0, `apply must succeed: ${r.stdout}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, true, `expected ok:true: ${r.stdout}`);
+      assert.ok(
+        !out.applied.some((a) => a.startsWith('projectIndex (')),
+        `an existing index must never be reported as applied: ${JSON.stringify(out.applied)}`,
+      );
+      assert.equal(
+        readFileSync(indexPath, 'utf-8'),
+        existingIndex,
+        'a pre-existing index.md must be left byte-for-byte untouched',
+      );
+    },
+  );
 });

--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -164,16 +164,86 @@ test('adr missing source → error', () => {
   );
 });
 
-test('project-index missing working_dir → error', () => {
+// A-1/BLOCKER fix: working_dir dropped from project-index's required fields.
+// An index without a cwd anchor is a genuine, unfilled state (crystallize.mjs's
+// auto-created index has none to substitute) — it must lint clean, not error.
+// status/started stay required (they always have a real value).
+test('project-index missing working_dir → clean (no longer required), but W13 warns', () => {
   const { r, out } = lintWithSchema(
     'projects/p/index.md',
     '---\ntitle: T\ntype: project-index\nstatus: active\nstarted: 2026-05-18\nupdated: 2026-05-18\ntags: [project]\n---\nbody\n',
   );
-  assert.equal(r.status, 1);
+  assert.equal(r.status, 0, `missing working_dir must not error: ${r.stdout}`);
   assert.ok(
-    out.errors.some((e) =>
-      e.message.includes('Missing required field for type "project-index": working_dir'),
-    ),
+    !out.errors.some((e) => e.message.includes('working_dir')),
+    `working_dir must not be flagged as an ERROR: ${r.stdout}`,
+  );
+  // CONCERN 1 fix: a missing anchor is a WARNING (W13) — doctor's manual report
+  // is not the only surface this shows up on, and cwd-first backfill only
+  // fires when the cwd's leaf directory name happens to match the slug.
+  assert.ok(
+    out.warns.some((w) => w.message.includes('working_dir anchor')),
+    `expected a W13-style missing-anchor warning: ${r.stdout}`,
+  );
+});
+
+test('project-index with an EMPTY working_dir (crystallize.mjs A-1 shape) → W13 warns, no error', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/index.md',
+    '---\ntitle: T\ntype: project-index\nstatus: active\nstarted: 2026-05-18\nupdated: 2026-05-18\nworking_dir: \ntags: [project]\n---\nbody\n',
+  );
+  assert.equal(r.status, 0, `empty working_dir must not error: ${r.stdout}`);
+  // Matched by message, not `id`: non-strict --json omits `id` on every
+  // warning class except W8 (lint.mjs's byte-identical-default guarantee) —
+  // `--strict does not promote W13` below is what checks the `id` itself.
+  assert.ok(
+    out.warns.some((w) => w.message.includes('working_dir anchor')),
+    `expected a missing-anchor warning for an empty (present-but-blank) working_dir: ${r.stdout}`,
+  );
+});
+
+test('project-index WITH a real working_dir → no working_dir-anchor warning', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/index.md',
+    '---\ntitle: T\ntype: project-index\nstatus: active\nstarted: 2026-05-18\nupdated: 2026-05-18\nworking_dir: /real/path\ntags: [project]\n---\nbody\n',
+  );
+  assert.equal(r.status, 0, `well-anchored index must lint clean: ${r.stdout}`);
+  assert.ok(
+    !out.warns.some((w) => w.message.includes('working_dir anchor')),
+    `an anchored project-index must not trip the missing-anchor warning: ${r.stdout}`,
+  );
+});
+
+test('--strict does not promote W13 (stays a warn, exit 0)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-w13-'));
+  writeFileSync(join(dir, 'SCHEMA.md'), VOCAB_SCHEMA);
+  const pagePath = join(dir, 'projects', 'p', 'index.md');
+  mkdirSync(dirname(pagePath), { recursive: true });
+  writeFileSync(
+    pagePath,
+    '---\ntitle: T\ntype: project-index\nstatus: active\nstarted: 2026-05-18\nupdated: 2026-05-18\ntags: [project]\n---\nbody\n',
+  );
+  const r = run('lint.mjs', [`--hypo-dir=${dir}`, '--json', '--strict']);
+  const out = JSON.parse(r.stdout);
+  rmSync(dir, { recursive: true, force: true });
+  assert.equal(r.status, 0, `W13 is excluded from STRICT_PROMOTE_IDS → exit 0: ${r.stdout}`);
+  assert.ok(
+    out.warns.some((w) => w.id === 'W13'),
+    `W13 must stay a warn under --strict: ${r.stdout}`,
+  );
+});
+
+test('project-index missing status/started → still errors (contract unchanged for those)', () => {
+  const { r, out } = lintWithSchema(
+    'projects/p/index.md',
+    '---\ntitle: T\ntype: project-index\nupdated: 2026-05-18\ntags: [project]\n---\nbody\n',
+  );
+  assert.equal(r.status, 1, `missing status/started must still error: ${r.stdout}`);
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Missing required field for type "project-index": status')),
+  );
+  assert.ok(
+    out.errors.some((e) => e.message.includes('Missing required field for type "project-index": started')),
   );
 });
 
@@ -1783,6 +1853,87 @@ test('w8-lint-omits-id-for-other-warns', () => {
     assert.ok(
       nonId.length >= 1,
       `expected non-W8 warns to omit id field: ${JSON.stringify(parsed.warns)}`,
+    );
+  });
+});
+
+// ── A-2 (project index lifecycle): W12 missing-index warning ────────────────
+// scripts/lint.mjs: a projects/<slug>/ directory with no index.md warns — never
+// errors, since a hard block would stop /compact for every pre-existing
+// project that predates crystallize.mjs's A-1 create-on-close.
+
+suite('W12: missing project index.md');
+
+test('project dir without index.md → W12 warn, ok:true, exit 0', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    mkdirSync(join(root, 'projects', 'no-index'), { recursive: true });
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, `missing index must not fail lint: ${r.stdout}`);
+    assert.equal(parsed.ok, true);
+    const w12 = (parsed.warns || []).filter((w) =>
+      /Missing project index: projects\/no-index\//.test(w.message),
+    );
+    assert.equal(w12.length, 1, `expected one W12 warn: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
+test('project dir WITH index.md → no W12 warn for it', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    mkdirSync(join(root, 'projects', 'has-index'), { recursive: true });
+    writeFileSync(
+      join(root, 'projects', 'has-index', 'index.md'),
+      '---\ntitle: has-index — Index\ntype: project-index\nstatus: active\nstarted: 2026-01-01\nupdated: 2026-01-01\nworking_dir: /tmp/x\n---\n\n# has-index\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, `well-formed index must not fail lint: ${r.stdout}`);
+    const w12 = (parsed.warns || []).filter((w) => /Missing project index/.test(w.message));
+    assert.equal(w12.length, 0, `has-index must not trigger W12: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
+// Any `_`-prefixed directory is excluded, not just `_template` — matching the
+// markdown collector's own convention (scripts/lib/wikilink.mjs's
+// skipUnderscoreDir treats `_`-prefixed dirs as scaffold, not content).
+test('any `_`-prefixed project directory is excluded from the W12 scan', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    mkdirSync(join(root, 'projects', '_scratch'), { recursive: true }); // no index.md
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    const w12 = (parsed.warns || []).filter((w) => /Missing project index/.test(w.message));
+    assert.equal(w12.length, 0, `_-prefixed dirs must be excluded: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
+// CONCERN 1 fix: W12's own statSync is now wrapped in try/catch (mirroring
+// doctor.mjs's identical project-anchor scan guard), so a dangling symlink
+// entry reaching THIS loop is skipped, not thrown. No end-to-end test via the
+// lint.mjs CLI is possible for this today: a bare dangling symlink placed
+// directly under projects/ is stat'd — and throws — earlier in the SAME run,
+// in two pre-existing unguarded traversals this slice does not touch
+// (scripts/lib/wikilink.mjs's walkMarkdown, run by collectPagesLint before the
+// page loop; scripts/lib/design-history-stale.mjs's own project loop, run for
+// W8 before W12). Both crash on the identical dangling-symlink shape,
+// independent of any fix here, so no fixture reaches W12's code at all while
+// they stay unguarded. See out_of_scope.
+
+test('--strict does not promote W12 (stays a warn, exit 0)', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    mkdirSync(join(root, 'projects', 'no-index'), { recursive: true });
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json', '--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, 'W12 is excluded from STRICT_PROMOTE_IDS → exit 0');
+    assert.equal(parsed.ok, true);
+    const w12 = (parsed.warns || []).filter((w) => w.id === 'W12');
+    assert.equal(
+      w12.length,
+      1,
+      `W12 must stay a warn under --strict: ${JSON.stringify(parsed.warns)}`,
     );
   });
 });


### PR DESCRIPTION
# English

## What changed

Session-close apply now seeds `projects/<name>/index.md` from the project template when a project does not have one, and `lint` gains two warn-only checks: a project directory with no `index.md` (W12), and a `project-index` with no `working_dir` anchor (W13).

## Why

`SCHEMA.md` declares `project-index` at `projects/*/index.md`, and `templates/projects/_template/` ships one, so an index is clearly meant to exist per project. Nothing in the pipeline created or noticed it. `crystallize.mjs` never mentioned the file at all, and `lint.mjs` only validated fields on an index that already existed, never the absence of one.

The result was that a new project's first close passed with no index and nobody said anything. In a real vault, roughly half the projects ended up without the one document that serves as a project's entry point. `hot.md` is a recent-session snapshot and `session-state.md` is the next-session handoff, so the index is the only place that shows overall progress and where things live.

## How

**Creation is scoped to the gap.** An existing `index.md` is never touched, and only the tokens the template defines get substituted. The five mandatory payload files are untouched, so the payload schema does not change. Creation happens after preflight passes, so an aborted close leaves nothing half-applied.

**`working_dir` is seeded empty rather than guessed.** Apply never receives the session's cwd, and `process.cwd()` is explicitly non-authoritative in this flow. A placeholder string would pass lint, but it would also be truthy, and both the anchor collector and the backfill candidate search read a truthy `working_dir` as "already anchored, do not offer to backfill". A fake value would permanently swallow the very recovery path it should trigger. An empty value stays falsy there, so the project keeps surfacing as a backfill candidate until a person fills in a real path.

That is also why `working_dir` left the `project-index` required-field list. W13 covers the same ground without forcing a fake value in, and it does not block the close that just created the file.

**Both new checks are warnings and neither is promoted under `--strict`.** A close must not be blocked by its own output, and a missing index is never the current close's fault to fix. `_`-prefixed directories are skipped, matching the markdown collector's existing convention.

**Index creation uses an exclusive create (`wx`).** "Never overwrite an existing index" is this feature's contract. The `existsSync`-then-`atomicWrite` shape used for every other target here cannot hold that contract: `atomicWrite`'s tmp+rename replaces whatever sits at the destination the instant rename fires, so a preceding existence check only narrows the race. The exclusive open makes the OS do check-and-create atomically, mirroring the base-store snapshot path; `EEXIST` means another writer got there first and the call reports a no-op.

## Manual verification

No hook, template, or init flow changed, so the hook-QA requirement does not apply. `lint` was run against the maintainer's real vault (read-only) to confirm the new checks behave on real data rather than fixtures only:

```
npm test        1765 passed, 0 failed
npm run lint    0 error(s), 164 warning(s)
```

The warning count rose by the W12 lines for the projects that genuinely have no index. Exit status stayed 0, which is the point of keeping both checks warn-only.

Every regression assertion was proven red by disabling the fix and re-running, then restored:

- index creation disabled: apply no longer records a created index
- W12 disabled: a project directory with no index produces no warning, and the `--strict` non-promotion assertion loses its subject
- placeholder restored in place of the empty value: the "working_dir must be empty, not a fake placeholder" assertion fails
- `wx` relaxed to `w`: a file created after the caller's missing-check is overwritten instead of surviving

## Migration notes

None for existing installs. Projects that already lack an index start showing a W12 warning and are not backfilled by this change; backfilling them is deliberately left out of scope.

---

# 한국어

## 변경 내용

세션 종료 적용 경로가 `index.md` 없는 프로젝트에 대해 프로젝트 템플릿에서 `projects/<name>/index.md`를 생성합니다. `lint`에는 경고 전용 검사 두 개가 생깁니다. `index.md`가 없는 프로젝트 디렉터리(W12)와 `working_dir` 앵커가 없는 `project-index`(W13)입니다.

## 이유

`SCHEMA.md`는 `project-index`를 `projects/*/index.md` 경로로 선언하고 `templates/projects/_template/`도 index를 싣고 있으니, 프로젝트마다 index가 있는 것이 설계 의도입니다. 그런데 파이프라인 어디에도 index를 만들거나 부재를 알아채는 지점이 없었습니다. `crystallize.mjs`는 이 파일을 문자열로도 언급하지 않았고 `lint.mjs`는 이미 존재하는 index의 필드만 검사할 뿐 없는 경우는 대상이 아니었습니다.

그래서 새 프로젝트의 첫 close가 index 없이 통과했고 아무도 알려주지 않았습니다. 실제 볼트에서는 프로젝트의 절반 가까이가 진입점 역할을 하는 문서 없이 남았습니다. `hot.md`는 최근 세션 스냅샷이고 `session-state.md`는 다음 세션 핸드오프라, 프로젝트 전체 진행과 산출물 위치를 보여주는 문서는 index뿐입니다.

## 방법

**생성은 빈 자리에만 합니다.** 이미 있는 `index.md`는 건드리지 않고 템플릿이 정의한 토큰만 치환합니다. payload의 5개 필수 파일은 손대지 않으므로 payload 스키마가 바뀌지 않습니다. 생성은 preflight 통과 후에 일어나므로 중단된 close가 반쯤 적용된 상태를 남기지 않습니다.

**`working_dir`은 추측하지 않고 빈 값으로 둡니다.** 적용 경로는 세션의 cwd를 받지 않고 이 흐름에서 `process.cwd()`는 권위가 없다고 명시돼 있습니다. 플레이스홀더 문자열을 넣으면 lint는 통과하지만 그 값이 truthy가 되고, 앵커 수집기와 backfill 후보 탐색이 truthy한 `working_dir`을 "이미 앵커됨, backfill 제안하지 말 것"으로 읽습니다. 가짜 값은 자기가 발동시켜야 할 복구 경로를 영구히 삼킵니다. 빈 값은 그 자리에서 falsy로 남으므로 사람이 실제 경로를 채울 때까지 프로젝트가 backfill 후보로 계속 노출됩니다.

`working_dir`이 `project-index` 필수 필드 목록에서 빠진 이유도 같습니다. W13이 가짜 값을 강요하지 않고 같은 자리를 덮으며, 방금 그 파일을 만든 close를 막지도 않습니다.

**새 검사 둘 다 경고이고 `--strict`에서 승격되지 않습니다.** close가 자기 산출물 때문에 막히면 안 되고, index가 없는 것은 지금 close의 잘못이 아닙니다. `_`로 시작하는 디렉터리는 건너뜁니다. markdown 수집기의 기존 관례와 맞춘 것입니다.

**index 생성은 배타 생성(`wx`)을 씁니다.** "기존 index는 절대 덮지 않는다"가 이 기능의 계약입니다. 여기 다른 대상들이 쓰는 `existsSync` 후 `atomicWrite` 형태로는 그 계약을 지킬 수 없습니다. `atomicWrite`의 tmp+rename은 rename이 발생하는 순간 목적지에 있는 것을 무엇이든 대체하므로, 앞선 존재 검사는 경쟁 창을 좁힐 뿐입니다. 배타 open은 검사와 생성을 OS가 원자적으로 처리합니다. base-store 스냅샷 경로와 같은 방식이고, `EEXIST`는 다른 writer가 먼저 도착했다는 뜻이라 호출이 no-op을 보고합니다.

## 수동 검증

훅, 템플릿, init 흐름 중 무엇도 바뀌지 않아 훅 QA 요건은 해당하지 않습니다. 픽스처만이 아니라 실제 데이터에서 새 검사가 어떻게 도는지 확인하려고 관리자의 실제 볼트에 `lint`를 읽기 전용으로 돌렸습니다.

```
npm test        1765 passed, 0 failed
npm run lint    0 error(s), 164 warning(s)
```

경고 수는 index가 실제로 없는 프로젝트들의 W12 줄만큼 늘었습니다. 종료 상태는 0으로 유지됐고 두 검사를 경고 전용으로 둔 이유가 바로 그것입니다.

모든 회귀 단언은 수정을 꺼서 red를 확인한 뒤 되돌렸습니다.

- index 생성 비활성화: 적용 결과가 생성된 index를 더는 기록하지 않음
- W12 비활성화: index 없는 프로젝트 디렉터리에 경고가 뜨지 않고 `--strict` 비승격 단언도 대상을 잃음
- 빈 값 대신 플레이스홀더 복원: "working_dir은 가짜 플레이스홀더가 아니라 비어 있어야 한다" 단언 실패
- `wx`를 `w`로 완화: 호출자의 부재 확인 이후 생긴 파일이 살아남지 못하고 덮임

## 마이그레이션 노트

기존 설치에는 없습니다. 이미 index가 없는 프로젝트는 W12 경고가 뜨기 시작하고 이 변경이 그것들을 채워주지는 않습니다. 백필은 의도적으로 범위 밖으로 뒀습니다.

---

## Changelog

- EN: A session close now creates `projects/<name>/index.md` from the template when a project has none, and `lint` warns (never errors) on a project with no index and on an index with no `working_dir` anchor.
- KO: 세션 종료 시 index가 없는 프로젝트에 `projects/<name>/index.md`를 템플릿에서 생성합니다. `lint`는 index 없는 프로젝트와 `working_dir` 앵커 없는 index에 경고를 냅니다(에러 아님).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
