### PR TITLE
feat(hooks): ask before a close artifact is written, instead of noticing afterward

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/hypo-close-guard.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/hooks/hypo-close-guard.mjs
+++ b/hooks/hypo-close-guard.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * hypo-close-guard.mjs — PreToolUse hook
+ *
+ * SCOPE: this guard closes the direct Write/Edit/MultiEdit bypass only — it is
+ * not a general unauthorized-close catcher. A write executed via Bash (shell
+ * redirection, sed, a script) never reaches PreToolUse's tool_input inspection
+ * and is out of scope. The regular `/hypo:crystallize --apply-session-close`
+ * path runs via Bash and already validates the transcript's close signal
+ * before it writes, so it neither trips this guard nor needs to.
+ *
+ * Intercepts a Write/Edit/MultiEdit BEFORE it lands, when it targets one of the
+ * two close-artifact files (session-state.md, hot.md). doctor's
+ * detectSessionCloseArtifact (hypo-shared.mjs, post-hoc) only ever sees a file
+ * AFTER the write, and only fires on 마감/종료 vocabulary — a wordless full
+ * rewrite (the 2026-07-28 hot.md incident) reads clean to it, because there is
+ * no prior version to diff against.
+ *
+ * Here there is no such blind spot: the PRIMARY signal is structural, not
+ * lexical. recordTouchedPaths (populated by hypo-auto-stage's PostToolUse,
+ * which has already run for every earlier write this session) already tracks
+ * which close-artifact file(s) this session wrote. If the write in front of us
+ * targets one of a project's pair (projects/<slug>/session-state.md,
+ * projects/<slug>/hot.md) and the OTHER one is already in that set, this
+ * session is rewriting both — regardless of what either file's text says. The
+ * pair is scoped to the SAME project directory on purpose: pairing by basename
+ * alone would fire on the root hot.md (which every session's Stop-chain
+ * hypo-hot-rebuild.mjs legitimately rewrites) against an unrelated project's
+ * session-state.md — a false positive, not a close. Root hot.md is therefore
+ * never a structural pair member; it can still trip the lexical signal below
+ * if it is literally rewritten with 마감/종료 wording.
+ *
+ * KNOWN WINDOW: the structural signal is only alive for one turn. Stop's
+ * auto-commit chain (hypo-auto-commit.mjs → commitTouchedPaths) commits and
+ * then CLEARS a session's touched-paths set every time Stop runs. Write
+ * session-state.md in turn 1 and hot.md in turn 2 (Stop runs in between) and
+ * the touched-paths file no longer has the first path — structuralHit reads
+ * false. This is accepted, not fixed: a real close writes both files in the
+ * same turn (see the JSDoc coverage note in hypo-shared.mjs's
+ * detectSessionCloseArtifact), so the main path is still caught; a fresh
+ * cross-turn persistence store is out of this guard's scope. Once the window
+ * closes, only the lexical signal (detectSessionCloseArtifact on the write's
+ * own new text) can still catch a close. See the test that pins this window
+ * (using the real commitTouchedPaths path, not a bare drain) in
+ * tests/close-hooks-gate.test.mjs.
+ *
+ * CASE FOLDING: the basename gate and the structural pairing comparison below
+ * are lowercase-folded. macOS's default volume is case-insensitive, so a write
+ * to `projects/foo/HOT.md` targets the same file `hot.md` does, and comparing
+ * basenames verbatim would read it as "not a close-artifact file" and skip the
+ * structural check entirely. This folding covers only OUR OWN comparisons;
+ * detectSessionCloseArtifact (hypo-shared.mjs, untouched here) does its own
+ * case-sensitive basename check internally, so a case-varied write can still
+ * dodge the LEXICAL signal — but the structural signal does not depend on file
+ * content at all, so it still catches it.
+ *
+ * detectSessionCloseArtifact runs as a SECONDARY trigger regardless of the
+ * structural outcome, so a lone wordy close is caught before its pair even
+ * lands, and the two defenses share one definition of "close" instead of
+ * drifting apart.
+ *
+ * UNDECIDABLE vs BROKEN: the structural signal reads the session's
+ * touched-paths cache directly (readTouchedPathsOrUndecidable below), not via
+ * hypo-shared's peekTouchedPaths, because peekTouchedPaths collapses a lock
+ * timeout, a corrupt cache file, AND a genuinely-empty session into the exact
+ * same `[]` — indistinguishable from the caller's side. Folding all three into
+ * "no structural signal, allow" would let a wordless close slip through
+ * exactly when this guard's own bookkeeping is unreliable, which is the worst
+ * moment for it to go quiet. So an undecidable read (lock timeout / corrupt
+ * cache / no session_id) is instead treated as a HIT — it folds into the same
+ * `ask` branch as a genuine structural match. This is deliberately distinct
+ * from the hook ITSELF breaking (unparseable stdin, an unexpected exception):
+ * that still exits silently below, because a broken guard must never block
+ * the user's actual work. readTouchedPathsOrUndecidable is built from the same
+ * exported primitives peekTouchedPaths itself uses (withFileLock,
+ * touchedPathsPath) — no new read-only API was added to hypo-shared.mjs for
+ * this.
+ *
+ * NO EXPLICIT ALLOW: `permissionDecision: "allow"` is not "stay quiet" — it
+ * tells Claude Code to bypass the user's NORMAL permission prompt for this
+ * tool call outright. This hook has no matcher (see NO MATCHER below), so it
+ * runs in front of every tool call, Bash included; printing an explicit allow
+ * anywhere would auto-approve permission prompts this guard has no business
+ * touching, which is the opposite of what a "confirm before a close" guard is
+ * for. So every pass-through path below prints NOTHING and exits 0, leaving
+ * Claude Code's normal permission policy exactly as it was. Only a genuine
+ * `ask` hit ever writes to stdout.
+ *
+ * A hit is never a deny. The hook only ASKS
+ * (hookSpecificOutput.permissionDecision = "ask") — the harness turns that into
+ * a confirmation in front of the write; approval stays with the human.
+ *
+ * NO MATCHER: this hook is registered under PreToolUse with no matcher (this
+ * repo's installer does not carry matchers through to settings — see
+ * scripts/init.mjs's `_extractFileNames` — and no other hook here uses one
+ * either), so it runs on every tool call. The early-return order below exists
+ * for exactly that: a non-write tool, or a write outside HYPO_DIR, returns
+ * before anything else runs.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { relative } from 'path';
+import {
+  HYPO_DIR,
+  detectSessionCloseArtifact,
+  hasUserCloseSignal,
+  isGateSkipped,
+  touchedPathsPath,
+  withFileLock,
+} from './hypo-shared.mjs';
+
+const CLOSE_ARTIFACT_BASENAMES = new Set(['session-state.md', 'hot.md']);
+// Mirrors hypo-auto-stage.mjs's WRITE_TOOLS: the tools that replace file bytes.
+const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit']);
+
+// The write's own new text. Write carries the whole file; Edit/MultiEdit carry
+// only the replaced snippet(s) — good enough for detectSessionCloseArtifact,
+// which matches a single bold heading line, not the whole document.
+function newTextOf(toolName, toolInput) {
+  if (toolName === 'Write') {
+    return typeof toolInput?.content === 'string' ? toolInput.content : '';
+  }
+  if (toolName === 'Edit') {
+    return typeof toolInput?.new_string === 'string' ? toolInput.new_string : '';
+  }
+  if (toolName === 'MultiEdit' && Array.isArray(toolInput?.edits)) {
+    return toolInput.edits
+      .map((e) => (typeof e?.new_string === 'string' ? e.new_string : ''))
+      .join('\n');
+  }
+  return '';
+}
+
+// See "UNDECIDABLE vs BROKEN" above. `{ok: true, paths}` on a clean read
+// (including a genuinely absent file — never touched this session, not an
+// error); `{ok: false}` when the read cannot be trusted (no session_id, a
+// corrupt/non-array cache file, or a lock timeout).
+function readTouchedPathsOrUndecidable(hypoDir, sessionId) {
+  if (!sessionId) return { ok: false };
+  const path = touchedPathsPath(hypoDir, sessionId);
+  try {
+    return withFileLock(path, () => {
+      if (!existsSync(path)) return { ok: true, paths: [] };
+      try {
+        const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+        if (!Array.isArray(parsed)) return { ok: false }; // corrupt shape
+        return { ok: true, paths: parsed.filter((p) => typeof p === 'string' && p) };
+      } catch {
+        return { ok: false }; // corrupt/unreadable JSON
+      }
+    });
+  } catch {
+    return { ok: false }; // lock timeout
+  }
+}
+
+let input = {};
+try {
+  const raw = await new Promise((r) => {
+    let d = '';
+    process.stdin.on('data', (c) => (d += c));
+    process.stdin.on('end', () => r(d));
+  });
+  input = JSON.parse(raw);
+} catch (err) {
+  // The hook ITSELF failed to read its own input — stay silent (see NO
+  // EXPLICIT ALLOW above); never write a permission decision over garbage.
+  process.stderr.write(`[hypo-close-guard] error: ${err?.message ?? String(err)}\n`);
+  process.exit(0);
+}
+
+try {
+  if (isGateSkipped() || !WRITE_TOOLS.has(input.tool_name)) {
+    process.exit(0);
+  }
+
+  const filePath = input.tool_input?.file_path ?? '';
+  if (!filePath || !(filePath === HYPO_DIR || filePath.startsWith(HYPO_DIR + '/'))) {
+    process.exit(0);
+  }
+
+  const rel = relative(HYPO_DIR, filePath);
+  const relParts = rel.split(/[\\/]/);
+  const base = relParts[relParts.length - 1];
+  const baseLower = base.toLowerCase();
+  if (!CLOSE_ARTIFACT_BASENAMES.has(baseLower)) {
+    process.exit(0);
+  }
+
+  // Structural signal (primary): the OTHER close-artifact file of the SAME
+  // project already written this session — projects/<slug>/session-state.md
+  // paired with projects/<slug>/hot.md ONLY (case-folded). A root hot.md
+  // (relParts.length !== 3, or not under "projects/") is never a pair member.
+  const otherBaseLower = baseLower === 'hot.md' ? 'session-state.md' : 'hot.md';
+  let structuralHit = false;
+  let structuralUndecidable = false;
+  if (relParts.length === 3 && relParts[0].toLowerCase() === 'projects') {
+    const otherPathLower = `${relParts[0].toLowerCase()}/${relParts[1].toLowerCase()}/${otherBaseLower}`;
+    const touchedResult = readTouchedPathsOrUndecidable(HYPO_DIR, input.session_id);
+    if (!touchedResult.ok) {
+      structuralUndecidable = true; // see "UNDECIDABLE vs BROKEN" above
+    } else {
+      structuralHit = touchedResult.paths.some((p) => p.toLowerCase() === otherPathLower);
+    }
+  }
+
+  // Lexical signal (secondary): same predicate doctor uses post-hoc, run here
+  // on the write's own new text.
+  const lexicalHit = detectSessionCloseArtifact({
+    path: filePath,
+    content: newTextOf(input.tool_name, input.tool_input),
+  }).matched;
+
+  if (!structuralHit && !structuralUndecidable && !lexicalHit) {
+    process.exit(0);
+  }
+
+  if (hasUserCloseSignal(input.transcript_path ?? null)) {
+    process.exit(0);
+  }
+
+  const why = structuralUndecidable
+    ? `whether session-state.md and hot.md are both being rewritten this session could not be determined (touched-paths cache unreadable or no session_id)`
+    : structuralHit
+      ? `both session-state.md and hot.md are being rewritten this session`
+      : `this write reads as a close announcement (마감/종료 wording)`;
+
+  console.log(
+    JSON.stringify({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'ask',
+        permissionDecisionReason:
+          `[WIKI CLOSE GUARD] ${rel} — ${why}, but no user close signal was seen ` +
+          `in this session. Confirm with the user before writing: did they actually ` +
+          `ask to close the session?\n` +
+          `To bypass: set HYPO_SKIP_GATE=1`,
+      },
+    }),
+  );
+} catch (err) {
+  // The hook ITSELF broke (unexpected exception) — stay silent, same as the
+  // stdin-parse failure above: a broken guard must never block real work.
+  process.stderr.write(`[hypo-close-guard] error: ${err?.message ?? String(err)}\n`);
+}

--- a/tests/close-hooks-gate.test.mjs
+++ b/tests/close-hooks-gate.test.mjs
@@ -19,10 +19,14 @@ import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
 import {
   HOME,
+  HOOKS,
   SESSION_TMP_HOME,
   buildCleanWikiTree,
+  commitTouchedPaths,
   extractTouchedWikiFiles,
   payloadForCleanWiki,
+  peekTouchedPaths,
+  recordTouchedPaths,
   run,
   runApply,
   runHook,
@@ -30,6 +34,7 @@ import {
   sessionLogReadCandidates,
   sessionLogShardPath,
   todayLocal,
+  touchedPathsPath,
   withCleanWiki,
   withTmpDir,
   withWiki,
@@ -897,4 +902,436 @@ test('missing log.md → exit 1 + log.md in missing list', () => {
       assert.ok(out.missing.includes('log.md'), `missing list should name log.md: ${r.stdout}`);
     },
   );
+});
+
+// ── ISSUE-77: hypo-close-guard.mjs (PreToolUse) — intercept a close artifact
+// BEFORE it lands, instead of only detecting it after (doctor's post-hoc
+// detectSessionCloseArtifact). ──────────────────────────────────────────────
+suite('hypo-close-guard.mjs — registration');
+
+test('hypo-close-guard.mjs is registered under hooks.json PreToolUse', () => {
+  const cfg = JSON.parse(readFileSync(join(HOOKS, 'hooks.json'), 'utf-8'));
+  const groups = cfg.hooks.PreToolUse || [];
+  const commands = groups.flatMap((g) => g.hooks.map((h) => h.command));
+  assert.ok(
+    commands.some((c) => /hypo-close-guard\.mjs$/.test(c)),
+    `PreToolUse must register hypo-close-guard.mjs, got: ${JSON.stringify(commands)}`,
+  );
+});
+
+suite('hypo-close-guard.mjs — contract');
+
+test('hook-itself failure (invalid JSON stdin) → silent pass-through, NOT an explicit allow', () => {
+  const r = runHook('hypo-close-guard.mjs', 'not-json');
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.equal(
+    r.stdout.trim(),
+    '',
+    `a broken hook must exit silently, never write a permission decision: ${r.stdout}`,
+  );
+});
+
+test('non-write tool (Read) targeting hot.md → silent (permission gate untouched)', () => {
+  withWiki(null, (dir) => {
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-read',
+        tool_name: 'Read',
+        tool_input: { file_path: join(dir, 'projects', 'test-project', 'hot.md') },
+      },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.stdout.trim(), '', `must not print an explicit allow: ${r.stdout}`);
+  });
+});
+
+test('write outside HYPO_DIR → silent (permission gate untouched)', () => {
+  const r = runHook('hypo-close-guard.mjs', {
+    session_id: 'sess-outside',
+    tool_name: 'Write',
+    tool_input: { file_path: '/tmp/not-the-wiki/hot.md', content: '# hi\n' },
+  });
+  assert.equal(r.stdout.trim(), '', `must not print an explicit allow: ${r.stdout}`);
+});
+
+test('write to an unrelated wiki file (not session-state.md/hot.md) → silent', () => {
+  withWiki(null, (dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-unrelated',
+        tool_name: 'Write',
+        tool_input: { file_path: join(dir, 'pages', 'note.md'), content: '# note\n' },
+      },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.stdout.trim(), '', `must not print an explicit allow: ${r.stdout}`);
+  });
+});
+
+test(
+  'structural signal: hot.md rewritten with NO 마감/종료 vocabulary, after session-state.md ' +
+    'was already touched this session and no user close signal → ask (2026-07-28 gap, PR #226)',
+  () => {
+    withWiki(null, (dir) => {
+      // Simulates hypo-auto-stage's PostToolUse having already accumulated an
+      // earlier write to session-state.md THIS session.
+      recordTouchedPaths(dir, 'sess-1', 'projects/test-project/session-state.md');
+      const r = runHook(
+        'hypo-close-guard.mjs',
+        {
+          session_id: 'sess-1',
+          tool_name: 'Write',
+          tool_input: {
+            file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+            // The literal text the 2026-07-28 incident wrote into hot.md — reads
+            // as a wrap-up to a human but names no 마감/종료 word, which is
+            // exactly the case close-signals.test.mjs pins as unreachable by
+            // detectSessionCloseArtifact alone.
+            content:
+              '**2026-07-28(13번째 세션): 세 스트림 병렬을 표준으로 등재하고 처음 실행했다.** 사용자 결정으로 …',
+          },
+        },
+        { HYPO_DIR: dir },
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.hookSpecificOutput.permissionDecision, 'ask');
+      assert.ok(
+        /WIKI CLOSE GUARD/.test(out.hookSpecificOutput.permissionDecisionReason),
+        `reason should name the guard: ${r.stdout}`,
+      );
+    });
+  },
+);
+
+test('structural signal fires in the opposite order too (session-state.md is the second write)', () => {
+  withWiki(null, (dir) => {
+    recordTouchedPaths(dir, 'sess-2', 'projects/test-project/hot.md');
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-2',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: join(dir, 'projects', 'test-project', 'session-state.md'),
+          content: '# no close words here\n',
+        },
+      },
+      { HYPO_DIR: dir },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'ask');
+  });
+});
+
+test(
+  'pairing is project-scoped: root hot.md does NOT structurally pair against an ' +
+    "unrelated project's session-state.md (codex review — root hot.md churns every " +
+    'session via hypo-hot-rebuild.mjs and must not false-positive)',
+  () => {
+    withWiki(null, (dir) => {
+      recordTouchedPaths(dir, 'sess-root', 'projects/test-project/session-state.md');
+      const r = runHook(
+        'hypo-close-guard.mjs',
+        {
+          session_id: 'sess-root',
+          tool_name: 'Write',
+          tool_input: {
+            file_path: join(dir, 'hot.md'), // ROOT hot.md, not projects/test-project/hot.md
+            content: '# ordinary rebuilt hot.md, no close wording\n',
+          },
+        },
+        { HYPO_DIR: dir },
+      );
+      assert.equal(
+        r.stdout.trim(),
+        '',
+        `root hot.md must not pair with another project's session-state.md: ${r.stdout}`,
+      );
+    });
+  },
+);
+
+test(
+  "KNOWN WINDOW: once Stop-chain auto-commit (the REAL commitTouchedPaths path, " +
+    'hooks/hypo-auto-commit.mjs → hypo-shared.mjs:1854) clears touched-paths, the ' +
+    "structural signal is gone in the NEXT turn — pins the guard's documented " +
+    "one-turn window, not a claim that it always catches (mirrors how PR #226 " +
+    'pinned its own gap)',
+  () => {
+    withWiki(null, (dir) => {
+      recordTouchedPaths(dir, 'sess-drained', 'projects/test-project/session-state.md');
+      // The actual Stop-chain call shape (hypo-auto-commit.mjs), not a bare
+      // drain: commitFn reports a successful commit, so commitTouchedPaths
+      // clears exactly what it peeked, under one lock — the real path that
+      // empties touched-paths between turns, not a simulation of it.
+      const result = commitTouchedPaths(dir, 'sess-drained', () => ({ committed: true }));
+      assert.equal(result.committed, true, 'the stub commitFn must report success');
+      assert.deepEqual(
+        peekTouchedPaths(dir, 'sess-drained'),
+        [],
+        'touched-paths must actually be empty after a real commitTouchedPaths clear',
+      );
+      const r = runHook(
+        'hypo-close-guard.mjs',
+        {
+          session_id: 'sess-drained',
+          tool_name: 'Write',
+          tool_input: {
+            file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+            // Same wordless-rewrite shape as the 2026-07-28 incident — only
+            // reachable pre-clear via the structural signal, which is now gone.
+            content:
+              '**2026-07-28(13번째 세션): 세 스트림 병렬을 표준으로 등재하고 처음 실행했다.** 사용자 결정으로 …',
+          },
+        },
+        { HYPO_DIR: dir },
+      );
+      assert.equal(
+        r.stdout.trim(),
+        '',
+        `after the clear, a wordless close in a NEW turn is a known miss, not a catch: ${r.stdout}`,
+      );
+    });
+  },
+);
+
+test('only ONE close-artifact file touched this session (no pair yet) and no wording → silent', () => {
+  withWiki(null, (dir) => {
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-lonely',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+          content: '# ordinary progress update, no close wording\n',
+        },
+      },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.stdout.trim(), '', `must not print an explicit allow: ${r.stdout}`);
+  });
+});
+
+test(
+  'CASE FOLDING: a mis-cased write (HOT.md) still structurally pairs against ' +
+    'session-state.md written earlier this session (macOS default volume is ' +
+    'case-insensitive — codex review)',
+  () => {
+    withWiki(null, (dir) => {
+      recordTouchedPaths(dir, 'sess-case', 'projects/test-project/session-state.md');
+      const r = runHook(
+        'hypo-close-guard.mjs',
+        {
+          session_id: 'sess-case',
+          tool_name: 'Write',
+          tool_input: {
+            // Deliberately wrong case: the real file on disk is hot.md.
+            file_path: join(dir, 'projects', 'test-project', 'HOT.md'),
+            content: '# ordinary wrap-up, no close wording\n',
+          },
+        },
+        { HYPO_DIR: dir },
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.hookSpecificOutput.permissionDecision,
+        'ask',
+        `a mis-cased basename must not dodge the structural signal: ${r.stdout}`,
+      );
+    });
+  },
+);
+
+test(
+  'CASE FOLDING: the reverse pairing direction also folds case (Session-State.md)',
+  () => {
+    withWiki(null, (dir) => {
+      recordTouchedPaths(dir, 'sess-case-2', 'projects/test-project/hot.md');
+      const r = runHook(
+        'hypo-close-guard.mjs',
+        {
+          session_id: 'sess-case-2',
+          tool_name: 'Write',
+          tool_input: {
+            file_path: join(dir, 'projects', 'test-project', 'Session-State.md'),
+            content: '# ordinary wrap-up, no close wording\n',
+          },
+        },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.hookSpecificOutput.permissionDecision, 'ask');
+    });
+  },
+);
+
+suite('hypo-close-guard.mjs — undecidable structural signal (ask, conservative)');
+
+test(
+  'UNDECIDABLE: no session_id on a project close-artifact write → ask, not silent ' +
+    "pass-through (main decision: 'cannot tell' must not read as 'clean')",
+  () => {
+    withWiki(null, (dir) => {
+      const r = runHook(
+        'hypo-close-guard.mjs',
+        {
+          // session_id deliberately omitted.
+          tool_name: 'Write',
+          tool_input: {
+            file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+            content: '# ordinary wrap-up, no close wording\n',
+          },
+        },
+        { HYPO_DIR: dir },
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(
+        out.hookSpecificOutput.permissionDecision,
+        'ask',
+        `an undecidable structural read must ask, not pass silently: ${r.stdout}`,
+      );
+      assert.ok(
+        /could not be determined/.test(out.hookSpecificOutput.permissionDecisionReason),
+        `reason should name the undecidable state: ${r.stdout}`,
+      );
+    });
+  },
+);
+
+test('UNDECIDABLE: a corrupt touched-paths cache file → ask, not silent pass-through', () => {
+  withWiki(null, (dir) => {
+    recordTouchedPaths(dir, 'sess-corrupt', 'projects/test-project/session-state.md');
+    // Corrupt the cache file recordTouchedPaths just wrote — same file
+    // readTouchedPathsOrUndecidable (hypo-close-guard.mjs) reads.
+    writeFileSync(touchedPathsPath(dir, 'sess-corrupt'), 'not valid json{{{');
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-corrupt',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+          content: '# ordinary wrap-up, no close wording\n',
+        },
+      },
+      { HYPO_DIR: dir },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.hookSpecificOutput.permissionDecision,
+      'ask',
+      `a corrupt cache must ask, not read as 'nothing touched': ${r.stdout}`,
+    );
+  });
+});
+
+test(
+  'UNDECIDABLE vs BROKEN: a hook-itself failure (bad stdin) stays silent even ' +
+    'though an undecidable structural read asks — the two must not be conflated',
+  () => {
+    const r = runHook('hypo-close-guard.mjs', 'not-json');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(
+      r.stdout.trim(),
+      '',
+      `a broken hook must stay silent, unlike an undecidable structural read: ${r.stdout}`,
+    );
+  },
+);
+
+suite('hypo-close-guard.mjs — contract (continued)');
+
+test('lexical signal alone: a wordy close heading fires before its pair ever lands (Edit new_string)', () => {
+  withWiki(null, (dir) => {
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-3',
+        tool_name: 'Edit',
+        tool_input: {
+          file_path: join(dir, 'projects', 'test-project', 'session-state.md'),
+          old_string: 'old heading',
+          new_string: '**2026-08-04 마감**',
+        },
+      },
+      { HYPO_DIR: dir },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'ask');
+  });
+});
+
+test('ISSUE-74 must not regress: a genuine user close signal in the transcript is NOT re-asked', () => {
+  withWiki(null, (dir) => {
+    recordTouchedPaths(dir, 'sess-4', 'projects/test-project/session-state.md');
+    const transcript = join(dir, 'transcript.jsonl');
+    writeFileSync(
+      transcript,
+      JSON.stringify({ type: 'user', message: { role: 'user', content: '세션 마무리 해줘' } }) +
+        '\n',
+    );
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-4',
+        transcript_path: transcript,
+        tool_name: 'Write',
+        tool_input: {
+          file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+          content: '**2026-08-04(1번째 세션): 세션을 마감했다.**',
+        },
+      },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(
+      r.stdout.trim(),
+      '',
+      `a genuine user close must not be re-asked: ${r.stdout}`,
+    );
+  });
+});
+
+test('HYPO_SKIP_GATE=1 bypasses the guard even on a structural hit', () => {
+  withWiki(null, (dir) => {
+    recordTouchedPaths(dir, 'sess-5', 'projects/test-project/session-state.md');
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-5',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+          content: 'wrap-up narrative, no close words',
+        },
+      },
+      { HYPO_DIR: dir, HYPO_SKIP_GATE: '1' },
+    );
+    assert.equal(r.stdout.trim(), '', `must not print an explicit allow: ${r.stdout}`);
+  });
+});
+
+test('touched-paths accumulated for a DIFFERENT session_id does not leak into this one', () => {
+  withWiki(null, (dir) => {
+    recordTouchedPaths(dir, 'sess-other', 'projects/test-project/session-state.md');
+    const r = runHook(
+      'hypo-close-guard.mjs',
+      {
+        session_id: 'sess-mine',
+        tool_name: 'Write',
+        tool_input: {
+          file_path: join(dir, 'projects', 'test-project', 'hot.md'),
+          content: 'wrap-up narrative, no close words',
+        },
+      },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.stdout.trim(), '', `must not print an explicit allow: ${r.stdout}`);
+  });
 });

--- a/tests/fixtures/npm-pack.files.json
+++ b/tests/fixtures/npm-pack.files.json
@@ -176,6 +176,10 @@
     "exec": false
   },
   {
+    "path": "hooks/hypo-close-guard.mjs",
+    "exec": false
+  },
+  {
     "path": "hooks/hypo-compact-guard.mjs",
     "exec": false
   },


### PR DESCRIPTION
# English

## What changed

A new PreToolUse hook, `hooks/hypo-close-guard.mjs`, intercepts a `Write`/`Edit`/`MultiEdit` aimed at a project's `session-state.md` or `hot.md` and asks the user to confirm before it lands. It only ever asks; it never denies, so approval stays with a human.

## Why

`doctor` already reports a session-close artifact that nobody authorized. By the time it does, the file is written and usually committed, and anyone who does not run `doctor` never finds out. The problem being solved is that the artifact gets written without the user asking for a close, and a report after the fact does not prevent that.

Intercepting the tool call does, for the simple reason that it happens first.

## How

The primary signal is structural rather than lexical. If this session already wrote the other file of that project's pair, both close artifacts are being rewritten, whatever the text happens to say.

That is what catches the case the existing post-hoc predicate provably cannot. A full rewrite that never uses close vocabulary gives a content matcher nothing to match on, and the current test suite pins that gap. Looking at which files are being replaced sidesteps wording entirely. The existing predicate still runs as a secondary trigger on the write's own new text, so a single wordy close is caught before its pair ever lands, and both defenses keep sharing one definition of "close" instead of drifting apart.

Three details are worth calling out, because each one is a way this could have gone quietly wrong:

**Every pass-through path writes nothing to stdout.** An explicit `permissionDecision: "allow"` is not a quiet yes: it skips the harness's own permission prompt. This hook is registered without a matcher, so every tool call in the session reaches it, and printing an allow would have auto-approved all of them, including `Bash`. A test asserts empty stdout on each pass-through path, so reintroducing an explicit allow turns it red.

**Path comparison is case-folded.** The default macOS volume is case-insensitive, so `projects/foo/HOT.md` reaches the real `hot.md` while a case-sensitive basename check waves it through, bypassing both signals at once.

**"Cannot tell" does not read as "nothing to see".** A structural read that cannot be decided (no session id, a corrupt cache, a lock timeout) asks. A failure of the hook itself stays silent, because a broken guard must not block the user's work. These are separate code paths, and separate tests.

Scope, stated plainly: this closes the direct `Write`/`Edit`/`MultiEdit` path. The regular close command runs through the CLI, which already validates the user's close signal before writing, and a write driven through `Bash` is out of reach here. The structural signal also lives only until the Stop-chain auto-commit clears the session's touched-paths, so it holds within a turn and not across one; past that only the lexical signal remains. Both limits are pinned by tests rather than papered over.

## Manual verification

Unit tests only prove the hook emits the right JSON, so the hook was run directly against a temp vault:

**Structural hit, no close signal in the transcript.** The session had already written `projects/qa-proj/session-state.md`; the guard then saw a `Write` to that project's `hot.md`:

```
{"continue":true,"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask",
 "permissionDecisionReason":"[WIKI CLOSE GUARD] projects/qa-proj/hot.md — both session-state.md
 and hot.md are being rewritten this session, but no user close signal was seen ..."}}
```

**A genuine close request in the transcript**, same structural hit: empty stdout, exit 0. It does not re-ask what the user already said.

**An unrelated tool** (`Bash`, running `ls`): empty stdout, exit 0. The hook does not touch the permission decision for anything it is not about.

**Turning each defense off, one at a time**, to confirm the assertions fail without it: case folding, the undecidable-structural branch, and the absence of an explicit allow. Each produced a red test.

Still unverified: whether the harness turns `permissionDecision: "ask"` into a visible confirmation in a live session. The output shape follows the documented PreToolUse contract, and this is the repo's first hook to use it, so that is worth watching on the first real close after this ships.

## Migration notes

None. The hook is registered under a new `PreToolUse` key that init and upgrade pick up from the manifest like any other event.

---

# 한국어

## 변경 내용

새 PreToolUse 훅 `hooks/hypo-close-guard.mjs`가 프로젝트의 `session-state.md`나 `hot.md`를 겨냥한 `Write`/`Edit`/`MultiEdit`를 파일이 쓰이기 전에 가로채 사용자에게 확인을 받습니다. 묻기만 하고 거절하지는 않아서, 승인은 사람 몫으로 남습니다.

## 이유

`doctor`는 아무도 승인하지 않은 세션 close 산출물을 이미 보고합니다. 그런데 그 시점에는 파일이 이미 쓰였고 대개 커밋까지 된 뒤이며, `doctor`를 안 돌리는 사람은 영영 모릅니다. 풀려는 문제는 사용자가 close를 요청하지 않았는데 모델이 산출물을 쓰는 것이고, 사후 보고는 그걸 막지 못합니다.

도구 호출을 가로채면 막힙니다. 그게 먼저 일어나기 때문입니다.

## 방법

주 신호는 어휘가 아니라 구조입니다. 이번 세션이 그 프로젝트 쌍의 다른 쪽을 이미 썼다면, 텍스트가 무슨 말을 하든 close 산출물 둘이 함께 다시 쓰이고 있는 것입니다.

기존 사후 판정 함수가 원리적으로 못 잡는 경우가 이걸로 잡힙니다. close 어휘를 전혀 안 쓰는 전면 교체는 내용 기반 매처에게 맞출 것을 아무것도 안 주고, 현재 테스트 스위트가 그 갭을 못박아 두고 있습니다. 어떤 파일이 교체되는지를 보면 문구 문제를 아예 비켜 갑니다. 기존 함수는 이 쓰기의 새 텍스트에 대해 보조 트리거로 계속 돌아서, 어휘가 있는 close 하나는 짝이 오기 전에 잡히고, 두 방어가 "close란 무엇인가"를 하나의 정의로 계속 공유합니다.

세 가지는 따로 짚어 둡니다. 각각 조용히 잘못될 수 있었던 지점입니다.

**통과 경로는 stdout에 아무것도 쓰지 않습니다.** 명시적 `permissionDecision: "allow"`는 조용한 승낙이 아니라 하네스의 권한 확인 자체를 건너뛰라는 지시입니다. 이 훅은 matcher 없이 등록돼 세션의 모든 도구 호출이 거쳐 가므로, allow를 찍었다면 `Bash`를 포함한 전부를 자동 승인했을 것입니다. 통과 경로마다 stdout이 비어 있음을 단언하는 테스트가 있어서, 명시적 allow가 다시 들어오면 그 즉시 red가 됩니다.

**경로 비교는 대소문자를 접습니다.** macOS 기본 볼륨은 대소문자를 무시하므로 `projects/foo/HOT.md`가 실제 `hot.md`에 닿는데, 대소문자를 그대로 비교하면 대상이 아니라고 판정해 두 신호를 한꺼번에 우회합니다.

**"판정 불가"를 "문제 없음"으로 읽지 않습니다.** 구조 판정이 불가능한 경우(session id 없음, 캐시 손상, 락 타임아웃)에는 묻습니다. 훅 자체가 고장 난 경우는 조용히 통과합니다. 망가진 가드가 사용자 작업을 막으면 안 되기 때문입니다. 둘은 별개의 코드 경로이고 테스트도 따로 있습니다.

범위를 그대로 적습니다. 이 변경이 닫는 것은 직접 `Write`/`Edit`/`MultiEdit` 경로입니다. 정규 close 명령은 CLI를 거치고 그 CLI가 쓰기 전에 이미 사용자 close 신호를 검증하며, `Bash`로 이뤄지는 쓰기는 여기서 손이 닿지 않습니다. 구조 신호도 Stop 체인의 auto-commit이 세션의 touched-paths를 비우기 전까지만 살아 있어서, 한 턴 안에서는 유효하고 턴을 넘기면 어휘 신호만 남습니다. 두 한계 모두 덮지 않고 테스트로 못박았습니다.

## 수동 검증

단위 테스트는 훅이 올바른 JSON을 낸다는 것만 증명하므로, 임시 볼트에 대고 훅을 직접 실행했습니다.

**구조 히트, transcript에 close 신호 없음.** 세션이 `projects/qa-proj/session-state.md`를 이미 썼고, 가드가 같은 프로젝트의 `hot.md`에 대한 `Write`를 봤습니다.

```
{"continue":true,"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask",
 "permissionDecisionReason":"[WIKI CLOSE GUARD] projects/qa-proj/hot.md — both session-state.md
 and hot.md are being rewritten this session, but no user close signal was seen ..."}}
```

**transcript에 진짜 close 요청이 있는 경우**, 같은 구조 히트: stdout 비어 있고 exit 0. 사용자가 이미 말한 것을 다시 묻지 않습니다.

**무관한 도구**(`Bash`로 `ls` 실행): stdout 비어 있고 exit 0. 자기 소관이 아닌 것의 권한 판정에는 손대지 않습니다.

**방어를 하나씩 꺼서** 그것 없이 단언이 실패하는지 확인했습니다. 대소문자 폴딩, 판정 불가 분기, 명시적 allow 부재. 각각 red가 났습니다.

아직 확인 못 한 것: 하네스가 `permissionDecision: "ask"`를 실제 세션에서 눈에 보이는 확인 창으로 바꾸는지. 출력 형태는 문서화된 PreToolUse 계약을 따르지만 이 저장소에서 그 계약을 쓰는 첫 훅이라, 배포 후 첫 실제 close에서 지켜볼 값어치가 있습니다.

## 마이그레이션 노트

None. 새 `PreToolUse` 키로 등록되고, init과 upgrade가 다른 이벤트와 똑같이 매니페스트에서 읽어 갑니다.

---

## Changelog

- EN: A session-close artifact written without you asking for a close now prompts for confirmation before the file lands, instead of being reported by `doctor` after it is already written and committed.
- KO: close를 요청하지 않았는데 쓰이는 세션 close 산출물이, 파일이 쓰이고 커밋된 뒤에 `doctor`로 보고되는 대신 쓰이기 전에 확인을 묻습니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
