### PR TITLE
fix(lock): stop stealing a live holder's lock, and publish the lock atomically

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -17,13 +17,14 @@ import {
   readdirSync,
   realpathSync,
   openSync,
-  closeSync,
   unlinkSync,
   renameSync,
+  linkSync,
 } from 'fs';
 import { join, relative, basename, dirname } from 'path';
 import { homedir, hostname, tmpdir } from 'os';
 import { spawnSync } from 'child_process';
+import { randomBytes } from 'crypto';
 
 const HOME = homedir();
 
@@ -1282,22 +1283,75 @@ function atomicWriteShared(path, content) {
   renameSync(tmp, path);
 }
 
+// Read the pid the current holder recorded in its lockfile (see withFileLock).
+// Returns null for anything we can't trust as a pid: empty/missing content (a
+// lock written before this pid-recording existed, or already gone), or content
+// that doesn't parse as a positive integer. null means "unknown holder" and the
+// caller falls back to the pre-liveness, mtime-only steal rule.
+function readLockHolderPid(lockPath) {
+  let raw;
+  try {
+    raw = readFileSync(lockPath, 'utf-8').trim();
+  } catch {
+    return null; // vanished/unreadable mid-check — let the caller's own catch handle it
+  }
+  // Canonical decimal only. `Number()` would accept '1e3' and '0x10' as pids,
+  // which contradicts what this function promises its callers: anything we
+  // can't trust is null, not a number we guessed at.
+  if (!/^[1-9][0-9]*$/.test(raw)) return null;
+  const pid = Number(raw);
+  return Number.isSafeInteger(pid) ? pid : null;
+}
+
+// Is `pid` still running? EPERM means it exists but we can't signal it (e.g. a
+// different user) — treat that as alive too, since "can't prove it's dead" must
+// not be steal-eligible.
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === 'EPERM';
+  }
+}
+
 /**
  * Run `fn` while holding an exclusive lock on `<targetPath>.lock`.
  *
- * Acquire is a spin on `openSync(lock, 'wx')`: EEXIST means another writer holds
- * it, so poll until it frees. A lock whose holder looks dead (mtime older than
- * `staleMs`) is stolen. Steal is recoverable friction in the normal case (the
- * stealer re-reads the committed bytes before writing), but NOT loss-free in two
- * edge cases, both requiring the lock to sit untouched for `staleMs`: (1) a LIVE
- * holder preempted past `staleMs` gets stolen from, so two writers run the
- * critical section and one update is lost; (2) between the stale `statSync` and
- * the `unlinkSync`, the holder can release and a fresh holder grab the same path,
- * whose lock we then remove. `staleMs` is set well above a normal close (seconds)
- * to make both extreme-low-probability. If the lock cannot be acquired within
- * `timeoutMs`, throw so the caller can fall back to the write=proposal gate — for
- * an append that means blocking the close (proposal-pending) with no artifact; the
- * next close re-appends (architecturally consistent with the existing fail-safe).
+ * Acquire is a spin on `linkSync(tmp, lock)`, where `tmp` already holds this
+ * process's pid in full: EEXIST means another writer holds it, so poll until it
+ * frees. Linking a complete file is what makes the lock's content trustworthy —
+ * a lock is never observable in a half-written state, so "no pid in there" always
+ * means a genuine pre-liveness lockfile and never a holder mid-acquire. The lock
+ * file's content is therefore the holder's own pid,
+ * so a lock whose mtime is older than `staleMs` is only stolen once we can also
+ * confirm the recorded holder is no longer running (`process.kill(pid, 0)`). A
+ * LIVE holder preempted past `staleMs` is therefore left alone — its lock is not
+ * stolen, so the second writer instead polls through to `timeoutMs` and throws,
+ * falling back to the write=proposal gate instead of racing the live holder's
+ * critical section (this was case (1) of the old mtime-only rule, and it's what
+ * closes it). A lock with no readable/parseable pid (written before this
+ * recording existed) falls back to the old mtime-only rule so pre-existing
+ * lockfiles from a live process on disk still get treated as steal-eligible once
+ * stale — see `readLockHolderPid`. Every steal, and every steal we refuse because
+ * the holder is alive, is logged to stderr so a preemption or an actual steal is
+ * never silent. One edge remains, unrelated to holder liveness: between the
+ * stale `statSync` and the `unlinkSync`, the holder can release and a fresh
+ * holder grab the same path, whose lock we then remove — `staleMs` is set well
+ * above a normal close (seconds) to make that extreme-low-probability, and it is
+ * out of scope here. Release is symmetric: we only unlink the lock while it still
+ * records OUR pid, so a writer that WAS stolen from never removes the lock of the
+ * holder that replaced it. If the lock cannot be acquired within `timeoutMs`,
+ * throw so the caller can fall back to the write=proposal gate — for an append
+ * that means blocking the close (proposal-pending) with no artifact; the next
+ * close re-appends (architecturally consistent with the existing fail-safe).
+ *
+ * Note what refusing to steal from a live holder trades away: a holder that is
+ * alive but permanently hung is now never stolen from, so every later close
+ * times out too. That is availability loss, not a deadlock (`timeoutMs` still
+ * bounds each attempt), but unlike an ordinary lock timeout it does NOT self-heal
+ * on the next close — it needs the hung process to go away. Losing an append is
+ * silent; blocking one is visible, so this is the direction to fail in.
  *
  * @param {string} targetPath file being guarded (lock is a sibling `.lock`)
  * @param {() => T} fn critical section
@@ -1310,10 +1364,49 @@ export function withFileLock(targetPath, fn, opts = {}) {
   const lockPath = `${targetPath}.lock`;
   mkdirSync(dirname(lockPath), { recursive: true });
   const start = Date.now();
-  let fd;
+  // Publish the lock ATOMICALLY: write the whole pid into a private sibling
+  // first, then `linkSync` it into place. `openSync(lockPath,'wx')` followed by
+  // a write cannot do this — it publishes an EMPTY lock and fills it in after,
+  // and a holder preempted inside that window looks exactly like a pid-less
+  // legacy lock, so a second writer steals it and both run the critical section.
+  // That is the very bug the liveness check exists to close, so the acquire has
+  // to be atomic for the check to mean anything. `link` also gives us the same
+  // EEXIST-if-taken primitive `wx` did, and it leaves nothing behind when the
+  // write fails: no link, no lock.
+  // The staging name is per-call random, and the staging write is exclusive.
+  // A predictable `<lock>.<pid>.tmp` would be reachable again by a later run of
+  // the same pid, and a crash between the link and the staging unlink leaves tmp
+  // and lock as two names for ONE inode — writing the staging file would then
+  // rewrite the live lock's bytes and mtime, resurrecting a dead lock under a
+  // live pid that the liveness check would then protect. Random + `wx` removes
+  // both the collision and the symlink it could otherwise be pointed through.
+  const tmpPath = `${lockPath}.${randomBytes(8).toString('hex')}.tmp`;
+  let staged = false;
+  // The live-holder refusal is re-evaluated on every poll, but it is one event,
+  // not `timeoutMs / pollMs` of them. Log each once per acquire or a single
+  // preemption buries the hook's stderr under ~100 identical lines.
+  let loggedLiveHolder = false;
+  let loggedSteal = false;
+  try {
   for (;;) {
     try {
-      fd = openSync(lockPath, 'wx');
+      if (!staged) {
+        try {
+          writeFileSync(tmpPath, String(process.pid), { flag: 'wx' });
+          staged = true;
+        } catch (stageErr) {
+          // Staging fails for the same reason acquisition does — an unwritable
+          // directory — and `openSync(lock,'wx')` used to report exactly that as
+          // EEXIST whenever a lock was already sitting there, sending it down the
+          // contention path. Preserve that: contend if a lock exists, and surface
+          // a genuine write failure otherwise rather than masking it as a timeout.
+          if (!existsSync(lockPath)) throw stageErr;
+          throw Object.assign(new Error('lock-contended'), { code: 'EEXIST' });
+        }
+      }
+      // Kept separate from staging on purpose: EPERM/EMLINK from the link are
+      // real failures, not contention, and must not decay into ELOCKTIMEOUT.
+      linkSync(tmpPath, lockPath);
       break;
     } catch (err) {
       if (err.code !== 'EEXIST') throw err;
@@ -1325,12 +1418,37 @@ export function withFileLock(targetPath, fn, opts = {}) {
       // the timeoutMs → ELOCKTIMEOUT contract (caller falls to the proposal gate).
       let stale = false;
       try {
-        // Steal a lock whose holder looks dead. Loss-free unless the holder is
-        // actually live-but-preempted past staleMs (see JSDoc edge cases).
+        // Steal-eligible by age alone; liveness is checked separately below
+        // before we actually act on it.
         stale = Date.now() - statSync(lockPath).mtimeMs > staleMs;
       } catch (statErr) {
         if (statErr.code === 'ENOENT') continue; // lock vanished; retry create now
         throw statErr; // unexpected stat failure — surface it, don't mask
+      }
+      if (stale) {
+        const holderPid = readLockHolderPid(lockPath);
+        if (holderPid !== null && isPidAlive(holderPid)) {
+          // LIVE holder preempted past staleMs: do NOT steal. Surface it so the
+          // preemption is visible, then fall through to the poll/timeout path
+          // below instead of racing a second writer into the critical section.
+          if (!loggedLiveHolder) {
+            console.error(
+              `[hypomnema] withFileLock: NOT stealing ${lockPath} — holder pid ${holderPid} is still alive past staleMs=${staleMs}`,
+            );
+            loggedLiveHolder = true;
+          }
+          stale = false;
+        } else if (!loggedSteal) {
+          // Also once per acquire: an un-removable stale lock re-enters this
+          // branch on every poll, and the steal is one event either way.
+          console.error(
+            `[hypomnema] withFileLock: stealing stale lock ${lockPath}` +
+              (holderPid !== null
+                ? ` (holder pid ${holderPid} is no longer running)`
+                : ' (no readable holder pid — pre-liveness lockfile)'),
+          );
+          loggedSteal = true;
+        }
       }
       if (stale) {
         try {
@@ -1353,16 +1471,33 @@ export function withFileLock(targetPath, fn, opts = {}) {
       sleepSync(pollMs);
     }
   }
+  } finally {
+    // The sibling is only ever a staging file: once linked, the lock IS the
+    // link, and on every failure path it must not survive as litter.
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* never created, or already gone */
+    }
+  }
   try {
     return fn();
   } finally {
+    // Only remove the lock if it is still OURS. Recording the pid makes this
+    // checkable: if we were stolen from (a legacy pid-less lock of ours, or the
+    // stat/unlink window below), the path now holds a DIFFERENT holder's lock and
+    // unlinking it unconditionally would hand a third writer the critical section
+    // while that holder is still inside it. Leaving a foreign lock alone costs
+    // nothing — its own holder releases it, or it goes stale.
     try {
-      closeSync(fd);
-    } catch {
-      /* fd already gone */
-    }
-    try {
-      unlinkSync(lockPath);
+      const stillOurs = readLockHolderPid(lockPath);
+      if (stillOurs === process.pid) unlinkSync(lockPath);
+      else if (existsSync(lockPath))
+        console.error(
+          `[hypomnema] withFileLock: not releasing ${lockPath} — it now holds ${
+            stillOurs === null ? 'no readable pid' : `pid ${stillOurs}`
+          }, so ours was stolen`,
+        );
     } catch {
       /* lock already stolen/removed */
     }

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -8,3 +8,7 @@
 # writes (crystallize apply, deriveRootLogEntries). Normally deleted immediately;
 # a crashed holder can leave a stale one, which must never be committed.
 *.lock
+# The lock is published by linking a staged sibling into place. `*.lock` does not
+# match the staging name, and a crash between the link and its cleanup leaves one
+# behind — where `git add -A` would happily pick it up.
+*.lock.*.tmp

--- a/tests/proposal-base.test.mjs
+++ b/tests/proposal-base.test.mjs
@@ -2807,6 +2807,141 @@ test('steals a stale lock whose holder died (mtime older than staleMs)', () => {
   });
 });
 
+// Atomicity here is a property of HOW the lock is published, and no black-box
+// assertion can observe the window it closes: create-then-write leaves the lock
+// empty for microseconds, and a test would have to preempt the holder inside
+// them. Pin the mechanism instead — reintroducing openSync-then-write on the
+// lock path is what would silently revive the race.
+test('publishes the lock by linking a complete file, never by creating an empty one (IMPR-32)', () => {
+  const src = readFileSync(join(REPO, 'hooks', 'hypo-shared.mjs'), 'utf-8');
+  const body = src.slice(src.indexOf('export function withFileLock'));
+  // Comments in here discuss the create-then-write shape by name, so strip them
+  // — otherwise the assertion below fires on the prose explaining why it's gone.
+  const acquire = body
+    .slice(0, body.indexOf('return fn();'))
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  assert.match(acquire, /linkSync\(tmpPath, lockPath\)/, 'the lock is published by link');
+  assert.equal(
+    /openSync\(\s*lockPath/.test(acquire),
+    false,
+    'the lock path is never created directly — that publishes it empty and a stealer reads it as a pid-less legacy lock',
+  );
+  // A predictable staging name is reachable by a later run of the same pid, and
+  // after a crash between the link and its cleanup the staging name and the lock
+  // are one inode — writing the former would rewrite the live lock.
+  assert.match(acquire, /randomBytes\(/, 'the staging name is per-call random');
+  assert.match(acquire, /flag: 'wx'/, 'the staging write is exclusive, never onto an existing file');
+});
+
+// A directory we cannot write to is not the same event as a lock someone else
+// holds, and only the second one may become ELOCKTIMEOUT. Conflating them sends
+// the caller to the proposal gate over what is really a broken vault.
+test('a staging failure with no lock present surfaces the real error, not a lock timeout (IMPR-32)', () => {
+  if ((process.getuid && process.getuid() === 0) || process.platform === 'win32') return;
+  withTmpDir((dir) => {
+    const sub = join(dir, 'sub');
+    mkdirSync(sub);
+    const target = join(sub, 'log.md');
+    chmodSync(sub, 0o555); // nothing can be created here, and no lock is held
+    try {
+      assert.throws(
+        () => wfl(target, () => {}, { timeoutMs: 200, pollMs: 20 }),
+        (err) => err.code === 'EACCES' || err.code === 'EPERM',
+        'an unwritable directory is a write failure, not contention',
+      );
+    } finally {
+      chmodSync(sub, 0o755);
+    }
+  });
+});
+
+// The lock is published by linking a fully-written sibling into place, so no
+// writer can ever observe an empty lock and mistake a holder mid-acquire for a
+// pid-less legacy lock (which it would then steal, reviving the exact race the
+// liveness check closes). The staging file must not outlive the acquire.
+test('leaves no staging file behind, and the published lock is never empty (IMPR-32)', () => {
+  withTmpDir((dir) => {
+    const target = join(dir, 'log.md');
+    wfl(target, () => {
+      assert.deepEqual(
+        readdirSync(dir).filter((f) => f.endsWith('.tmp')),
+        [],
+        'the staging sibling is gone by the time the critical section runs — the lock is the link, not a file we are still filling in',
+      );
+    });
+    assert.deepEqual(readdirSync(dir), [], 'no lock and no staging residue after release');
+  });
+});
+
+// Release must be as ownership-aware as acquire. A writer that was stolen from
+// used to unlink whatever lock sat at the path on its way out, handing a third
+// writer the critical section while the current holder was still inside it.
+test('does not release a lock that was stolen and now belongs to another holder (IMPR-32)', () => {
+  withTmpDir((dir) => {
+    const target = join(dir, 'log.md');
+    const lockPath = `${target}.lock`;
+    wfl(target, () => {
+      // Simulate being stolen from mid-critical-section: our lock is replaced by
+      // a live foreign holder's. A pid we are certain is not ours and not alive
+      // would be indistinguishable from a dead holder, so use a live one.
+      writeFileSync(lockPath, String(process.ppid));
+    });
+    assert.equal(
+      existsSync(lockPath),
+      true,
+      "the foreign holder's lock survives our release — we only remove a lock still recording our own pid",
+    );
+  });
+});
+
+// The liveness check is only as good as the pid actually being on disk. Without
+// this, dropping the write leaves every real lock empty — the stealer reads no
+// pid, falls back to the mtime-only rule, and the defense is dead in production
+// while the test above still passes (it writes the pid itself). (IMPR-32)
+test('records the holder pid in the lock file while the critical section runs (IMPR-32)', () => {
+  withTmpDir((dir) => {
+    const target = join(dir, 'log.md');
+    const lockPath = `${target}.lock`;
+    let recorded = null;
+    wfl(target, () => {
+      recorded = readFileSync(lockPath, 'utf-8').trim();
+    });
+    assert.equal(
+      recorded,
+      String(process.pid),
+      'the lock file holds the holder pid, which is what makes the liveness check possible',
+    );
+  });
+});
+
+test('does not steal a lock whose recorded holder pid is still alive, even past staleMs — the holder keeps its entry (IMPR-32)', () => {
+  withTmpDir((dir) => {
+    const target = join(dir, 'log.md');
+    const lockPath = `${target}.lock`;
+    writeFileSync(target, '- entry from writer 1\n'); // writer 1's already-committed entry
+    writeFileSync(lockPath, String(process.pid)); // writer 1 still holds it — we ARE that pid
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, old, old); // preempted well past staleMs, but still alive
+    assert.throws(
+      () =>
+        wfl(
+          target,
+          () => writeFileSync(target, readFileSync(target, 'utf-8') + '- entry from writer 2\n'),
+          { staleMs: 1000, timeoutMs: 200, pollMs: 20 },
+        ),
+      /lock-timeout/,
+      'writer 2 must time out instead of stealing a live lock',
+    );
+    assert.equal(
+      readFileSync(target, 'utf-8'),
+      '- entry from writer 1\n',
+      "writer 1's entry survives — a live holder's lock is never stolen out from under it",
+    );
+    assert.equal(existsSync(lockPath), true, "writer 1's lock is left intact");
+  });
+});
+
 test('throws lock-timeout when a fresh lock is held past timeoutMs', () => {
   withTmpDir((dir) => {
     const target = join(dir, 'log.md');


### PR DESCRIPTION
# English

## What changed

`withFileLock` no longer steals a lock from a holder that is still running, and it no longer publishes a lock that is momentarily empty.

The lock file now carries its holder's pid. An aged lock (mtime older than `staleMs`) is stolen only once that pid is confirmed gone. Release is symmetric: a writer removes the lock only while it still records that writer's own pid. Acquire writes the pid into a per-call random sibling, created exclusively, and links that file into place.

## Why

The old rule was mtime alone. A holder that was merely preempted past `staleMs` lost its lock while still inside the critical section, and a second writer walked in beside it.

For an append that failure is invisible. An overwrite conflict parks an artifact you can find later; an append conflict leaves nothing at all. It is also not the transient lock failure the design already accounts for, where the next close simply re-derives the entry. A stolen lock is a silent overwrite, and nothing downstream ever notices the entry that went missing.

## How

Three changes hold this up, and each one is load-bearing:

1. **The pid is recorded**, so a stealer has something to check.
2. **Liveness is checked before the steal**, via `process.kill(pid, 0)`. `EPERM` counts as alive: "cannot prove it is dead" must not be enough to take a lock away.
3. **The lock is published atomically.** This is the one that is easy to miss. Creating the lock and then writing into it leaves it empty for a moment, and a holder preempted inside that window is indistinguishable from a pid-less legacy lock, which is precisely what a second writer steals. Without atomic publish the liveness check guards a door that is already open.

Staging failures stay separable from link failures. An unwritable directory surfaces as itself, rather than decaying into a lock timeout that would send the caller to the proposal gate over a broken vault. A lock with no readable pid still falls back to the old mtime rule: failing closed there would let one leftover from a crashed pre-upgrade process block every later close permanently, with no self-heal, which is the opposite of the existing design, where a lock failure is transient and the next close simply re-derives the entry.

Two limits are documented in the JSDoc rather than fixed. Between the staleness `statSync` and the `unlink`, a holder can release and a fresh holder take the same path, whose lock is then removed. And a holder that is alive but permanently hung is now never stolen from, so later closes keep timing out; that is availability loss rather than a deadlock, and it does not self-heal. Losing an append is silent, blocking one is visible, so this is the direction to fail in.

## Manual verification

`hooks/hypo-shared.mjs` and a template changed, so beyond the suite:

**Two real processes, one lock.** The unit tests use the test runner's own pid, which cannot prove an inter-process decision. A holder took the lock and idled well past `staleMs` while a second process tried to append:

```
[hypomnema] withFileLock: NOT stealing .../qa-log.md.lock — holder pid 51165 is still alive past staleMs=500
writer 51171: refused with ELOCKTIMEOUT
holder 51165: appended and released
final file: - holder 51165
```

The holder's entry survived, the second writer fell to the timeout contract, and no `.lock` or staging file was left behind.

**Fresh init into a pinned `HOME`.** `node scripts/init.mjs --hypo-dir=<tmp>/vault --no-shell --no-commands --no-git-init` with `HOME` pointed at a temp dir, then read the generated `.gitignore`: both `*.lock` and the new `*.lock.*.tmp` are present. The staging name is not matched by `*.lock`, and a crash between the link and its cleanup leaves one behind where `git add -A` would pick it up.

**Turning each defense off, one at a time**, to confirm the new assertions actually fail: pid recording, the liveness check, ownership-aware release, atomic publish, and the staging/link error split. Each one produced a red test; none of them passes on a defense that is switched off.

## Migration notes

None. Existing lock files simply have no pid recorded, and those keep the previous mtime-only behavior.

---

# 한국어

## 변경 내용

`withFileLock`이 살아 있는 holder의 락을 더 이상 뺏지 않고, 잠시라도 비어 있는 락을 공개하지 않습니다.

락 파일이 holder의 pid를 담습니다. mtime이 `staleMs`를 넘긴 락도 그 pid가 사라진 것이 확인돼야 뺏습니다. 릴리스도 대칭입니다. 락이 여전히 자기 pid를 담고 있을 때만 지웁니다. 획득은 호출마다 난수 이름의 형제 파일을 배타 생성해 pid를 쓴 뒤, 그 파일을 링크로 제자리에 올립니다.

## 이유

옛 규칙은 mtime 하나였습니다. 그래서 그저 `staleMs`를 넘겨 선점당한 holder가 임계 구역 안에 있는 채로 락을 잃고, 두 번째 writer가 그 옆으로 들어왔습니다.

append에서는 이 실패가 보이지 않습니다. overwrite 충돌은 나중에 찾을 수 있는 아티팩트를 남기지만 append 충돌은 아무것도 안 남깁니다. 설계가 이미 감안한 일시적 락 실패와도 다릅니다. 그쪽은 다음 close가 엔트리를 다시 파생해 스스로 낫습니다. 뺏긴 락은 조용한 덮어쓰기라, 사라진 엔트리를 아무도 눈치채지 못합니다.

## 방법

세 가지가 이걸 떠받치고, 하나도 장식이 아닙니다.

1. **pid를 기록합니다.** 그래야 뺏으려는 쪽이 확인할 것이 생깁니다.
2. **뺏기 전에 생존을 확인합니다.** `process.kill(pid, 0)`을 씁니다. `EPERM`은 살아 있는 것으로 셉니다. "죽었다고 증명하지 못했다"가 락을 빼앗을 근거가 되면 안 됩니다.
3. **락을 원자적으로 공개합니다.** 놓치기 쉬운 것이 이겁니다. 락을 만든 뒤에 내용을 채우면 그 사이 잠깐 비어 있고, 그 창에서 선점당한 holder는 pid 없는 구형 락과 구별되지 않습니다. 두 번째 writer가 뺏는 것이 정확히 그것입니다. 원자적 공개가 없으면 생존 확인은 이미 열려 있는 문을 지키는 셈입니다.

staging 실패와 링크 실패는 분리해 둡니다. 쓰기 불가 디렉터리는 그 자체로 드러나야지, 락 타임아웃으로 둔갑해 망가진 볼트 때문에 호출자를 proposal 게이트로 보내면 안 됩니다. pid를 못 읽는 락은 여전히 옛 mtime 규칙으로 폴백합니다. 여기서 fail-closed로 가면 업그레이드 전에 죽은 프로세스가 남긴 락 하나가 이후 모든 close를 영구히 막고 self-heal 경로가 사라집니다. 락 실패를 일시적인 것으로 보고 다음 close가 엔트리를 다시 파생하게 둔 기존 설계와 정반대입니다.

두 가지 한계는 고치는 대신 JSDoc에 적었습니다. staleness `statSync`와 `unlink` 사이에 holder가 릴리스하고 새 holder가 같은 경로를 잡으면 그 락이 지워집니다. 그리고 살아 있지만 영원히 멈춘 holder는 이제 절대 안 뺏기므로 이후 close가 계속 타임아웃합니다. 데드락이 아니라 가용성 저하이고, 스스로 낫지는 않습니다. append를 잃는 것은 조용하고 막는 것은 보이니, 실패한다면 이쪽 방향이 맞습니다.

## 수동 검증

`hooks/hypo-shared.mjs`와 템플릿을 바꿨으므로 스위트 외에 다음을 확인했습니다.

**실제 프로세스 둘, 락 하나.** 단위 테스트는 러너 자신의 pid를 쓰므로 프로세스 간 판정을 증명하지 못합니다. holder가 락을 잡고 `staleMs`를 한참 넘겨 멈춰 있는 동안 두 번째 프로세스가 append를 시도했습니다.

```
[hypomnema] withFileLock: NOT stealing .../qa-log.md.lock — holder pid 51165 is still alive past staleMs=500
writer 51171: refused with ELOCKTIMEOUT
holder 51165: appended and released
final file: - holder 51165
```

holder의 엔트리가 남았고, 두 번째 writer는 타임아웃 계약대로 떨어졌으며, `.lock`도 staging 파일도 잔해가 없습니다.

**`HOME`을 고정한 fresh init.** `HOME`을 임시 디렉터리로 두고 `node scripts/init.mjs --hypo-dir=<tmp>/vault --no-shell --no-commands --no-git-init`을 돌린 뒤 생성된 `.gitignore`를 읽었습니다. `*.lock`과 새 `*.lock.*.tmp`가 모두 있습니다. staging 이름은 `*.lock`에 안 걸리고, 링크와 정리 사이에 죽으면 하나가 남아 `git add -A`에 딸려 들어갑니다.

**방어를 하나씩 꺼서** 새 단언이 실제로 실패하는지 확인했습니다. pid 기록, 생존 확인, 소유권 릴리스, 원자적 공개, staging과 링크의 오류 분리. 각각 red가 났고, 꺼진 방어 위에서 통과하는 단언은 없습니다.

## 마이그레이션 노트

None. 기존 락 파일은 pid가 기록돼 있지 않을 뿐이고, 그런 락은 종전 mtime 전용 동작을 그대로 따릅니다.

---

## Changelog

- EN: Fixed a silent lost update in the session-log append path: a lock is no longer taken from a holder that is still running, and it is never published in a momentarily empty state where a second writer would read it as abandoned.
- KO: 세션 로그 append 경로의 조용한 갱신 유실을 고쳤습니다. 살아 있는 holder의 락을 더 이상 뺏지 않고, 두 번째 writer가 버려진 락으로 읽을 만한 빈 상태로 공개하지도 않습니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
