### PR TITLE
fix(hooks): tell an unanswered git probe from a "not ignored" answer

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -459,31 +459,82 @@ export function pageUsageLoggingAllowed(hypoDir, sessionId) {
 // subprocess, so cache its result per session. The verdict cached here is only
 // the git signal, never the composite allow decision, so the fresh .hypoignore
 // re-check above always still runs.
+// How long an unanswered probe suppresses the next one. Long enough that a git
+// that is genuinely wedged costs one 10s wait per half-minute instead of one per
+// prompt, short enough that a blip clears on its own well inside a session.
+const PROBE_BACKOFF_MS = 30000;
+
 function gitIgnoresPageUsageCached(hypoDir, sessionId) {
+  // Without a session id every caller lands on the same `default` cache file, so
+  // one session's verdict would answer for the next one — and the file outlives
+  // both, sitting in tmpdir with nothing to expire it. A verdict that cannot be
+  // scoped to a session is not cached at all: re-probe every time instead of
+  // serving a stale `true` after .gitignore coverage has been removed.
+  const scoped = Boolean(sessionId);
   const cachePath = pageUsageGuardCachePath(sessionId, hypoDir);
-  try {
-    if (existsSync(cachePath)) {
-      const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
-      if (typeof cached.gitIgnored === 'boolean') return cached.gitIgnored;
+  if (scoped) {
+    try {
+      if (existsSync(cachePath)) {
+        const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
+        if (typeof cached.gitIgnored === 'boolean') return cached.gitIgnored;
+        // A recorded outage still stands until it expires. This is what keeps a
+        // wedged git off the UserPromptSubmit path: hypo-lookup calls this before
+        // it prints, so a 10s wait here is 10s of dead prompt, every prompt.
+        if (typeof cached.unavailableUntil === 'number' && Date.now() < cached.unavailableUntil) {
+          return false;
+        }
+      }
+    } catch {
+      // corrupt cache → recompute below
     }
-  } catch {
-    // corrupt cache → recompute below
   }
 
-  let gitIgnored = false;
+  // check-ignore answers with an exit code: 0 = ignored, 1 = not ignored. Every
+  // other outcome means the probe never got to answer — 128 for a fatal git
+  // error (hypoDir not a repo yet), or a null status when the 2s timeout fired
+  // or the spawn itself failed, which is what a machine under heavy process
+  // load produces. Treating those as a plain `false` is the bug this guards
+  // against: it is indistinguishable from git actually saying "not ignored",
+  // and the verdict then gets cached, so one blip keeps logging disabled for
+  // the rest of the session even after the condition clears.
+  // The bound is here to survive a git that never returns (an index.lock held by
+  // a dead process, a corrupt repo), not to race a busy machine. It used to be
+  // 2s, which a loaded box clears by a hair: instrumenting a one-process-per-suite
+  // run produced eight ETIMEDOUT probes, every one of them landing between 2011ms
+  // and 2254ms. check-ignore on a real vault costs single-digit milliseconds, so
+  // the old bound was three orders of magnitude tighter than the work and was
+  // measuring scheduler latency instead of git. 10s still catches a true hang.
+  let probe = null;
   try {
-    gitIgnored =
-      spawnSync('git', ['-C', hypoDir, 'check-ignore', '-q', '--', PAGE_USAGE_REL], {
-        timeout: 2000,
-      }).status === 0;
+    probe = spawnSync('git', ['-C', hypoDir, 'check-ignore', '-q', '--', PAGE_USAGE_REL], {
+      timeout: 10000,
+    });
   } catch {
-    gitIgnored = false;
+    probe = null;
   }
 
-  try {
-    writeFileSync(cachePath, JSON.stringify({ gitIgnored }));
-  } catch {
-    // cache write failure is non-fatal; the git probe just reruns next prompt
+  // Inconclusive → fail closed for this call. The verdict is never cached as an
+  // answer; what gets recorded is that the probe is down, and only until the
+  // backoff expires. So a scheduler blip self-heals within the session, while a
+  // wedged git is waited on once per backoff window rather than once per prompt.
+  if (!probe || (probe.status !== 0 && probe.status !== 1)) {
+    if (scoped) {
+      try {
+        writeFileSync(cachePath, JSON.stringify({ unavailableUntil: Date.now() + PROBE_BACKOFF_MS }));
+      } catch {
+        // non-fatal; the probe just runs again next prompt
+      }
+    }
+    return false;
+  }
+
+  const gitIgnored = probe.status === 0;
+  if (scoped) {
+    try {
+      writeFileSync(cachePath, JSON.stringify({ gitIgnored }));
+    } catch {
+      // cache write failure is non-fatal; the git probe just reruns next prompt
+    }
   }
   return gitIgnored;
 }

--- a/tests/close-signals.test.mjs
+++ b/tests/close-signals.test.mjs
@@ -1949,6 +1949,69 @@ test('guard true when both .gitignore and .hypoignore cover .cache/', () => {
   });
 });
 
+// A probe that never answered is not the same as git saying "not ignored".
+// check-ignore exits 0 (ignored) or 1 (not ignored); 128 means git errored out,
+// and a null status means the 2s timeout fired or the spawn failed outright —
+// which is what a machine running one process per suite actually produces. The
+// old code collapsed all of those into `false` and then cached it, so one blip
+// kept logging disabled for the whole session even after the cause cleared.
+// That is the flake behind the .cache/ guard failing only under --shards=N.
+test('an inconclusive git probe records an outage, never a verdict', () => {
+  withTmpDir((dir) => {
+    const sessionId = 'b1-inconclusive';
+    const cachePath = pageUsageGuardCachePath(sessionId, dir);
+    try {
+      writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+      writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+
+      // Not a git repo yet → check-ignore exits 128, i.e. it did not answer.
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId), false);
+      const recorded = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      assert.equal(
+        recorded.gitIgnored,
+        undefined,
+        'an unanswered probe must never be written down as an answer',
+      );
+      assert.equal(typeof recorded.unavailableUntil, 'number');
+
+      // The outage stamp suppresses re-probing while it stands. That is what
+      // keeps a wedged git from costing a full timeout on every prompt.
+      gitRepo(dir);
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId), false);
+
+      // Once it lapses, the answer is recomputed rather than served from the
+      // outage — the old code cached `false` here and never recovered.
+      writeFileSync(cachePath, JSON.stringify({ unavailableUntil: Date.now() - 1 }));
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId), true);
+    } finally {
+      rmSync(cachePath, { force: true });
+    }
+  });
+});
+
+// Without a session id the cache key collapses to `default`, so one session's
+// verdict would answer for the next — and nothing expires the file. The guard
+// re-probes instead, which is what lets removed .gitignore coverage take effect.
+test('no session id → the git verdict is not cached at all', () => {
+  withTmpDir((dir) => {
+    const cachePath = pageUsageGuardCachePath(undefined, dir);
+    try {
+      rmSync(cachePath, { force: true });
+      gitRepo(dir);
+      writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+      writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+      assert.equal(pageUsageLoggingAllowed(dir, undefined), true);
+      assert.ok(!existsSync(cachePath), 'an unscoped verdict must not be written');
+
+      // Coverage removed → the next call must see it, not a stale `true`.
+      writeFileSync(join(dir, '.gitignore'), 'unrelated/\n');
+      assert.equal(pageUsageLoggingAllowed(dir, undefined), false);
+    } finally {
+      rmSync(cachePath, { force: true });
+    }
+  });
+});
+
 test('guard false when only .gitignore covers .cache/ (both signals required)', () => {
   withTmpDir((dir) => {
     gitRepo(dir);


### PR DESCRIPTION
# English

## What changed

The page-usage logging guard now distinguishes a `git check-ignore` probe that answered from one that never got to answer, and it no longer caches the second kind as if it were an answer.

Three things:

- An inconclusive probe still fails closed, but what gets written down is an outage with a 30 second backoff, not a verdict. A transient failure clears inside the session; a genuinely wedged git costs one wait per backoff window instead of one per prompt.
- The subprocess bound went from 2 seconds to 10.
- When there is no session id, the verdict is not cached at all.

## Why

`check-ignore` exits 0 (ignored) or 1 (not ignored). Anything else means it did not answer: 128 when the vault is not a git repo yet, and a null status when the timeout fired or the spawn failed. The old code read all of those as "not ignored" and cached that, so one blip disabled page-usage logging for the rest of the session even after the cause was gone.

Two concrete failure paths:

1. A repo that becomes a repo mid-session (or any transient git error) recorded a permanent `false`. This reproduces with no load at all.
2. Under a one-process-per-suite test run, the 2 second bound fired on a loaded machine. Instrumenting such a run caught eight ETIMEDOUT probes, every one landing between 2011ms and 2254ms, against work that costs single-digit milliseconds on a real vault. The bound was measuring scheduler latency rather than git, and the suite-isolation run it broke is the thing that proves suites do not depend on each other, so its signal was permanently lost in that noise.

The missing session id case is separate: without one, every caller shares a single `default` cache file in the OS temp directory with nothing to expire it, so one session's verdict answers for the next. Removing `.cache/` coverage from `.gitignore` would not take effect.

## How

`gitIgnoresPageUsageCached` now inspects `probe.status` explicitly and only treats 0 and 1 as answers. Anything else writes `{ unavailableUntil }` and returns false. A stored outage suppresses re-probing until it lapses, which is what keeps a wedged git off the `UserPromptSubmit` path: `hypo-lookup` calls this before it prints, so a full timeout there is a dead prompt every prompt.

Raising the bound alone would not have been enough, because a single call still fails closed. Not caching alone would not have been enough either, because the same call keeps timing out. Both were needed.

## Manual verification

Unit tests cannot reach the hook entry point, so the guard was driven through `hooks/hypo-lookup.mjs` against a throwaway git-backed vault with a matching `index.md`:

```
# 1. guard passes, session id present
echo '{"prompt":"locking guidance for hooks","session_id":"qa-sess-1"}' | HYPO_DIR=<vault> node hooks/hypo-lookup.mjs
  -> [WIKI LOOKUP: 1 page(s) matched]; .cache/page-usage.jsonl has 1 record

# 2. no session id (older payload shape)
echo '{"prompt":"locking guidance for hooks","session_id":null}' | ...
  -> 1 record written, and zero hypo-pageusage-guard-default-*.json files created

# 3. .gitignore coverage removed, no session id
  -> no record written (no stale `true` served)
```

Suite-isolated runs, which is where the flake showed:

```
node tests/parallel.mjs --shards=278
  before: 1824 passed / 3 failed, then 1819 passed / 8 failed
  after:  0 failed on four consecutive runs (101s, 112s, 115s, 183s wall)
```

`npm test` 1828 passed / 0 failed. `npm run lint` 0 errors.

Not covered: the deployed copy under a live session was not exercised, because this machine reads hooks from the plugin cache rather than `~/.claude/hooks/`. The three cases above ran against the worktree copy invoked the way the runtime invokes it.

## Migration notes

None. The cache file format gained an `unavailableUntil` key; older files carrying only `gitIgnored` are still read, and an unrecognised file is recomputed.

---

# 한국어

## 변경 내용

page-usage 로깅 가드가 `git check-ignore` probe의 "답한 경우"와 "답하지 못한 경우"를 구별하고, 후자를 답인 것처럼 캐시하지 않습니다.

세 가지입니다.

- 판정 불가는 여전히 fail-closed지만, 기록되는 것은 판정이 아니라 30초짜리 일시 장애입니다. 일시적 실패는 세션 안에서 스스로 풀리고, 진짜로 뭉개진 git은 프롬프트마다가 아니라 backoff 창마다 한 번 비용을 뭅니다.
- 서브프로세스 상한을 2초에서 10초로 올렸습니다.
- 세션 ID가 없으면 판정을 아예 캐시하지 않습니다.

## 이유

`check-ignore`는 0(무시됨) 또는 1(무시 안 됨)으로 답합니다. 그 밖은 답하지 못한 것입니다. 볼트가 아직 git 저장소가 아니면 128이고, 타임아웃이 발화하거나 spawn이 실패하면 status가 null입니다. 옛 코드는 이 전부를 "무시 안 됨"으로 읽고 캐시했습니다. blip 한 번이 원인이 사라진 뒤에도 세션 내내 로깅을 꺼 놓았습니다.

구체적인 실패 경로가 둘입니다.

1. 세션 도중 저장소가 되는 볼트(또는 일시적 git 오류)가 영구 `false`로 기록됐습니다. 부하가 전혀 없어도 재현됩니다.
2. 스위트당 프로세스 1개 실행에서 2초 상한이 부하 걸린 머신에서 발화했습니다. 계기를 박아 잡은 ETIMEDOUT 8건이 전부 2011~2254ms였고, 실제 볼트에서 이 작업은 한 자릿수 ms입니다. 상한이 git이 아니라 스케줄러 지연을 재고 있었습니다. 그리고 이 실행은 스위트끼리 서로 의존하지 않음을 증명하는 수단인데, 항상 빨간 상태라 그 신호가 잡음에 묻혀 있었습니다.

세션 ID 누락은 별개 문제입니다. ID가 없으면 모든 호출이 OS 임시 디렉터리의 `default` 캐시 파일 하나를 공유하고 그 파일을 만료시키는 것이 없어서, 한 세션의 판정이 다음 세션에 답합니다. `.gitignore`에서 `.cache/` 커버리지를 없애도 반영되지 않습니다.

## 방법

`gitIgnoresPageUsageCached`가 `probe.status`를 명시적으로 보고 0과 1만 답으로 취급합니다. 그 밖은 `{ unavailableUntil }`을 쓰고 false를 돌려줍니다. 기록된 장애는 만료 전까지 재probe를 막는데, 이것이 뭉개진 git을 `UserPromptSubmit` 경로에서 떼어 놓습니다. `hypo-lookup`이 출력 전에 이 함수를 부르므로, 거기서의 타임아웃은 그대로 죽은 프롬프트가 됩니다.

상한만 올려서는 부족합니다. 한 번의 호출은 여전히 fail-closed로 떨어지니까요. 캐시만 안 해도 부족합니다. 같은 호출이 계속 타임아웃하니까요. 둘 다 필요했습니다.

## 수동 검증

단위 테스트는 훅 진입점까지 못 가므로, 일회용 git 볼트와 그에 맞는 `index.md`를 만들어 `hooks/hypo-lookup.mjs`로 직접 태웠습니다.

```
# 1. 가드 통과, 세션 ID 있음
echo '{"prompt":"locking guidance for hooks","session_id":"qa-sess-1"}' | HYPO_DIR=<vault> node hooks/hypo-lookup.mjs
  -> [WIKI LOOKUP: 1 page(s) matched]; .cache/page-usage.jsonl 1건 기록

# 2. 세션 ID 없음 (구형 payload)
echo '{"prompt":"locking guidance for hooks","session_id":null}' | ...
  -> 1건 기록되고, hypo-pageusage-guard-default-*.json 은 0건 생성

# 3. .gitignore 커버 제거, 세션 ID 없음
  -> 기록 없음 (낡은 `true` 를 내주지 않음)
```

flake가 드러나던 스위트 격리 실행입니다.

```
node tests/parallel.mjs --shards=278
  수정 전: 1824 passed / 3 failed, 이어서 1819 passed / 8 failed
  수정 후: 4회 연속 0 failed (벽시계 101s, 112s, 115s, 183s)
```

`npm test` 1828 passed / 0 failed. `npm run lint` 0 error.

다루지 못한 것: 실제 세션에서 배포된 사본이 발화하는 것은 확인하지 못했습니다. 이 머신은 `~/.claude/hooks/`가 아니라 플러그인 캐시에서 훅을 읽습니다. 위 세 경우는 워크트리 사본을 런타임과 같은 방식으로 호출한 것입니다.

## 마이그레이션 노트

없음. 캐시 파일 형식에 `unavailableUntil` 키가 생겼지만, `gitIgnored`만 든 옛 파일도 그대로 읽고, 알 수 없는 파일은 다시 계산합니다.

---

## Changelog

- EN: Page-usage logging no longer stays off for the rest of a session after a single `git check-ignore` probe fails to answer, and the probe's timeout was raised so it stops firing on a loaded machine (#230).
- KO: `git check-ignore` probe가 한 번 답하지 못했다고 해서 page-usage 로깅이 세션 내내 꺼져 있지 않고, 부하 걸린 머신에서 상한이 발화하지 않도록 타임아웃을 올렸습니다 (#230).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
