### PR TITLE
refactor(sync): put the sync-op verdict in one place so the two surfaces cannot diverge

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -20,6 +20,7 @@ import {
   readSyncState,
   clearSyncState,
   recordSyncSuccess,
+  classifySyncOp,
   readClearMarker,
   clearClearMarker,
   loadHypoIgnore,
@@ -306,14 +307,15 @@ function syncStateNotice(pullOk) {
     return '';
   }
   const last = entries[entries.length - 1];
-  // 'conflict-unresolved' (the merge --abort itself failed, syncRemote) is the
-  // more dangerous of the two conflict ops: the tree may still be half-merged
-  // (unmerged index entries, or an in-progress MERGE_HEAD), so the plain
-  // "pull --no-rebase" advice below is not enough and would be actively wrong
-  // — it tells the user their local work is safely committed when it may not
-  // be. Check this BEFORE the generic startsWith('conflict') branch so it gets
-  // its own guidance rather than being swallowed by the 'conflict' wording.
-  if (last.op === 'conflict-unresolved') {
+  // classifySyncOp (hypo-shared.mjs) is the single judgment both this hook
+  // and doctor.mjs's checkSyncState branch on, so the two surfaces cannot
+  // silently diverge on WHICH op gets which treatment: this exact check used
+  // to be an exact `=== 'conflict'` comparison here that missed
+  // 'conflict-unresolved' — the MORE dangerous op, since the abort itself
+  // failed and the tree may still be half-merged — while doctor already
+  // caught it via startsWith('conflict').
+  const cls = classifySyncOp(last.op);
+  if (cls === 'conflict-unresolved') {
     return (
       `[WIKI: remote diverged AND the automatic merge-abort failed — the working ` +
       `tree may still be half-merged (unmerged paths or an in-progress merge). ` +
@@ -323,16 +325,24 @@ function syncStateNotice(pullOk) {
       `— or run \`git -C ${HYPO_DIR} merge --abort\` to discard it instead, before continuing.]`
     );
   }
-  // startsWith, not ===: matches doctor.mjs's checkSyncState, which already
-  // treats every 'conflict*' op the same way. An exact-match check here used
-  // to miss 'conflict-unresolved' — the MORE dangerous op — and fall through
-  // to the generic "last sync failed" line below, which carries no manual-
-  // merge guidance at all.
-  if (String(last.op || '').startsWith('conflict')) {
+  if (cls === 'conflict') {
     return (
       `[WIKI: remote diverged — auto-merge was aborted to protect your edits ` +
       `(your local work is committed and safe; the other machine's version is on the remote). ` +
       `Resolve manually: \`git -C ${HYPO_DIR} pull --no-rebase\`, fix conflicts, then push.]`
+    );
+  }
+  // An unrecognized `conflict*` op — some future syncRemote failure mode this
+  // hook has no dedicated branch for. Neither the clean-conflict claim above
+  // ("committed and safe") nor the conflict-unresolved claim ("the abort
+  // failed") is known to be true here, so assert neither: say plainly that
+  // the state is unknown and treat it as unresolved until a human checks.
+  if (cls === 'unknown-conflict') {
+    return (
+      `[WIKI: remote diverged — an unrecognized conflict-related sync failure was recorded ` +
+      `(op='${last.op}'). Its resolution state cannot be confirmed automatically, so treat it ` +
+      `as unresolved: do NOT commit or push yet. Inspect \`git -C ${HYPO_DIR} status\` first for ` +
+      `unmerged paths or an in-progress merge before continuing.]`
     );
   }
   return `[WIKI: last sync failed: ${last.op || '?'} — ${last.error || 'unknown'}]`;

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1674,6 +1674,39 @@ function syncStatePath(hypoDir) {
 }
 
 /**
+ * Classify a sync-state `op` into the guidance branch it needs. Centralized
+ * here — rather than each surface repeating its own string check — because
+ * hypo-session-start.mjs's syncStateNotice and doctor.mjs's checkSyncState
+ * used to each carry their own comparison, and drifted: session-start's
+ * exact `=== 'conflict'` check silently missed 'conflict-unresolved' (the
+ * MORE dangerous op, since the abort itself failed and the tree may still be
+ * half-merged) and fell through to the generic "last sync failed" line,
+ * while doctor's `startsWith('conflict')` already caught it. Both
+ * callers now branch on this single function's return value, so they cannot
+ * silently diverge on WHICH op gets which treatment again — only on the
+ * prose each renders for a given branch.
+ *
+ * Both known ops are matched by EXACT string, not startsWith: a future
+ * `conflict-*` value this function has never seen (e.g. a new syncRemote
+ * failure mode added later) must not silently fall into either known
+ * bucket. 'conflict' asserts the abort succeeded and local work is safely
+ * committed; 'conflict-unresolved' asserts the abort itself failed. Neither
+ * claim is known to hold for an op nobody has written a branch for yet, so
+ * it gets its own conservative 'unknown-conflict' bucket instead of
+ * inheriting either surface's reassurance by accident.
+ *
+ * @param {string} op
+ * @returns {'conflict-unresolved'|'conflict'|'unknown-conflict'|'other'}
+ */
+export function classifySyncOp(op) {
+  const s = String(op || '');
+  if (s === 'conflict-unresolved') return 'conflict-unresolved';
+  if (s === 'conflict') return 'conflict';
+  if (s.startsWith('conflict')) return 'unknown-conflict';
+  return 'other';
+}
+
+/**
  * Append a sync failure entry. Best-effort — never throws, since a failed
  * failure-log must not break the Stop hook that calls it.
  *

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -25,6 +25,7 @@ import { parseFrontmatter } from './lib/frontmatter.mjs';
 import {
   readSyncState,
   readSyncLastSuccess,
+  classifySyncOp,
   projectSuggestionsPath,
   collectProjectWorkingDirs,
   detectSessionCloseArtifact,
@@ -1092,21 +1093,24 @@ function checkSyncState(hypoDir) {
             .map((e) => `${e.op || '?'}@${e.timestamp || '?'}`)
             .join(', ')}${entries.length > 5 ? ` (+${entries.length - 5} more)` : ''}.`
         : '';
-    // 'conflict-unresolved' (the merge --abort itself failed, syncRemote) is
-    // the more dangerous of the two conflict ops: the tree may still be
-    // half-merged (unmerged index entries, or an in-progress MERGE_HEAD).
-    // Checked BEFORE the generic startsWith('conflict') branch below — that
-    // branch used to swallow this op too and claim "your local work is
-    // committed", which is not true when the abort itself failed, and its
-    // `git pull --no-rebase` advice would simply be refused by git while a
-    // merge is still in progress. Wording mirrors hypo-session-start.mjs's
+    // classifySyncOp (hooks/hypo-shared.mjs) is the single judgment both this
+    // check and hypo-session-start.mjs's syncStateNotice branch on, so the
+    // two surfaces cannot silently diverge on WHICH op gets which treatment.
+    // 'conflict-unresolved' — the merge --abort itself failed — is the more
+    // dangerous of the two conflict ops: the tree may still be
+    // half-merged (unmerged index entries, or an in-progress MERGE_HEAD), so
+    // it gets dedicated guidance rather than the plain-conflict branch below,
+    // which claims "your local work is committed" (not true when the abort
+    // itself failed) and advises `git pull --no-rebase` (git would simply
+    // refuse that mid-merge). Wording mirrors hypo-session-start.mjs's
     // syncStateNotice so the two surfaces never contradict each other.
-    if (last.op === 'conflict-unresolved') {
+    const cls = classifySyncOp(last.op);
+    if (cls === 'conflict-unresolved') {
       warn(
         'Sync state',
         `${entries.length} unresolved sync issue(s) — last: remote diverged AND the automatic merge-abort failed; the working tree may still be half-merged (unmerged paths or an in-progress merge). Do NOT commit or push yet. Run \`git status\` first: if a merge is in progress, resolve the conflicts, then \`git add <resolved paths>\` and \`git commit\` (git refuses a commit while unmerged entries remain staged) — or run \`git merge --abort\` to discard it instead, before continuing.${unresolvedList}${successSuffix}`,
       );
-    } else if (String(last.op || '').startsWith('conflict')) {
+    } else if (cls === 'conflict') {
       // A merge conflict needs a real manual merge, not a plain push/pull —
       // give the same explicit guidance session-start does instead of the
       // generic hint. This branch is unmerged-index-free by construction (the
@@ -1114,6 +1118,16 @@ function checkSyncState(hypoDir) {
       warn(
         'Sync state',
         `${entries.length} unresolved sync issue(s) — last: remote diverged (merge conflict). Your local work is committed; the other machine's version is on the remote. Resolve with \`git pull --no-rebase\`, fix conflicts, \`git add\` them, then commit and push.${unresolvedList}${successSuffix}`,
+      );
+    } else if (cls === 'unknown-conflict') {
+      // An unrecognized `conflict*` op — a future syncRemote failure mode
+      // this check has no dedicated branch for. Neither the 'conflict'
+      // branch's "committed" claim nor the 'conflict-unresolved' branch's
+      // "abort failed" claim is known to hold here, so assert neither:
+      // report the state as unknown and treat it as unresolved.
+      warn(
+        'Sync state',
+        `${entries.length} unresolved sync issue(s) — last: remote diverged — an unrecognized conflict-related sync failure ('${last.op}') was recorded. Its resolution state cannot be confirmed automatically — treat it as unresolved. Run \`git status\` first to check for unmerged paths or an in-progress merge before committing or pushing.${unresolvedList}${successSuffix}`,
       );
     } else {
       warn(

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -329,6 +329,48 @@ test('doctor-sync-state-warn: conflict-unresolved entry → dedicated half-merge
   });
 });
 
+// A `conflict*` op this check has no dedicated branch for (a future
+// syncRemote failure mode, neither 'conflict' nor 'conflict-unresolved')
+// must not default into the plain-conflict "committed" reassurance via a
+// startsWith('conflict') fallback — that claim is not known to hold for an
+// unrecognized op, and neither is 'conflict-unresolved''s "the abort failed".
+// Report the state as unknown and treat it as unresolved instead.
+test('doctor-sync-state-warn: unrecognized conflict-* op → conservative unresolved guidance, no borrowed claim', () => {
+  withTmpDir((dir) => {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    mkdirSync(join(dir, 'projects'), { recursive: true });
+    mkdirSync(join(dir, 'sources'), { recursive: true });
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-08-05T00:00:00Z',
+        op: 'conflict-future-op',
+        error: 'unrecognized failure mode',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Sync state');
+    assert.ok(check, 'Sync state check not found');
+    assert.equal(check.status, 'warn', `expected warn: ${check.detail}`);
+    assert.ok(
+      /diverged/.test(check.detail) && /unresolved/.test(check.detail),
+      `unrecognized conflict-* op must warn as unresolved: ${check.detail}`,
+    );
+    assert.ok(
+      !/your local work is committed/i.test(check.detail),
+      `unrecognized conflict-* op must NOT borrow the clean-conflict "committed" claim: ${check.detail}`,
+    );
+    assert.ok(
+      !/automatic merge-abort failed/i.test(check.detail),
+      `unrecognized conflict-* op must NOT borrow the conflict-unresolved "abort failed" claim: ${check.detail}`,
+    );
+  });
+});
+
 // FEAT-34: last-success timestamp visibility in the sync-state check.
 suite('doctor.mjs — FEAT-34: sync-last-success visibility');
 

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -25,6 +25,7 @@ import {
   computeSessionGrowth,
   recordSyncSuccess,
   readSyncLastSuccess,
+  classifySyncOp,
 } from '../hooks/hypo-shared.mjs';
 import { test, suite } from './harness.mjs';
 import {
@@ -2197,10 +2198,169 @@ test('session-start surfaces a conflict-unresolved entry with half-merged-tree g
       `conflict-unresolved must warn about a possibly half-merged tree, not the plain conflict wording: ${ctx}`,
     );
     assert.ok(
-      !ctx.includes('your local work is committed and safe'),
-      `conflict-unresolved must NOT reuse the clean-conflict "committed and safe" claim (the abort itself failed): ${ctx}`,
+      // /i, not a literal-substring check: the clean-conflict branch could be
+      // reworded ("Your local work is committed", capitalized, no "and safe")
+      // without tripping an exact-substring negative — this must catch any
+      // rephrasing of the same false reassurance, matching doctor.test.mjs's
+      // equivalent check.
+      !/your local work is committed/i.test(ctx),
+      `conflict-unresolved must NOT reuse the clean-conflict "committed" claim (the abort itself failed): ${ctx}`,
     );
   });
+});
+
+// A `conflict*` op this hook has no dedicated branch for (a future syncRemote
+// failure mode neither 'conflict' nor 'conflict-unresolved') must NOT default
+// into the clean-conflict "committed and safe" reassurance — that claim is
+// not known to hold for an unrecognized op — nor assert the conflict-
+// unresolved branch's "the abort failed", which is equally unverified here.
+test('session-start treats an unrecognized conflict-* op as unresolved, without either conflict branch\'s claim', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-08-05T00:00:00Z',
+        op: 'conflict-future-op',
+        error: 'unrecognized failure mode',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = runStart(dir);
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(ctx.includes('remote diverged'), `unknown-conflict notice missing: ${ctx}`);
+    assert.ok(/unresolved/.test(ctx), `unknown-conflict must say to treat it as unresolved: ${ctx}`);
+    assert.ok(
+      !/your local work is committed/i.test(ctx),
+      `unknown-conflict must NOT borrow the clean-conflict "committed" claim: ${ctx}`,
+    );
+    assert.ok(
+      !/automatic merge-abort failed/i.test(ctx),
+      `unknown-conflict must NOT borrow the conflict-unresolved "abort failed" claim (not verified for an unknown op): ${ctx}`,
+    );
+  });
+});
+
+test('session-start emits no conflict/half-merged guidance for an unrelated op (regression guard)', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'sync-state.json'),
+      JSON.stringify({
+        timestamp: '2026-05-14T00:00:00Z',
+        op: 'push',
+        error: 'network timeout',
+        host: 'test',
+      }) + '\n',
+    );
+    const r = runStart(dir);
+    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    assert.ok(ctx.includes('last sync failed'), `generic sync notice missing: ${ctx}`);
+    assert.ok(!ctx.includes('remote diverged'), `unrelated op must not get conflict wording: ${ctx}`);
+    assert.ok(!/half-merged/.test(ctx), `unrelated op must not get half-merged wording: ${ctx}`);
+  });
+});
+
+suite('IMPR-31 — session-start and doctor share one sync-op judgment');
+
+test('classifySyncOp: exhaustive op set (conflict-unresolved / conflict / unknown-conflict / other)', () => {
+  assert.equal(classifySyncOp('conflict-unresolved'), 'conflict-unresolved');
+  assert.equal(classifySyncOp('conflict'), 'conflict');
+  // An unrecognized conflict-* value must NOT fall into the known 'conflict'
+  // bucket by startsWith accident — it gets its own conservative bucket.
+  assert.equal(classifySyncOp('conflict-future-op'), 'unknown-conflict');
+  assert.equal(classifySyncOp('conflict-abort-failed'), 'unknown-conflict');
+  assert.equal(classifySyncOp('pull'), 'other');
+  assert.equal(classifySyncOp('push'), 'other');
+  assert.equal(classifySyncOp(undefined), 'other');
+  assert.equal(classifySyncOp(''), 'other');
+});
+
+// Regression guard for the exact split this fix closes: before it,
+// hypo-session-start.mjs used an exact `=== 'conflict'` check that missed
+// 'conflict-unresolved' while doctor.mjs's `startsWith('conflict')` already
+// caught it. Both surfaces now branch on classifySyncOp, so this drives every
+// op through BOTH real hooks/scripts and asserts they land on the same
+// wording family — a defense a per-surface test cannot catch, since each of
+// those only proves its own surface, never that the two still agree.
+test('session-start and doctor render the same wording family for every sync-state op (parity)', () => {
+  const ops = [
+    'conflict-unresolved',
+    'conflict',
+    'conflict-future-op',
+    'pull',
+    'push',
+    'future-unknown-op',
+  ];
+  for (const op of ops) {
+    withGrowthWiki((dir) => {
+      mkdirSync(join(dir, '.cache'), { recursive: true });
+      writeFileSync(
+        join(dir, '.cache', 'sync-state.json'),
+        JSON.stringify({ timestamp: '2026-06-19T00:00:00Z', op, error: 'x', host: 'test' }) + '\n',
+      );
+      const startCtx = JSON.parse(runStart(dir).stdout).additionalContext || '';
+      const doctorOut = JSON.parse(
+        run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']).stdout,
+      );
+      const doctorDetail = doctorOut.find((c) => c.label === 'Sync state')?.detail || '';
+
+      const cls = classifySyncOp(op);
+      if (cls === 'conflict-unresolved') {
+        assert.ok(
+          /half-merged/.test(startCtx),
+          `session-start missing half-merged wording for op=${op}: ${startCtx}`,
+        );
+        assert.ok(
+          /half-merged/.test(doctorDetail),
+          `doctor missing half-merged wording for op=${op}: ${doctorDetail}`,
+        );
+      } else if (cls === 'conflict') {
+        assert.ok(
+          /diverged/.test(startCtx) && !/half-merged/.test(startCtx),
+          `session-start conflict wording wrong for op=${op}: ${startCtx}`,
+        );
+        assert.ok(
+          /diverged/.test(doctorDetail) && !/half-merged/.test(doctorDetail),
+          `doctor conflict wording wrong for op=${op}: ${doctorDetail}`,
+        );
+      } else if (cls === 'unknown-conflict') {
+        // The policy this branch pins: an unrecognized conflict-* op must be
+        // treated conservatively — surfaced and unresolved — but WITHOUT
+        // borrowing either known branch's claim (neither "committed and
+        // safe" nor "the abort failed" is verified for an op nobody wrote a
+        // branch for). This is the case the earlier version of this test
+        // could not catch: 'conflict-future-op' used to fall into the plain
+        // 'conflict' bucket via startsWith and get the false "committed and
+        // safe" reassurance on both surfaces.
+        assert.ok(
+          /diverged/.test(startCtx) && /unresolved/.test(startCtx),
+          `session-start unknown-conflict wording wrong for op=${op}: ${startCtx}`,
+        );
+        assert.ok(
+          !/your local work is committed/i.test(startCtx),
+          `session-start unknown-conflict must not reuse the committed claim for op=${op}: ${startCtx}`,
+        );
+        assert.ok(
+          /diverged/.test(doctorDetail) && /unresolved/.test(doctorDetail),
+          `doctor unknown-conflict wording wrong for op=${op}: ${doctorDetail}`,
+        );
+        assert.ok(
+          !/your local work is committed/i.test(doctorDetail),
+          `doctor unknown-conflict must not reuse the committed claim for op=${op}: ${doctorDetail}`,
+        );
+      } else {
+        assert.ok(
+          !/diverged/.test(startCtx) && !/half-merged/.test(startCtx),
+          `session-start must not use conflict wording for op=${op}: ${startCtx}`,
+        );
+        assert.ok(
+          !/diverged/.test(doctorDetail) && !/half-merged/.test(doctorDetail),
+          `doctor must not use conflict wording for op=${op}: ${doctorDetail}`,
+        );
+      }
+    });
+  }
 });
 
 // ── FEAT-34: last-success timestamp visibility ──────────────────────────────


### PR DESCRIPTION
# English

## What changed

`classifySyncOp` now owns the verdict on a recorded sync failure, and both surfaces that advise the user (the session-start banner and `hypo:doctor`) call it instead of carrying their own string comparison. An unrecognized conflict-shaped op gets its own conservative branch.

## Why

`syncRemote` records four op values. A merge conflict whose `merge --abort` succeeded is `conflict`: the tree is back at a clean local commit. One whose abort failed is `conflict-unresolved`: the tree may still be half-merged. The second is the dangerous one, and it needs different advice.

Two surfaces read that state. Each carried its own comparison. They agree today because #225 fixed both in the same commit, but nothing made them agree, so changing one could silently reintroduce the split that #225 closed. This is not a bug report; it is removing the conditions for the same bug to come back.

## How

The verdict lives in `hooks/hypo-shared.mjs` because hooks are copied standalone into `~/.claude/hooks/` and cannot import from `scripts/`. `doctor.mjs` already imported that module, and the `scripts/` to `hooks/` direction is the allowed one.

Cross-review caught a real hazard in the first draft. Matching conflict-prefixed values with `startsWith` sent every future one down the reassuring branch, so a later `conflict-abort-failed` would have been told "your local work is committed and safe". The classifier now matches the two known values exactly and routes anything else conflict-shaped to its own bucket, which says the resolution state cannot be confirmed and to treat it as unresolved.

That bucket deliberately does not reuse the `conflict-unresolved` wording. That text asserts the automatic abort failed, which nobody can know of a value that has never been seen. Borrowing it would trade one wrong claim for another.

## Manual verification

```
npm test                              -> 1856 passed, 0 failed
npm run lint                          -> 0 error(s)
node scripts/check-pack-surface.mjs   -> 133 files, 0 closure violations
```

Regression proof, each defense disabled in turn and restored:

| disabled | assertion that went red |
|---|---|
| session-start reverted to its own comparison, doctor left on the shared one | parity, plus both conflict-branch tests |
| classifier back to `startsWith` (unknown ops reassured) | unknown-conflict on both surfaces, exhaustive op set |
| unknown bucket collapsed into `conflict-unresolved` | same three, on the borrowed "abort failed" claim |

The parity test spawns both surfaces for every op and compares the wording family, which is what makes the first row fail. Cross-review noted its limit honestly: it derives expectations from the same classifier, so two surfaces that each duplicated equivalent logic would still pass. It pins behavioral parity, not the single-source structure.

No hook QA run for this branch. The session-start hook changed, so the deployed copy's behavior is worth confirming before merge if you want the stronger guarantee. The argument that it is low risk: the four op values in the tree today classify exactly as before, and the new branch is reachable only by an op value that nothing currently writes.

## Migration notes

None. No existing op value changes classification.

---

# 한국어

## 변경 내용

기록된 동기화 실패를 어떻게 볼지는 이제 `classifySyncOp` 이 정합니다. 사용자에게 안내하는 두 표면(세션 시작 배너와 `hypo:doctor`)이 각자 문자열 비교를 들고 있는 대신 그 함수를 호출합니다. 인식되지 않는 conflict 계열 op 는 별도의 보수적 분기로 갑니다.

## 이유

`syncRemote` 는 네 가지 op 를 기록합니다. `merge --abort` 가 성공한 머지 충돌은 `conflict` 이고 트리가 깨끗한 로컬 커밋으로 돌아온 상태입니다. abort 가 실패한 쪽은 `conflict-unresolved` 이고 트리가 여전히 half-merged 일 수 있습니다. 후자가 위험한 쪽이고 다른 안내가 필요합니다.

두 표면이 그 상태를 읽습니다. 각자 비교를 들고 있었습니다. 지금 일치하는 것은 #225 가 둘을 같은 커밋에서 고쳤기 때문이지 무엇도 그것을 강제하지 않았습니다. 한쪽을 바꾸면 #225 가 닫은 갈림이 조용히 되살아납니다. 버그 보고가 아니라 같은 버그가 돌아올 조건을 없애는 작업입니다.

## 방법

판정은 `hooks/hypo-shared.mjs` 에 둡니다. 훅은 `~/.claude/hooks/` 로 단독 복사되므로 `scripts/` 를 임포트할 수 없습니다. `doctor.mjs` 는 이미 그 모듈을 임포트하고 있었고, `scripts/` → `hooks/` 방향이 허용된 쪽입니다.

교차 검토가 초안의 실제 위험을 짚었습니다. conflict 접두를 `startsWith` 로 잡으면 앞으로 추가되는 값이 전부 안심 분기로 갑니다. 나중에 `conflict-abort-failed` 가 생기면 "your local work is committed and safe" 를 받습니다. 이제 알려진 두 값만 정확히 매치하고, 그 밖의 conflict 계열은 자기 버킷으로 보내 해소 상태를 확인할 수 없으니 unresolved 로 취급하라고 안내합니다.

그 버킷은 `conflict-unresolved` 문구를 **일부러** 재사용하지 않습니다. 그 텍스트는 자동 abort 가 실패했다고 단정하는데, 아무도 본 적 없는 값이 그런지는 알 수 없습니다. 빌려 쓰면 틀린 단정 하나를 다른 틀린 단정으로 바꾸는 것뿐입니다.

## 수동 검증

```
npm test                              -> 1856 passed, 0 failed
npm run lint                          -> 0 error(s)
node scripts/check-pack-surface.mjs   -> 133 files, 0 closure violations
```

회귀 증명. 방어를 하나씩 껐다가 되돌렸습니다.

| 무력화한 것 | red 가 난 단언 |
|---|---|
| session-start 만 자기 비교로 복원(doctor 는 공유 함수 유지) | parity, 그리고 conflict 분기 테스트 둘 |
| 분류기를 `startsWith` 로 복원(미지 op 가 안심 분기로) | 두 표면의 unknown-conflict, exhaustive op set |
| unknown 버킷을 `conflict-unresolved` 로 합침 | 위 셋, 빌려 온 "abort 실패" 단정에서 |

parity 테스트는 op 마다 두 표면을 실제로 spawn 해 문구 계열을 비교하고, 그래서 첫 행이 실패합니다. 다만 교차 검토가 그 한계를 정직하게 짚었습니다. 기대값을 같은 분류기에서 얻으므로, 두 표면이 각각 동등한 로직을 복제해도 통과합니다. 행동 parity 를 고정하지 단일 출처 구조까지 강제하지는 않습니다.

이 브랜치의 훅 QA 는 하지 않았습니다. session-start 훅이 바뀌었으니 더 강한 보증을 원하면 머지 전에 배포 사본 동작을 확인해 주세요. 위험이 낮다고 보는 근거는, 현재 트리의 네 op 값이 이전과 정확히 같게 분류되고 새 분기는 지금 아무도 기록하지 않는 op 값으로만 도달 가능하다는 것입니다.

## 마이그레이션 노트

None. 기존 op 값의 분류가 바뀌지 않습니다.

---

## Changelog

- EN: None (no user-visible change today; the four op values in the tree classify exactly as before, and the new branch is reachable only by an op value nothing currently writes)
- KO: None (지금 사용자에게 보이는 변화 없음. 현재 네 op 값의 분류가 이전과 같고, 새 분기는 아직 아무도 기록하지 않는 op 값으로만 도달합니다)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
