### PR TITLE
fix(close): stop the approval from expiring on the step the product itself demands

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -4233,6 +4233,9 @@ export function resolveTranscriptBySessionId(
  *   • INVALIDATE a fresh user intent that expires the lease: any other genuine
  *                user text, `/clear`, `popAll`, a non-close queued_command, a
  *                non-close AskUserQuestion selection.
+ *   • NEUTRAL    additionally: a typed `apply-proposals <nonce>` whose nonce this
+ *                transcript shows `proposal challenge` minting (see "the approval
+ *                line" below).
  *   • NEUTRAL    everything the model can produce or the harness injects: system/
  *                sdk replay, isMeta bodies, sidechain, interruptedMessageId
  *                companions, assistant, tool_result, task-notification.
@@ -4245,9 +4248,45 @@ export function resolveTranscriptBySessionId(
  * known limit (no leaf pointer exists to resolve it — see the branch note on the
  * function), mitigated by the lease.
  *
+ * THE APPROVAL LINE IS NOT A CHANGE OF MIND. The lease exists to catch a user who
+ * changed their mind, and it also caught the user for doing what the close
+ * procedure told them to do. `proposal challenge` instructs the user to type
+ * `apply-proposals <nonce>`, which can never be a close phrase, so typing it
+ * expired the close grant given a turn earlier (measured 2026-08-06: the close
+ * needed three approval round trips because of it). Two gates read one transcript
+ * under two rules, and passing one broke the other.
+ *
+ * So one carve-out: a user message that IS the approval line, for a nonce this
+ * transcript shows being minted, is NEUTRAL. It never grants; a lease that was not
+ * already live stays dead. The mint has to be correlated, not merely present:
+ * `collectMinted` reads only a tool_result correlated to a Bash tool_use, and only
+ * when the surrounding challenge framing is there too, so a hex the model typed in
+ * its own prose (or any other tool's output) is not a mint. Order is part of it:
+ * the set fills as the walk goes, so a message can never mint the nonce it spends.
+ * An unminted hex is ordinary text and still expires the lease.
+ *
+ * What this does NOT cover: an AskUserQuestion answer during the close procedure
+ * (the skill's Step 1a reflections) still expires the lease. A carve-out was
+ * written for it and withdrawn, because "the answer does not read as a retraction"
+ * is fail-open on an open class of phrasings, and this repo routes an unknown value
+ * to the cautious branch. Recognizing a close-procedure answer POSITIVELY needs a
+ * marker on the question, and the model authors the question. The round trip stays.
+ *
  * Threat model: an honest-but-drifting model that does not forge the
  * transcript. This is a safety interlock, not an authorization boundary — a model
- * that forges records is out of scope and documented so.
+ * that forges records is out of scope and documented so. The carve-out does not
+ * move that boundary: it only PRESERVES a grant the user already gave, so the model
+ * still cannot manufacture one. The residual it does carry: a model that runs an
+ * arbitrary Bash command can print the challenge framing itself and plant a mint.
+ * That buys it nothing on its own, because the user still has to send the approval
+ * line, and the result is neutrality rather than a grant.
+ *
+ * A command invocation is NOT a channel here. `/hypo:crystallize` typed by the user
+ * was accepted as a grant for one review round and removed: the harness records a
+ * model-issued Skill call as the same non-meta `<command-name>` user record
+ * (verified against Claude Code 2.1.243's `processPromptSlashCommand`), so the
+ * model could have closed the session by calling its own skill. The premise that a
+ * command tag proves a human typed it is false.
  *
  * Fail-closed: any read/parse error, or an unresolvable branch, → false.
  */
@@ -4344,9 +4383,42 @@ export function hasUserCloseSignal(transcriptPath) {
   // staleness limit, mitigated by the lease: any later live user intent, on any
   // branch, still expires it.
   const askIds = new Set();
+  // Bash tool_use ids, so a mint can be tied to a command that actually ran rather
+  // than to any string in the file. Filled in the same content scan as askIds.
+  const bashIds = new Set();
   let granted = false;
+  // The nonces this transcript shows `proposal challenge` minting. Producer, not
+  // just presence: the hex has to arrive in a NON-error tool_result of a Bash
+  // tool_use, wrapped in the challenge's own framing. Model prose carrying a
+  // plausible hex, an isMeta/system body, and any other tool's output all fail
+  // that, which matters because a mint neutralizes the user's next message. The
+  // set fills as the walk goes, so a message cannot mint the nonce it spends.
+  const mintedNonces = new Set();
+  const challengeMint = new RegExp(
+    `must type this line in the conversation:\\s*${APPROVAL_PHRASE} ([a-f0-9]{32,})\\s*Then run: hypomnema proposal resolve`,
+    'g',
+  );
+  const approvalLine = new RegExp(`^${APPROVAL_PHRASE}\\s+([a-f0-9]{32,})$`);
+  const collectMinted = (o) => {
+    const c = (o.message ?? o).content;
+    if (!Array.isArray(c)) return;
+    for (const b of c) {
+      if (!b || typeof b !== 'object') continue;
+      if (b.type !== 'tool_result' || !b.tool_use_id || !bashIds.has(b.tool_use_id)) continue;
+      if (b.is_error === true) continue;
+      const text = typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
+      if (typeof text !== 'string' || !text.includes(APPROVAL_PHRASE)) continue;
+      for (const m of text.matchAll(challengeMint)) mintedNonces.add(m[1]);
+    }
+  };
 
   for (const o of recs) {
+    // Genuine user text of this record, or null when the record is on a channel
+    // the model can reach. Computed once here: the mint scan below is the exact
+    // complement of it (mint from everything that is NOT the user's own text).
+    const userText = eventUserText(o);
+    if (userText == null) collectMinted(o);
+
     // Queue operations. The queue carries no correlation key (measured), so the
     // ENQUEUE content is the decision — not a later contentless dequeue, which
     // would need pairing we cannot do. Reading the enqueue also keeps the live
@@ -4396,25 +4468,29 @@ export function hasUserCloseSignal(transcriptPath) {
     }
 
     // Record AskUserQuestion tool_use ids (assistant record, always precedes its
-    // answer in line order).
+    // answer in line order). Bash ids ride along in the same scan, for the mint
+    // correlation above.
     const content = (o.message ?? o).content;
     if (Array.isArray(content)) {
       for (const b of content) {
-        if (
-          b &&
-          typeof b === 'object' &&
-          b.type === 'tool_use' &&
-          b.name === 'AskUserQuestion' &&
-          b.id
-        )
-          askIds.add(b.id);
+        if (!b || typeof b !== 'object' || b.type !== 'tool_use' || !b.id) continue;
+        if (b.name === 'AskUserQuestion') askIds.add(b.id);
+        else if (b.name === 'Bash') bashIds.add(b.id);
       }
     }
 
-    // Genuine user text → grant on a close phrase, invalidate on anything else.
-    const text = eventUserText(o);
-    if (text != null && text !== '') {
-      granted = isClosePattern(text);
+    // Genuine user text → grant on a close phrase, invalidate on anything else,
+    // minus the one carve-out for what the product itself asked the user to send.
+    if (userText != null && userText !== '') {
+      const spend = approvalLine.exec(userText.trim());
+      if (spend && mintedNonces.has(spend[1])) {
+        // The approval line `proposal challenge` tells the user to type, bound to a
+        // nonce this transcript minted. Neutral, never a grant: an untouched
+        // `granted` that was false stays false. An unminted hex is ordinary text and
+        // falls through to the invalidating branch below.
+        continue;
+      }
+      granted = isClosePattern(userText);
       continue;
     }
 

--- a/tests/close-signals.test.mjs
+++ b/tests/close-signals.test.mjs
@@ -359,7 +359,10 @@ test('commit message "세션을 종료했다" (with object particle + honorific-
 });
 
 test('commit message "close the 13th session" (digit ordinal) → matched', () => {
-  assert.equal(detectSessionCloseArtifact({ commitMessage: 'close the 13th session' }).matched, true);
+  assert.equal(
+    detectSessionCloseArtifact({ commitMessage: 'close the 13th session' }).matched,
+    true,
+  );
 });
 
 // The EN pattern's middle slot is now an ORDINAL only (the shape every real
@@ -1401,6 +1404,243 @@ test('close, then a non-close AskUserQuestion selection → false (lease expires
           ],
         },
       },
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// ── the approval line must not expire the close lease (ISSUE-74) ──
+// One carve-out survives review: a typed `apply-proposals <nonce>` for a nonce this
+// transcript shows `proposal challenge` minting. The command-channel carve-out was
+// removed after codex showed a model-issued Skill call produces the same non-meta
+// <command-name> user record, and the AskUserQuestion carve-out was removed because
+// "does not read as a retraction" is fail-open on an open class of phrasings.
+// Those two removals are pinned here as NEGATIVES, so re-adding either turns red.
+suite('hasUserCloseSignal(): the minted approval line, and what is NOT a channel');
+
+// The nonce shape `proposal challenge` mints (randomBytes(16).toString('hex')).
+const NONCE = '0f1e2d3c4b5a69788796a5b4c3d2e1f0';
+const OTHER_NONCE = 'aaaabbbbccccddddeeeeffff00001111';
+// The challenge output verbatim (scripts/proposal.mjs). The drift pin below keeps
+// this fixture honest against the real writer.
+const CHALLENGE_TEXT = (nonce) =>
+  '\nTo approve the 1 overwrite(s) above, the USER must type this line in the conversation:\n\n' +
+  `    apply-proposals ${nonce}\n\nThen run: hypomnema proposal resolve --session-id=s\n`;
+const TOOL_USE = (name, id) => ({
+  type: 'assistant',
+  message: { content: [{ type: 'tool_use', name, id, input: {} }] },
+});
+// A tool_result record: role:'user' in the transcript, but no text block, so it is
+// never genuine user text.
+const TOOL_RESULT = (id, content, extra = {}) => ({
+  type: 'user',
+  message: {
+    role: 'user',
+    content: [{ type: 'tool_result', tool_use_id: id, content, ...extra }],
+  },
+});
+// The minting pair as it really lands: the model runs `proposal challenge` via Bash
+// and the challenge output comes back correlated to that Bash tool_use.
+const MINT = (nonce) => [TOOL_USE('Bash', 'bash-1'), TOOL_RESULT('bash-1', CHALLENGE_TEXT(nonce))];
+const TYPED = (text) => USER({ message: { role: 'user', content: text }, promptSource: 'typed' });
+// A slash-command / Skill invocation as the harness records it. Not a channel: the
+// model's own Skill call produces this same shape.
+const COMMAND_TAGS = (name, args) =>
+  USER({
+    message: {
+      role: 'user',
+      content:
+        `<command-message>${name}</command-message>\n` +
+        `<command-name>/${name}</command-name>` +
+        (args ? `\n<command-args>${args}</command-args>` : ''),
+    },
+  });
+const ASK = (id) => ({
+  type: 'assistant',
+  message: { content: [{ type: 'tool_use', name: 'AskUserQuestion', id }] },
+});
+const ANSWER = (id, picked) =>
+  TOOL_RESULT(id, `Your questions have been answered: "?"="${picked}"`);
+
+test('typing the minted approval line does not expire the close lease', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [USER(CLOSE), ...MINT(NONCE), TYPED(`apply-proposals ${NONCE}`)]);
+    assert.equal(hasUserCloseSignal(p), true);
+  });
+});
+
+// THE CARVE-OUT NEVER GRANTS. Same transcript minus the close: neutral leaves the
+// lease exactly where it was, and where it was is "never granted".
+test('the approval line alone is not a close signal (neutral never creates a grant)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [...MINT(NONCE), TYPED(`apply-proposals ${NONCE}`)]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('an approval line whose nonce this transcript never minted still expires the lease', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      ...MINT(NONCE),
+      TYPED(`apply-proposals ${OTHER_NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('a user message cannot mint the nonce it then spends (no self-mint, order held)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      TYPED(`apply-proposals ${NONCE}`),
+      TYPED(`apply-proposals ${NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// PRODUCER, not presence: the model can write the challenge framing into its own
+// prose, and that must not neutralize the user's next message.
+test('the challenge framing in ASSISTANT prose is not a mint', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      { type: 'assistant', message: { content: [{ type: 'text', text: CHALLENGE_TEXT(NONCE) }] } },
+      TYPED(`apply-proposals ${NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('the challenge framing from a NON-Bash tool is not a mint', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      TOOL_USE('Read', 'read-1'),
+      TOOL_RESULT('read-1', CHALLENGE_TEXT(NONCE)),
+      TYPED(`apply-proposals ${NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('an uncorrelated tool_result (no tool_use behind it) is not a mint', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      TOOL_RESULT('ghost-1', CHALLENGE_TEXT(NONCE)),
+      TYPED(`apply-proposals ${NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('a FAILED challenge run (is_error) is not a mint', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      TOOL_USE('Bash', 'bash-1'),
+      TOOL_RESULT('bash-1', CHALLENGE_TEXT(NONCE), { is_error: true }),
+      TYPED(`apply-proposals ${NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('a bare hex in Bash output, without the challenge framing, is not a mint', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      TOOL_USE('Bash', 'bash-1'),
+      TOOL_RESULT('bash-1', `apply-proposals ${NONCE}\n`),
+      TYPED(`apply-proposals ${NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('the approval line must be the WHOLE message, as the TTY channel requires', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      ...MINT(NONCE),
+      TYPED(`동의 안 해, 그냥 인용만 할게: apply-proposals ${NONCE}`),
+    ]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// DRIFT PIN: the mint matcher anchors on two literals from `proposal challenge`'s
+// output. If that output is reworded, the carve-out silently stops working (a
+// re-typed approval starts expiring the lease again) and no other test notices.
+test('the mint matcher still anchors on what proposal challenge actually prints', () => {
+  const src = readFileSync(join(REPO, 'scripts', 'proposal.mjs'), 'utf-8');
+  for (const literal of [
+    'must type this line in the conversation:',
+    'Then run: hypomnema proposal resolve',
+  ]) {
+    assert.ok(src.includes(literal), `proposal.mjs no longer prints: ${literal}`);
+  }
+  // And the fixture above is what that template renders.
+  assert.ok(CHALLENGE_TEXT(NONCE).includes(`apply-proposals ${NONCE}`));
+});
+
+// NOT A CHANNEL (removed after review): a `<command-name>` user record proves
+// nothing about who produced it. Claude Code routes a model-issued Skill call
+// through the same slash-command path, so an invocation record can be the model's
+// own. Each variant below must stay a non-grant.
+test('a command invocation record is not a close signal, in any namespace form', () => {
+  withTmpDir((dir) => {
+    for (const rec of [
+      COMMAND_TAGS('hypo:crystallize'),
+      COMMAND_TAGS('other-plugin:crystallize'),
+      COMMAND_TAGS('crystallize'),
+      COMMAND_TAGS('hypo:crystallize', '위키 지식합성 진행해줘'),
+      // the XML block pasted on its own, with no <command-message> wrapper
+      TYPED('<command-name>/hypo:crystallize</command-name>'),
+    ]) {
+      const p = writeJsonl(dir, [rec]);
+      assert.equal(hasUserCloseSignal(p), false, JSON.stringify(rec.message.content));
+    }
+  });
+});
+
+test('a command invocation after a close still expires the lease (it is user text)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [USER(CLOSE), COMMAND_TAGS('hypo:crystallize')]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+// NOT A CHANNEL (removed after review): an AskUserQuestion answer that is not a
+// close still expires the lease, including phrasings no retraction list would have
+// held. This is the fail-closed direction the repo's unknown-enum rule asks for.
+test('a non-close AskUserQuestion answer expires the lease, whatever its wording', () => {
+  withTmpDir((dir) => {
+    for (const picked of ['지금 종료하지 말아 줘', '지금 쓴다', '3개', 'whatever']) {
+      const p = writeJsonl(dir, [USER(CLOSE), ASK('q'), ANSWER('q', picked)]);
+      assert.equal(hasUserCloseSignal(p), false, picked);
+    }
+  });
+});
+
+// THE FENCE (ISSUE-31): the carve-out does not touch typed user text, so a user who
+// asks for more work after a close still expires the lease.
+test('typed non-close text after a grant still expires the lease (over-close defense)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [USER(CLOSE), TYPED('아 잠깐, 이거 먼저 고쳐줘')]);
+    assert.equal(hasUserCloseSignal(p), false);
+  });
+});
+
+test('typed non-close text after the approval line still expires the lease', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      ...MINT(NONCE),
+      TYPED(`apply-proposals ${NONCE}`),
+      TYPED('하나만 더 해줘'),
     ]);
     assert.equal(hasUserCloseSignal(p), false);
   });


### PR DESCRIPTION
# English

## What changed

`hasUserCloseSignal` now treats the proposal-approval line as neutral. Typing
`apply-proposals <nonce>` no longer expires a live close approval, and it never
creates one. The line only counts when this transcript actually shows the
challenge command minting that nonce.

Nothing else about the gate moved. A typed message that is not a close phrase
still expires the approval, exactly as before.

## Why

Closing a session almost always got refused on the first try, and the cause was
the procedure arguing with itself.

The approval is a lease: every user message that is not itself a close phrase
invalidates it. That is the right defence against someone changing their mind
mid-close. But the proposal-approval protocol instructs the user to type
`apply-proposals <nonce>`, and that line can never read as a close phrase. So
obeying the instruction cancelled the approval that made the instruction appear.
Two gates read the same transcript by different rules, and passing one
invalidated the other.

The user reported it as "this happens every single time I ask to wrap up, this
is not an edge case."

## How

Minting is read from the challenge command's own output, not from the presence
of a hex string. A nonce counts as minted only when it arrives in a non-error
`tool_result` belonging to a Bash `tool_use`, wrapped in the challenge's own
framing. Model prose that mentions a plausible hex is not a mint, nor is another
tool's output, nor a failed run. The minted set fills as the walk proceeds, so a
message cannot mint the nonce it then spends.

The approval line must be the whole message, matching what the TTY channel
requires the user to type.

An earlier draft of this change also treated a slash-command invocation record
as an approval channel, on the premise that only a human can produce one. Review
disproved the premise: the model's own `Skill` invocation produces the same
non-meta user record, and the close skill has no model-invocation guard. That
would have let the model approve its own close, which is the exact failure this
gate exists to prevent. The channel was removed rather than narrowed, because no
regex can separate the two producers.

## Manual verification

Run against real transcripts on this machine, comparing this branch against
`origin/main`. `hasUserCloseSignal` takes a transcript path, so each prefix was
written to a file before the call.

Historical behaviour is unchanged:

    859 prefixes across 15 real transcripts
    verdicts that differ from origin/main: 0
    prefixes where the gate grants: 52   (so the input discriminates)
    exceptions thrown: 0

The fix fires on a real minted nonce. Built from a transcript that contains an
actual `proposal challenge` run, truncated at that command's `tool_result`, then
extended with a real close record and the real approval line:

    close only (baseline)              old=true   new=true
    close, then the minted line        old=false  new=true    <- the fix
    close, then a nonce never minted   old=false  new=false
    close, then ordinary typed text    old=false  new=false
    prefix with no close at all        old=false  new=false

The third and fourth rows are the defences: a forged nonce still expires the
lease, and an ordinary typed message still expires it, so a session cannot be
closed without being asked to be. The last row shows the neutral branch cannot
manufacture an approval.

Deployed-copy check: the module imports nothing from `scripts/` and uses Node
built-ins only, so the standalone copy the plugin loader serves resolves the
same way as the checkout copy.

Known gap, not addressed here: the close skill also raises an `AskUserQuestion`
during its advisory step, and answering it still expires the approval. That
round trip remains. Recognising those answers safely needs a marker the skill
itself writes, which is a change to the command and skill files rather than to
this gate.

## Migration notes

None. No configuration, no vault file, and no command signature changed. The
gate is stricter about what counts as a mint and more permissive about the
approval line, both inside the same function; an installed copy picks the
change up on the next upgrade with nothing to do by hand.

# 한국어

## 변경 내용

`hasUserCloseSignal`이 proposal 승인 줄을 중립으로 다룬다. `apply-proposals <nonce>`를
타이핑해도 살아 있는 close 승인이 만료되지 않고, 그 줄이 승인을 새로 만들지도 않는다.
이 트랜스크립트가 실제로 그 nonce를 발급한 것이 보일 때만 인정한다.

게이트의 나머지는 그대로다. close 문구가 아닌 타이핑 발화는 예전처럼 승인을 만료시킨다.

## 이유

세션을 닫으려 하면 첫 시도가 거의 항상 거부됐다. 절차가 스스로와 다투고 있었다.

승인은 lease다. close 문구가 아닌 사용자 메시지는 전부 승인을 무효로 만든다. 마음이 바뀐
사용자를 잡는다는 목적에서는 옳다. 그런데 proposal 승인 프로토콜이 사용자에게
`apply-proposals <nonce>`를 타이핑하라고 지시하고, 그 줄은 close 문구일 수가 없다. 지시를
따르는 행위가 그 지시를 띄운 승인을 취소한 것이다. 두 게이트가 같은 트랜스크립트를 서로 다른
규칙으로 읽어, 한쪽을 통과하면 다른 쪽이 무효가 됐다.

사용자 보고는 "마무리하라고 할 때마다 매번 발생해, 이번이 엣지한 게 아니야"였다.

## 방법

발급 판정을 hex 문자열의 존재가 아니라 challenge 명령의 출력에서 읽는다. Bash `tool_use`에
속한 non-error `tool_result`에, challenge 자신의 문구에 감싸여 도착할 때만 발급으로 친다.
그럴듯한 hex를 언급하는 모델 산문도, 다른 툴의 출력도, 실패한 실행도 발급이 아니다. 발급
집합은 워크가 진행되며 채워지므로, 어떤 메시지도 자기가 쓸 nonce를 자기가 발급할 수 없다.

승인 줄은 메시지 전체여야 한다. TTY 채널이 사용자에게 타이핑을 요구하는 그 형태다.

이 변경의 초안은 슬래시 커맨드 호출 레코드도 승인 채널로 인정했다. 사람만 그 레코드를 만들 수
있다는 전제였는데, 검토가 전제를 깼다. 모델의 `Skill` 호출도 같은 비메타 user 레코드를
만들고, close 스킬에는 모델 호출을 막는 설정이 없다. 그대로 뒀다면 모델이 자기 close를 스스로
승인할 수 있었고, 그건 이 게이트가 존재하는 이유인 바로 그 실패다. 어떤 정규식도 두 생산자를
가르지 못하므로 채널을 좁히지 않고 제거했다.

## 수동 검증

이 머신의 실제 트랜스크립트로 이 브랜치와 `origin/main`을 대조했다. `hasUserCloseSignal`은
트랜스크립트 경로를 받으므로, 프리픽스마다 파일로 쓴 뒤 호출했다.

기존 동작은 그대로다.

    실제 트랜스크립트 15개에서 프리픽스 859개
    origin/main 과 판정이 다른 지점: 0
    게이트가 승인을 내는 지점: 52   (입력이 판별력을 갖는다는 뜻)
    발생한 예외: 0

실제로 발급된 nonce에서 수정이 발화한다. `proposal challenge`가 실제로 돌아간 트랜스크립트를
그 명령의 `tool_result`에서 자르고, 실제 close 레코드와 실제 승인 줄을 이어 붙여 만들었다.

    close 만 (기준선)            old=true   new=true
    close → 발급된 승인 줄        old=false  new=true    <- 수정
    close → 발급 안 된 nonce      old=false  new=false
    close → 평범한 타이핑 발화     old=false  new=false
    close 가 전혀 없는 프리픽스    old=false  new=false

셋째와 넷째 줄이 방어다. 위조된 nonce도, 평범한 타이핑 발화도 여전히 lease를 만료시키므로,
요청받지 않은 close는 성립하지 않는다. 마지막 줄은 중립 분기가 승인을 만들어내지 못함을 보인다.

배포 사본 확인: 이 모듈은 `scripts/`에서 아무것도 import 하지 않고 Node 내장 모듈만 쓴다.
플러그인 로더가 제공하는 독립 사본도 체크아웃 사본과 같은 방식으로 해석된다.

여기서 다루지 않은 남은 갭: close 스킬은 조언 단계에서 `AskUserQuestion`도 띄우는데, 그 답을
고르면 여전히 승인이 만료된다. 그 왕복은 남는다. 그 답들을 안전하게 인정하려면 스킬이 직접
쓰는 마커가 필요하고, 그건 이 게이트가 아니라 커맨드·스킬 파일을 바꾸는 일이다.

## 마이그레이션 노트

없다. 설정도, 볼트 파일도, 명령 시그니처도 바뀌지 않았다. 발급으로 인정하는 범위가
좁아지고 승인 줄 처리가 느슨해졌을 뿐이며 둘 다 같은 함수 안이다. 설치된 사본은 다음
업그레이드에서 그대로 반영되고 손으로 할 일은 없다.

## Changelog

- EN: Closing a session no longer needs a second confirmation after you type the proposal-approval line. The line is now neutral: it cannot expire a close approval, and it cannot create one. A message that is not a close phrase still expires the approval, so a session is never closed without being asked.
- KO: proposal 승인 줄을 타이핑한 뒤 세션 종료를 다시 확인받지 않아도 된다. 이 줄은 이제 중립이라 close 승인을 만료시키지도, 새로 만들지도 않는다. close 문구가 아닌 발화는 예전처럼 승인을 만료시키므로, 요청하지 않은 종료는 여전히 일어나지 않는다.

## Checklist

- [x] `npm test` (1886 passed, 0 failed)
- [x] `node tests/parallel.mjs --shards=286` (suite isolation, 1886 passed)
- [x] `npm run lint` (0 errors)
- [x] `npm run check:tracker-ids`
- [x] Manual verification against real transcripts (above)
- [x] Regression proof: each defence disabled in turn, the pinning assertion goes red, restored and re-verified
- [x] No attribution footer, no session URL, no internal tracker ids
- [ ] Live-session hook QA after deploy (the deployed copy is exercised by `/hypo:crystallize` in a real session; queued with the same check still owed for two earlier hook changes on this release)
