### PR TITLE
fix(rename): make the move atomic so an interrupted rename can be re-run

### DIFF
--- a/scripts/rename.mjs
+++ b/scripts/rename.mjs
@@ -39,13 +39,14 @@ import {
   existsSync,
   readFileSync,
   writeFileSync,
-  rmSync,
   mkdirSync,
   readdirSync,
   renameSync,
   statSync,
   lstatSync,
   realpathSync,
+  chmodSync,
+  rmSync,
 } from 'fs';
 import { join, basename, dirname, normalize, isAbsolute, sep } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
@@ -225,6 +226,66 @@ function fail(args, msg) {
   if (args.json) console.log(JSON.stringify({ ok: false, error: msg }, null, 2));
   else console.error(`✗ ${msg}`);
   process.exit(1);
+}
+
+/** Atomic write via tmp+rename (same pattern as crystallize.mjs/proposal.mjs's
+ * atomicWrite): a crash or full disk mid-write leaves the ORIGINAL bytes at
+ * `path` untouched, never a truncated/partial file. Needed for every rewrite
+ * this script lands on a page that already has content on disk — including a
+ * page's own self-referential rewrite — because a plain writeFileSync
+ * truncates before writing and a crash in that gap destroys the one copy. */
+function atomicWrite(path, content) {
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+  // Swapping in a fresh inode also swaps in fresh permissions, so a 0444 or 0600
+  // page would come back 0644 and this rewrite would quietly widen it. Carry the
+  // existing mode over. Ownership, ACLs and hard-link identity are NOT carried;
+  // a vault page with any of those is outside what this script claims to handle.
+  let mode = null;
+  try {
+    mode = statSync(path).mode;
+  } catch {
+    mode = null; // new file, nothing to preserve
+  }
+  // `wx` so a collision is an error rather than a silent clobber of somebody
+  // else's temp, and drop the temp if anything after it fails (a full disk,
+  // a rename that cannot land) instead of leaving `.tmp` litter in the vault.
+  try {
+    writeFileSync(tmp, content, { flag: 'wx' });
+    if (mode !== null) chmodSync(tmp, mode);
+    renameSync(tmp, path);
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      // best effort; the original at `path` is untouched either way
+    }
+    throw err;
+  }
+}
+
+// Refuse an --apply that would have to cross a filesystem/mount boundary,
+// BEFORE any rewrite is written to disk. renameSync cannot move across
+// devices (throws EXDEV); falling back to write-then-remove in that case
+// reintroduces the exact non-convergent "both paths exist, --to-already-exists
+// forever" crash window a single renameSync exists to close. Call this first,
+// so a device mismatch is refused with the vault untouched — not discovered
+// mid-move with inbound links already rewritten.
+function assertSameDevice(args, fromAbsPath, toAbsPath) {
+  let ancestor = dirname(toAbsPath);
+  while (!existsSync(ancestor)) ancestor = dirname(ancestor);
+  let fromDev, toDev;
+  try {
+    fromDev = statSync(fromAbsPath).dev;
+    toDev = statSync(ancestor).dev;
+  } catch {
+    return; // can't tell in advance — let the real move surface the real error
+  }
+  if (fromDev !== toDev) {
+    fail(
+      args,
+      `--from and --to are on different filesystems/mounts — an atomic move is not possible across that boundary. Move it by hand instead of --apply.`,
+    );
+  }
 }
 
 // ── directory mode ─────────────────────────────────────────────────────────────
@@ -545,7 +606,7 @@ function runDirectory(args, fromDirRel, ignorePatterns) {
 
   // Rewrite inbound references across the vault.
   const externalWrites = new Map(); // abs path → content (non-moved source files)
-  const movedBodies = new Map(); // new rel → content (moved page bodies, written post-move)
+  const movedBodies = new Map(); // OLD rel → content (moved-page bodies, written pre-rename)
   const fileResults = [];
   const ambiguities = [];
   let totalRewrites = 0;
@@ -577,21 +638,45 @@ function runDirectory(args, fromDirRel, ignorePatterns) {
       const landRel = inSubtree ? movedByRel.get(p.rel).toPage.rel : p.rel;
       fileResults.push({ file: landRel, rewrites });
       totalRewrites += rewrites.length;
-      if (inSubtree) movedBodies.set(movedByRel.get(p.rel).toPage.rel, content);
+      // Keyed by the OLD rel: this gets written at the OLD path, before the
+      // subtree rename, so the content travels with the directory move instead
+      // of racing it (see the apply block below).
+      if (inSubtree) movedBodies.set(p.rel, content);
       else externalWrites.set(p.path, content);
     }
     if (ambiguous.length > 0) ambiguities.push({ file: p.rel, ambiguous });
   }
 
-  // Apply: external rewrites in place → renameSync the whole subtree (carries
-  // non-.md assets) → write rewritten moved bodies at their new paths.
+  // Apply: refuse a cross-device move up front (assertSameDevice) → external
+  // rewrites in place → moved-page bodies rewritten at their OLD paths → THEN
+  // renameSync the whole subtree in one syscall (carries non-.md assets and the
+  // just-rewritten bodies along with it).
+  //
+  // Writing moved bodies before the rename (not after, as this used to) matters
+  // for convergence: a crash after renameSync but before those writes used to
+  // leave `projects/new/*` links still pointing at `projects/old/*` forever —
+  // --from no longer resolves (the directory already moved), so a re-run failed
+  // with "did not resolve to a unique existing page" instead of finishing the
+  // job. Writing pre-rename means the content moves atomically with the
+  // directory: there is no window where the subtree has moved but its own
+  // internal links have not been rewritten yet.
   let moved = false;
   if (args.apply) {
-    for (const [path, content] of externalWrites) writeFileSync(path, content);
+    assertSameDevice(args, fromAbs, toAbs);
+    for (const [path, content] of externalWrites) atomicWrite(path, content);
+    for (const [oldRel, content] of movedBodies) {
+      atomicWrite(join(args.hypoDir, oldRel), content);
+    }
     mkdirSync(dirname(toAbs), { recursive: true });
-    renameSync(fromAbs, toAbs);
-    for (const [newRel, content] of movedBodies) {
-      writeFileSync(join(args.hypoDir, newRel), content);
+    try {
+      renameSync(fromAbs, toAbs);
+    } catch (err) {
+      // assertSameDevice above should already have refused this. A device
+      // change mid-run is the only way to reach EXDEV here — fail loudly
+      // instead of an unsafe write-then-remove fallback; every write above is
+      // already atomic, so a re-run picks up cleanly.
+      if (err.code !== 'EXDEV') throw err;
+      fail(args, `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`);
     }
     moved = true;
   }
@@ -730,6 +815,12 @@ function run(args) {
     }
   }
 
+  // Refuse a cross-device --apply before anything below writes a single byte
+  // (see assertSameDevice) — the external rewrite loop right after this can
+  // otherwise land partial vault changes ahead of a move that turns out to be
+  // impossible.
+  if (args.apply) assertSameDevice(args, fromPage.path, toPath);
+
   // Rewrite inbound references across every NON-preserved page (skip the moved
   // page itself — self-references are rewritten on its own content separately).
   const fileResults = [];
@@ -748,12 +839,12 @@ function run(args) {
       fileResults.push({ file: p.rel, rewrites });
       totalRewrites += rewrites.length;
       if (args.apply && content !== raw) {
-        // The from-page is about to move; write its rewritten body to the NEW
-        // path below, not the old one.
+        // The from-page is about to move; stash its own rewritten body — it is
+        // written to the OLD path below, right before the rename, not here.
         if (p.rel === fromPage.rel) {
           fromPage._rewritten = content;
         } else {
-          writeFileSync(p.path, content);
+          atomicWrite(p.path, content);
         }
       } else if (p.rel === fromPage.rel) {
         fromPage._rewritten = content;
@@ -764,15 +855,33 @@ function run(args) {
     }
   }
 
-  // Move the file (--apply only): write the (possibly self-rewritten) body at the
-  // new path, then drop the old one. Done as write-then-remove rather than a raw
-  // rename so the carried-over self-reference rewrites are preserved.
+  // Move the file (--apply only): if the from-page carries a self-rewritten body
+  // (its own [[foo]]-style links needed retargeting), write it to the OLD path
+  // first (atomically — a crash mid-write must never corrupt the one copy),
+  // then renameSync the file into place. A rename is one syscall with no
+  // observable intermediate state, so a crash either lands before it (old path
+  // still has the rewritten body, re-run converges) or after it (new path exists,
+  // nothing to redo) — never both paths present at once, which is the state a
+  // prior write-then-remove could leave and that the --to-already-exists guard
+  // above then refuses to recover from.
   let moved = false;
   if (args.apply) {
+    if (fromPage._rewritten !== undefined) atomicWrite(fromPage.path, fromPage._rewritten);
     mkdirSync(dirname(toPath), { recursive: true });
-    const body = fromPage._rewritten ?? readFileSync(fromPage.path, 'utf-8');
-    writeFileSync(toPath, body);
-    if (toPath !== fromPage.path) rmSync(fromPage.path, { force: true });
+    if (toPath !== fromPage.path) {
+      try {
+        renameSync(fromPage.path, toPath);
+      } catch (err) {
+        // assertSameDevice above should already have refused a cross-device
+        // move before any write happened. Reaching EXDEV here means the mount
+        // changed mid-run — fail loudly rather than silently falling back to
+        // write-then-remove, which is exactly the non-atomic state this fix
+        // removes. fromPage.path still holds the valid (possibly rewritten)
+        // body, so a re-run picks up cleanly once the device issue is gone.
+        if (err.code !== 'EXDEV') throw err;
+        fail(args, `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`);
+      }
+    }
     moved = true;
   }
 

--- a/tests/rename-wikilink.test.mjs
+++ b/tests/rename-wikilink.test.mjs
@@ -4,8 +4,21 @@
 // build on each other; suites may not — that is what lets the runner shard.
 
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync } from 'node:fs';
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  symlinkSync,
+  cpSync,
+  chmodSync,
+  statSync,
+  mkdtempSync,
+  rmSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join, basename } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   collectPagesLint,
   collectPagesLinkable,
@@ -16,11 +29,33 @@ import {
   extractWikilinks,
 } from '../scripts/lib/wikilink.mjs';
 import { test, suite } from './harness.mjs';
-import { run, withTmpDir } from './helpers.mjs';
+import { run, withTmpDir, SCRIPTS, SESSION_TMP_HOME } from './helpers.mjs';
 
 // ── rename.mjs (inbound wikilink rewrite) ─────────────────────────────────────
 
 suite('rename.mjs');
+
+// Rewrites go through a temp file and a rename, which means a brand new inode.
+// A new inode carries new permissions, so without carrying the old mode over an
+// inbound rewrite would quietly turn a 0600 page into 0644 and widen it.
+test('an inbound rewrite keeps the page mode it found (no widening via temp+rename)', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nself\n');
+    const priv = join(dir, 'pages', 'private.md');
+    writeFileSync(priv, '---\ntitle: private\n---\nsee [[foo]].\n');
+    chmodSync(priv, 0o600);
+
+    const r = run('rename.mjs', [`--hypo-dir=${dir}`, '--from=foo', '--to=bar', '--apply', '--json']);
+    assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+    assert.ok(readFileSync(priv, 'utf-8').includes('[[bar]]'), 'the link was actually rewritten');
+    assert.equal(
+      statSync(priv).mode & 0o777,
+      0o600,
+      'a rewritten page keeps its original mode',
+    );
+  });
+});
 
 test('rewrites bare / alias / anchor inbound links and moves the page', () => {
   withTmpDir((dir) => {
@@ -303,6 +338,175 @@ test('--to with a regular-file ancestor → refused before any rewrite (page mod
       'no inbound rewrite landed before refusal',
     );
   });
+});
+
+// Regression: the move step used to be write-to-new-path, then rmSync the old
+// one — two syscalls with an observable gap between them. A crash landing in
+// that gap left both paths on disk, and re-running hit the --to-already-exists
+// guard forever (exit 1, no way out without a manual delete). The fix folds the
+// move into a single renameSync, so the only two states reachable are "old path
+// only" and "new path only" — never both.
+//
+// This proves it by actually killing a child process bracketing the real
+// renameSync call — right before it and right after it — rather than before
+// the unrelated body-write step. Killing before body-write would pass under a
+// write-then-remove implementation too (nothing has moved yet either way), so
+// it wouldn't tell the two implementations apart. Killing on the renameSync
+// call itself is the only place that distinguishes "one syscall" from "two
+// syscalls with a gap".
+//
+// The kill hook is NOT in the shipped script: this builds ONE throwaway copy
+// of scripts/ with both anchors patched, and every crash test below spawns
+// that copy. scripts/rename.mjs in the repo stays exactly as written above.
+const KILL_COPY_ROOT = mkdtempSync(join(tmpdir(), 'hypo-rename-kill-'));
+process.on('exit', () => {
+  try {
+    rmSync(KILL_COPY_ROOT, { recursive: true, force: true });
+  } catch {}
+});
+const KILL_SCRIPTS = join(KILL_COPY_ROOT, 'scripts');
+const KILL_RENAME = join(KILL_SCRIPTS, 'rename.mjs');
+cpSync(SCRIPTS, KILL_SCRIPTS, { recursive: true });
+{
+  let src = readFileSync(KILL_RENAME, 'utf-8');
+  const pageAnchor = 'renameSync(fromPage.path, toPath);';
+  const dirAnchor = 'renameSync(fromAbs, toAbs);';
+  assert.ok(src.includes(pageAnchor), `page-mode renameSync anchor not found — did rename.mjs change?`);
+  assert.ok(src.includes(dirAnchor), `dir-mode renameSync anchor not found — did rename.mjs change?`);
+  src = src.replace(
+    pageAnchor,
+    `if (process.env.HYPO_TEST_KILL_PAGE_PRE) process.kill(process.pid, 'SIGKILL');\n        ${pageAnchor}\n        if (process.env.HYPO_TEST_KILL_PAGE_POST) process.kill(process.pid, 'SIGKILL');`,
+  );
+  src = src.replace(
+    dirAnchor,
+    `if (process.env.HYPO_TEST_KILL_DIR_PRE) process.kill(process.pid, 'SIGKILL');\n      ${dirAnchor}\n      if (process.env.HYPO_TEST_KILL_DIR_POST) process.kill(process.pid, 'SIGKILL');`,
+  );
+  writeFileSync(KILL_RENAME, src);
+}
+
+test('crash bracketing the single-file renameSync converges, two paths never coexist (page mode)', () => {
+  for (const [envVar, label] of [
+    ['HYPO_TEST_KILL_PAGE_PRE', 'pre-rename'],
+    ['HYPO_TEST_KILL_PAGE_POST', 'post-rename'],
+  ]) {
+    withTmpDir((base) => {
+      const wiki = join(base, 'wiki');
+      const home = join(base, 'home');
+      mkdirSync(join(wiki, 'pages'), { recursive: true });
+      mkdirSync(home, { recursive: true });
+      // Self-referential link forces fromPage._rewritten, so the pre-rename
+      // write actually runs before the PRE kill point.
+      writeFileSync(join(wiki, 'pages', 'foo.md'), '---\ntitle: foo\n---\nsee [[foo]] itself.\n');
+
+      const cmd = [KILL_RENAME, `--hypo-dir=${wiki}`, '--from=foo', '--to=bar', '--apply', '--json'];
+      const killed = spawnSync(process.execPath, cmd, {
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: home, [envVar]: '1' },
+      });
+      assert.equal(killed.signal, 'SIGKILL', `[${label}] expected the kill hook to fire: ${killed.stderr}`);
+
+      const fooPath = join(wiki, 'pages', 'foo.md');
+      const barPath = join(wiki, 'pages', 'bar.md');
+      const fooExists = existsSync(fooPath);
+      const barExists = existsSync(barPath);
+      // The property the fix pins: renameSync is one syscall, so no kill point
+      // can observe both the old and the new path at once.
+      assert.ok(!(fooExists && barExists), `[${label}] old and new path must never coexist after a crash`);
+      assert.ok(fooExists || barExists, `[${label}] exactly one path must survive the crash`);
+
+      const rerun = spawnSync(process.execPath, cmd, { encoding: 'utf-8', env: { ...process.env, HOME: home } });
+      if (fooExists) {
+        // Killed before the rename: --from still resolves, re-run finishes the move.
+        assert.equal(
+          rerun.status,
+          0,
+          `[${label}] re-run from the pre-rename state must converge: ${rerun.stdout}${rerun.stderr}`,
+        );
+        assert.ok(existsSync(barPath), `[${label}] bar.md exists after re-run`);
+        assert.ok(!existsSync(fooPath), `[${label}] foo.md gone after re-run`);
+        const bar = readFileSync(barPath, 'utf-8');
+        assert.ok(bar.includes('[[bar]]'), `[${label}] self-reference rewrite carried through: ${bar}`);
+      } else {
+        // Killed after the rename: the move already landed, --from correctly
+        // no longer resolves — nothing left to converge.
+        assert.equal(
+          rerun.status,
+          1,
+          `[${label}] already-moved re-run must report --from missing, not redo anything: ${rerun.stdout}`,
+        );
+      }
+    });
+  }
+});
+
+// Same property, directory mode (BLOCKER: moved-body content used to be written
+// AFTER renameSync, so a crash between them left the relocated subtree's own
+// internal links pointing at the pre-move prefix forever — --from no longer
+// resolved once the directory had moved, so re-run couldn't repair it. The fix
+// writes moved bodies at their OLD paths before the rename, so the content
+// travels with the directory instead of racing it.
+test('crash bracketing the directory renameSync converges, two dirs never coexist (directory mode)', () => {
+  for (const [envVar, label] of [
+    ['HYPO_TEST_KILL_DIR_PRE', 'pre-rename'],
+    ['HYPO_TEST_KILL_DIR_POST', 'post-rename'],
+  ]) {
+    withTmpDir((base) => {
+      const wiki = join(base, 'wiki');
+      const home = join(base, 'home');
+      mkdirSync(join(wiki, 'projects', 'old'), { recursive: true });
+      mkdirSync(home, { recursive: true });
+      // a → b is an intra-subtree full-slug link: it MUST be rewritten to the
+      // new prefix, so a non-empty moved-body write actually happens.
+      writeFileSync(
+        join(wiki, 'projects', 'old', 'a.md'),
+        '---\ntitle: a\n---\nsee [[projects/old/b]].\n',
+      );
+      writeFileSync(join(wiki, 'projects', 'old', 'b.md'), '---\ntitle: b\n---\nb page\n');
+
+      const cmd = [
+        KILL_RENAME,
+        `--hypo-dir=${wiki}`,
+        '--from=projects/old',
+        '--to=projects/new',
+        '--apply',
+        '--json',
+      ];
+      const killed = spawnSync(process.execPath, cmd, {
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: home, [envVar]: '1' },
+      });
+      assert.equal(killed.signal, 'SIGKILL', `[${label}] expected the kill hook to fire: ${killed.stderr}`);
+
+      const oldDir = join(wiki, 'projects', 'old');
+      const newDir = join(wiki, 'projects', 'new');
+      const oldExists = existsSync(oldDir);
+      const newExists = existsSync(newDir);
+      assert.ok(!(oldExists && newExists), `[${label}] old and new directory must never coexist after a crash`);
+      assert.ok(oldExists || newExists, `[${label}] exactly one directory must survive the crash`);
+
+      const rerun = spawnSync(process.execPath, cmd, { encoding: 'utf-8', env: { ...process.env, HOME: home } });
+      if (oldExists) {
+        assert.equal(
+          rerun.status,
+          0,
+          `[${label}] re-run from the pre-rename state must converge: ${rerun.stdout}${rerun.stderr}`,
+        );
+        assert.ok(existsSync(join(newDir, 'a.md')), `[${label}] a.md exists at the new path after re-run`);
+        assert.ok(!existsSync(oldDir), `[${label}] projects/old gone after re-run`);
+        const a = readFileSync(join(newDir, 'a.md'), 'utf-8');
+        assert.ok(
+          a.includes('[[projects/new/b]]'),
+          `[${label}] intra-subtree link rewritten to the new prefix: ${a}`,
+        );
+      } else {
+        assert.equal(
+          rerun.status,
+          1,
+          `[${label}] already-moved re-run must report --from missing, not redo anything: ${rerun.stdout}`,
+        );
+      }
+    });
+  }
 });
 
 // ── rename.mjs directory mode (subtree relocation) ────────────────────────────


### PR DESCRIPTION
# English

## What changed

`rename.mjs` now moves a page (and a directory subtree) with a single `renameSync`, with all content written before it. A cross-device `--apply` is refused up front instead of falling back to a non-atomic move, and every rewrite of an existing page goes through a temp file plus a rename.

## Why

Renaming has to move a file and rewrite the vault's inbound wikilinks together. If it stops halfway, what it leaves behind decides whether you can just run it again.

Three points were killed with SIGKILL to find out. Two of them left a vault that never recovers:

1. **Page mode, between the new-path write and the old-path removal.** Both paths held the file, every inbound link already said the new name, and the re-run hit `--to already exists: ... Rename cannot overwrite a live page` and exited 1. The only way out was deleting the stray file by hand. It also looks like success from the outside, which is what makes it the worst of the three.
2. **Directory mode, between the subtree rename and the moved-body writes.** The subtree was at its new path, but pages inside it still linked to their own old paths, and the re-run failed with `--from did not resolve to a unique existing page` because the old directory was gone.

The remaining interruption points (partway through the inbound rewrite loop) already converged on a re-run, and still do.

Two smaller problems came out of fixing those. `renameSync` cannot cross a mount, and an `EXDEV` fallback to write-then-remove would put case 1 straight back. And writing a rewritten body in place truncates before it writes, so a crash or a full disk there destroys the only copy of a page.

## How

Content is written before the rename, never after. In page mode the self-referential rewrite lands at the old path; in directory mode the moved bodies are keyed by their old paths and written before the subtree moves. Either way the rename carries finished content, so there is no window where the file has moved but its links have not.

`assertSameDevice` runs before the first write in both modes and refuses a cross-mount `--apply` with the vault untouched. Reaching `EXDEV` after that means the mount changed mid-run, which fails loudly rather than falling back.

`atomicWrite` writes to a temp in the same directory and renames it into place. It copies the original file mode across, because a fresh inode comes with fresh permissions and an inbound rewrite would otherwise widen a `0600` page to `0644`. Ownership, ACLs and hard-link identity are not preserved; a vault page relying on those is outside what this script handles, and that is stated at the function.

## Manual verification

Beyond the suite, the old behaviour was reproduced directly to confirm the bug existed, by injecting `process.kill(process.pid, 'SIGKILL')` into a scratch copy of the pre-fix script:

```
# page mode, old implementation, killed between the write and the remove
  both pages/foo.md and pages/bar.md present
  re-run: exit 1, "already exists: pages/bar.md"

# directory mode, old implementation, killed after the subtree rename
  projects/old gone, projects/new present
  projects/new/a.md still links [[projects/old/b]]
  re-run: exit 1, "--from did not resolve to a unique existing page: projects/old"

# page mode, new implementation, killed right after renameSync
  only pages/bar.md present, content intact
```

`npm test` 1829 passed / 0 failed. `npm run lint` 0 errors.

Not covered by a test: the cross-device refusal (needs a real second mount) and a crash landing inside `atomicWrite`'s own write.

## Migration notes

None. A `--apply` that spans a mount boundary now fails with an explanation instead of moving the file; that path previously produced a non-atomic move.

---

# 한국어

## 변경 내용

`rename.mjs`가 페이지와 디렉터리 서브트리를 `renameSync` 한 번으로 옮기고, 내용은 전부 그 전에 씁니다. 디바이스를 넘는 `--apply`는 비원자적 이동으로 폴백하지 않고 사전에 거부하며, 이미 내용이 있는 페이지에 대한 모든 재작성은 임시 파일과 rename을 거칩니다.

## 이유

rename은 파일 이동과 볼트 인바운드 위키링크 재작성을 함께 해야 성립합니다. 중간에 멈추면, 남는 상태가 "그냥 다시 돌리면 되는가"를 결정합니다.

SIGKILL로 세 지점을 죽여 확인했습니다. 그중 둘이 회복 불가능한 볼트를 남겼습니다.

1. **페이지 모드, 새 경로 쓰기와 옛 경로 삭제 사이.** 두 경로에 파일이 다 있고 인바운드 링크는 이미 새 이름을 가리키는데, 재실행이 `--to already exists: ... Rename cannot overwrite a live page`로 exit 1이었습니다. 손으로 지우는 것 말고는 벗어날 길이 없었습니다. 게다가 밖에서 보면 성공한 것처럼 보여서, 셋 중 가장 나쁜 지점입니다.
2. **디렉터리 모드, 서브트리 rename과 moved body 쓰기 사이.** 서브트리는 새 경로에 있는데 그 안 페이지들은 여전히 자기 옛 경로를 가리키고, 옛 디렉터리가 사라져서 재실행이 `--from did not resolve to a unique existing page`로 실패했습니다.

나머지 중단 지점(인바운드 재작성 루프 중간)은 원래도 재실행으로 수렴했고 지금도 그렇습니다.

이를 고치는 과정에서 작은 문제 둘이 나왔습니다. `renameSync`는 마운트를 넘지 못하는데 `EXDEV`에서 write-then-remove로 폴백하면 1번을 그대로 되살립니다. 그리고 재작성본을 제자리에 쓰면 truncate가 먼저라, 그 지점의 크래시나 디스크 가득 참이 페이지의 유일한 사본을 파괴합니다.

## 방법

내용은 항상 rename 전에 씁니다. 페이지 모드에서는 자기참조 재작성본이 옛 경로에 떨어지고, 디렉터리 모드에서는 moved body를 옛 경로 키로 잡아 서브트리 이동 전에 씁니다. 어느 쪽이든 rename이 완성된 내용을 실어 옮기므로, 파일은 옮겨졌는데 링크는 안 바뀐 창이 없습니다.

`assertSameDevice`는 양쪽 모드 모두 첫 쓰기보다 앞에서 돌고, 마운트를 넘는 `--apply`를 볼트를 건드리지 않은 채로 거부합니다. 그 뒤에 `EXDEV`에 닿으면 실행 중 마운트가 바뀐 것이라, 폴백하지 않고 명시적으로 실패합니다.

`atomicWrite`는 같은 디렉터리의 임시 파일에 쓰고 rename으로 밀어 넣습니다. 원본 파일 mode를 복사해 옮기는데, 새 inode는 새 권한을 갖기 때문에 그러지 않으면 인바운드 재작성 한 번이 `0600` 페이지를 `0644`로 넓힙니다. 소유권·ACL·hard-link 동일성은 보존하지 않으며, 그것에 기대는 볼트 페이지는 이 스크립트가 다루는 범위 밖이라고 함수에 명시했습니다.

## 수동 검증

스위트와 별개로, 결함이 실재했음을 확인하려고 수정 전 스크립트의 스크래치 사본에 `process.kill(process.pid, 'SIGKILL')`을 심어 옛 동작을 직접 재현했습니다.

```
# 페이지 모드, 옛 구현, 쓰기와 삭제 사이에서 kill
  pages/foo.md 와 pages/bar.md 가 둘 다 존재
  재실행: exit 1, "already exists: pages/bar.md"

# 디렉터리 모드, 옛 구현, 서브트리 rename 직후 kill
  projects/old 사라지고 projects/new 존재
  projects/new/a.md 는 여전히 [[projects/old/b]] 를 가리킴
  재실행: exit 1, "--from did not resolve to a unique existing page: projects/old"

# 페이지 모드, 새 구현, renameSync 직후 kill
  pages/bar.md 만 존재, 내용 온전
```

`npm test` 1829 passed / 0 failed. `npm run lint` 0 error.

테스트로 덮지 못한 것: 크로스 디바이스 거부(실제 두 번째 마운트가 필요)와 `atomicWrite` 자체의 쓰기 도중 크래시.

## 마이그레이션 노트

없음. 마운트 경계를 넘는 `--apply`는 이제 파일을 옮기는 대신 이유를 설명하며 실패합니다. 그 경로는 이전에 비원자적 이동을 만들어 냈습니다.

---

## Changelog

- EN: An interrupted `rename --apply` can now always be re-run: the move is a single atomic step, so it no longer leaves a page at two paths (page mode) or a moved subtree whose own links still point at the old path (directory mode), both of which used to refuse every re-run (#231).
- KO: 중단된 `rename --apply`를 이제 항상 다시 돌릴 수 있습니다. 이동이 원자적 한 단계라, 페이지가 두 경로에 남거나(페이지 모드) 옮겨진 서브트리의 링크가 옛 경로를 가리킨 채 남는(디렉터리 모드) 상태가 생기지 않습니다. 둘 다 예전에는 재실행이 거부되던 상태입니다 (#231).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
