### PR TITLE
feat(rename): detect a rename that was interrupted, instead of leaving broken links

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "scripts/lib/pkg-json.mjs",
     "scripts/lib/plugin-detect.mjs",
     "scripts/lib/project-create.mjs",
+    "scripts/lib/rename-marker.mjs",
     "scripts/lib/schema-vocab.mjs",
     "scripts/lib/template-schema-version.mjs",
     "scripts/lib/wd-match.mjs",

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -13,12 +13,13 @@
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { join, relative, extname } from 'path';
+import { join, relative, extname, dirname } from 'path';
 import { homedir } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
+import { readRenameMarker, renameMarkerPath, RENAME_MARKER_REL } from './lib/rename-marker.mjs';
 import { resolveGitHooksDir } from './lib/git-hooks-dir.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import {
@@ -507,6 +508,116 @@ function checkGit(hypoDir) {
       `Points outside this repository (${resolved.path}) — /hypo:init will not install there`,
     );
   }
+}
+
+// rename.mjs --apply writes .cache/rename-in-progress.json before its first
+// inbound-link rewrite and removes it only after the terminal move lands (see
+// rename.mjs's writeRenameMarker/clearRenameMarker). A marker still present
+// means the process died mid-run: some inbound wikilinks may already point at
+// `to` while the page/directory itself still sits at `from`. checkBrokenLinks
+// below would just report those as generic broken links (W4's doctor
+// counterpart) with no clue why — this names the cause and the exact fix.
+// Re-running the SAME command converges on its own (the module docstring's
+// move-last invariant): nothing to merge or roll back by hand.
+// Best-effort: does this vault's git repo leave `markerPath` un-ignored (either
+// already tracked, or plain untracked-and-stageable)? `git check-ignore` answers
+// both at once — a tracked file is also reported "not ignored" by it, since
+// .gitignore rules don't retroactively apply to tracked paths. Fails CLOSED to
+// "don't know, say nothing": no `.git`, no git on PATH, or any non-0/1 exit
+// (128 = not a repo / path outside it / other error) all return false, because
+// this is advisory-only and a wrong guess is worse than silence (codex CONCERN 3
+// — never turn an inconclusive git query into an error of its own).
+function markerNotGitIgnored(hypoDir, markerPath) {
+  if (!existsSync(join(hypoDir, '.git'))) return false;
+  const rel = relative(hypoDir, markerPath);
+  const r = spawnSync('git', ['-C', hypoDir, 'check-ignore', '-q', rel], { encoding: 'utf-8' });
+  if (r.error || r.status === null) return false;
+  if (r.status !== 0 && r.status !== 1) return false; // 128 etc — inconclusive
+  return r.status === 1; // check-ignore's "not ignored" exit code
+}
+
+function checkIncompleteRename(hypoDir) {
+  // "no marker" and "a marker we cannot read" are different answers and must not
+  // collapse. readRenameMarker returns null for both, so ask the filesystem
+  // which one it is: a present-but-unreadable marker still means a rename did
+  // not finish, and reporting that as a pass would make the detector fail open
+  // on exactly the case it exists for.
+  const markerPath = renameMarkerPath(hypoDir);
+  const present = existsSync(markerPath);
+  if (!present) {
+    pass('Incomplete rename', 'No rename-in-progress marker found');
+    return;
+  }
+
+  // codex CONCERN 3: a legacy/custom vault whose .gitignore predates
+  // templates/gitignore's `.cache/` entry (init never edits an existing
+  // .gitignore) can let `git add -A` commit this marker, producing a ghost
+  // warning on another machine that never ran a rename at all. Advisory only —
+  // never turns the rename itself into an error — appended to every branch
+  // below that reports on a present marker.
+  const gitAdvisory = markerNotGitIgnored(hypoDir, markerPath)
+    ? ` This vault's git repo does not ignore ${dirname(RENAME_MARKER_REL)}/ — \`git add -A\` could commit this marker and produce a ghost warning on another machine. Add \`.cache/\` to .gitignore.`
+    : '';
+
+  const marker = readRenameMarker(hypoDir);
+  if (!marker || !marker.from || !marker.to) {
+    warn(
+      'Incomplete rename',
+      `${markerPath} exists but is unreadable or missing its from/to fields, so a rename did not finish and this cannot say which one. Inspect the file, re-run that rename to converge, then delete the marker.${gitAdvisory}`,
+    );
+    return;
+  }
+
+  // codex BLOCKER 2: the marker alone cannot distinguish a genuinely stuck
+  // rename from one that finished right before the process died — rename.mjs's
+  // move (renameSync) is the terminal step, and the marker is only cleared
+  // AFTER it. Cross-check `from`/`to` (vault-root-relative) against the
+  // filesystem to tell the three reachable states apart.
+  const { mode, from, to, started_at } = marker;
+  const label = mode === 'directory' ? 'directory' : 'page';
+  const fromExists = existsSync(join(hypoDir, from));
+  const toExists = existsSync(join(hypoDir, to));
+  const cmd = `node ${join(PKG_ROOT, 'scripts', 'rename.mjs')} --hypo-dir=${hypoDir} --from=${from} --to=${to} --apply`;
+
+  if (fromExists && !toExists) {
+    // The real in-progress case: --from still resolves, so re-running the
+    // IDENTICAL command converges on its own (rename.mjs's move-last invariant).
+    warn(
+      'Incomplete rename',
+      `a ${label} rename from '${from}' to '${to}' did not finish` +
+        (started_at ? ` (started ${started_at})` : '') +
+        ` — some inbound links may already point at the new name while the ${label} itself has not moved. Re-run the identical rename to converge: ${cmd}${gitAdvisory}`,
+    );
+    return;
+  }
+
+  if (!fromExists && toExists) {
+    // The move already landed — renameSync is one syscall, so this can only mean
+    // the process died AFTER it and BEFORE clearRenameMarker ran. Re-running the
+    // same command here would just fail (`--from` no longer resolves — see
+    // rename.mjs's own "did not resolve to a unique existing page" refusal), so
+    // suggesting a re-run (the prior behavior) handed the user a command that
+    // errors. Nothing to converge: the marker is pure leftover.
+    warn(
+      'Incomplete rename',
+      `a ${label} rename from '${from}' to '${to}' already finished (the ${label} moved) but its ` +
+        `in-progress marker was never cleared — the process likely died right after the move landed. ` +
+        `Nothing left to redo; just delete the stale marker: rm ${markerPath}${gitAdvisory}`,
+    );
+    return;
+  }
+
+  // Both paths exist, or neither does — the marker's from/to no longer map onto
+  // a determinable state (e.g. something else since recreated one of the two
+  // paths). Refuse to guess in either direction; a human needs to look.
+  warn(
+    'Incomplete rename',
+    `${markerPath} names a ${label} rename from '${from}' to '${to}', but ${
+      fromExists && toExists
+        ? 'BOTH the from and to paths currently exist'
+        : 'NEITHER the from nor the to path currently exists'
+    } — cannot tell whether the rename finished. Inspect both paths by hand, then either re-run the rename or delete the marker: ${markerPath}${gitAdvisory}`,
+  );
 }
 
 function checkBrokenLinks(hypoDir, ignorePatterns = []) {
@@ -1830,6 +1941,7 @@ if (rootOk) {
   checkFiles(args.hypoDir);
   checkScanIgnoreFile(args.hypoDir);
   checkBrokenLinks(args.hypoDir, ignorePatterns);
+  checkIncompleteRename(args.hypoDir);
   checkVerifyBy(args.hypoDir, ignorePatterns);
 }
 checkHooks(coreManagedByPlugin);

--- a/scripts/lib/rename-marker.mjs
+++ b/scripts/lib/rename-marker.mjs
@@ -1,0 +1,39 @@
+// scripts/lib/rename-marker.mjs
+//
+// The crash-recovery marker for rename.mjs --apply. Shared read-only path/parse
+// logic between the writer (rename.mjs) and the reader (doctor.mjs) so the two
+// never drift on where the marker lives or what shape it is in.
+//
+// Kept under .cache/ deliberately, matching every other runtime marker this repo
+// already writes there (sync-state.json, session-closed-*.marker, proposals/,
+// project-suggestions.json). Two things fall out of that placement for free:
+//   - it is JSON, not .md, so every vault walker (scripts/lib/wikilink.mjs) that
+//     only ever collects .md files simply never sees it — no lint/rename/graph
+//     scan needs to know this file exists.
+//   - .cache/ ships in templates/.hypoignore's default pattern list, so a scan
+//     that DOES walk directories rather than just filtering by extension
+//     (doctor's own checkBrokenLinks walker) is also covered on any vault that
+//     carries that baseline — which every vault already needs, since .cache/
+//     holds the pre-commit secret-gate's own state.
+// No .hyposcanignore entry or scan-logic change was needed to get this property;
+// it comes from where the file lives, not from a new exclusion rule.
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export const RENAME_MARKER_REL = '.cache/rename-in-progress.json';
+
+export function renameMarkerPath(hypoDir) {
+  return join(hypoDir, RENAME_MARKER_REL);
+}
+
+// Best-effort read: a missing or corrupt marker both mean "nothing to report" —
+// this runs inside doctor's health scan and must never throw.
+export function readRenameMarker(hypoDir) {
+  const path = renameMarkerPath(hypoDir);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}

--- a/scripts/rename.mjs
+++ b/scripts/rename.mjs
@@ -52,6 +52,7 @@ import { join, basename, dirname, normalize, isAbsolute, sep } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
 import { collectPagesRename, slugForms } from './lib/wikilink.mjs';
+import { RENAME_MARKER_REL, renameMarkerPath, readRenameMarker } from './lib/rename-marker.mjs';
 
 // ── arg parsing ───────────────────────────────────────────────────────────────
 
@@ -260,6 +261,81 @@ function atomicWrite(path, content) {
       // best effort; the original at `path` is untouched either way
     }
     throw err;
+  }
+}
+
+// ── crash-recovery marker ────────────────────────────────────────────────────
+// Written as the FIRST disk write of an --apply run (right after the last guard
+// passes, before any inbound-link rewrite lands) and cleared as the LAST action
+// (right after the terminal renameSync). If the process dies in between, this
+// is the only trace left that the rename is incomplete: --from still resolves
+// at that point (the move itself hasn't happened yet — see the module
+// docstring's move-last invariant), so a re-run of the identical command
+// converges on its own. Nothing else in the vault says "you need to re-run it".
+//
+// Fail-closed by construction: writeRenameMarker calls fail() (process.exit(1))
+// on any write error, so --apply never proceeds without a marker on disk. A
+// detector with no reliable marker is worse than no detector at all.
+function writeRenameMarker(args, marker) {
+  const path = join(args.hypoDir, RENAME_MARKER_REL);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    atomicWrite(path, JSON.stringify(marker, null, 2));
+  } catch (err) {
+    fail(
+      args,
+      `could not write the rename-in-progress marker (${err.message}) — refusing --apply without it: it is the only signal a crash mid-rewrite would leave behind.`,
+    );
+  }
+}
+
+// codex BLOCKER: writeRenameMarker above used to atomicWrite unconditionally,
+// so a SECOND rename whose own --apply started after a FIRST one crashed mid-run
+// would silently clobber the first rename's marker — permanently erasing the
+// only trace that the first rename's move/rewrite is incomplete. Called right
+// before writeRenameMarker in both modes, so the check runs before this run's
+// marker (or anything else) touches disk.
+//
+// Three outcomes:
+//   - no marker on disk                → nothing to conflict with, proceed.
+//   - marker names THIS exact command  → this is the legitimate re-run path the
+//     whole mechanism exists to let converge (identical mode/from/to). Proceed;
+//     writeRenameMarker below simply overwrites it with a fresh started_at —
+//     mode/from/to don't change, only the timestamp does.
+//   - marker names a DIFFERENT command, or can't be parsed at all → refuse. A
+//     marker we can't parse might belong to this command or a different one;
+//     "can't tell" must resolve to refuse, not to a silent overwrite.
+function guardExistingMarker(args, thisMarker) {
+  const path = renameMarkerPath(args.hypoDir);
+  if (!existsSync(path)) return;
+  const marker = readRenameMarker(args.hypoDir);
+  if (!marker || !marker.from || !marker.to) {
+    fail(
+      args,
+      `${path} exists but could not be parsed (or is missing from/to), so it cannot be told apart from this rename's own marker. Inspect it by hand, finish or discard the rename it describes, then delete the marker before retrying.`,
+    );
+  }
+  const same =
+    marker.mode === thisMarker.mode && marker.from === thisMarker.from && marker.to === thisMarker.to;
+  if (!same) {
+    fail(
+      args,
+      `a rename is already in progress (${marker.mode === 'directory' ? 'directory' : 'page'} '${marker.from}' → '${marker.to}', marker at ${path}) — finish that rename first (re-run the identical command), or confirm it is safe and delete the marker, before starting a different one.`,
+    );
+  }
+}
+
+// A failure here is not fatal — the move already succeeded — but a marker left
+// behind would make doctor misreport a finished rename as incomplete, so it is
+// surfaced (stderr) rather than swallowed.
+function clearRenameMarker(args) {
+  const path = join(args.hypoDir, RENAME_MARKER_REL);
+  try {
+    rmSync(path, { force: true });
+  } catch (err) {
+    console.error(
+      `⚠ rename completed, but could not remove the in-progress marker (${err.message}) — remove ${path} by hand.`,
+    );
   }
 }
 
@@ -663,6 +739,14 @@ function runDirectory(args, fromDirRel, ignorePatterns) {
   let moved = false;
   if (args.apply) {
     assertSameDevice(args, fromAbs, toAbs);
+    const thisMarker = {
+      mode: 'directory',
+      from: fromDirRel,
+      to: toDirRel,
+      started_at: new Date().toISOString(),
+    };
+    guardExistingMarker(args, thisMarker);
+    writeRenameMarker(args, thisMarker);
     for (const [path, content] of externalWrites) atomicWrite(path, content);
     for (const [oldRel, content] of movedBodies) {
       atomicWrite(join(args.hypoDir, oldRel), content);
@@ -678,6 +762,7 @@ function runDirectory(args, fromDirRel, ignorePatterns) {
       if (err.code !== 'EXDEV') throw err;
       fail(args, `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`);
     }
+    clearRenameMarker(args);
     moved = true;
   }
 
@@ -819,7 +904,17 @@ function run(args) {
   // (see assertSameDevice) — the external rewrite loop right after this can
   // otherwise land partial vault changes ahead of a move that turns out to be
   // impossible.
-  if (args.apply) assertSameDevice(args, fromPage.path, toPath);
+  if (args.apply) {
+    assertSameDevice(args, fromPage.path, toPath);
+    const thisMarker = {
+      mode: 'page',
+      from: fromPage.rel,
+      to: toRel,
+      started_at: new Date().toISOString(),
+    };
+    guardExistingMarker(args, thisMarker);
+    writeRenameMarker(args, thisMarker);
+  }
 
   // Rewrite inbound references across every NON-preserved page (skip the moved
   // page itself — self-references are rewritten on its own content separately).
@@ -882,6 +977,7 @@ function run(args) {
         fail(args, `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`);
       }
     }
+    clearRenameMarker(args);
     moved = true;
   }
 

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -1716,3 +1716,225 @@ test('pkgRoot .git is corrupt so git status exits nonzero → warn "cannot class
     }
   });
 });
+
+// ── 'Incomplete rename' — .cache/rename-in-progress.json detection ────────────
+//
+// rename.mjs writes this marker before its first inbound-link rewrite and
+// removes it after the terminal move (see tests/rename-wikilink.test.mjs's
+// "crash-recovery marker" suite, which owns rename.mjs's write/clear side).
+// This suite owns doctor.mjs's READ side: report shape when the marker is
+// absent, well-formed, or present-but-broken.
+
+suite("doctor.mjs — 'Incomplete rename' marker detection");
+
+function markerFixtureWiki(dir) {
+  writeFileSync(join(dir, 'hypo-config.md'), '# config');
+  mkdirSync(join(dir, 'pages'), { recursive: true });
+  mkdirSync(join(dir, 'projects'), { recursive: true });
+  mkdirSync(join(dir, 'sources'), { recursive: true });
+  mkdirSync(join(dir, '.cache'), { recursive: true });
+}
+
+test('no marker file → Incomplete rename passes', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Incomplete rename');
+    assert.ok(check, 'Incomplete rename check not found');
+    assert.equal(check.status, 'pass', `expected pass with no marker: ${check.detail}`);
+  });
+});
+
+test('a well-formed marker → warn naming from/to and a runnable re-run command', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    // codex BLOCKER 2: doctor now cross-checks from/to against the filesystem to
+    // tell a genuinely-stuck rename apart from a finished one whose marker just
+    // never got cleared. `from` present + `to` absent is what "genuinely
+    // mid-rename, --from still resolves" actually looks like — without this the
+    // fixture named neither path and fell into the (correct, but different)
+    // "cannot tell" branch instead of the re-run branch this test means to pin.
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/foo.md',
+        to: 'pages/bar.md',
+        started_at: '2026-08-04T00:00:00.000Z',
+      }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Incomplete rename');
+    assert.ok(check, 'Incomplete rename check not found');
+    assert.equal(check.status, 'warn', `expected warn with a marker present: ${check.detail}`);
+    assert.ok(check.detail.includes('pages/foo.md'), `detail must name the from-page: ${check.detail}`);
+    assert.ok(check.detail.includes('pages/bar.md'), `detail must name the to-page: ${check.detail}`);
+    assert.ok(
+      /node .*rename\.mjs .*--from=pages\/foo\.md .*--to=pages\/bar\.md .*--apply/.test(check.detail),
+      `detail must include an exact runnable re-run command: ${check.detail}`,
+    );
+  });
+});
+
+// The fail-open case the coordinator caught: readRenameMarker collapses "no
+// file" and "unreadable file" to the same null, so checkIncompleteRename must
+// ask existsSync() separately and never let a present-but-broken marker fall
+// through to the "no marker" pass branch.
+test('marker file exists but is invalid JSON → warn, not pass', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    writeFileSync(join(dir, '.cache', 'rename-in-progress.json'), '{oops');
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Incomplete rename');
+    assert.ok(check, 'Incomplete rename check not found');
+    assert.equal(
+      check.status,
+      'warn',
+      `a present-but-corrupt marker must warn, not silently pass: ${check.detail}`,
+    );
+  });
+});
+
+test('marker file parses but is missing from/to → warn, not pass', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    writeFileSync(join(dir, '.cache', 'rename-in-progress.json'), JSON.stringify({}));
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Incomplete rename');
+    assert.ok(check, 'Incomplete rename check not found');
+    assert.equal(
+      check.status,
+      'warn',
+      `a present marker missing from/to must warn, not silently pass: ${check.detail}`,
+    );
+  });
+});
+
+// codex BLOCKER 2 (three-state read side): a marker whose `from` no longer
+// exists but whose `to` does is a FINISHED rename, not a stuck one — the move
+// (renameSync) is the terminal step and the marker only clears after it, so a
+// crash right there is exactly the "done, marker leftover" state. The prior
+// single-branch warn always said "re-run", which fails here (--from no longer
+// resolves). Reproducing the real SIGKILL window is covered in
+// rename-wikilink.test.mjs (owns the KILL_RENAME harness); this pins doctor's
+// own read-side classification directly off a hand-built marker + fs state.
+test('marker present, from gone, to exists (move finished, marker leftover) → warn "clean up", not "re-run"', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    writeFileSync(join(dir, 'pages', 'bar.md'), '---\ntitle: bar\n---\nbar page\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/foo.md',
+        to: 'pages/bar.md',
+        started_at: '2026-08-01T00:00:00.000Z',
+      }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
+    assert.ok(check, 'Incomplete rename check not found');
+    assert.equal(check.status, 'warn', `stale-but-finished marker must still warn: ${check.detail}`);
+    assert.ok(
+      !/re-run/i.test(check.detail),
+      `must not suggest a re-run that would fail (--from no longer resolves): ${check.detail}`,
+    );
+    assert.ok(
+      /delete|clean|remove/i.test(check.detail),
+      `must point at deleting the leftover marker: ${check.detail}`,
+    );
+  });
+});
+
+// The genuine in-progress case still gets the re-run guidance — this pins the
+// OTHER branch of the three-state split so a fix to the stale branch can't
+// silently regress this one.
+test('marker present, from exists, to absent (genuinely mid-rename) → warn with a re-run command', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/foo.md',
+        to: 'pages/bar.md',
+        started_at: '2026-08-01T00:00:00.000Z',
+      }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
+    assert.equal(check.status, 'warn');
+    assert.ok(
+      /re-run/i.test(check.detail) && /--apply/.test(check.detail),
+      `genuinely-stuck marker must still suggest the re-run: ${check.detail}`,
+    );
+  });
+});
+
+// codex CONCERN 3: a legacy/custom vault whose .gitignore predates
+// templates/gitignore's `.cache/` entry can let `git add -A` commit this
+// marker, producing a ghost warning on a machine that never ran a rename.
+// Advisory only, and additive to whichever branch above fires.
+suite("doctor.mjs — 'Incomplete rename' gitignore advisory (CONCERN 3)");
+
+test('marker in a git repo that does NOT ignore .cache/ → doctor appends a gitignore hint', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    gitRepo(dir);
+    // No .gitignore at all — .cache/ is not excluded.
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({ mode: 'page', from: 'pages/foo.md', to: 'pages/bar.md', started_at: '2026-08-01T00:00:00.000Z' }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
+    assert.equal(check.status, 'warn');
+    assert.ok(
+      /gitignore/i.test(check.detail) && check.detail.includes('.cache/'),
+      `un-ignored .cache/ in a git repo must get a gitignore hint: ${check.detail}`,
+    );
+  });
+});
+
+test('marker in a git repo that DOES ignore .cache/ → no gitignore hint', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir);
+    gitRepo(dir);
+    writeFileSync(join(dir, '.gitignore'), '.cache/\n');
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({ mode: 'page', from: 'pages/foo.md', to: 'pages/bar.md', started_at: '2026-08-01T00:00:00.000Z' }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
+    assert.equal(check.status, 'warn');
+    assert.ok(
+      !/gitignore/i.test(check.detail),
+      `a properly-ignored .cache/ must not get the gitignore hint: ${check.detail}`,
+    );
+  });
+});
+
+test('marker in a non-git vault → no gitignore hint, no crash', () => {
+  withTmpDir((dir) => {
+    markerFixtureWiki(dir); // no gitRepo(dir) — no .git at all
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({ mode: 'page', from: 'pages/foo.md', to: 'pages/bar.md', started_at: '2026-08-01T00:00:00.000Z' }),
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    assert.ok(r.status !== null && r.status <= 1, `doctor must not crash on a non-git vault: ${r.stdout}${r.stderr}`);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
+    assert.equal(check.status, 'warn');
+    assert.ok(!/gitignore/i.test(check.detail), `non-git vault must get no gitignore hint: ${check.detail}`);
+  });
+});

--- a/tests/fixtures/npm-pack.files.json
+++ b/tests/fixtures/npm-pack.files.json
@@ -332,6 +332,10 @@
     "exec": false
   },
   {
+    "path": "scripts/lib/rename-marker.mjs",
+    "exec": false
+  },
+  {
     "path": "scripts/lib/schema-vocab.mjs",
     "exec": false
   },

--- a/tests/rename-wikilink.test.mjs
+++ b/tests/rename-wikilink.test.mjs
@@ -371,8 +371,16 @@ cpSync(SCRIPTS, KILL_SCRIPTS, { recursive: true });
   let src = readFileSync(KILL_RENAME, 'utf-8');
   const pageAnchor = 'renameSync(fromPage.path, toPath);';
   const dirAnchor = 'renameSync(fromAbs, toAbs);';
+  // atomicWrite is the ONE place every mid-loop write (marker + every inbound
+  // rewrite, in both modes) actually lands on disk, so counting its calls is
+  // the one hook that can bracket "some rewrites landed, some didn't" without
+  // caring which mode or which file is currently being written.
+  const atomicWriteDecl = 'function atomicWrite(path, content) {';
+  const atomicWriteAnchor = 'renameSync(tmp, path);';
   assert.ok(src.includes(pageAnchor), `page-mode renameSync anchor not found — did rename.mjs change?`);
   assert.ok(src.includes(dirAnchor), `dir-mode renameSync anchor not found — did rename.mjs change?`);
+  assert.ok(src.includes(atomicWriteDecl), `atomicWrite declaration not found — did rename.mjs change?`);
+  assert.ok(src.includes(atomicWriteAnchor), `atomicWrite renameSync anchor not found — did rename.mjs change?`);
   src = src.replace(
     pageAnchor,
     `if (process.env.HYPO_TEST_KILL_PAGE_PRE) process.kill(process.pid, 'SIGKILL');\n        ${pageAnchor}\n        if (process.env.HYPO_TEST_KILL_PAGE_POST) process.kill(process.pid, 'SIGKILL');`,
@@ -380,6 +388,11 @@ cpSync(SCRIPTS, KILL_SCRIPTS, { recursive: true });
   src = src.replace(
     dirAnchor,
     `if (process.env.HYPO_TEST_KILL_DIR_PRE) process.kill(process.pid, 'SIGKILL');\n      ${dirAnchor}\n      if (process.env.HYPO_TEST_KILL_DIR_POST) process.kill(process.pid, 'SIGKILL');`,
+  );
+  src = src.replace(atomicWriteDecl, `let __atomicWriteCalls = 0;\n${atomicWriteDecl}`);
+  src = src.replace(
+    atomicWriteAnchor,
+    `${atomicWriteAnchor}\n    __atomicWriteCalls++;\n    if (process.env.HYPO_TEST_KILL_AFTER_N && __atomicWriteCalls >= Number(process.env.HYPO_TEST_KILL_AFTER_N)) process.kill(process.pid, 'SIGKILL');`,
   );
   writeFileSync(KILL_RENAME, src);
 }
@@ -881,6 +894,295 @@ test('directory move: dry-run reports but writes nothing', () => {
       readFileSync(join(dir, 'pages', 'ext.md'), 'utf-8').includes('[[projects/old/index]]'),
       'dry-run does not rewrite',
     );
+  });
+});
+
+// ── rename.mjs — crash-recovery marker (.cache/rename-in-progress.json) ───────
+//
+// The marker itself: written before the first inbound-link rewrite of an
+// --apply run, removed right after the terminal renameSync. Pins the write/
+// clear lifecycle, dry-run's no-write guarantee, fail-closed on a write
+// failure, and (via KILL_RENAME) that a crash mid-loop leaves a genuinely
+// partial, marker-recorded state a re-run converges from.
+
+suite('rename.mjs — crash-recovery marker');
+
+test('successful --apply clears the marker (page mode)', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(join(dir, 'pages', 'a.md'), '---\ntitle: a\n---\nsee [[foo]].\n');
+    const r = run('rename.mjs', [`--hypo-dir=${dir}`, '--from=foo', '--to=bar', '--apply', '--json']);
+    assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'rename-in-progress.json')),
+      'marker must be gone after a successful --apply',
+    );
+  });
+});
+
+test('successful --apply clears the marker (directory mode)', () => {
+  withTmpDir((dir) => {
+    dirFixture(dir);
+    const r = run('rename.mjs', [
+      `--hypo-dir=${dir}`,
+      '--from=projects/old',
+      '--to=projects/new',
+      '--apply',
+      '--json',
+    ]);
+    assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'rename-in-progress.json')),
+      'marker must be gone after a successful --apply',
+    );
+  });
+});
+
+test('dry-run writes no marker', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(join(dir, 'pages', 'a.md'), '---\ntitle: a\n---\nsee [[foo]].\n');
+    const r = run('rename.mjs', [`--hypo-dir=${dir}`, '--from=foo', '--to=bar', '--json']);
+    assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'rename-in-progress.json')),
+      'a dry-run (no --apply) must never write the marker',
+    );
+  });
+});
+
+// Fail-closed: if the marker itself cannot be written, --apply must not
+// proceed to any other write — a detector with no reliable marker would be
+// worse than no detector. Forces the failure by making .cache/ unwritable
+// (pre-created so mkdirSync's recursive no-op succeeds, but atomicWrite's
+// writeFileSync inside it cannot).
+test('marker write failure is fail-closed: --apply aborts before any rewrite or move', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(join(dir, 'pages', 'a.md'), '---\ntitle: a\n---\nsee [[foo]].\n');
+    chmodSync(join(dir, '.cache'), 0o500); // read+execute only — no write inside it
+    try {
+      const r = run('rename.mjs', [`--hypo-dir=${dir}`, '--from=foo', '--to=bar', '--apply', '--json']);
+      assert.notEqual(r.status, 0, `--apply must fail when the marker cannot be written: ${r.stdout}${r.stderr}`);
+      assert.ok(existsSync(join(dir, 'pages', 'foo.md')), 'foo.md must not have moved');
+      assert.ok(!existsSync(join(dir, 'pages', 'bar.md')), 'bar.md must not exist');
+      const a = readFileSync(join(dir, 'pages', 'a.md'), 'utf-8');
+      assert.ok(a.includes('[[foo]]') && !a.includes('[[bar]]'), `a.md must be untouched: ${a}`);
+    } finally {
+      chmodSync(join(dir, '.cache'), 0o700); // let withTmpDir's cleanup remove it
+    }
+  });
+});
+
+// codex BLOCKER 1: writeRenameMarker used to atomicWrite unconditionally, so a
+// SECOND rename's --apply would silently clobber a FIRST rename's still-open
+// marker — erasing the only trace that the first rename is incomplete forever.
+test('existing marker for a DIFFERENT rename → --apply refused, zero rewrites, zero moves', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(join(dir, 'pages', 'other.md'), '---\ntitle: other\n---\nother page\n');
+    writeFileSync(join(dir, 'pages', 'a.md'), '---\ntitle: a\n---\nsee [[foo]].\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/other.md',
+        to: 'pages/moved.md',
+        started_at: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    const r = run('rename.mjs', [
+      `--hypo-dir=${dir}`,
+      '--from=foo',
+      '--to=bar',
+      '--apply',
+      '--json',
+    ]);
+    assert.equal(r.status, 1, `a different in-progress marker must refuse --apply: ${r.stdout}${r.stderr}`);
+    assert.ok(existsSync(join(dir, 'pages', 'foo.md')), 'foo.md not moved (0 moves)');
+    assert.ok(!existsSync(join(dir, 'pages', 'bar.md')), 'bar.md not created');
+    const a = readFileSync(join(dir, 'pages', 'a.md'), 'utf-8');
+    assert.ok(a.includes('[[foo]]') && !a.includes('[[bar]]'), '0 inbound rewrites happened');
+    const marker = JSON.parse(readFileSync(join(dir, '.cache', 'rename-in-progress.json'), 'utf-8'));
+    assert.deepEqual(
+      marker,
+      { mode: 'page', from: 'pages/other.md', to: 'pages/moved.md', started_at: '2026-01-01T00:00:00.000Z' },
+      'the OTHER rename\'s marker must survive untouched, not be overwritten',
+    );
+  });
+});
+
+// codex BLOCKER 1, convergence half: a marker naming THIS EXACT command is the
+// legitimate re-run path the whole detector exists to let converge. If this
+// regresses, the BLOCKER 1 fix broke the feature it was protecting.
+test('existing marker for the SAME rename → --apply proceeds and converges (re-run path not blocked)', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    writeFileSync(join(dir, 'pages', 'a.md'), '---\ntitle: a\n---\nsee [[foo]].\n');
+    writeFileSync(
+      join(dir, '.cache', 'rename-in-progress.json'),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/foo.md',
+        to: 'pages/bar.md',
+        started_at: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    const r = run('rename.mjs', [
+      `--hypo-dir=${dir}`,
+      '--from=foo',
+      '--to=bar',
+      '--apply',
+      '--json',
+    ]);
+    assert.equal(r.status, 0, `a same-command marker must not block the legitimate re-run: ${r.stdout}${r.stderr}`);
+    assert.ok(existsSync(join(dir, 'pages', 'bar.md')), 'bar.md exists');
+    assert.ok(!existsSync(join(dir, 'pages', 'foo.md')), 'foo.md gone');
+    assert.ok(
+      readFileSync(join(dir, 'pages', 'a.md'), 'utf-8').includes('[[bar]]'),
+      'inbound rewrite happened',
+    );
+    assert.ok(
+      !existsSync(join(dir, '.cache', 'rename-in-progress.json')),
+      'marker cleared after the same-command rename converges',
+    );
+  });
+});
+
+// codex BLOCKER 1, unreadable-marker half: "can't tell if it's the same
+// command" must resolve to refuse, never to a silent overwrite.
+test('existing marker that cannot be read (corrupt JSON, or missing from/to) → --apply refused', () => {
+  for (const bad of ['{oops', JSON.stringify({ mode: 'page' })]) {
+    withTmpDir((dir) => {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      mkdirSync(join(dir, '.cache'), { recursive: true });
+      writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+      writeFileSync(join(dir, '.cache', 'rename-in-progress.json'), bad);
+      const r = run('rename.mjs', [
+        `--hypo-dir=${dir}`,
+        '--from=foo',
+        '--to=bar',
+        '--apply',
+        '--json',
+      ]);
+      assert.equal(
+        r.status,
+        1,
+        `an unreadable/incomplete marker must refuse --apply (cannot judge same-command): ${r.stdout}${r.stderr}`,
+      );
+      assert.ok(existsSync(join(dir, 'pages', 'foo.md')), 'foo.md not moved');
+      assert.ok(!existsSync(join(dir, 'pages', 'bar.md')), 'bar.md not created');
+    });
+  }
+});
+
+// codex BLOCKER 2: renameSync is the terminal step; the marker is cleared only
+// AFTER it. A crash bracketing that exact point (reusing the KILL_RENAME copy
+// and its HYPO_TEST_KILL_PAGE_POST hook — see the "single-file renameSync
+// converges" test above) leaves the marker present with `from` gone and `to`
+// present: the rename is DONE, not stuck. doctor must tell the two apart —
+// the old single-branch warn always said "re-run", which for this state is a
+// command that fails (`--from` no longer resolves).
+test('doctor.mjs after a post-renameSync crash: marker present + move done → "clean up the marker", not "re-run"', () => {
+  withTmpDir((base) => {
+    const wiki = join(base, 'wiki');
+    const home = join(base, 'home');
+    mkdirSync(join(wiki, 'pages'), { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(wiki, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+
+    const cmd = [KILL_RENAME, `--hypo-dir=${wiki}`, '--from=foo', '--to=bar', '--apply', '--json'];
+    const killed = spawnSync(process.execPath, cmd, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: home, HYPO_TEST_KILL_PAGE_POST: '1' },
+    });
+    assert.equal(killed.signal, 'SIGKILL', `expected the kill hook to fire post-rename: ${killed.stderr}`);
+
+    const markerPath = join(wiki, '.cache', 'rename-in-progress.json');
+    assert.ok(existsSync(markerPath), 'the marker must survive a post-move crash');
+    assert.ok(!existsSync(join(wiki, 'pages', 'foo.md')), 'from is gone (the move landed)');
+    assert.ok(existsSync(join(wiki, 'pages', 'bar.md')), 'to exists (the move landed)');
+
+    const doctorR = run('doctor.mjs', [`--hypo-dir=${wiki}`, '--json']);
+    const checks = JSON.parse(doctorR.stdout);
+    const check = checks.find((c) => c.label === 'Incomplete rename');
+    assert.ok(check, 'Incomplete rename check not found');
+    assert.equal(check.status, 'warn', `stale-but-done marker must still warn (not pass): ${check.detail}`);
+    assert.ok(
+      !/re-run/i.test(check.detail),
+      `must NOT tell the user to re-run a command that would fail (--from no longer resolves): ${check.detail}`,
+    );
+    assert.ok(
+      /delete|clean|remove/i.test(check.detail) && check.detail.includes(markerPath),
+      `must point at deleting the stale marker: ${check.detail}`,
+    );
+
+    // Following doctor's own advice — deleting the marker — must leave a clean
+    // report on the next run. No rerun of the rename itself: nothing to converge.
+    rmSync(markerPath, { force: true });
+    const doctorR2 = run('doctor.mjs', [`--hypo-dir=${wiki}`, '--json']);
+    const check2 = JSON.parse(doctorR2.stdout).find((c) => c.label === 'Incomplete rename');
+    assert.equal(check2.status, 'pass', `following the guidance must leave doctor clean: ${check2.detail}`);
+  });
+});
+
+test('crash mid-rewrite-loop: marker records mode/from/to, page not yet moved, rewrite genuinely partial — re-run converges and clears the marker', () => {
+  withTmpDir((base) => {
+    const wiki = join(base, 'wiki');
+    const home = join(base, 'home');
+    mkdirSync(join(wiki, 'pages'), { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(wiki, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
+    for (const name of ['a', 'b', 'c', 'd']) {
+      writeFileSync(join(wiki, 'pages', `${name}.md`), `---\ntitle: ${name}\n---\nsee [[foo]].\n`);
+    }
+    const cmd = [KILL_RENAME, `--hypo-dir=${wiki}`, '--from=foo', '--to=bar', '--apply', '--json'];
+    // atomicWrite call #1 is the marker itself; #2-#5 are the four inbound
+    // rewrites. Killing after #3 lands the marker plus exactly two of the four
+    // rewrites — a genuinely partial state — strictly before the terminal
+    // renameSync, which does not go through atomicWrite at all.
+    const killed = spawnSync(process.execPath, cmd, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: home, HYPO_TEST_KILL_AFTER_N: '3' },
+    });
+    assert.equal(killed.signal, 'SIGKILL', `expected the kill hook to fire: ${killed.stdout}${killed.stderr}`);
+
+    const markerPath = join(wiki, '.cache', 'rename-in-progress.json');
+    assert.ok(existsSync(markerPath), 'marker must survive the crash');
+    const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    assert.equal(marker.mode, 'page');
+    assert.equal(marker.from, 'pages/foo.md');
+    assert.equal(marker.to, 'pages/bar.md');
+    assert.ok(marker.started_at, 'marker must record a started_at timestamp');
+
+    assert.ok(existsSync(join(wiki, 'pages', 'foo.md')), 'foo.md must not have moved yet');
+    assert.ok(!existsSync(join(wiki, 'pages', 'bar.md')), 'bar.md must not exist yet');
+    const rewrittenCount = ['a', 'b', 'c', 'd'].filter((n) =>
+      readFileSync(join(wiki, 'pages', `${n}.md`), 'utf-8').includes('[[bar]]'),
+    ).length;
+    assert.ok(
+      rewrittenCount > 0 && rewrittenCount < 4,
+      `rewrite must be genuinely partial, not all-or-nothing: ${rewrittenCount}/4 rewritten`,
+    );
+
+    // Re-running the SAME command (no kill env) must converge and clear the marker.
+    const rerun = spawnSync(process.execPath, cmd, { encoding: 'utf-8', env: { ...process.env, HOME: home } });
+    assert.equal(rerun.status, 0, `re-run must converge: ${rerun.stdout}${rerun.stderr}`);
+    assert.ok(existsSync(join(wiki, 'pages', 'bar.md')), 'bar.md must exist after re-run');
+    assert.ok(!existsSync(join(wiki, 'pages', 'foo.md')), 'foo.md must be gone after re-run');
+    for (const n of ['a', 'b', 'c', 'd']) {
+      const body = readFileSync(join(wiki, 'pages', `${n}.md`), 'utf-8');
+      assert.ok(body.includes('[[bar]]'), `${n}.md must be fully rewritten after re-run: ${body}`);
+    }
+    assert.ok(!existsSync(markerPath), 'marker must be removed after the re-run converges');
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`rename.mjs --apply` writes `.cache/rename-in-progress.json` before its first inbound-link rewrite and removes it right after the move lands. `hypo:doctor` reads that marker and reports what did not finish, along with the exact thing to do about it.

## Why

Renaming a page rewrites every inbound wikilink across the vault and then moves the file. #231 made the move atomic and put it last, so a crash leaves the page at its old path with some links already pointing at the new name, and re-running the identical command converges from there.

What was missing is that nothing told you to re-run it. `lint` reports the half-rewritten links as ordinary broken links with no hint that a rename is the cause, so a vault can sit in that state indefinitely and the links stay broken.

## How

The marker is the whole mechanism. No staging directory, no backup copies, no transaction log: the move is already atomic and a re-run already converges, so there is nothing to roll back. The marker only has to say "this is unfinished, run it again".

Failing to write the marker refuses the `--apply`. A detector whose marker is optional does not detect anything.

Three things cross-review caught before this landed, all of which would have shipped a detector that reports confidently and is wrong.

**A second rename overwrote the first one's marker.** If rename A died and rename B then succeeded, B cleared A's marker and A's half-rewritten links became permanently undetectable. An `--apply` now reads any existing marker first. Identical `mode`/`from`/`to` means this is the legitimate re-run and it proceeds; anything else is refused with the other rename's paths in the message; an unreadable marker is refused too, since it cannot be told apart from this one and "cannot judge" is not "allow".

**A crash between the move and the marker removal made a finished rename look unfinished**, and doctor answered it by suggesting a re-run of a command whose `--from` no longer resolves. doctor now checks both paths on disk. `from` present means genuinely mid-rename, so re-run. `to` present without `from` means the move finished and only the marker is stale, so delete it and redo nothing. Anything else is reported as undecidable for a human to inspect.

**An older vault can commit the marker.** `.cache/` ships in the vault template's gitignore, but `init` does not edit an existing `.gitignore`, so a legacy vault carries the marker into git and a phantom warning to another machine. When doctor reports a marker it now checks whether the path is actually ignored and appends a gitignore hint when it is not. A vault that is not a git repo, or a probe that cannot answer, skips the hint silently rather than erroring.

## Manual verification

```
npm test                              -> 1849 passed, 0 failed
npm run lint                          -> 0 error(s)
node scripts/check-pack-surface.mjs   -> 133 files, 0 closure violations
```

The crash windows were reproduced, not reasoned about. A throwaway patched copy of `scripts/` kills itself with SIGKILL at a chosen point:

- After the 3rd `atomicWrite` (marker plus 2 of 4 inbound rewrites): the marker survives with the right `mode`/`from`/`to`, the page has not moved, and the rewrite is genuinely partial (neither 0 nor all 4). Re-running converges and clears the marker.
- Right after `renameSync`: the page has moved, the marker is stale, and doctor recommends deleting it with no re-run wording anywhere in the detail string.
- With `.cache/` unwritable: `--apply` exits non-zero with zero rewrites and zero moves.

Regression proof, each defense disabled in turn and restored:

| disabled | assertion that went red |
|---|---|
| marker write | fail-closed, crash recovery |
| marker removal | clears on success (page and directory), re-run converges |
| fail-closed downgraded to a warning | fail-closed |
| doctor's corrupt-marker branch back to pass | invalid JSON, missing from/to |
| existing-marker guard | different rename refused, unreadable refused |
| doctor's stale branch (always suggest re-run) | clean up not re-run, post-move crash |
| gitignore hint | un-ignored `.cache/` gets a hint |
| guard refusing every marker | four legitimate re-run paths break |

That last row is the one worth keeping: an over-broad guard would have blocked the very re-run this feature exists to recommend.

**Not covered:** this is SIGKILL-level durability. `atomicWrite` does not fsync the file or its directory, so ordering across a power loss or OS crash is not claimed.

## Migration notes

None. Existing vaults need no action. The marker is created on demand and removed on success.

---

# 한국어

## 변경 내용

`rename.mjs --apply`가 첫 인바운드 링크 재작성 전에 `.cache/rename-in-progress.json`을 쓰고, 이동이 착지한 직후에 지웁니다. `hypo:doctor`가 그 마커를 읽어 무엇이 안 끝났는지와 무엇을 해야 하는지를 알려 줍니다.

## 이유

페이지 이름을 바꾸면 볼트 전체의 인바운드 wikilink를 재작성한 뒤 파일을 옮깁니다. #231이 이동을 원자적으로 만들고 맨 뒤에 두어서, 크래시가 나면 페이지는 옛 경로에 있고 일부 링크만 새 이름을 가리키며, 같은 명령을 다시 돌리면 거기서 수렴합니다.

빠져 있던 것은 재실행해야 한다는 사실을 아무도 알려주지 않는다는 점입니다. `lint`는 절반만 재작성된 링크를 그냥 깨진 링크로 보고할 뿐 rename이 원인이라는 단서를 주지 않아서, 볼트가 그 상태로 무기한 남고 링크는 계속 깨져 있습니다.

## 방법

마커가 메커니즘의 전부입니다. 스테이징 디렉터리도, 백업 사본도, 트랜잭션 로그도 없습니다. 이동은 이미 원자적이고 재실행은 이미 수렴하므로 되돌릴 것이 없습니다. 마커는 "이건 안 끝났으니 다시 돌려라"만 말하면 됩니다.

마커를 못 쓰면 `--apply`를 거부합니다. 마커가 선택적인 감지 장치는 아무것도 감지하지 못합니다.

교차 검토가 머지 전에 세 가지를 잡았습니다. 셋 다 자신 있게 보고하면서 틀리는 감지 장치를 내보낼 뻔한 것들입니다.

**두 번째 rename이 첫 번째의 마커를 덮어썼습니다.** rename A가 죽고 rename B가 성공하면 B가 A의 마커를 지워서, A의 절반짜리 재작성이 영구히 감지 불가가 됩니다. 이제 `--apply`가 기존 마커를 먼저 읽습니다. `mode`/`from`/`to`가 같으면 정당한 재실행이므로 진행하고, 다르면 상대 rename의 경로를 메시지에 담아 거부하며, 읽을 수 없는 마커도 거부합니다. 이번 것과 구별할 수 없기 때문이고, "판정 불가"는 "통과"가 아닙니다.

**이동과 마커 삭제 사이의 크래시가 끝난 rename을 미완으로 보이게 했고**, doctor는 거기에 `--from`이 더 이상 해석되지 않는 명령을 재실행하라고 답했습니다. 이제 doctor가 두 경로를 디스크에서 확인합니다. `from`이 있으면 진짜 미완이니 재실행, `from`이 없고 `to`가 있으면 이동은 끝났고 마커만 남은 것이니 지우기만 하고 다시 할 것은 없음, 그 외에는 판정 불가로 보고해 사람이 보게 합니다.

**오래된 볼트는 마커를 커밋할 수 있습니다.** `.cache/`는 볼트 템플릿의 gitignore에 있지만 `init`이 기존 `.gitignore`를 고치지 않아서, legacy 볼트는 마커를 git에 싣고 다른 머신으로 유령 경고를 옮깁니다. 이제 doctor가 마커를 보고할 때 그 경로가 실제로 무시되는지 확인하고, 아니면 gitignore 안내를 덧붙입니다. git 저장소가 아니거나 조회가 답을 못 주면 오류 없이 안내만 조용히 생략합니다.

## 수동 검증

```
npm test                              -> 1849 passed, 0 failed
npm run lint                          -> 0 error(s)
node scripts/check-pack-surface.mjs   -> 133 files, 0 closure violations
```

크래시 창은 추론이 아니라 재현했습니다. `scripts/`의 일회용 패치 사본이 지정한 지점에서 SIGKILL로 자살합니다.

- 3번째 `atomicWrite` 뒤(마커 + 인바운드 4건 중 2건): 마커가 올바른 `mode`/`from`/`to`로 살아남고, 페이지는 안 옮겨졌고, 재작성이 진짜 부분적입니다(0도 4도 아님). 재실행하면 수렴하고 마커가 사라집니다.
- `renameSync` 직후: 페이지는 옮겨졌고 마커는 stale이며, doctor가 삭제를 권하고 detail 문자열 어디에도 재실행 문구가 없습니다.
- `.cache/`를 쓰기 불가로 만든 상태: `--apply`가 비0으로 종료하고 재작성 0, 이동 0입니다.

회귀 증명. 방어를 하나씩 껐다가 되돌렸습니다.

| 무력화한 것 | red가 난 단언 |
|---|---|
| 마커 쓰기 | fail-closed, 크래시 복구 |
| 마커 지우기 | 성공 시 정리(page/directory), 재실행 수렴 |
| fail-closed를 경고로 격하 | fail-closed |
| doctor 손상 마커 분기를 pass로 복원 | 잘못된 JSON, from/to 누락 |
| 기존 마커 가드 | 다른 rename 거부, 읽기 불가 거부 |
| doctor stale 분기(항상 재실행 안내) | 재실행이 아니라 정리, 이동 후 크래시 |
| gitignore 안내 | 무시되지 않는 `.cache/`에 안내 |
| 마커가 있으면 무조건 거부 | 정당한 재실행 경로 4건이 깨짐 |

마지막 행이 남길 가치가 있습니다. 과잉 가드는 이 기능이 권하려고 존재하는 바로 그 재실행을 막았을 겁니다.

**다루지 않은 것:** 이 보장은 SIGKILL 수준입니다. `atomicWrite`가 파일이나 디렉터리를 fsync하지 않으므로 전원 손실이나 OS 크래시를 건넌 순서는 주장하지 않습니다.

## 마이그레이션 노트

None. 기존 볼트는 할 일이 없습니다. 마커는 필요할 때 만들어지고 성공 시 사라집니다.

---

## Changelog

- EN: `hypo:doctor` now detects a rename that was interrupted partway and tells you whether to re-run it or just delete the leftover marker, instead of leaving the half-rewritten links to show up as ordinary broken links (#233)
- KO: `hypo:doctor`가 중간에 끊긴 rename을 감지해, 재실행해야 하는지 남은 마커만 지우면 되는지 알려 줍니다. 절반만 재작성된 링크가 그냥 깨진 링크로만 보이던 것이 바뀝니다 (#233)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
