### PR TITLE
chore: release v1.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "hypo",
       "source": "./",
       "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "homepage": "https://github.com/sk-lim19f/Hypomnema"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hypo",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "LLM-native personal wiki system — session-aware knowledge base for Claude Code",
   "author": {
     "name": "sk-lim19f",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to Hypomnema are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-08-25
+
+### New Features
+
+#### English
+
+- `hypo:doctor` now detects a rename that was interrupted partway and tells you whether to re-run it or just delete the leftover marker, instead of leaving the half-rewritten links to show up as ordinary broken links. ([#233](https://github.com/sk-lim19f/Hypomnema/pull/233))
+- A session-close artifact written without you asking for a close now prompts for confirmation before the file lands, instead of being reported by `doctor` after it is already written and committed. ([#229](https://github.com/sk-lim19f/Hypomnema/pull/229))
+- `doctor` now surfaces a session that was closed by hand without the user-confirmation gate firing, correlating close artifacts (session-state headings, hot.md narratives, close-worded commits) against the session-closed markers on disk. Warn-only. ([#226](https://github.com/sk-lim19f/Hypomnema/pull/226))
+- A session close now creates `projects/<name>/index.md` from the template when a project has none, and `lint` warns (never errors) on a project with no index and on an index with no `working_dir` anchor. ([#227](https://github.com/sk-lim19f/Hypomnema/pull/227))
+- `hypo:doctor` now shows the last successful pull and push time, distinguishing a healthy vault from one that has never synced. ([#223](https://github.com/sk-lim19f/Hypomnema/pull/223))
+
+#### 한국어
+
+- `hypo:doctor`가 중간에 끊긴 rename을 감지해, 재실행해야 하는지 남은 마커만 지우면 되는지 알려 줍니다. 절반만 재작성된 링크가 그냥 깨진 링크로 보이던 것이 바뀝니다. ([#233](https://github.com/sk-lim19f/Hypomnema/pull/233))
+- close를 요청하지 않았는데 쓰이는 세션 close 산출물이, 파일이 쓰이고 커밋된 뒤에 `doctor`로 보고되는 대신 쓰이기 전에 확인을 묻습니다. ([#229](https://github.com/sk-lim19f/Hypomnema/pull/229))
+- `doctor`가 사용자 확인 게이트를 거치지 않고 손으로 닫힌 세션을 찾아냅니다. close 산출물(session-state 마감 헤딩, hot.md 종료 서술, close 어휘 커밋)을 디스크의 session-closed 마커와 대조해 경고만 냅니다. ([#226](https://github.com/sk-lim19f/Hypomnema/pull/226))
+- 세션 종료 시 index가 없는 프로젝트에 `projects/<name>/index.md`를 템플릿에서 생성합니다. `lint`는 index 없는 프로젝트와 `working_dir` 앵커 없는 index에 경고를 냅니다(에러 아님). ([#227](https://github.com/sk-lim19f/Hypomnema/pull/227))
+- `hypo:doctor`가 마지막 pull·push 성공 시각을 보여줘, 정상 볼트와 한 번도 동기화 안 된 볼트를 구분합니다. ([#223](https://github.com/sk-lim19f/Hypomnema/pull/223))
+
+### Bug Fixes
+
+#### English
+
+- Closing a session no longer needs a second confirmation after you type the proposal-approval line. The line is now neutral: it cannot expire a close approval, and it cannot create one. A message that is not a close phrase still expires the approval, so a session is never closed without being asked. ([#236](https://github.com/sk-lim19f/Hypomnema/pull/236))
+- Hooks now resolve their package root from where the code is actually running, so a plugin-channel update no longer leaves them running one version while the scripts they invoke resolve under another. ([#235](https://github.com/sk-lim19f/Hypomnema/pull/235))
+- An interrupted `rename --apply` can now always be re-run: the move is a single atomic step, so it no longer leaves a page at two paths (page mode) or a moved subtree whose own links still point at the old path (directory mode), both of which used to refuse every re-run. ([#231](https://github.com/sk-lim19f/Hypomnema/pull/231))
+- Page-usage logging no longer stays off for the rest of a session after a single `git check-ignore` probe fails to answer, and the probe's timeout was raised so it stops firing on a loaded machine. ([#230](https://github.com/sk-lim19f/Hypomnema/pull/230))
+- Fixed a silent lost update in the session-log append path: a lock is no longer taken from a holder that is still running, and it is never published in a momentarily empty state where a second writer would read it as abandoned. ([#228](https://github.com/sk-lim19f/Hypomnema/pull/228))
+- A failed merge-abort (`conflict-unresolved`) now gets its own recovery guidance in both `doctor` and the session-start notice, instead of the clean-conflict wording that wrongly claimed local work was committed and safe; `doctor` also names the last successful sync and lists several unresolved failures rather than only the most recent one. ([#225](https://github.com/sk-lim19f/Hypomnema/pull/225))
+- `hypomnema` now rejects an unknown flag with exit 2 instead of silently running init, implements and documents `--version`, lists the `proposal` subcommand in `--help`, and stops `lint`, `stats` and `graph` from reporting a clean scan when no vault was found. ([#224](https://github.com/sk-lim19f/Hypomnema/pull/224))
+- Vault auto-commit now commits only the current session's touched paths, so a concurrent session's staged files are no longer swept into an unrelated commit. ([#222](https://github.com/sk-lim19f/Hypomnema/pull/222))
+- Hook installation and `hypo:doctor` now resolve the git hooks directory from git, fixing an `ENOTDIR` crash in linked worktrees and a false "not installed" report when `core.hooksPath` is set. ([#221](https://github.com/sk-lim19f/Hypomnema/pull/221))
+
+#### 한국어
+
+- proposal 승인 줄을 타이핑한 뒤 세션 종료를 다시 확인받지 않아도 됩니다. 이 줄은 이제 중립이라 close 승인을 만료시키지도, 새로 만들지도 않습니다. close 문구가 아닌 발화는 예전처럼 승인을 만료시키므로, 요청하지 않은 종료는 여전히 일어나지 않습니다. ([#236](https://github.com/sk-lim19f/Hypomnema/pull/236))
+- 훅이 실제로 실행되는 위치에서 package root를 정합니다. 플러그인 채널로 업데이트해도 훅과 그 훅이 부르는 스크립트가 서로 다른 버전에서 도는 일이 없습니다. ([#235](https://github.com/sk-lim19f/Hypomnema/pull/235))
+- 중단된 `rename --apply`를 이제 항상 다시 돌릴 수 있습니다. 이동이 원자적 한 단계라, 페이지가 두 경로에 남거나(페이지 모드) 옮겨진 서브트리의 링크가 옛 경로를 가리킨 채 남는(디렉터리 모드) 상태가 생기지 않습니다. 둘 다 예전에는 재실행이 거부되던 상태입니다. ([#231](https://github.com/sk-lim19f/Hypomnema/pull/231))
+- `git check-ignore` probe가 한 번 답하지 못했다고 해서 page-usage 로깅이 세션 내내 꺼져 있지 않고, 부하 걸린 머신에서 상한이 발화하지 않도록 타임아웃을 올렸습니다. ([#230](https://github.com/sk-lim19f/Hypomnema/pull/230))
+- 세션 로그 append 경로의 조용한 갱신 유실을 고쳤습니다. 살아 있는 holder의 락을 더 이상 뺏지 않고, 두 번째 writer가 버려진 락으로 읽을 만한 빈 상태로 공개하지도 않습니다. ([#228](https://github.com/sk-lim19f/Hypomnema/pull/228))
+- merge abort가 실패한 상태(`conflict-unresolved`)가 `doctor`와 session-start 안내 양쪽에서 전용 복구 안내를 받습니다. 로컬 작업이 커밋돼 안전하다고 잘못 단정하던 일반 충돌 문구를 쓰지 않습니다. `doctor`는 마지막 성공 sync를 함께 보여주고, 가장 최근 하나가 아니라 여러 미해결 실패를 나열합니다. ([#225](https://github.com/sk-lim19f/Hypomnema/pull/225))
+- `hypomnema`가 알 수 없는 플래그를 조용히 init으로 흘리는 대신 exit 2로 거부하고, `--version`을 구현해 문서화했으며, `--help`에 `proposal` 서브커맨드를 싣고, `lint`, `stats`, `graph`가 볼트를 찾지 못했을 때 정상 스캔인 것처럼 보고하지 않습니다. ([#224](https://github.com/sk-lim19f/Hypomnema/pull/224))
+- 볼트 auto-commit이 이번 세션이 건드린 경로만 커밋해, 동시에 도는 다른 세션의 staged 파일이 무관한 커밋에 섞이지 않습니다. ([#222](https://github.com/sk-lim19f/Hypomnema/pull/222))
+- 훅 설치와 `hypo:doctor`가 훅 디렉터리를 git에서 해석합니다. linked worktree에서 나던 `ENOTDIR` 크래시와 `core.hooksPath` 설정 시의 잘못된 "미설치" 보고를 고쳤습니다. ([#221](https://github.com/sk-lim19f/Hypomnema/pull/221))
+
 ## [1.7.0] - 2026-07-20
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypomnema",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypomnema",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "bin": {
         "hypomnema": "scripts/init.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypomnema",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "LLM-native personal wiki system for Claude Code",
   "type": "module",
   "license": "MIT",

--- a/qa-runs/2026-08-25.md
+++ b/qa-runs/2026-08-25.md
@@ -1,0 +1,163 @@
+# QA run 2026-08-25: v1.7.1 pre-release hook QA
+
+Three hook changes ship in v1.7.1 and none had a real-session QA run:
+PR #232 (page-usage guard probe injection), PR #235 (`PKG_ROOT` self-location),
+PR #236 (close approval lease). Unit tests cover the checkout copy; the failure
+modes these changes touch only appear in the deployed copy, so this run installs
+the release candidate into an isolated `HOME` and exercises it there.
+
+Candidate: `ea493df` on `main`, packed with `npm pack`.
+Isolated root: a scratch `HOME` with `hypomnema` installed under
+`<HOME>/.npm/lib/node_modules/hypomnema` and a vault at `<HOME>/hypomnema`.
+Every command ran as `env -u HYPO_DIR HOME=<isolated>` so the developer's real
+vault and plugin cache were never touched.
+
+---
+
+## Correction to an earlier measurement in this session
+
+The first pass of the #236 transcript work passed the transcript **contents** to
+`hasUserCloseSignal`, whose parameter is a transcript **path**. Every call
+returned `false` on input it could not parse, and the resulting numbers ("856
+prefixes, 0 verdict differences") measured nothing. Everything below was re-run
+with a path, and the re-run is what the PR body carries.
+
+Worth keeping: a differential that reports "no differences" is indistinguishable
+from a harness that is not exercising the code at all. The re-run added a
+counter for how many prefixes the gate actually grants (52 of 859), which is
+what makes the zero-difference result meaningful.
+
+---
+
+## 1. PR #235, `PKG_ROOT` resolves from where the code runs
+
+The bug was a cache (`~/.claude/hypo-pkg.json`) that nothing updated, so a hook
+could resolve the package root to a stale or hostile path. Review of that fix
+also caught a candidate-acceptance contract that checked a path's _shape_ and so
+let `$HOME` through.
+
+Plugin layout (hook loaded from inside the package, which is how the plugin
+loader serves it):
+
+| cache state             | `PKG_ROOT`            | verdict                                  |
+| ----------------------- | --------------------- | ---------------------------------------- |
+| cache absent            | the real install path | self-location works with no cache at all |
+| cache points at `$HOME` | the real install path | the hostile cache is ignored             |
+
+npm/manual layout (hooks copied to `~/.claude/hooks/`, outside the package):
+
+| cache state                                | `PKG_ROOT`            |
+| ------------------------------------------ | --------------------- |
+| cache valid                                | the real install path |
+| cache absent                               | `null`                |
+| cache points at a path that does not exist | `null`                |
+| cache points at `$HOME`                    | `null`                |
+
+`null` here is the correct outcome, not a regression. In this layout the hook
+file genuinely sits outside any package, so self-location has no package root to
+find, and the contract refuses to adopt an unrelated tree rather than guessing.
+Every consumer is written as `PKG_ROOT ? join(PKG_ROOT, ...) : null`, so the
+feature degrades to "skipped" instead of building a path into someone's home
+directory.
+
+**Verdict: pass.** The case the fix targets (plugin layout) self-locates with no
+cache and ignores a hostile one. The case it cannot serve (hooks outside the
+package) fails closed.
+
+## 2. Deployed copies are the same bytes
+
+`hypo-shared.mjs`, `hypo-close-guard.mjs`, and `hypo-lookup.mjs` in the isolated
+`~/.claude/hooks/` are byte-identical to the checkout. Both hooks executed
+against synthetic event JSON on stdin exited 0 with empty stderr, which is the
+load-time check that matters here: `PKG_ROOT` resolves at module load, so a
+resolution that throws would surface as a non-zero exit on any hook invocation.
+
+## 3. PR #236, close approval measured against real transcripts
+
+15 real transcripts from this machine, 859 prefixes, each written to a file and
+passed by path. Compared against `origin/main`:
+
+    verdicts differing from origin/main: 0
+    prefixes where the gate grants:      52
+    exceptions thrown:                   0
+
+The grant count is the control: without it, "0 differences" would also be what a
+broken harness produces.
+
+Positive case, built from a transcript containing a real `proposal challenge`
+run, truncated at that command's `tool_result` and extended with a real close
+record and the real approval line:
+
+| scenario                             | old   | new      |
+| ------------------------------------ | ----- | -------- |
+| close only                           | true  | true     |
+| close, then the minted approval line | false | **true** |
+| close, then a nonce never minted     | false | false    |
+| close, then ordinary typed text      | false | false    |
+| prefix containing no close at all    | false | false    |
+
+Row 2 is the fix. Rows 3 and 4 are the defences holding: a forged nonce and an
+ordinary typed message both still expire the lease. Row 5 shows the neutral
+branch cannot manufacture an approval.
+
+The same three verdicts reproduce when the function is imported from the
+deployed copy rather than the checkout.
+
+**Verdict: pass.**
+
+## 4. Something the QA turned up that is worth acting on
+
+Real user records carry `origin: {"kind": "human"}` and `promptSource: "typed"`.
+Review of #236 removed the slash-command approval channel because nothing in the
+record distinguished a human invocation from the model's own `Skill` call, and
+concluded that reopening it would need a host-recorded, verifiable
+human-producer field. These two fields are exactly that. Whether they are
+trustworthy for this purpose is not settled here, but the follow-up now has
+something concrete to check rather than a dead end.
+
+## 5. Live worker session against the isolated HOME
+
+A single Claude worker ran inside the isolated `HOME` and drove the CLI directly.
+All 15 registered hooks resolved to files that exist and executed without error.
+`--apply-session-close` refused in the right order and for the right reason at
+each step: no payload, then no session id, then an unresolvable transcript, then
+`no-user-close-signal`. With a close phrase present it reached
+`stage: proposal-pending`, appended the two append-target files, parked the three
+overwrite targets as proposals, and stopped at the point where a person has to
+type the approval line. Re-running the same payload moved the applied entries to
+`skipped` and left the proposal count unchanged, so the idempotence holds.
+
+The worker deliberately did not forge an approval line into the transcript to get
+past that point, since doing so is the exact act the gate exists to refuse. The
+path after approval (a successful `resolve` and the marker write) is therefore
+**not covered**.
+
+Two findings came out of it, both filed and both pre-existing rather than
+introduced by this release:
+
+- The close path writes a wikilink into the root `log.md` pointing at a project
+  `hot.md` that its own run just parked, and its `postApply` lint reports
+  `ok: true` while `doctor` reports the broken link. `scripts/lint.mjs` scans
+  `pages`, `projects` and `journal` only; root `*.md` files are collected as link
+  targets and never linted. Confirmed by planting the same broken link under
+  `pages/`, where lint catches it.
+- `--check-session-close` reported `project: (unresolved)` for a vault where
+  `--apply-session-close`, given the same payload, resolved the project by name.
+  Two inference paths for one question.
+
+Smaller notes: `proposal challenge` reports `invalid --session-id` before
+mentioning that `--ids` is also required, and `hypo-close-guard` does not inspect
+`Bash` invocations of the close script (its own comment states this is out of
+scope, so it is a naming expectation rather than a defect).
+
+The worker also flagged that the installed package read `1.7.0` everywhere. That
+is the version bump being step 1 of the release checklist, which had not run yet;
+the code under test was `ea493df`. Version agreement was re-checked after the
+bump with `npm run check:versions`.
+
+## 6. Still not covered
+
+Hook firing driven by the harness's own events inside a live Claude Code session.
+Both this run and the worker fed hooks their event JSON directly, which is the
+same entry point the harness uses, so what remains untested is event delivery and
+ordering, not the hook bodies.

--- a/templates/hypo-config.md
+++ b/templates/hypo-config.md
@@ -1,7 +1,7 @@
 ---
 title: Hypomnema Config
 type: config
-version: "1.7.0"
+version: "1.7.1"
 created: YYYY-MM-DD
 ---
 


### PR DESCRIPTION
# English

## What changed

Cuts v1.7.1. Bumps the version across `package.json`, the lockfile, the plugin
and marketplace manifests, and `templates/hypo-config.md`, and adds the
`[1.7.1]` CHANGELOG section assembled from the merged PRs. Also lands the
pre-release hook QA record for this release.

No product code changes here. Everything the release ships already merged.

## Why

Sixteen PRs merged since v1.7.0 and none of them are released. The release
carries three hook changes, so this cut is gated on a hook QA run rather than on
the unit suite alone.

The shipping scope was narrowed deliberately. v1.7.1 now carries the defects
that were already merged plus one that had to land first; the rest of the open
v1.7.1 work moved to v1.7.2, and the improvements moved to v1.8.0 because an
improvement belongs to a minor, not a patch.

## How

Followed the release checklist in `docs/CONTRIBUTING.md`: bump, sync the
lockfile, collect the CHANGELOG draft from the merged PR bodies, finalize it by
hand in both languages, then run the full gate set locally.

The CHANGELOG draft was edited down: two entries whose collected text was "None"
were dropped, since a release note that says nothing is not a release note.

## Manual verification

Full gate set, each run standalone and judged by exit code:

    npm test                   0
    npm run lint               0
    npm run check:versions     0
    npm run check:bilingual    0
    npm run smoke:plugin       0
    npm run smoke-pack         0
    npm run check:tracker-ids  0
    npm run check:pack-surface 0

Hook QA against a release candidate installed into an isolated `HOME`, recorded
in `qa-runs/2026-08-25.md`. Summary of what it established:

- `PKG_ROOT` self-locates correctly in the plugin layout with no cache present
  and ignores a cache pointing at `$HOME`. In the npm layout, where the hooks are
  copied outside the package, it resolves to `null` rather than adopting an
  unrelated tree, and every consumer guards on that.
- The deployed hook files are byte-identical to the checkout and load without
  error.
- The close-approval change was measured against 15 real transcripts (859
  prefixes): no verdict differs from the pre-change code, no exceptions, and the
  gate grants on 52 of those prefixes, which is what makes the zero-difference
  result meaningful rather than a silently broken harness.
- A live worker session drove the close path to the point where a person must
  type the approval line, and stopped there. The path past approval is not
  covered.

The QA also found two defects. Both are pre-existing rather than introduced
here, and both are filed against the next patch: the close path writes a broken
wikilink into the root `log.md` that its own `postApply` lint cannot see because
root `*.md` is outside the lint scan scope, and `--check-session-close` resolves
a different project than `--apply-session-close` does for the same payload.

## Migration notes

None. No configuration, no vault file, and no command signature changed by this
PR. Installed copies pick up the release through their normal update path.

# 한국어

## 변경 내용

v1.7.1을 끊습니다. `package.json`, 락파일, 플러그인·마켓플레이스 매니페스트,
`templates/hypo-config.md`의 버전을 올리고, 머지된 PR들에서 모은 `[1.7.1]`
CHANGELOG 섹션을 넣습니다. 이번 릴리스의 사전 훅 QA 기록도 함께 들어갑니다.

제품 코드 변경은 없습니다. 릴리스가 싣는 것은 전부 이미 머지된 것입니다.

## 이유

v1.7.0 이후 PR 16건이 머지됐고 아직 하나도 출하되지 않았습니다. 이 릴리스에 훅 변경이
셋 실리므로, 유닛 스위트만이 아니라 훅 QA를 통과해야 끊을 수 있습니다.

출하 범위는 의도적으로 좁혔습니다. v1.7.1은 이미 머지된 결함들과 먼저 들어가야 했던
하나를 싣고, 남은 v1.7.1 작업은 v1.7.2로 옮겼습니다. 개선 항목은 patch가 아니라 minor에
속하므로 v1.8.0으로 보냈습니다.

## 방법

`docs/CONTRIBUTING.md`의 릴리스 체크리스트를 따랐습니다. 버전 bump, 락파일 동기화,
머지된 PR 본문에서 CHANGELOG 초안 수집, 한/영 양쪽 손질, 그다음 전체 게이트 로컬 실행
순입니다.

CHANGELOG 초안은 덜어냈습니다. 수집된 문구가 "None"이던 항목 둘을 뺐습니다. 아무것도
말하지 않는 릴리스 노트는 릴리스 노트가 아닙니다.

## 수동 검증

전체 게이트를 각각 단독 실행해 종료 코드로 판정했습니다.

    npm test                   0
    npm run lint               0
    npm run check:versions     0
    npm run check:bilingual    0
    npm run smoke:plugin       0
    npm run smoke-pack         0
    npm run check:tracker-ids  0
    npm run check:pack-surface 0

격리된 `HOME`에 릴리스 후보를 설치해 훅 QA를 돌렸고 `qa-runs/2026-08-25.md`에
기록했습니다. 확인된 것은 이렇습니다.

- 플러그인 배치에서 `PKG_ROOT`가 캐시 없이도 자기 위치로 정확히 해석하고, 캐시가
  `$HOME`을 가리켜도 무시합니다. 훅이 패키지 밖으로 복사되는 npm 배치에서는 무관한
  트리를 채택하는 대신 `null`로 떨어지고, 소비처가 전부 그 값을 검사합니다.
- 배포된 훅 파일이 체크아웃과 byte 동일하고 오류 없이 로드됩니다.
- close 승인 변경을 실제 트랜스크립트 15개(프리픽스 859개)로 쟀습니다. 변경 전 코드와
  판정이 다른 지점 0, 예외 0이고, 그 프리픽스 중 52개에서 게이트가 승인을 냅니다. 이
  대조군이 있어야 "차이 0"이 조용히 망가진 하네스와 구별됩니다.
- 실제 워커 세션이 close 경로를 사람이 승인 줄을 타이핑해야 하는 지점까지 몰고 가서
  멈췄습니다. 승인 이후 구간은 확인하지 못했습니다.

QA가 결함 둘을 찾았습니다. 이번 변경이 만든 것이 아니라 기존 결함이고, 둘 다 다음
patch로 등재했습니다. 하나는 close 경로가 루트 `log.md`에 쓰는 깨진 wikilink를 자신의
`postApply` lint가 못 보는 것(루트 `*.md`가 lint 스캔 범위 밖)이고, 다른 하나는 같은
payload에 `--check-session-close`와 `--apply-session-close`가 서로 다른 프로젝트를
잡는 것입니다.

## 마이그레이션 노트

없습니다. 이 PR이 설정, 볼트 파일, 명령 시그니처를 바꾸지 않습니다. 설치된 사본은 평소
업데이트 경로로 이 릴리스를 받습니다.

## Changelog

- EN: Release v1.7.1. See the `[1.7.1]` section of `CHANGELOG.md` for what shipped.
- KO: v1.7.1 릴리스. 출하 내용은 `CHANGELOG.md`의 `[1.7.1]` 섹션에 있습니다.

## Checklist

- [x] Full gate set run standalone, judged by exit code (all 0)
- [x] Pre-release hook QA against a candidate in an isolated `HOME` (`qa-runs/2026-08-25.md`)
- [x] CHANGELOG section carries both `#### English` and `#### 한국어`
- [x] No attribution footer, no session URL, no internal tracker ids
- [ ] Annotated tag pushed after this merges (bilingual body, specific tag only)
