### PR TITLE
fix(hooks): resolve PKG_ROOT from where the code actually runs, not from a cache nobody updates

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -37,6 +37,7 @@ import {
   currentDevice,
   scopeVisible,
   readVisibilityScope,
+  pkgRootDriftStatus,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -50,6 +51,9 @@ import {
   computeSiblingNotice,
   siblingAlreadyNotified,
   markSiblingNotified,
+  pkgRootDriftAlreadyNotified,
+  markPkgRootDriftNotified,
+  clearPkgRootDriftNotified,
 } from './version-check.mjs';
 import { snapshotBase, overwriteTargets } from './base-store.mjs';
 import { listProposals } from './proposal-store.mjs';
@@ -211,6 +215,52 @@ function buildSiblingNotice() {
     if (siblingAlreadyNotified(cache, notice.key)) return '';
     markSiblingNotified(cachePath, notice.key);
     return notice.line;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * pkgRoot drift notice. hypo-shared.mjs's resolvePkgRoot() already
+ * self-corrects PKG_ROOT in memory whenever the code's own resolved location
+ * disagrees with the cached hypo-pkg.json — but silent self-correction is the
+ * exact failure this closes: the user's own `upgrade` habit stops mattering
+ * and nothing ever tells them hypo-pkg.json fell behind. Surfaced once per
+ * (cached → self-location) pair via the same notify-once cache the sibling
+ * notice above uses — a fresh drift (new self-location) re-notifies, but
+ * staying on the same drifted state doesn't nag every session.
+ *
+ * Tri-state (pkgRootDriftStatus): 'match' CLEARS any earlier mark (checked
+ * FIRST, unconditionally — even under opt-out, so a drift that resolves while
+ * opted out doesn't leave a stale mark that then suppresses a genuine
+ * recurrence once opt-out is lifted); 'unknown' touches nothing (self-location
+ * could not be resolved this session — the permanent steady state for the
+ * npm/manual channel, not evidence either way); only 'drift' can produce a
+ * banner, and opt-out is checked there so an opted-out session never marks a
+ * pair as notified it never actually showed.
+ */
+function buildPkgRootDriftNotice() {
+  try {
+    const status = pkgRootDriftStatus();
+    const cachePath = defaultCachePath();
+    if (status.status === 'match') {
+      clearPkgRootDriftNotified(cachePath);
+      return '';
+    }
+    if (status.status === 'unknown') return '';
+    if (isOptedOut()) return '';
+    const key = `${status.cached || '(none)'}->${status.self}`;
+    const cache = readCache(cachePath);
+    if (pkgRootDriftAlreadyNotified(cache, key)) return '';
+    markPkgRootDriftNotified(cachePath, key);
+    return (
+      `[Hypomnema] Package metadata drift: hypo-pkg.json still points at ` +
+      `\`${status.cached || '(none)'}\`, but the code actually running resolves to ` +
+      `\`${status.self}\`.\n` +
+      `  Hooks already resolved the correct root for this session — this is a ` +
+      `heads-up, not a blocker.\n` +
+      `  → run \`/hypo:upgrade --apply\` to bring hypo-pkg.json back in sync.`
+    );
   } catch {
     return '';
   }
@@ -449,15 +499,17 @@ process.stdin.on('end', () => {
     const clearRecoveryLine = buildClearRecoveryLine(data.source);
     const updateLine = buildUpdateNotice();
     const siblingLine = buildSiblingNotice();
-    // The update + stale-sibling banners must reach the USER. On a
-    // SessionStart hook that exits 0, stderr is invisible in the normal TUI
-    // (only shown on exit 2 / --verbose) and additionalContext is model-only —
-    // `systemMessage` is the documented user-visible channel. Route those two
-    // banners there. They ALSO stay in noticePrefix → additionalContext below,
-    // so the model and the user start the session looking at the same state.
-    // (The other stderr notices — sync/growth/clear/suggest — are intentionally
-    // transcript/--verbose only and out of this banner's scope.)
-    const userMessage = [updateLine, siblingLine].filter(Boolean).join('\n\n');
+    const pkgDriftLine = buildPkgRootDriftNotice();
+    // The update + stale-sibling + pkgRoot-drift banners must reach the USER.
+    // On a SessionStart hook that exits 0, stderr is invisible in the normal
+    // TUI (only shown on exit 2 / --verbose) and additionalContext is
+    // model-only — `systemMessage` is the documented user-visible channel.
+    // Route those banners there. They ALSO stay in noticePrefix →
+    // additionalContext below, so the model and the user start the session
+    // looking at the same state. (The other stderr notices —
+    // sync/growth/clear/suggest — are intentionally transcript/--verbose only
+    // and out of this banner's scope.)
+    const userMessage = [updateLine, siblingLine, pkgDriftLine].filter(Boolean).join('\n\n');
     if (userMessage) outExtra = { ...outExtra, systemMessage: userMessage };
     const notices = [
       syncLine,
@@ -466,6 +518,7 @@ process.stdin.on('end', () => {
       clearRecoveryLine,
       updateLine,
       siblingLine,
+      pkgDriftLine,
     ].filter(Boolean);
     let noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
     if (syncLine) process.stderr.write(`\n\x1b[33m${syncLine}\x1b[0m\n`);
@@ -475,6 +528,7 @@ process.stdin.on('end', () => {
       process.stderr.write(`\n\x1b[33m${clearRecoveryLine.split('\n')[0]}\x1b[0m\n`);
     if (updateLine) process.stderr.write(`\n\x1b[33m${updateLine}\x1b[0m\n`);
     if (siblingLine) process.stderr.write(`\n\x1b[33m${siblingLine}\x1b[0m\n`);
+    if (pkgDriftLine) process.stderr.write(`\n\x1b[33m${pkgDriftLine}\x1b[0m\n`);
     const cwd = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || 'default';
     const MARKER_FILE = sessionMarkerPath(sessionId);

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -21,10 +21,11 @@ import {
   renameSync,
   linkSync,
 } from 'fs';
-import { join, relative, basename, dirname } from 'path';
+import { join, relative, basename, dirname, isAbsolute } from 'path';
 import { homedir, hostname, tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 import { randomBytes } from 'crypto';
+import { fileURLToPath } from 'url';
 
 const HOME = homedir();
 
@@ -95,18 +96,195 @@ export const LOG_PATH = join(HYPO_DIR, 'log.md');
 export const HOT_PATH = join(HYPO_DIR, 'hot.md');
 export const GUIDE_PATH = join(HYPO_DIR, 'hypo-guide.md');
 
-// Package root: written by init/upgrade to ~/.claude/hypo-pkg.json
-function resolvePkgRoot() {
-  const p = join(HOME, '.claude', 'hypo-pkg.json');
-  if (!existsSync(p)) return null;
+// Package root: written by init/upgrade to ~/.claude/hypo-pkg.json.
+//
+// The plugin channel is the primary distribution path, and
+// Claude Code's own plugin manager updates hooks WITHOUT ever touching
+// hypo-pkg.json — only our own init/upgrade write it. So after a plugin
+// auto-update this file can point at a stale pkgRoot indefinitely with no
+// signal to the user, and PKG_ROOT (resolved here) is what lint/feedback
+// scripts get resolved through — a hook can run at the new version while the
+// script it shells out to still runs from the old one.
+//
+// An earlier version of this cross-check queried ~/.claude/settings.json's
+// `enabledPlugins` + the plugin registry to positively attribute an active
+// install. That was wrong: Claude Code layers `enabledPlugins` across
+// user/project/local/managed settings (project overrides user), and a plugin
+// with no explicit key is enabled by default — so a single-file read of the
+// user settings can neither prove "enabled" nor "disabled". Querying it was
+// certain to misjudge some real layout.
+//
+// This code already knows the one thing that can't be wrong: where IT is
+// running from. `import.meta.url`, walked up to the nearest package.json,
+// names the actual root of the code executing right now — no
+// settings/registry guessing needed. That's `selfLocationPkgRoot()` below.
+//
+// Never throw: this runs at hook-module load time (`export const PKG_ROOT =
+// resolvePkgRoot()`), so a throw here takes the whole hook process down.
+// Every read below is try/caught and every helper fails open to null.
+
+/** Non-mutating read of the cached pointer, or null on any absence/corruption. */
+function readCachedPkgRoot() {
   try {
+    const p = join(HOME, '.claude', 'hypo-pkg.json');
+    if (!existsSync(p)) return null;
     const v = JSON.parse(readFileSync(p, 'utf-8')).pkgRoot;
     return typeof v === 'string' && v ? v : null;
   } catch {
     return null;
   }
 }
+
+// A pkgRoot is usable only as an ABSOLUTE path to a real package directory
+// whose package.json carries a version. A relative path (e.g. ".") resolves
+// against whatever cwd the reading process happens to have; a directory that
+// merely EXISTS but carries no versioned package.json is a pointer nothing
+// can actually resolve scripts through. Same contract for every source of a
+// pkgRoot value in this file — the cache included (a cached `pkgRoot: "."`
+// used to pass on directory-existence alone).
+//
+// NOT sufficient by itself for self-location (see selfLocationPkgRoot below):
+// "absolute path + a package.json with SOME version" is true of any Node
+// package anywhere on disk, including one that has nothing to do with
+// Hypomnema — e.g. `$HOME/package.json` from an unrelated project. This
+// contract answers "is this a real, resolvable directory", not "is this OUR
+// package". Callers that need the latter also require self-containment.
+function isUsablePkgRootLocal(pkgRoot) {
+  if (typeof pkgRoot !== 'string' || !pkgRoot || !isAbsolute(pkgRoot)) return false;
+  try {
+    const v = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf-8')).version;
+    return typeof v === 'string' && v.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// True iff `candidateRoot` actually CONTAINS the module that is running right
+// now — i.e. `<candidateRoot>/hooks/hypo-shared.mjs` is, on disk, the exact
+// same file as `ownRealPath` (this module's own realpath). This is the
+// decisive check self-location needs and isUsablePkgRootLocal alone cannot
+// give it: a versioned package.json only proves SOME package lives at
+// `candidateRoot`, not that it is the Hypomnema install this code is part of.
+// Without this, walking up from an unrelated location (a standalone-copied
+// hooks/ dir sitting under a directory that happens to have its own,
+// unrelated package.json a few levels up — e.g. `$HOME/package.json`) would
+// silently adopt that unrelated tree as PKG_ROOT, and every script path built
+// from it (`join(PKG_ROOT, 'scripts', 'lint.mjs')`, the crystallize recovery
+// command in hypo-auto-minimal-crystallize.mjs, etc.) would point at files
+// that were never shipped there.
+//
+// Both paths are realpath'd before comparing so a symlinked candidate or a
+// symlinked ancestor of the running module (macOS's /var → /private/var, a
+// symlinked plugin cache dir) still compares correctly. Fails closed (false)
+// on any read error — a candidate this can't positively confirm is never
+// adopted.
+function candidateContainsRunningModule(candidateRoot, ownRealPath) {
+  try {
+    return realpathSync(join(candidateRoot, 'hooks', 'hypo-shared.mjs')) === ownRealPath;
+  } catch {
+    return false;
+  }
+}
+
+// Walk up from the PARENT of the directory this module (hooks/hypo-shared.mjs)
+// is actually running from, looking for the nearest ancestor that is (a) a
+// usable package root AND (b) actually contains this exact running module —
+// that IS the package root of the code currently executing, regardless of
+// which channel put it there (plugin, npm, dev checkout).
+//
+// Plugin mode runs hooks straight out of the plugin's own cache directory
+// (`${CLAUDE_PLUGIN_ROOT}/hooks/...`), so this resolves directly to whatever
+// the plugin loader most recently updated — exactly the channel that can
+// silently drift ahead of hypo-pkg.json. A manual/npm install COPIES hooks
+// standalone into ~/.claude/hooks/ with no package.json alongside (the "hooks
+// import only Node built-ins, nothing outside the hooks dir" contract), so
+// this correctly finds nothing self-containing there and resolvePkgRoot()
+// falls through to the cache — which IS authoritative for that channel, since
+// our own init/upgrade own writing it. And even if SOME unrelated ancestor
+// happens to carry its own versioned package.json (a plain "usable" root),
+// candidateContainsRunningModule rejects it: that ancestor's own hooks/
+// subdirectory (if it even has one) is not this file.
+//
+// Bounded walk: up to 6 candidate ancestors above hooks/'s own parent (the
+// ordinary root sits at the very first one; a few extra levels tolerate an
+// unusual nesting depth). Never throws, fails open to null on any error.
+function selfLocationPkgRoot() {
+  let hooksDir, ownRealPath;
+  try {
+    hooksDir = dirname(fileURLToPath(import.meta.url));
+    ownRealPath = realpathSync(join(hooksDir, 'hypo-shared.mjs'));
+  } catch {
+    return null; // can't even resolve our own path — nothing to self-contain against
+  }
+  try {
+    let dir = dirname(hooksDir); // first candidate: the ordinary root, one level above hooks/
+    for (let i = 0; i < 6; i++) {
+      if (isUsablePkgRootLocal(dir) && candidateContainsRunningModule(dir, ownRealPath)) {
+        return dir;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break; // reached filesystem root
+      dir = parent;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Resolution order: self-location wins whenever it resolves — it is a direct,
+// self-containment-verified fact about the code currently running, not an
+// inference. Only when it cannot resolve (the standalone-copied hooks case
+// above, or a genuine read failure) does the cache get to answer, and only
+// after passing the same usable-root contract as everything else here.
+function resolvePkgRoot() {
+  const self = selfLocationPkgRoot();
+  if (self) return self;
+  const cached = readCachedPkgRoot();
+  return isUsablePkgRootLocal(cached) ? cached : null;
+}
 export const PKG_ROOT = resolvePkgRoot();
+
+// realpath a path for comparison, falling back to the raw value on any error
+// (missing/unreadable/etc — the comparison then just degrades to a literal
+// string compare, same as before this existed). Never throws.
+function canonicalPath(p) {
+  if (typeof p !== 'string' || !p) return p;
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+// Tri-state comparison between the cache and the code's own resolved
+// location, for the SURFACING decision only (resolvePkgRoot() above already
+// self-corrects PKG_ROOT in memory regardless of this). Three outcomes:
+//   'match'   — cache and self-location agree (or both resolve to nothing
+//               comparable) → any earlier drift mark should be CLEARED.
+//   'drift'   — self-location resolves and DISAGREES with the cache → notify.
+//   'unknown' — self-location could not be resolved at all → leave any
+//               existing mark untouched. This is the PERMANENT steady state
+//               for the npm/manual channel (no package.json ships next to the
+//               standalone-copied hooks), not a rare hiccup — collapsing it
+//               into 'match' would let that channel silently clear a mark it
+//               never had grounds to judge, and collapsing it into 'drift'
+//               would falsely warn a channel with nothing to compare against.
+//
+// The equality check canonicalizes BOTH sides first: the cache may record a
+// symlink alias of the very same physical root selfLocationPkgRoot() just
+// walked to (a symlinked plugin cache dir, or the same /var vs /private/var
+// split candidateContainsRunningModule already has to handle) — a literal
+// string compare would misreport that as drift.
+//
+// Never throws (every helper it calls already fails open).
+export function pkgRootDriftStatus() {
+  const self = selfLocationPkgRoot();
+  if (!self) return { status: 'unknown' };
+  const cached = readCachedPkgRoot();
+  if (canonicalPath(self) === canonicalPath(cached)) return { status: 'match' };
+  return { status: 'drift', cached, self };
+}
 
 // Optional H2 allowlist for hot.md validation.
 // Set HYPO_ALLOWED_HOT_H2=comma,separated,headings to enable.

--- a/hooks/version-check.mjs
+++ b/hooks/version-check.mjs
@@ -385,6 +385,51 @@ export function markSiblingNotified(path, key) {
   }
 }
 
+// ── pkgRoot drift notice ────────────────────────────────────────────────────
+// Same notify-once shape as the sibling banner above, in a field of its own
+// (`pkgRootDriftNotifiedFor`) so the two never suppress each other — they are
+// unrelated tuples that happen to share this cache file.
+
+/** Has this exact (cached → self-location) pkgRoot-drift pair already been surfaced? */
+export function pkgRootDriftAlreadyNotified(cache, key) {
+  return Boolean(cache && cache.pkgRootDriftNotifiedFor === key);
+}
+
+/** Record that the pkgRoot-drift banner for `key` was shown (read-merge-write). */
+export function markPkgRootDriftNotified(path, key) {
+  try {
+    const cache = readCache(path) || {};
+    cache.pkgRootDriftNotifiedFor = key;
+    writeCacheAtomic(path, cache);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Clear a previously-recorded pkgRoot-drift mark once the drift is observed
+ * to be resolved (cache catches up with self-location again — status
+ * 'match'). Without this the mark is permanent: the SAME (cached →
+ * self-location) pair recurring later — e.g. hypo-pkg.json catches up, then a
+ * later plugin update or a manual edit drifts it right back to the identical
+ * pair — would stay silently suppressed forever, because only a DIFFERENT
+ * pair would ever produce a new key. Callers must NOT call this on status
+ * 'unknown' (self-location could not be resolved) — that would wrongly wipe a
+ * mark this session had no grounds to judge one way or the other. Read-merge-
+ * write, best-effort (a failure here just means the notice stays suppressed
+ * one extra cycle, never a crash).
+ */
+export function clearPkgRootDriftNotified(path) {
+  try {
+    const cache = readCache(path);
+    if (!cache || !('pkgRootDriftNotifiedFor' in cache)) return;
+    delete cache.pkgRootDriftNotifiedFor;
+    writeCacheAtomic(path, cache);
+  } catch {
+    /* best-effort */
+  }
+}
+
 /**
  * Shared one-line message for the init/upgrade downgrade guard (P). `op` is
  * 'init' or 'upgrade'. Kept here so guard text stays identical across both CLIs.

--- a/tests/notifier.test.mjs
+++ b/tests/notifier.test.mjs
@@ -15,6 +15,7 @@ import {
   symlinkSync,
   unlinkSync,
   cpSync,
+  realpathSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -835,8 +836,12 @@ suite('update-notifier (ISSUE-5): banner routed to user-visible systemMessage');
 function withFakeNpmInstall(installedVersion, fn) {
   const base = mkdtempSync(join(tmpdir(), 'hypo-npm-'));
   try {
-    const root = join(base, 'node_modules', 'hypomnema');
-    mkdirSync(root, { recursive: true });
+    const rawRoot = join(base, 'node_modules', 'hypomnema');
+    mkdirSync(rawRoot, { recursive: true });
+    // realpath: os.tmpdir() is a symlink on macOS (/var → /private/var), and
+    // self-location (hooks/hypo-shared.mjs) resolves through it — a raw join()
+    // here would carry the symlinked form and never equal that.
+    const root = realpathSync(rawRoot);
     cpSync(HOOKS, join(root, 'hooks'), { recursive: true }); // hooks are self-contained
     writeFileSync(
       join(root, 'package.json'),
@@ -845,6 +850,14 @@ function withFakeNpmInstall(installedVersion, fn) {
     const home = join(base, 'home');
     const cacheDir = join(home, '.claude', 'hypomnema', 'cache');
     mkdirSync(cacheDir, { recursive: true });
+    // Point the cache at this same root so self-location and the cache agree
+    // (status 'match') — otherwise every probe through this fixture would
+    // ALSO carry a pkgRoot-drift banner (a real, separate notice) that these
+    // update-notifier tests predate and don't assert on.
+    writeFileSync(
+      join(home, '.claude', 'hypo-pkg.json'),
+      JSON.stringify({ pkgRoot: root, pkgVersion: installedVersion }),
+    );
     const wiki = join(base, 'wiki');
     mkdirSync(wiki, { recursive: true });
     fn({
@@ -912,6 +925,434 @@ test('session-start: opted out (CI) → update banner suppressed on every channe
       runFakeStart(hook, home, wiki, 'upd-issue5-optout', { CI: 'true' }).stdout,
     );
     assert.ok(!('systemMessage' in out), 'opted-out session must not surface an update banner');
+  });
+});
+
+// ── ISSUE-70: pkgRoot self-location vs cache (resolvePkgRoot / pkgRootDriftStatus)
+// resolvePkgRoot() (hooks/hypo-shared.mjs) is exported as a const computed at
+// import time, so exercising different HOME/self-location combinations needs
+// a fresh child process per scenario — mirrors lib-core.test.mjs's
+// marker-scan pattern rather than re-importing (cached) in this process.
+//
+// A settings.json/plugin-registry cross-check approach was tried and
+// reverted here (codex review): Claude Code layers `enabledPlugins` across
+// user/project/local/managed settings with project overriding user, and a
+// plugin absent from the map is enabled by default — so a single settings
+// file can prove neither "enabled" nor "disabled", and the registry lookup
+// built on top of it was certain to misjudge some real layout. The code
+// already knows where IT is running from (import.meta.url), so self-location
+// replaces that guesswork entirely; see hooks/hypo-shared.mjs's
+// selfLocationPkgRoot() doc comment for the resolution order.
+suite('ISSUE-70: pkgRoot self-location vs cache (resolvePkgRoot / pkgRootDriftStatus)');
+
+function seedHypoPkg(home, pkgRoot) {
+  const claudeDir = join(home, '.claude');
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(
+    join(claudeDir, 'hypo-pkg.json'),
+    JSON.stringify({ pkgRoot, pkgVersion: '1.0.0' }),
+  );
+}
+
+// A pkgRoot usable per isUsablePkgRootLocal (hooks/hypo-shared.mjs): absolute
+// path, real package.json, non-empty version.
+function seedUsableRoot(root, version = '1.7.0') {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'hypomnema', version }));
+}
+
+// Copies just hooks/ into a throwaway tmp dir, so a hook running FROM that
+// copy is not self-containing anywhere in its bounded ancestor walk — mirrors
+// the real npm/manual deploy (hooks copied standalone into ~/.claude/hooks/)
+// where self-location genuinely cannot resolve. Caller must clean up the
+// returned dir.
+function standaloneHooksCopy() {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-standalone-hooks-'));
+  cpSync(HOOKS, join(dir, 'hooks'), { recursive: true });
+  return dir;
+}
+
+// Copies hooks/ WITH its own versioned package.json one level up, so a hook
+// run from the copy self-locates to `root` (the same shape as REPO, or a real
+// plugin/npm install). realpath-normalized so a self-location comparison
+// against `root` is never fooled by os.tmpdir()'s symlink on macOS.
+function withFakePkgInstall(version, fn) {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-fake-pkgroot-'));
+  try {
+    const root = join(base, 'install-root');
+    mkdirSync(root, { recursive: true });
+    const realRoot = realpathSync(root);
+    cpSync(HOOKS, join(realRoot, 'hooks'), { recursive: true });
+    writeFileSync(join(realRoot, 'package.json'), JSON.stringify({ name: 'hypomnema', version }));
+    fn(realRoot);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+// Probes hooks/hypo-shared.mjs's exported PKG_ROOT + pkgRootDriftStatus() in a
+// fresh child process. `hooksSharedPath` defaults to THIS checkout's real
+// hooks/hypo-shared.mjs, whose self-location always resolves to REPO (REPO
+// has its own versioned package.json one level above hooks/) — the direct
+// analogue of a plugin/dev install actually running. Pass a path under
+// standaloneHooksCopy() to exercise the self-location-unresolvable branch.
+function probePkgRoot(home, hooksSharedPath = join(HOOKS, 'hypo-shared.mjs')) {
+  const script = `
+    const { PKG_ROOT, pkgRootDriftStatus } = await import(${JSON.stringify(hooksSharedPath)});
+    console.log(JSON.stringify({ PKG_ROOT, status: pkgRootDriftStatus() }));
+  `;
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home, HYPO_DIR: '' },
+  });
+  assert.equal(r.status, 0, `probe process should exit 0: ${r.stderr}`);
+  return JSON.parse(r.stdout.trim());
+}
+
+test('resolvePkgRoot: self-location wins over a disagreeing cache (status: drift)', () => {
+  withTmpHome((home) => {
+    const staleRoot = join(home, 'stale-cached-root');
+    mkdirSync(staleRoot, { recursive: true });
+    seedHypoPkg(home, staleRoot);
+    const { PKG_ROOT, status } = probePkgRoot(home);
+    assert.equal(
+      PKG_ROOT,
+      REPO,
+      "PKG_ROOT must be the code's own resolved location, not the stale cache",
+    );
+    assert.equal(status.status, 'drift');
+    assert.equal(status.cached, staleRoot);
+    assert.equal(status.self, REPO);
+  });
+});
+
+test('resolvePkgRoot: cache matches self-location → status match, no noise', () => {
+  withTmpHome((home) => {
+    seedHypoPkg(home, REPO);
+    const { PKG_ROOT, status } = probePkgRoot(home);
+    assert.equal(PKG_ROOT, REPO);
+    assert.deepEqual(status, { status: 'match' });
+  });
+});
+
+test('resolvePkgRoot: hypo-pkg.json missing or corrupt never throws (self-location still resolves)', () => {
+  withTmpHome((home) => {
+    // no hypo-pkg.json at all
+    let r = probePkgRoot(home);
+    assert.equal(r.PKG_ROOT, REPO);
+    assert.equal(r.status.status, 'drift'); // cached=null !== self=REPO
+
+    // corrupt hypo-pkg.json
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'hypo-pkg.json'), '{not json');
+    r = probePkgRoot(home);
+    assert.equal(r.PKG_ROOT, REPO);
+  });
+});
+
+test('resolvePkgRoot: self-location unresolvable (standalone-copied hooks, mirrors the npm/manual deploy) → status unknown, falls back to a usable cache', () => {
+  withTmpHome((home) => {
+    const standaloneDir = standaloneHooksCopy();
+    try {
+      const usableCache = join(home, 'cached-root');
+      seedUsableRoot(usableCache);
+      seedHypoPkg(home, usableCache);
+      const r = probePkgRoot(home, join(standaloneDir, 'hooks', 'hypo-shared.mjs'));
+      assert.equal(r.status.status, 'unknown');
+      assert.equal(
+        r.PKG_ROOT,
+        usableCache,
+        'falls back to the (usable) cache when self-location cannot resolve',
+      );
+    } finally {
+      rmSync(standaloneDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('resolvePkgRoot: cache contract — an unusable cached pkgRoot (no package.json, or relative) is never returned, even with self-location unresolvable', () => {
+  withTmpHome((home) => {
+    const standaloneDir = standaloneHooksCopy();
+    try {
+      const hooksSharedPath = join(standaloneDir, 'hooks', 'hypo-shared.mjs');
+
+      // (a) existing directory, no package.json at all
+      const bareDir = join(home, 'cached-dir-no-package-json');
+      mkdirSync(bareDir, { recursive: true });
+      seedHypoPkg(home, bareDir);
+      let r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(r.PKG_ROOT, null, 'a cached dir with no package.json must not be returned');
+      assert.equal(r.status.status, 'unknown');
+
+      // (b) relative cached pkgRoot — must never be adopted
+      seedHypoPkg(home, '.');
+      r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(r.PKG_ROOT, null, 'a relative cached pkgRoot must not be returned');
+
+      // (c) package.json present but missing a version field
+      const versionlessRoot = join(home, 'versionless-root');
+      mkdirSync(versionlessRoot, { recursive: true });
+      writeFileSync(join(versionlessRoot, 'package.json'), JSON.stringify({ name: 'hypomnema' }));
+      seedHypoPkg(home, versionlessRoot);
+      r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(r.PKG_ROOT, null, 'a cached package.json without a version must not be usable');
+    } finally {
+      rmSync(standaloneDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('resolvePkgRoot: self-containment — an UNRELATED versioned package.json two levels above a standalone hooks copy is rejected → status unknown, falls back to cache', () => {
+  withTmpHome((home) => {
+    // codex repro shape: hooks copied standalone (no package.json alongside),
+    // but some ANCESTOR above it happens to carry its own, unrelated, perfectly
+    // "usable" package.json — e.g. $HOME/package.json from some other project,
+    // with the standalone hooks/ living a level or two under $HOME. That
+    // ancestor has no hooks/ of its own at all, so self-containment fails on a
+    // plain ENOENT; isUsablePkgRootLocal alone (no self-containment check)
+    // would have wrongly accepted it purely for having a versioned package.json.
+    const base = mkdtempSync(join(tmpdir(), 'hypo-unrelated-pkg-'));
+    try {
+      const root = realpathSync(base); // e.g. stands in for $HOME
+      writeFileSync(
+        join(root, 'package.json'),
+        JSON.stringify({ name: 'some-unrelated-package', version: '3.0.0' }),
+      );
+      const nestedHooksDir = join(root, 'nested', 'hooks'); // e.g. $HOME/.claude/hooks
+      mkdirSync(nestedHooksDir, { recursive: true });
+      cpSync(HOOKS, nestedHooksDir, { recursive: true });
+
+      const usableCache = join(home, 'cached-root');
+      seedUsableRoot(usableCache);
+      seedHypoPkg(home, usableCache);
+
+      const r = probePkgRoot(home, join(nestedHooksDir, 'hypo-shared.mjs'));
+      assert.equal(
+        r.status.status,
+        'unknown',
+        'an unrelated-but-usable ancestor package.json must never be adopted as self-location',
+      );
+      assert.equal(r.PKG_ROOT, usableCache, 'must fall back to the cache, not the unrelated package');
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+test('resolvePkgRoot: self-containment — an ancestor with A hooks/hypo-shared.mjs at the right path, but not THIS one, is rejected', () => {
+  withTmpHome((home) => {
+    const base = mkdtempSync(join(tmpdir(), 'hypo-foreign-ancestor-'));
+    try {
+      const root = realpathSync(base);
+      // An ancestor that is otherwise a perfectly valid candidate: usable
+      // package.json, AND a hooks/hypo-shared.mjs sitting at exactly the path
+      // the walk checks — but that file is a foreign stub, not the module
+      // actually running.
+      writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'x', version: '9.9.9' }));
+      mkdirSync(join(root, 'hooks'), { recursive: true });
+      writeFileSync(join(root, 'hooks', 'hypo-shared.mjs'), '// foreign stub, not the real module\n');
+
+      // The REAL running module lives nested one level deeper, so `root` is
+      // an ancestor the walk will actually reach and test.
+      const nestedHooksDir = join(root, 'nested', 'hooks');
+      mkdirSync(nestedHooksDir, { recursive: true });
+      cpSync(HOOKS, nestedHooksDir, { recursive: true });
+
+      const usableCache = join(home, 'cached-root');
+      seedUsableRoot(usableCache);
+      seedHypoPkg(home, usableCache);
+
+      const r = probePkgRoot(home, join(nestedHooksDir, 'hypo-shared.mjs'));
+      assert.equal(
+        r.status.status,
+        'unknown',
+        'an ancestor with A hooks/hypo-shared.mjs, but not THIS one, must not be adopted',
+      );
+      assert.equal(r.PKG_ROOT, usableCache);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+test('resolvePkgRoot: self and a symlink alias of the SAME physical root compare as match (canonical path)', () => {
+  withFakePkgInstall('1.7.0', (realRoot) => {
+    withTmpHome((home) => {
+      const aliasPath = join(home, 'plugin-alias');
+      symlinkSync(realRoot, aliasPath);
+      seedHypoPkg(home, aliasPath); // cache records the symlink, not the real path
+      const r = probePkgRoot(home, join(realRoot, 'hooks', 'hypo-shared.mjs'));
+      assert.deepEqual(
+        r.status,
+        { status: 'match' },
+        'a symlink alias of the same physical root must not read as drift',
+      );
+      assert.equal(r.PKG_ROOT, realRoot);
+    });
+  });
+});
+
+// ── ISSUE-70: session-start pkgRoot-drift notice + throttle ──────────────────
+suite('ISSUE-70: session-start pkgRoot-drift notice + throttle');
+
+function runSessionStartAt(hookPath, home, sessionId, extraEnv = {}) {
+  return spawnSync(process.execPath, [hookPath], {
+    input: JSON.stringify({ cwd: home, session_id: sessionId }),
+    encoding: 'utf-8',
+    env: { ...process.env, ...NOTIFY_ON, HYPO_DIR: '', HOME: home, ...extraEnv },
+  });
+}
+
+test('session-start: pkgRoot drift surfaces a one-shot notice, then throttles', () => {
+  withFakePkgInstall('1.7.0', (fakeRoot) => {
+    withTmpHome((home) => {
+      const staleRoot = join(home, 'stale-root');
+      mkdirSync(staleRoot, { recursive: true });
+      seedHypoPkg(home, staleRoot);
+      const hook = join(fakeRoot, 'hooks', 'hypo-session-start.mjs');
+
+      const first = runSessionStartAt(hook, home, 'pkgdrift-test');
+      assert.match(first.stderr, /Package metadata drift/);
+      const out = JSON.parse(first.stdout);
+      assert.match(out.additionalContext || '', /Package metadata drift/);
+      assert.match(out.systemMessage || '', /Package metadata drift/);
+
+      // second start: same tuple already notified → suppressed
+      const second = runSessionStartAt(hook, home, 'pkgdrift-test');
+      assert.doesNotMatch(second.stderr, /Package metadata drift/);
+    });
+  });
+});
+
+test('session-start: no drift (cache matches self-location) → no notice (no false nag)', () => {
+  withFakePkgInstall('1.7.0', (fakeRoot) => {
+    withTmpHome((home) => {
+      seedHypoPkg(home, fakeRoot);
+      const r = runSessionStartAt(
+        join(fakeRoot, 'hooks', 'hypo-session-start.mjs'),
+        home,
+        'pkgdrift-ok',
+      );
+      assert.doesNotMatch(r.stderr, /Package metadata drift/);
+    });
+  });
+});
+
+test('session-start: opted out (CI) suppresses the pkgRoot-drift notice', () => {
+  withFakePkgInstall('1.7.0', (fakeRoot) => {
+    withTmpHome((home) => {
+      const staleRoot = join(home, 'stale-root');
+      mkdirSync(staleRoot, { recursive: true });
+      seedHypoPkg(home, staleRoot);
+      const r = runSessionStartAt(
+        join(fakeRoot, 'hooks', 'hypo-session-start.mjs'),
+        home,
+        'pkgdrift-optout',
+        { CI: 'true' },
+      );
+      assert.doesNotMatch(r.stderr, /Package metadata drift/);
+    });
+  });
+});
+
+test('session-start: drift → notice → resolves (mark cleared) → same pair recurs → notice fires again', () => {
+  withFakePkgInstall('1.7.0', (fakeRoot) => {
+    withTmpHome((home) => {
+      const staleRoot = join(home, 'stale-root');
+      mkdirSync(staleRoot, { recursive: true });
+      const hook = join(fakeRoot, 'hooks', 'hypo-session-start.mjs');
+
+      // 1) drift → notice fires
+      seedHypoPkg(home, staleRoot);
+      const first = runSessionStartAt(hook, home, 'pkgdrift-recur-1');
+      assert.match(first.stderr, /Package metadata drift/);
+
+      // 2) drift resolves (cache now matches self-location) → no notice, and
+      // the prior mark must be cleared, not left standing
+      seedHypoPkg(home, fakeRoot);
+      const second = runSessionStartAt(hook, home, 'pkgdrift-recur-2');
+      assert.doesNotMatch(second.stderr, /Package metadata drift/);
+
+      // 3) the SAME (cached → self-location) pair recurs (cache falls back to
+      // staleRoot) → must notify again, not stay permanently suppressed
+      seedHypoPkg(home, staleRoot);
+      const third = runSessionStartAt(hook, home, 'pkgdrift-recur-3');
+      assert.match(
+        third.stderr,
+        /Package metadata drift/,
+        'the same pair must re-notify after resolving in between, not stay silenced forever',
+      );
+    });
+  });
+});
+
+test('session-start: an opted-out session still clears a resolved drift mark (opt-out ordering)', () => {
+  withFakePkgInstall('1.7.0', (fakeRoot) => {
+    withTmpHome((home) => {
+      const staleRoot = join(home, 'stale-root');
+      mkdirSync(staleRoot, { recursive: true });
+      const hook = join(fakeRoot, 'hooks', 'hypo-session-start.mjs');
+
+      // 1) not opted out: drift → notice fires, mark set
+      seedHypoPkg(home, staleRoot);
+      const first = runSessionStartAt(hook, home, 'pkgdrift-optclear-1');
+      assert.match(first.stderr, /Package metadata drift/);
+
+      // 2) drift resolves AND this run IS opted out (CI) — the clear must
+      // still happen (status 'match' is checked before the opt-out check)
+      seedHypoPkg(home, fakeRoot);
+      const second = runSessionStartAt(hook, home, 'pkgdrift-optclear-2', { CI: 'true' });
+      assert.doesNotMatch(second.stderr, /Package metadata drift/);
+
+      // 3) back to normal (not opted out), the same pair recurs — if step 2
+      // failed to clear the mark, this would stay wrongly suppressed
+      seedHypoPkg(home, staleRoot);
+      const third = runSessionStartAt(hook, home, 'pkgdrift-optclear-3');
+      assert.match(
+        third.stderr,
+        /Package metadata drift/,
+        'an opted-out session must still clear a resolved mark, or a later real session stays silenced',
+      );
+    });
+  });
+});
+
+test('session-start: self-location unresolvable (status unknown) leaves an existing drift mark untouched', () => {
+  withFakePkgInstall('1.7.0', (fakeRoot) => {
+    withTmpHome((home) => {
+      const staleRoot = join(home, 'stale-root');
+      mkdirSync(staleRoot, { recursive: true });
+      seedHypoPkg(home, staleRoot);
+      const hook = join(fakeRoot, 'hooks', 'hypo-session-start.mjs');
+
+      // 1) drift → notice fires, mark set
+      const first = runSessionStartAt(hook, home, 'pkgdrift-unknown-1');
+      assert.match(first.stderr, /Package metadata drift/);
+
+      // 2) run from a STANDALONE-copied hook (no package.json in its
+      // ancestry) → self-location cannot resolve → status 'unknown' → must
+      // not touch the mark either way
+      const standaloneDir = standaloneHooksCopy();
+      try {
+        const unknownRun = runSessionStartAt(
+          join(standaloneDir, 'hooks', 'hypo-session-start.mjs'),
+          home,
+          'pkgdrift-unknown-2',
+        );
+        assert.doesNotMatch(unknownRun.stderr, /Package metadata drift/);
+      } finally {
+        rmSync(standaloneDir, { recursive: true, force: true });
+      }
+
+      // 3) back on the drift-resolving install, the SAME pair must still be
+      // suppressed — proving step 2 did not clear the mark
+      const third = runSessionStartAt(hook, home, 'pkgdrift-unknown-3');
+      assert.doesNotMatch(
+        third.stderr,
+        /Package metadata drift/,
+        'an unknown-status session must not have cleared the mark from step 1',
+      );
+    });
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`resolvePkgRoot` no longer trusts `~/.claude/hypo-pkg.json`. It works out the package root from `import.meta.url`, walking up from the running `hypo-shared.mjs` until it finds the directory that actually contains that exact file. The cache is only a fallback, and it now has to satisfy the same contract.

## Why

Updating through the plugin channel leaves `hypo-pkg.json` at whatever it said on install day. The plugin manager performs the update, and nothing on that path rewrites the file: `upgrade.mjs` and `init.mjs` are the only writers, so a user who never runs them never gets a correction. Measured on 2026-07-20 with the install at 1.7.0 and the metadata still pointing at 1.6.2. The plugin channel is the primary distribution route, so this is the normal path, not an edge case.

The second layer is what made it bite. `resolvePkgRoot` returned that value unchecked: it did not confirm the directory still existed, let alone that it was this package. `PKG_ROOT` resolves the lint and feedback scripts, so the hooks ran at one version while the scripts they invoke resolved under another, silently, until the old cache got reclaimed and it turned into `MODULE_NOT_FOUND`.

#211 already made `upgrade` and `doctor` report the drift when they are called. The gap was that nothing calls them. Detection existed; a trigger did not. Adding a third "reports when invoked" layer would not have helped.

## How

The hook answers the question from its own position. The code that is executing knows where it lives, so no registry lookup, no settings parsing, and no inference about which install is active. Drift becomes a direct comparison: what the cache claims versus where the code is.

Three attempts were needed, and cross-review refuted the first two.

Picking the newest registry entry by `lastUpdated` let an inactive legacy entry outrank the live one. Reading `enabledPlugins` from `~/.claude/settings.json` missed that the key also lives in project, local, and managed settings, that project overrides user, and that `defaultEnabled` is `true` so an absent key proves nothing. Accepting any absolute path with a versioned `package.json` adopted `$HOME` as the root whenever a standalone hooks copy had one two levels up, which would have pointed lint and the crystallize recovery command at `$HOME/scripts`.

A candidate is now accepted only when `realpath` of its `hooks/hypo-shared.mjs` is the running module. Having a file at that path is not enough; it has to be this one. `realpath` alone would not have fixed the third case, since canonicalizing an unrelated `$HOME` still leaves it unrelated.

Drift status is three-valued. "Cannot tell" is not "no drift": an unresolvable self-location leaves the notice mark alone rather than clearing it, so one bad session no longer re-arms a banner the user already dismissed. Paths are canonicalized before comparison, so a symlink alias of the same physical root reads as a match rather than as drift.

## Manual verification

```
npm test                              -> 1870 passed, 0 failed
npm run lint                          -> 0 error(s)
node scripts/check-pack-surface.mjs   -> 133 files, 0 closure violations
```

Rebased onto #234 and re-run, since that PR touches the same file.

Regression proof, each defense disabled in turn and restored:

| disabled | assertion that went red |
|---|---|
| self-location (cache only) | 7, including every drift-notice test |
| cache usable contract loosened to "directory exists" | 11, including two close-path tests that only fail because a wrong `PKG_ROOT` misresolves their scripts |
| three-valued status collapsed to two | 4, on `unknown` clearing a mark it should have left alone |
| self-containment check removed | 2, on the unrelated-ancestor and wrong-copy fixtures |
| canonical path comparison removed | 1, on the symlink alias reading as drift |

The second row is the useful one: it shows this contract reaches further than the notice it was written for.

`PKG_ROOT` resolves at module load in a top-level `export const`, so throwing there kills every hook and the user's session. Every filesystem and JSON path added here sits inside a `try`/`catch` that falls through to the next candidate, and the child-process assertions confirm exit 0 rather than just checking a return value.

**No real-session hook QA for this branch.** `hooks/hypo-shared.mjs` changed, so confirm the deployed copy before merge if you want the stronger guarantee.

## Known gaps, tracked separately

A standalone npm or manual install has no self-location by construction: `init.mjs` copies only `hooks/` into `~/.claude/hooks/`, so there is no `package.json` beside it. The cache is that path's only answer and its `pkgVersion` is still unchecked, which means the original symptom survives there.

When a plugin install and a manual one coexist, each copy resolves correctly to its own root, and the two roots differ. This repo's own dev machine is in that state; `upgrade.mjs` already warns about it.

## Migration notes

None. A correct install resolves to the same root it did before.

---

# 한국어

## 변경 내용

`resolvePkgRoot` 가 `~/.claude/hypo-pkg.json` 을 더는 믿지 않습니다. `import.meta.url` 로 지금 도는 `hypo-shared.mjs` 에서 위로 올라가며 **바로 그 파일을 담고 있는** 디렉터리를 찾아 package root 로 씁니다. 캐시는 폴백일 뿐이고, 이제 같은 계약을 통과해야 합니다.

## 이유

플러그인 채널로 업데이트하면 `hypo-pkg.json` 은 설치 시점 값에 머뭅니다. 갱신은 플러그인 매니저가 하는데 그 경로에는 이 파일을 고칠 주체가 없습니다. `upgrade.mjs` 와 `init.mjs` 가 유일한 writer 라, 그것들을 안 돌리는 사용자는 영영 정정을 못 받습니다. 2026-07-20 실측에서 설치본은 1.7.0인데 메타데이터는 1.6.2였습니다. 플러그인이 주 배포 채널이므로 예외가 아니라 기본 경로입니다.

두 번째 층이 피해를 실재로 만들었습니다. `resolvePkgRoot` 가 그 값을 검증 없이 돌려줬습니다. 디렉터리가 남아 있는지도, 그게 우리 패키지인지도 보지 않았습니다. `PKG_ROOT` 로 lint·feedback 스크립트를 해석하므로, 훅은 한 버전에서 돌고 그 훅이 부르는 스크립트는 다른 버전에서 도는 상태가 조용히 성립하다가, 옛 캐시가 회수되면 `MODULE_NOT_FOUND` 로 터집니다.

#211 이 이미 `upgrade` 와 `doctor` 가 **호출됐을 때** 드리프트를 보고하게 만들어 뒀습니다. 문제는 호출 자체가 안 일어난다는 것이었습니다. 탐지는 있고 트리거가 없었습니다. "호출되면 보고하는" 층을 하나 더 붙여도 소용없습니다.

## 방법

훅이 자기 위치에서 답합니다. 실행 중인 코드는 자기가 어디 사는지 이미 아니까, registry 조회도 settings 파싱도 어느 설치가 활성인지 추론할 일도 없습니다. 드리프트는 "캐시가 뭐라 하는가" 대 "코드가 어디 있는가" 의 직접 비교가 됩니다.

세 번 시도했고 교차 검토가 앞의 둘을 반박했습니다.

`lastUpdated` 최신순으로 registry 항목을 고르면 비활성 legacy 가 살아 있는 쪽을 이길 수 있었습니다. `~/.claude/settings.json` 의 `enabledPlugins` 를 읽는 방식은 그 키가 project·local·managed 설정에도 있고 project 가 user 를 덮으며 `defaultEnabled` 기본값이 `true` 라 키 부재가 아무것도 증명하지 않는다는 점을 놓쳤습니다. 절대 경로에 versioned `package.json` 이면 채택하는 계약은, standalone 훅 사본 두 단계 위에 그런 파일이 있으면 `$HOME` 을 root 로 삼아 lint 와 crystallize 복구 명령을 `$HOME/scripts` 로 보냈을 겁니다.

이제 후보는 `hooks/hypo-shared.mjs` 의 `realpath` 가 **지금 도는 모듈일 때만** 채택됩니다. 그 경로에 파일이 있는 것으로는 부족하고 그게 "이" 파일이어야 합니다. `realpath` 만 추가했다면 세 번째 경우는 안 풀립니다. 무관한 `$HOME` 을 canonicalize 해도 무관한 채로 남으니까요.

드리프트 상태는 3값입니다. "판정 불가" 는 "드리프트 없음" 이 아닙니다. self-location 을 못 구하면 알림 mark 를 지우지 않고 그대로 둡니다. 그래서 한 세션의 실패가 사용자가 이미 닫은 배너를 다시 띄우지 않습니다. 비교 전에 경로를 canonical 로 정규화해서, 같은 물리 루트의 symlink alias 는 드리프트가 아니라 일치로 읽힙니다.

## 수동 검증

```
npm test                              -> 1870 passed, 0 failed
npm run lint                          -> 0 error(s)
node scripts/check-pack-surface.mjs   -> 133 files, 0 closure violations
```

#234 가 같은 파일을 건드려서 그 위로 rebase 한 뒤 다시 돌렸습니다.

회귀 증명. 방어를 하나씩 껐다가 되돌렸습니다.

| 무력화한 것 | red 가 난 단언 |
|---|---|
| self-location(캐시만) | 7건, 드리프트 알림 테스트 전부 포함 |
| 캐시 usable 계약을 "디렉터리 존재" 로 완화 | 11건, 잘못된 `PKG_ROOT` 가 스크립트를 오해석해 깨진 close 경로 2건 포함 |
| 3값 상태를 2값으로 축소 | 4건, `unknown` 이 건드리면 안 될 mark 를 지우는 지점 |
| 자기 포함 검증 제거 | 2건, 무관한 조상·다른 사본 픽스처 |
| canonical 경로 비교 제거 | 1건, symlink alias 가 드리프트로 읽히는 지점 |

두 번째 행이 쓸모 있습니다. 이 계약이 원래 쓰인 알림보다 훨씬 멀리까지 닿는다는 것을 보여줍니다.

`PKG_ROOT` 는 top-level `export const` 로 모듈 로드 시 해석되므로 거기서 던지면 훅 전체가 죽고 사용자 세션이 망가집니다. 여기서 추가한 파일시스템·JSON 경로는 전부 `try`/`catch` 안에서 다음 후보로 떨어지고, 자식 프로세스 단언이 반환값이 아니라 exit 0 으로 확인합니다.

**이 브랜치의 실세션 훅 QA 는 하지 않았습니다.** `hooks/hypo-shared.mjs` 가 바뀌었으니 더 강한 보증을 원하면 머지 전에 배포 사본을 확인해 주세요.

## 알려진 갭 (별건으로 등재)

standalone npm/수동 설치는 self-location 이 구조적으로 없습니다. `init.mjs` 가 `hooks/` 만 `~/.claude/hooks/` 로 복사해 옆에 `package.json` 이 없습니다. 그 경로는 캐시가 유일한 답이고 `pkgVersion` 비교도 없어서 원래 증상이 남습니다.

플러그인 설치와 수동 설치가 공존하면 두 사본이 각자 자기 루트로 정확히 해석하고, 그 두 루트가 다릅니다. 이 레포의 개발 머신이 그 상태이고 `upgrade.mjs` 가 이미 경고하고 있습니다.

## 마이그레이션 노트

None. 정상 설치는 이전과 같은 루트로 해석됩니다.

---

## Changelog

- EN: Hooks now resolve their package root from where the code is actually running, so a plugin-channel update no longer leaves them running one version while the scripts they invoke resolve under another (#235)
- KO: 훅이 실제로 실행되는 위치에서 package root 를 정하도록 바뀌었습니다. 플러그인 채널로 업데이트해도 훅과 그 훅이 부르는 스크립트가 서로 다른 버전에서 도는 일이 없습니다 (#235)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
