### PR TITLE
test(hooks): stop racing a real git probe to test the page-usage guard

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -435,7 +435,11 @@ export function pageUsageGuardCachePath(sessionId, hypoDir) {
   return join(tmpdir(), `hypo-pageusage-guard-${safe}-${h.toString(36)}.json`);
 }
 
-export function pageUsageLoggingAllowed(hypoDir, sessionId) {
+// `probeFn` is test-only: tests inject a fake to control the "did git answer"
+// outcome deterministically instead of racing a real subprocess under shard
+// load. Production callers never pass it, so they always get `runGitCheckIgnore`
+// below, byte-for-byte the same spawnSync call this file always made.
+export function pageUsageLoggingAllowed(hypoDir, sessionId, probeFn) {
   // The load-bearing commit gate is .hypoignore: it is what hypo-auto-stage and
   // commitWikiChanges actually filter on. Re-check it FRESH on every call (it is
   // cheap, no subprocess) so that if coverage is removed mid-session the guard
@@ -452,7 +456,7 @@ export function pageUsageLoggingAllowed(hypoDir, sessionId) {
   }
   if (!hypoIgnored) return false;
 
-  return gitIgnoresPageUsageCached(hypoDir, sessionId);
+  return gitIgnoresPageUsageCached(hypoDir, sessionId, probeFn);
 }
 
 // git check-ignore is the belt signal (defends a manual `git add`); it spawns a
@@ -464,7 +468,16 @@ export function pageUsageLoggingAllowed(hypoDir, sessionId) {
 // prompt, short enough that a blip clears on its own well inside a session.
 const PROBE_BACKOFF_MS = 30000;
 
-function gitIgnoresPageUsageCached(hypoDir, sessionId) {
+// The real probe: check-ignore answers with an exit code, 0 = ignored, 1 = not
+// ignored. Split out to a named function so `gitIgnoresPageUsageCached` can take
+// a substitute in tests without touching what production actually spawns.
+function runGitCheckIgnore(hypoDir) {
+  return spawnSync('git', ['-C', hypoDir, 'check-ignore', '-q', '--', PAGE_USAGE_REL], {
+    timeout: 10000,
+  });
+}
+
+function gitIgnoresPageUsageCached(hypoDir, sessionId, probeFn = runGitCheckIgnore) {
   // Without a session id every caller lands on the same `default` cache file, so
   // one session's verdict would answer for the next one — and the file outlives
   // both, sitting in tmpdir with nothing to expire it. A verdict that cannot be
@@ -491,9 +504,9 @@ function gitIgnoresPageUsageCached(hypoDir, sessionId) {
 
   // check-ignore answers with an exit code: 0 = ignored, 1 = not ignored. Every
   // other outcome means the probe never got to answer — 128 for a fatal git
-  // error (hypoDir not a repo yet), or a null status when the 2s timeout fired
-  // or the spawn itself failed, which is what a machine under heavy process
-  // load produces. Treating those as a plain `false` is the bug this guards
+  // error (hypoDir not a repo yet), or a null status when the timeout below
+  // fired or the spawn itself failed, which is what a machine under heavy
+  // process load produces. Treating those as a plain `false` is the bug this guards
   // against: it is indistinguishable from git actually saying "not ignored",
   // and the verdict then gets cached, so one blip keeps logging disabled for
   // the rest of the session even after the condition clears.
@@ -506,9 +519,7 @@ function gitIgnoresPageUsageCached(hypoDir, sessionId) {
   // measuring scheduler latency instead of git. 10s still catches a true hang.
   let probe = null;
   try {
-    probe = spawnSync('git', ['-C', hypoDir, 'check-ignore', '-q', '--', PAGE_USAGE_REL], {
-      timeout: 10000,
-    });
+    probe = probeFn(hypoDir);
   } catch {
     probe = null;
   }

--- a/tests/close-signals.test.mjs
+++ b/tests/close-signals.test.mjs
@@ -1940,32 +1940,59 @@ test('verify.mjs stays independent of the shared predicate (A1 invariant)', () =
 // ── B1: page-usage logging coverage guard (fail-closed) ──────────────────────
 suite('hypo-shared.mjs — page-usage logging guard (B1)');
 
+// Fake probes stand in for the real `spawnSync('git', ['check-ignore', ...])`
+// call: same shape (`{ status }` or a throw/null for "never answered"), no
+// subprocess. That makes the guard's own branching deterministic — the flake
+// this suite used to have came from racing a real git process across 278
+// concurrent shards, not from the guard logic itself. `runGitCheckIgnore`
+// (the production default in hypo-shared.mjs) is exercised separately, below,
+// by the one real-git integration test.
+const fakeProbe = (status) => () => ({ status });
+const fakeProbeThrows = () => {
+  throw new Error('spawn failed');
+};
+
+// A probe that records whether it was consulted. Needed because a *throwing*
+// probe cannot prove "the guard short-circuited before the probe": the guard
+// wraps the call in `try/catch` and turns a throw into `probe = null`, which
+// then returns `false` — the same answer the short-circuit gives. So a test
+// asserting `false` passes whether or not the probe ran. Counting the calls is
+// what actually distinguishes the two, and it is the only way to pin that the
+// composite guard never pays for a subprocess once .hypoignore has already
+// denied. Verified by re-running the short-circuit regression proof against it.
+const countingProbe = (status) => {
+  const fn = () => {
+    fn.calls += 1;
+    return { status };
+  };
+  fn.calls = 0;
+  return fn;
+};
+
 test('guard true when both .gitignore and .hypoignore cover .cache/', () => {
   withTmpDir((dir) => {
-    gitRepo(dir);
-    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
     writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
-    assert.equal(pageUsageLoggingAllowed(dir, 'b1-both'), true);
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-both', fakeProbe(0)), true);
   });
 });
 
 // A probe that never answered is not the same as git saying "not ignored".
 // check-ignore exits 0 (ignored) or 1 (not ignored); 128 means git errored out,
-// and a null status means the 2s timeout fired or the spawn failed outright —
-// which is what a machine running one process per suite actually produces. The
-// old code collapsed all of those into `false` and then cached it, so one blip
-// kept logging disabled for the whole session even after the cause cleared.
-// That is the flake behind the .cache/ guard failing only under --shards=N.
+// and a null status means the timeout fired or the spawn failed outright — which
+// is what a machine under heavy process load produces. The old code collapsed
+// all of those into `false` and then cached it, so one blip kept logging
+// disabled for the whole session even after the cause cleared. That is the
+// flake this test pins: simulated here instead of raced, so it is deterministic
+// and instant instead of depending on the real 10s timeout ever firing.
 test('an inconclusive git probe records an outage, never a verdict', () => {
   withTmpDir((dir) => {
     const sessionId = 'b1-inconclusive';
     const cachePath = pageUsageGuardCachePath(sessionId, dir);
     try {
-      writeFileSync(join(dir, '.gitignore'), '.cache/\n');
       writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
 
-      // Not a git repo yet → check-ignore exits 128, i.e. it did not answer.
-      assert.equal(pageUsageLoggingAllowed(dir, sessionId), false);
+      // status 128 (git errored) is one shape of "never answered".
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId, fakeProbe(128)), false);
       const recorded = JSON.parse(readFileSync(cachePath, 'utf-8'));
       assert.equal(
         recorded.gitIgnored,
@@ -1974,15 +2001,60 @@ test('an inconclusive git probe records an outage, never a verdict', () => {
       );
       assert.equal(typeof recorded.unavailableUntil, 'number');
 
-      // The outage stamp suppresses re-probing while it stands. That is what
-      // keeps a wedged git from costing a full timeout on every prompt.
-      gitRepo(dir);
-      assert.equal(pageUsageLoggingAllowed(dir, sessionId), false);
+      // The outage stamp suppresses re-probing while it stands: a probe that
+      // would now say "ignored" is still not consulted, proving the backoff
+      // — not the probe — is what answered `false` here.
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId, fakeProbe(0)), false);
 
-      // Once it lapses, the answer is recomputed rather than served from the
-      // outage — the old code cached `false` here and never recovered.
+      // A thrown spawn (the other shape of "never answered": spawnSync itself
+      // failing) is inconclusive the same way once the backoff lapses.
       writeFileSync(cachePath, JSON.stringify({ unavailableUntil: Date.now() - 1 }));
-      assert.equal(pageUsageLoggingAllowed(dir, sessionId), true);
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId, fakeProbeThrows), false);
+
+      // Once the backoff lapses and the probe finally answers, the verdict is
+      // recomputed rather than served from the outage — the old code cached
+      // `false` here and never recovered.
+      writeFileSync(cachePath, JSON.stringify({ unavailableUntil: Date.now() - 1 }));
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId, fakeProbe(0)), true);
+    } finally {
+      rmSync(cachePath, { force: true });
+    }
+  });
+});
+
+// `{ status: null }` is the shape spawnSync actually returns when the timeout
+// fires, and a fired timeout under process load is the exact flake that opened
+// ISSUE-79 — yet nothing pinned it: the test above covers 128 and a throw only.
+// Narrowing the guard to `status === 128` would keep every one of those green
+// while reintroducing the original bug, so this walks the null path end to end.
+suite('hypo-shared.mjs — page-usage guard, timed-out probe (B1b)');
+
+test('a timed-out probe ({ status: null }) is an outage, not a "not ignored" answer', () => {
+  withTmpDir((dir) => {
+    const sessionId = 'b1b-timeout';
+    const cachePath = pageUsageGuardCachePath(sessionId, dir);
+    try {
+      writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId, fakeProbe(null)), false);
+      const recorded = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      assert.equal(
+        recorded.gitIgnored,
+        undefined,
+        'a timed-out probe must never be written down as an answer',
+      );
+      assert.equal(typeof recorded.unavailableUntil, 'number');
+
+      // While the outage stands, a probe that would now answer "ignored" is not
+      // even called — the backoff is what suppresses the next subprocess, which
+      // is the whole point of not paying a timeout on every prompt.
+      const probe = countingProbe(0);
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId, probe), false);
+      assert.equal(probe.calls, 0, 'the backoff must suppress the probe, not just its verdict');
+
+      // Once it lapses, the guard recovers on its own.
+      writeFileSync(cachePath, JSON.stringify({ unavailableUntil: Date.now() - 1 }));
+      assert.equal(pageUsageLoggingAllowed(dir, sessionId, fakeProbe(0)), true);
     } finally {
       rmSync(cachePath, { force: true });
     }
@@ -1997,15 +2069,13 @@ test('no session id → the git verdict is not cached at all', () => {
     const cachePath = pageUsageGuardCachePath(undefined, dir);
     try {
       rmSync(cachePath, { force: true });
-      gitRepo(dir);
-      writeFileSync(join(dir, '.gitignore'), '.cache/\n');
       writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
-      assert.equal(pageUsageLoggingAllowed(dir, undefined), true);
+      assert.equal(pageUsageLoggingAllowed(dir, undefined, fakeProbe(0)), true);
       assert.ok(!existsSync(cachePath), 'an unscoped verdict must not be written');
 
-      // Coverage removed → the next call must see it, not a stale `true`.
-      writeFileSync(join(dir, '.gitignore'), 'unrelated/\n');
-      assert.equal(pageUsageLoggingAllowed(dir, undefined), false);
+      // Coverage removed (probe now answers "not ignored") → the next call
+      // must see it, not a stale `true` served from a cache.
+      assert.equal(pageUsageLoggingAllowed(dir, undefined, fakeProbe(1)), false);
     } finally {
       rmSync(cachePath, { force: true });
     }
@@ -2014,58 +2084,99 @@ test('no session id → the git verdict is not cached at all', () => {
 
 test('guard false when only .gitignore covers .cache/ (both signals required)', () => {
   withTmpDir((dir) => {
-    gitRepo(dir);
-    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
-    assert.equal(pageUsageLoggingAllowed(dir, 'b1-git-only'), false);
+    // No .hypoignore → the composite guard must short-circuit before it ever
+    // reaches the probe. Count the calls rather than throwing from the probe:
+    // the guard swallows a throw into `probe = null` and returns `false`, which
+    // is the same answer the short-circuit gives, so a throwing probe cannot
+    // tell the two apart.
+    const probe = countingProbe(0);
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-git-only', probe), false);
+    assert.equal(probe.calls, 0, 'a denied .hypoignore must short-circuit before the probe');
   });
 });
 
 test('guard false when only .hypoignore covers .cache/', () => {
   withTmpDir((dir) => {
-    gitRepo(dir);
     writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
-    assert.equal(pageUsageLoggingAllowed(dir, 'b1-hypo-only'), false);
+    // .hypoignore alone clears the short-circuit; the probe still has to say
+    // "not ignored" for the composite verdict to be false.
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-hypo-only', fakeProbe(1)), false);
   });
 });
 
 test('guard false in a non-git vault (fail-closed)', () => {
   withTmpDir((dir) => {
-    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
     writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
-    assert.equal(pageUsageLoggingAllowed(dir, 'b1-nogit'), false);
+    // A non-repo vault is exactly what makes check-ignore exit 128 in real git;
+    // fakeProbe(128) simulates that without needing an actual non-repo dir.
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-nogit', fakeProbe(128)), false);
   });
 });
 
 test('git probe is cached per session (no recompute of the git signal)', () => {
   withTmpDir((dir) => {
-    gitRepo(dir);
-    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
     writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
-    assert.equal(pageUsageLoggingAllowed(dir, 'b1-cache'), true);
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-cache', fakeProbe(0)), true);
     const cachePath = pageUsageGuardCachePath('b1-cache', dir);
     assert.ok(existsSync(cachePath), 'guard must write a session cache file');
-    // Remove .gitignore coverage. A fresh git probe would now say "not ignored",
-    // but the git signal is cached, so with .hypoignore still present the verdict
-    // stays true, proving the 2nd call skipped the git subprocess.
-    rmSync(join(dir, '.gitignore'));
-    assert.equal(pageUsageLoggingAllowed(dir, 'b1-cache'), true, 'git signal must be cached');
+    // A second call with a probe that would now say "not ignored" must still
+    // read `true` from the cache, proving the 2nd call skipped the probe.
+    assert.equal(
+      pageUsageLoggingAllowed(dir, 'b1-cache', fakeProbe(1)),
+      true,
+      'git signal must be cached',
+    );
   });
 });
 
 test('privacy: removing .hypoignore mid-session flips the guard closed', () => {
   withTmpDir((dir) => {
-    gitRepo(dir);
-    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
     writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
-    assert.equal(pageUsageLoggingAllowed(dir, 'b1-privacy'), true);
+    assert.equal(pageUsageLoggingAllowed(dir, 'b1-privacy', fakeProbe(0)), true);
     // .hypoignore is the load-bearing commit gate and is re-checked fresh every
-    // call: dropping it must immediately deny logging even within the session.
+    // call: dropping it must immediately deny logging even within the session,
+    // before the (still "ignored") probe is ever consulted again.
     rmSync(join(dir, '.hypoignore'));
+    const probe = countingProbe(0);
     assert.equal(
-      pageUsageLoggingAllowed(dir, 'b1-privacy'),
+      pageUsageLoggingAllowed(dir, 'b1-privacy', probe),
       false,
       'a mid-session .hypoignore removal must fail closed',
     );
+    // What stops the probe here is the .hypoignore short-circuit, which runs
+    // before the cache is ever consulted (pageUsageLoggingAllowed returns on
+    // `!hypoIgnored` before calling gitIgnoresPageUsageCached at all).
+    // But this assertion does not *pin* that: the first call above already
+    // cached a verdict for this session, so removing the short-circuit still
+    // leaves the cache to answer without a subprocess, and the count stays 0.
+    // Confirmed by regression proof — forcing the probe call ahead of the
+    // short-circuit failed b1-git-only and left this test green. So what this
+    // pins is "the denial costs no subprocess"; the short-circuit itself is
+    // pinned by b1-git-only, which has no cache to hide behind.
+    assert.equal(probe.calls, 0, 'and the denial must cost no subprocess');
+  });
+});
+
+// The one place *this suite* still spawns a real `git check-ignore` — not the
+// only one in the test tree. The B2 hook E2E tests in tests/lookup-usage.test.mjs
+// run hypo-lookup.mjs as a child process, and that hook calls the guard with two
+// args, so it takes the default probe and spawns real git too. Those cannot take
+// an injected probe (the seam does not cross a process boundary) and real git is
+// the point of a hook E2E, so the shard-load exposure is reduced here, not
+// eliminated tree-wide. Recorded on ISSUE-79 rather than papered over.
+//
+// Unscoped so the guard's session cache is never touched: two independent real
+// probes (ignored, then not-ignored) with no shared state between them. That
+// removes cache contention, not process contention.
+test('real git check-ignore: ignored/not-ignored round trip (integration)', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    writeFileSync(join(dir, '.hypoignore'), '.cache/\n');
+    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, undefined), true);
+
+    writeFileSync(join(dir, '.gitignore'), 'unrelated/\n');
+    assert.equal(pageUsageLoggingAllowed(dir, undefined), false);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

The page-usage coverage guard no longer depends on a real `git check-ignore` subprocess to test its own branching. The probe is now a named function that the guard takes as an optional trailing argument, defaulting to exactly the `spawnSync` call it always made. Production callers pass two arguments and are unaffected. The guard's tests inject a fake that answers immediately.

## Why

A run with one suite per process (`node tests/parallel.mjs --shards=N`) failed the `.cache/` coverage guard intermittently: the fixture covers the path in both `.gitignore` and `.hypoignore`, so the guard should return true, and it returned false. Round-robin `npm test` and a single `--grep` always passed. The failure reproduced on an untouched `main`.

The guard spawns `git check-ignore` and treats any exit code other than 0 or 1 as "the probe never answered". With N node processes each spawning its own git child, that spawn sometimes times out. #230 already widened the bound from 2s to 10s and made an unanswered probe a recorded outage instead of a cached verdict. What remains is the residual contention that 10s does not remove, and raising the bound again only moves it.

This matters beyond one red test. While a shard-isolation run always has one failure in it, that run cannot tell you anything: a genuine new violation of suite independence is indistinguishable from the known noise.

## How

`runGitCheckIgnore` is split out of `gitIgnoresPageUsageCached`, which now takes `probeFn = runGitCheckIgnore`. `pageUsageLoggingAllowed` forwards a third argument the same way. The 0, 1, 128, null, and throw branches are now exercised directly rather than waiting for a loaded machine to produce them.

Two things surfaced while writing it.

A throwing probe cannot prove "the guard short-circuited before spawning". The call sits inside `try/catch`, so a throw becomes `probe = null` and returns `false`, which is also what the short-circuit returns. The assertion passed whether or not the probe ran. Counting the calls is what distinguishes the two, confirmed by forcing the probe ahead of the short-circuit and watching the count assertion go red.

Nothing pinned `{ status: null }`, which is the shape a fired timeout actually produces and therefore the exact flake. Narrowing the guard to `status === 128` kept every existing assertion green. The null path now walks outage recording, backoff suppression, and recovery end to end.

## Manual verification

```
npm test                          -> 1833 passed, 0 failed
npm run lint                      -> 0 error(s)
node tests/parallel.mjs --shards=278  -> 1833 passed, 0 failed
```

The shard-isolation run was done twice, once while another test run was competing for the same cores, since process contention is the condition this bug needs.

Regression proof, each defense disabled in turn and restored:

| disabled | assertion that went red |
|---|---|
| inconclusive probe cached as a verdict | an inconclusive git probe records an outage, never a verdict |
| backoff check removed | same |
| session cache read removed | git probe is cached per session |
| probe called ahead of the short-circuit | guard false when only .gitignore covers .cache/ |
| outage narrowed to `status === 128` | a timed-out probe is an outage, not a "not ignored" answer |

**A real-session hook QA run has not been done for this branch.** The argument that it is not needed: `runGitCheckIgnore` is the previous inline call moved verbatim (same argv, same 10s timeout), and the only production caller, `hypo-lookup.mjs`, passes two arguments, so the default parameter resolves to it. The deployed copy therefore executes the same `spawnSync` as before. Confirm this before merge if you want the stronger guarantee.

## Migration notes

None. No behavior change reaches an installed copy.

---

# 한국어

## 변경 내용

page-usage 커버리지 가드가 자기 분기를 검증하려고 실제 `git check-ignore` 서브프로세스에 기대지 않습니다. probe가 이름 붙은 함수가 되어 가드의 선택적 마지막 인자로 들어가고, 기본값은 원래 하던 `spawnSync` 호출 그대로입니다. 프로덕션 호출부는 두 인자를 넘기므로 영향이 없습니다. 가드 테스트는 즉답하는 fake를 주입합니다.

## 이유

스위트 하나당 프로세스 하나로 도는 실행(`node tests/parallel.mjs --shards=N`)에서 `.cache/` 커버리지 가드가 간헐적으로 실패했습니다. 픽스처가 `.gitignore`와 `.hypoignore` 양쪽으로 경로를 덮으므로 가드는 true를 내야 하는데 false가 나왔습니다. 라운드로빈 `npm test`와 단일 `--grep`은 늘 통과했고, 손대지 않은 `main`에서도 그대로 재현됐습니다.

가드는 `git check-ignore`를 띄우고 종료 코드가 0이나 1이 아니면 "probe가 답을 못 줬다"로 봅니다. N개 node 프로세스가 각자 git 자식을 띄우는 상황에서 그 spawn이 이따금 타임아웃합니다. #230이 이미 상한을 2s에서 10s로 넓히고 답 없는 probe를 캐시된 판정이 아니라 기록된 장애로 바꿨습니다. 남은 것은 10s가 없애지 못하는 잔여 경합이고, 상한을 또 올리는 것은 경계를 미룰 뿐입니다.

빨간 테스트 하나의 문제가 아닙니다. 샤드 격리 실행에 항상 실패 1건이 들어 있으면 그 실행은 아무것도 말해주지 못합니다. 스위트 독립성을 실제로 깨뜨린 새 위반이 이 잡음과 구별되지 않습니다.

## 방법

`gitIgnoresPageUsageCached`에서 `runGitCheckIgnore`를 뽑아내고, 그 함수가 `probeFn = runGitCheckIgnore`를 받습니다. `pageUsageLoggingAllowed`도 같은 방식으로 세 번째 인자를 넘깁니다. 이제 0, 1, 128, null, throw 분기를 부하 걸린 머신이 만들어 주기를 기다리지 않고 직접 태웁니다.

쓰면서 두 가지가 드러났습니다.

throw하는 probe로는 "가드가 spawn 전에 단락했다"를 증명할 수 없습니다. 호출이 `try/catch` 안에 있어서 throw가 `probe = null`이 되고 `false`를 반환하는데, 단락도 같은 `false`를 반환합니다. probe가 불렸든 안 불렸든 단언이 통과했습니다. 호출 횟수를 세야 둘이 구별되고, probe를 단락보다 앞에 두어 횟수 단언이 red가 되는 것으로 확인했습니다.

`{ status: null }`을 고정하는 단언이 없었습니다. 타임아웃이 실제로 만드는 형태이고 따라서 바로 그 flake입니다. 가드를 `status === 128`로 좁혀도 기존 단언이 전부 green이었습니다. 이제 null 경로가 장애 기록, backoff 억제, 회복까지 이어서 검증됩니다.

## 수동 검증

```
npm test                          -> 1833 passed, 0 failed
npm run lint                      -> 0 error(s)
node tests/parallel.mjs --shards=278  -> 1833 passed, 0 failed
```

샤드 격리 실행은 두 번 했고, 그중 한 번은 다른 테스트 실행이 같은 코어를 두고 경합하는 중이었습니다. 프로세스 경합이 이 버그가 필요로 하는 조건이기 때문입니다.

회귀 증명. 방어를 하나씩 껐다가 되돌렸습니다.

| 무력화한 것 | red가 난 단언 |
|---|---|
| 판정 불가 probe를 verdict로 캐시 | an inconclusive git probe records an outage, never a verdict |
| backoff 체크 제거 | 위와 같음 |
| 세션 캐시 읽기 제거 | git probe is cached per session |
| probe를 단락보다 먼저 호출 | guard false when only .gitignore covers .cache/ |
| 장애 판정을 `status === 128`로 좁힘 | a timed-out probe is an outage, not a "not ignored" answer |

**이 브랜치에 대한 실제 세션 훅 QA는 하지 않았습니다.** 필요 없다고 보는 근거는 이렇습니다. `runGitCheckIgnore`는 기존 인라인 호출을 그대로 옮긴 것이고(argv 동일, 10s 타임아웃 동일), 유일한 프로덕션 호출부인 `hypo-lookup.mjs`가 두 인자를 넘기므로 기본 파라미터가 그 함수로 해석됩니다. 따라서 배포된 사본은 이전과 같은 `spawnSync`를 실행합니다. 더 강한 보증을 원하면 머지 전에 확인해 주세요.

## 마이그레이션 노트

None. 설치된 사본에 도달하는 동작 변경이 없습니다.

---

## Changelog

- EN: None (test-only change; the guard's production path is unchanged)
- KO: None (테스트 전용 변경, 가드의 프로덕션 경로는 그대로)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
