### PR TITLE
feat(capture): let a hook declare its interpreter, so python and bash hooks can be captured

### DIFF
--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -76,6 +76,8 @@ import {
   scanSettingsHooks,
   parseCapturableHookCommand,
   HOOK_EVENT_ALLOWLIST,
+  HOOK_INTERPRETER_EXT,
+  DEFAULT_HOOK_INTERPRETER,
   SKILL_ROOT_FILE,
   EXT_PREFIX,
   withSrcExecBits,
@@ -90,8 +92,9 @@ const HOME = homedir();
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Captured types and their singular manifest `type` value. commands/agents install
-// as top-level `.md` files; hooks install as `.mjs` and additionally register a
-// settings.json entry (reverse of forward-sync); skills install as a DIRECTORY.
+// as top-level `.md` files; hooks install as an interpreter-specific executable
+// (.mjs/.py/.sh) and additionally register a settings.json entry
+// (reverse of forward-sync); skills install as a DIRECTORY.
 const CAPTURE_TYPES = ['commands', 'agents', 'hooks', 'skills'];
 // The flat, single-file types. `TYPE_EXT` has no `skills` entry on purpose: a skill
 // has no install extension, and letting it through a flat helper would silently
@@ -101,7 +104,20 @@ const FLAT_TYPES = ['commands', 'agents', 'hooks'];
 // registration instead, and skills have their own directory scanner.
 const READDIR_TYPES = ['commands', 'agents'];
 const TYPE_SINGULAR = { commands: 'command', agents: 'agent', hooks: 'hook', skills: 'skill' };
-const TYPE_EXT = { commands: '.md', agents: '.md', hooks: '.mjs' };
+// `TYPE_EXT` has no `hooks` entry either, for the same reason as skills: a hook's
+// extension depends on its interpreter (HOOK_INTERPRETER_EXT), not its type.
+// captureFileExt() is the one place that resolves it; every hook-touching call
+// site below goes through that, not this map.
+const TYPE_EXT = { commands: '.md', agents: '.md' };
+
+/** The install/wiki-storage extension for one capture candidate. hooks vary by
+ * interpreter (mirrors buildHookCommand/parseCapturableHookCommand in
+ * extensions.mjs); the other flat types have one fixed extension. */
+function captureFileExt(c) {
+  return c.type === 'hooks'
+    ? HOOK_INTERPRETER_EXT[c.interpreter ?? DEFAULT_HOOK_INTERPRETER]
+    : TYPE_EXT[c.type];
+}
 
 // Ceilings for a captured skill subtree (skills-capture design §3). A hand-authored
 // skill is a handful of files; a vendored one (gstack: 14,311 files / 1.1GB, mostly
@@ -124,9 +140,14 @@ function pkgJsonPath() {
  * hooks/commands + already-synced hypo-ext-* copies), anything already owned
  * (a recorded SHA for its install path means the wiki already manages it), and
  * non-.md files. Symlink/non-regular is checked by the caller (needs an fs stat).
+ * `type` must be a flat readdir type with a single fixed extension (TYPE_EXT);
+ * hooks have no entry there (extension depends on interpreter) and are never
+ * routed through this function — scanCandidates only calls it for READDIR_TYPES.
  */
 export function isCaptureCandidate(type, file, recorded) {
-  if (!file.endsWith(TYPE_EXT[type])) return { ok: false, reason: `not a ${TYPE_EXT[type]} file` };
+  const ext = TYPE_EXT[type];
+  if (!ext) return { ok: false, reason: `capture-by-readdir does not cover ${type}` };
+  if (!file.endsWith(ext)) return { ok: false, reason: `not a ${ext} file` };
   const lower = file.toLowerCase();
   if (lower === 'hypo' || lower.startsWith('hypo-')) {
     return { ok: false, reason: 'reserved hypo namespace' };
@@ -296,10 +317,14 @@ export function planSkillCapture({
 /**
  * Reverse-generate the sidecar manifest for a capture candidate. commands/agents
  * carry only `{ type, installName }`; hooks additionally carry the settings
- * registration fields `{ event, matcher?, timeout? }`. matcher/timeout are omitted
- * when absent (an empty-string matcher is already normalized to undefined by the
- * scanner) via conditional spread, so the in-memory object never carries an
- * `undefined`-valued key that would break the planCapture deep-equality check.
+ * registration fields `{ event, matcher?, timeout?, interpreter? }`. Every
+ * optional field is omitted when it would equal its default (an empty-string
+ * matcher is already normalized to undefined by the scanner; `node` is the
+ * default interpreter) via conditional spread, so the in-memory object never
+ * carries an `undefined`-valued key or a redundant explicit default, either of
+ * which would break the planCapture deep-equality check against a manifest
+ * captured before interpreter support landed (a `.mjs` hook's manifest must stay byte-for-byte
+ * identical, or every prior capture becomes a false conflict).
  */
 function buildWantManifest(c) {
   const manifest = { type: TYPE_SINGULAR[c.type], installName: c.stem };
@@ -307,6 +332,9 @@ function buildWantManifest(c) {
     manifest.event = c.event;
     if (c.matcher !== undefined && c.matcher !== '') manifest.matcher = c.matcher;
     if (c.timeout !== undefined) manifest.timeout = c.timeout;
+    if (c.interpreter !== undefined && c.interpreter !== DEFAULT_HOOK_INTERPRETER) {
+      manifest.interpreter = c.interpreter;
+    }
   }
   return manifest;
 }
@@ -438,8 +466,9 @@ function subsetOf(keys, allowed) {
  * canonical.
  *
  * A candidate must satisfy ALL of: strict command grammar
- * (`parseCapturableHookCommand`) resolving under `~/.claude/hooks/`; the resolved
- * `.mjs` is a real regular file (no symlink / non-regular); `type === 'command'`;
+ * (`parseCapturableHookCommand`, which also recovers the interpreter — node,
+ * python3, or bash) resolving under `~/.claude/hooks/`; the resolved
+ * file is a real regular file (no symlink / non-regular); `type === 'command'`;
  * the event is in `HOOK_EVENT_ALLOWLIST`; a preservable shape (F3); the case-folded
  * basename appears exactly once across all settings hooks (F6); and the stem is not
  * a core hook, not the reserved hypo namespace, and not already wiki-owned.
@@ -479,7 +508,7 @@ export function scanHookCandidates(claudeHome, settingsPath, recorded, coreBasen
       skipped.push({ type: 'hooks', command: rec.command, reason: parsed.reason });
       continue;
     }
-    const { stem, basename } = parsed;
+    const { stem, basename, interpreter } = parsed;
     const label = `hooks/${basename}`;
 
     // Duplicate first: a basename registered 2+ times is uniformly skipped so both
@@ -547,6 +576,7 @@ export function scanHookCandidates(claudeHome, settingsPath, recorded, coreBasen
       event: rec.event,
       matcher: rec.matcher,
       timeout: rec.timeout,
+      interpreter,
       label,
     });
   }
@@ -993,7 +1023,7 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
       captureOneSkill({ c, extDir, guard, wikiRoot, args, captured, skipped, created });
       continue;
     }
-    const fileExt = TYPE_EXT[c.type];
+    const fileExt = captureFileExt(c);
     const wikiStem = `${EXT_PREFIX}${c.stem}`;
     const typeDir = join(extDir, c.type);
     const filePath = join(typeDir, `${wikiStem}${fileExt}`);
@@ -1024,11 +1054,12 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
     const plan = planCapture({ wantManifest, srcSha, existingFileSha, existingManifestRaw });
 
     // installFile is the ORIGINAL name the far machine installs under (installName
-    // adoption); for hooks that is `<stem>.mjs`, for commands/agents `<stem>.md`.
+    // adoption); for hooks that is `<stem>` plus its interpreter's extension
+    // (`.mjs`/`.py`/`.sh`), for commands/agents `<stem>.md`.
     const installFile = `${c.stem}${fileExt}`;
     // Ownership keys sync must record for the adoption to count. Hooks track BOTH
-    // the `.mjs` and its `.manifest.json` sidecar under the install path (success
-    // criterion d); commands/agents track only the single install file.
+    // the main file and its `.manifest.json` sidecar under the install path
+    // (success criterion d); commands/agents track only the single install file.
     const requiredKeys =
       c.type === 'hooks'
         ? [`hooks/${installFile}`, `hooks/${c.stem}.manifest.json`]
@@ -1173,7 +1204,7 @@ function report(captured, skipped, failed, dryRun) {
       const dest =
         c.type === 'skills'
           ? `extensions/skills/${EXT_PREFIX}${c.stem}/`
-          : `extensions/${c.type}/${EXT_PREFIX}${c.stem}${TYPE_EXT[c.type]}`;
+          : `extensions/${c.type}/${EXT_PREFIX}${c.stem}${captureFileExt(c)}`;
       log(`  ${c.type}/${c.file} → ${dest}`);
     }
   }

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -15,8 +15,10 @@
  *
  * Security (plan §5 #9): only files matching the `hypo-ext-<name>.<ext>` basename
  * whitelist are discovered, and the settings.json command string is always
- * constructed here as `node $HOME/.claude/hooks/<basename>` — never sourced from
- * the manifest. A manifest cannot inject an arbitrary command path.
+ * constructed here as `<interpreter> $HOME/.claude/hooks/<basename>` — never
+ * sourced from the manifest verbatim. `interpreter` is validated against
+ * HOOK_INTERPRETER_EXT's allowlist before it is ever allowed to reach the command
+ * string, so a manifest cannot inject an arbitrary command path or executable.
  */
 
 import {
@@ -54,8 +56,53 @@ export const EXT_PREFIX = 'hypo-ext-';
 // Codex supports hooks + commands only; skills/agents are Claude-only.
 export const CODEX_TYPES = ['hooks', 'commands'];
 
-// Per-type expected file extension. Hooks are executable .mjs; the rest are .md.
-const TYPE_FILE_EXT = { hooks: '.mjs', commands: '.md', skills: '.md', agents: '.md' };
+// Per-type expected file extension. Hooks have no single extension (see
+// HOOK_INTERPRETER_EXT below); the rest are .md.
+const TYPE_FILE_EXT = { commands: '.md', skills: '.md', agents: '.md' };
+
+// Hook interpreter allowlist. Before this, capture rejected every non-node hook.
+// This is a trust boundary: a manifest `interpreter` value, and a settings.json
+// command prefix on the reverse-capture path, are only ever accepted from this
+// exact set. Nothing outside it can reach a settings.json command string, which
+// is what makes a captured manifest safe to replay as an executable command.
+// Each interpreter maps to the one file extension it installs and captures
+// under, keeping buildHookCommand/parseCapturableHookCommand/resolveInstallFile
+// in agreement on what "a node hook" or "a python hook" even means.
+export const HOOK_INTERPRETER_EXT = { node: '.mjs', python3: '.py', bash: '.sh' };
+export const HOOK_INTERPRETERS = new Set(Object.keys(HOOK_INTERPRETER_EXT));
+
+// A manifest with no `interpreter` field predates this allowlist (backward
+// compatible): it is interpreted as `node`, matching the only interpreter that
+// ever existed before. buildHookCommand/resolveInstallFile default to this so
+// an existing `.mjs` hook's command string and install path never change.
+export const DEFAULT_HOOK_INTERPRETER = 'node';
+
+/** The install/capture extension for one hook interpreter, defaulting a missing
+ * value to `node` (backward compatible). Callers only reach this after the
+ * interpreter has already been validated against HOOK_INTERPRETERS (by
+ * parseManifest for the forward path, by parseCapturableHookCommand for the
+ * reverse path) — this is a lookup, not a second validation. */
+export function hookExtFor(interpreter) {
+  return HOOK_INTERPRETER_EXT[interpreter ?? DEFAULT_HOOK_INTERPRETER];
+}
+
+/**
+ * Derive a hook's sidecar `.manifest.json` install name from its main install
+ * filename, whichever interpreter extension it carries (`.mjs`/`.py`/`.sh`).
+ * A plain `installFile.replace(/\.mjs$/, ...)` — the node-only shape this replaced — only
+ * matched node hooks; for a python/bash installFile it silently no-opped,
+ * which would point the manifest copy at the hook's OWN install path (main
+ * file and sidecar landing on the same destPath) instead of a distinct
+ * `.manifest.json`. Returns `installFile` unchanged if it carries none of the
+ * known extensions (unreachable in practice: every caller's installFile is
+ * built from HOOK_INTERPRETER_EXT).
+ */
+export function hookManifestNameFor(installFile) {
+  for (const ext of Object.values(HOOK_INTERPRETER_EXT)) {
+    if (installFile.endsWith(ext)) return `${installFile.slice(0, -ext.length)}.manifest.json`;
+  }
+  return installFile;
+}
 
 // Singular manifest `type` value per directory (capture design §3). A captured
 // extension's sidecar manifest must declare a `type` matching its parent dir
@@ -128,11 +175,17 @@ export function isValidInstallStem(stem) {
  * Resolve the install filename for a discovered extension (capture design §3).
  * Returns `{ installFile }` — the basename under `~/.claude/<type>/`. Defaults
  * to `ext.file` (the wiki storage name) so existing hypo-ext-* extensions are
- * untouched (backward compatible). Only commands/agents with a sidecar manifest
- * whose `type` matches the directory AND whose `installName` is valid install
- * under the user's original name. A present-but-invalid installName yields
- * `{ skip, warn }` — the extension is dropped rather than silently installed
- * under a surprising name.
+ * untouched (backward compatible). Only commands/agents/hooks with a sidecar
+ * manifest whose `type` matches the directory AND whose `installName` is valid
+ * install under the user's original name. A present-but-invalid installName
+ * yields `{ skip, warn }` — the extension is dropped rather than silently
+ * installed under a surprising name.
+ *
+ * For hooks, the extension is the manifest's `interpreter` (default `node`),
+ * not the fixed `.mjs`: `python3 $HOME/.claude/hooks/foo.py` and
+ * `bash $HOME/.claude/hooks/bar.sh` are both valid install shapes. parseManifest
+ * already rejected any `interpreter` outside HOOK_INTERPRETERS, so a `parsed.ok`
+ * manifest's value here is trusted without re-checking.
  */
 export function resolveInstallFile(ext) {
   if (!INSTALLNAME_TYPES.has(ext.type) || !ext.manifestPath) {
@@ -153,7 +206,8 @@ export function resolveInstallFile(ext) {
       warn: `${ext.type}/${ext.file}: invalid installName "${m.installName}" — extension skipped`,
     };
   }
-  return { installFile: m.installName + TYPE_FILE_EXT[ext.type] };
+  const fileExt = ext.type === 'hooks' ? hookExtFor(m.interpreter) : TYPE_FILE_EXT[ext.type];
+  return { installFile: m.installName + fileExt };
 }
 
 /**
@@ -221,10 +275,18 @@ export function parseExtKey(key, coveredTypes) {
   if (installFile.includes('/') || installFile.includes('\\')) return null;
   if (installFile.includes('..') || installFile.startsWith('.')) return null;
   const MANIFEST_SUFFIX = '.manifest.json';
-  const suffix =
-    type === 'hooks' && installFile.endsWith(MANIFEST_SUFFIX)
-      ? MANIFEST_SUFFIX
-      : TYPE_FILE_EXT[type];
+  let suffix;
+  if (type === 'hooks' && installFile.endsWith(MANIFEST_SUFFIX)) {
+    suffix = MANIFEST_SUFFIX;
+  } else if (type === 'hooks') {
+    // A hook's main file may end in any interpreter's extension (.mjs/.py/.sh);
+    // reject anything that matches none of them rather than guessing one.
+    const match = Object.values(HOOK_INTERPRETER_EXT).find((e) => installFile.endsWith(e));
+    if (match === undefined) return null;
+    suffix = match;
+  } else {
+    suffix = TYPE_FILE_EXT[type];
+  }
   if (!installFile.endsWith(suffix)) return null;
   const stem = installFile.slice(0, -suffix.length);
   if (stem.length === 0) return null;
@@ -624,7 +686,6 @@ export function discoverExtensions(extDir, hypoignorePatterns, hypoDir) {
     } catch {
       continue;
     }
-    const fileExt = TYPE_FILE_EXT[type];
     for (const fname of entries) {
       if (fname === '.gitkeep') continue;
       // Manifests are paired with their sibling, not discovered standalone.
@@ -665,7 +726,13 @@ export function discoverExtensions(extDir, hypoignorePatterns, hypoDir) {
       }
 
       if (!isRegularFile(srcPath)) continue;
-      if (!fname.endsWith(fileExt)) continue;
+      // A hook's wiki storage file may carry any interpreter's extension
+      // (.mjs/.py/.sh); every other type has exactly one.
+      const fileExt =
+        type === 'hooks'
+          ? Object.values(HOOK_INTERPRETER_EXT).find((e) => fname.endsWith(e))
+          : TYPE_FILE_EXT[type];
+      if (!fileExt || !fname.endsWith(fileExt)) continue;
       const stem = fname.slice(0, -fileExt.length);
       if (!SAFE_EXT_STEM.test(stem)) {
         result.warnings.push(
@@ -728,6 +795,14 @@ export function parseManifest(path) {
   if (m.timeout !== undefined && (typeof m.timeout !== 'number' || m.timeout <= 0)) {
     return { ok: false, error: 'timeout must be a positive number' };
   }
+  // Trust boundary: interpreter drives the settings.json command
+  // prefix, so it is validated here, the same place event/matcher/timeout are —
+  // a malformed manifest is dropped whole, never partially trusted downstream.
+  // Absent is fine (defaults to `node`, backward compatible); present-but-
+  // unknown is not.
+  if (m.interpreter !== undefined && !HOOK_INTERPRETERS.has(m.interpreter)) {
+    return { ok: false, error: `unknown hook interpreter: ${m.interpreter}` };
+  }
   // Boundary normalization: `matcher: ""` is a
   // valid string per the type check above, but every downstream call site
   // disagrees on what it means — `if (entry.matcher)` (line ~641) silently
@@ -744,11 +819,20 @@ export function parseManifest(path) {
 
 /**
  * Build the settings.json entries expected for the discovered hook extensions.
- * The command string is constructed here (never from the manifest) via the shared
- * `buildHookCommand`, using the installName-resolved install filename so a captured
- * hook registers under its original name and its command matches the installed
- * `.mjs`. Extensions whose manifest is missing, not registrable, or whose
- * installName is invalid (resolveInstallFile skip) yield no entry.
+ * The command string is constructed here (never from the manifest path/verbatim)
+ * via the shared `buildHookCommand`, using the installName-resolved install
+ * filename so a captured hook registers under its original name and its command
+ * matches the installed file. The interpreter (default `node`) comes from the
+ * manifest, but only after parseManifest has already validated it against
+ * HOOK_INTERPRETERS — `parsed.ok` here means it is trustworthy. Extensions whose
+ * manifest is missing, not registrable, whose installName is invalid
+ * (resolveInstallFile skip), or whose resolved install filename's extension
+ * disagrees with its own interpreter (a wiki-storage-name hook whose file
+ * extension and manifest interpreter were never checked against each other)
+ * yield no entry — the last case is what keeps this function and
+ * parseCapturableHookCommand mirrors of each other on every path, not only the
+ * installName-rename one, including doctor.mjs's direct call on unfiltered
+ * discovery.
  */
 export function buildExpectedSettingsEntries(discoveredHooks, targetHooksDir) {
   const entries = [];
@@ -758,7 +842,15 @@ export function buildExpectedSettingsEntries(discoveredHooks, targetHooksDir) {
     if (!parsed.ok || !parsed.registrable) continue;
     const resolved = resolveInstallFile(ext);
     if (resolved.skip) continue;
-    const command = buildHookCommand(targetHooksDir, resolved.installFile);
+    const interpreter = parsed.manifest.interpreter ?? DEFAULT_HOOK_INTERPRETER;
+    // Forward and reverse must never drift: an install filename whose extension
+    // disagrees with the manifest's own interpreter (possible for a wiki-storage
+    // hook with no installName override, e.g. a `.py` file and no `interpreter`
+    // field, which defaults to node) would build a command
+    // parseCapturableHookCommand can never re-accept. Refuse to emit it rather
+    // than register a hook under a command its own source cannot run.
+    if (!resolved.installFile.endsWith(hookExtFor(interpreter))) continue;
+    const command = buildHookCommand(targetHooksDir, resolved.installFile, interpreter);
     entries.push({
       name: ext.name,
       file: ext.file,
@@ -777,40 +869,55 @@ export function buildExpectedSettingsEntries(discoveredHooks, targetHooksDir) {
  * strict parser (`parseCapturableHookCommand`) mirror this one shape so the two
  * directions can never drift. `hooksDir` is `<HOME>/.claude/hooks`, rewritten to
  * a `$HOME` literal so a captured registration stays portable across machines.
+ *
+ * `interpreter` defaults to `node` (backward compatible: a manifest predating
+ * interpreter support has none, and its command string must stay byte-identical). Any other
+ * value must already be in HOOK_INTERPRETERS — this function trusts its caller
+ * rather than re-validating, so every caller must route through parseManifest
+ * (forward path) or parseCapturableHookCommand (reverse path) first.
  */
-export function buildHookCommand(hooksDir, installFile) {
-  return `node ${hooksDir.replace(HOME, '$HOME')}/${installFile}`;
+export function buildHookCommand(hooksDir, installFile, interpreter = DEFAULT_HOOK_INTERPRETER) {
+  if (!HOOK_INTERPRETERS.has(interpreter)) {
+    throw new Error(`buildHookCommand: unknown interpreter "${interpreter}"`);
+  }
+  return `${interpreter} ${hooksDir.replace(HOME, '$HOME')}/${installFile}`;
 }
 
 // The exact canonical hook path prefix that `buildHookCommand` emits for a dir
 // under HOME. The strict parser accepts only this literal — an absolute path, a
 // `~`, or an env prefix all diverge and are rejected with a visible reason.
 const CAPTURABLE_HOOK_PATH_PREFIX = '$HOME/.claude/hooks/';
-const CAPTURABLE_NODE_PREFIX = 'node ';
-const MJS_EXT = '.mjs';
 
 /**
- * Strict, fs-free parser for a capturable hook command (capture design F4). It
- * accepts ONLY the byte-for-byte shape `buildHookCommand` produces for a dir
- * under HOME: `node $HOME/.claude/hooks/<stem>.mjs`. Returns
- * `{ ok:true, stem, basename }` on a match, else `{ ok:false, reason }` with a
- * distinct reason per rejection axis so a caller can surface why a hook was not
- * captured (never a silent drop). This is deliberately NOT the lenient
- * `_extractCommandFileName` used by init: capture eligibility must be exact.
+ * Strict, fs-free parser for a capturable hook command (capture design F4,
+ * widened to non-node interpreters). It accepts ONLY the byte-for-byte shape
+ * `buildHookCommand` produces for a dir under HOME:
+ * `<interpreter> $HOME/.claude/hooks/<stem><ext>`, where `interpreter` is in
+ * HOOK_INTERPRETERS and `ext` is that interpreter's HOOK_INTERPRETER_EXT value
+ * (a `python3` command must end in `.py`, never `.mjs` — the interpreter and
+ * the extension are read together, not independently). Returns
+ * `{ ok:true, stem, basename, interpreter }` on a match, else
+ * `{ ok:false, reason }` with a distinct reason per rejection axis so a caller
+ * can surface why a hook was not captured (never a silent drop). This is
+ * deliberately NOT the lenient `_extractCommandFileName` used by init: capture
+ * eligibility must be exact.
  */
 export function parseCapturableHookCommand(command) {
   if (typeof command !== 'string') return { ok: false, reason: 'not-a-string' };
   // A newline in a command would break the one-line canonical shape and could
   // smuggle a second statement past a prefix check.
   if (/[\r\n]/.test(command)) return { ok: false, reason: 'contains-newline' };
-  if (!command.startsWith(CAPTURABLE_NODE_PREFIX)) {
-    return { ok: false, reason: 'bad-node-prefix' };
+  const spaceIdx = command.indexOf(' ');
+  const interpreter = spaceIdx === -1 ? command : command.slice(0, spaceIdx);
+  if (!HOOK_INTERPRETERS.has(interpreter)) {
+    return { ok: false, reason: 'bad-interpreter-prefix' };
   }
-  const rest = command.slice(CAPTURABLE_NODE_PREFIX.length);
-  // Reject extra leading whitespace (a double space or a tab after `node`): the
-  // builder emits exactly one space, so anything more is a lossy divergence.
+  const rest = command.slice(interpreter.length + 1);
+  // Reject extra leading whitespace (a double space or a tab after the
+  // interpreter): the builder emits exactly one space, so anything more is a
+  // lossy divergence.
   if (rest.length === 0 || rest[0] === ' ' || rest[0] === '\t') {
-    return { ok: false, reason: 'bad-node-prefix' };
+    return { ok: false, reason: 'bad-interpreter-prefix' };
   }
   if (!rest.startsWith(CAPTURABLE_HOOK_PATH_PREFIX)) {
     // Covers `~`, a relative path, an env prefix, and an absolute path — none
@@ -823,16 +930,17 @@ export function parseCapturableHookCommand(command) {
   if (tail.includes('/') || tail.includes('\\') || tail.includes('..')) {
     return { ok: false, reason: 'nested-segment' };
   }
-  if (!tail.endsWith(MJS_EXT)) {
-    return { ok: false, reason: 'not-mjs' };
+  const ext = HOOK_INTERPRETER_EXT[interpreter];
+  if (!tail.endsWith(ext)) {
+    return { ok: false, reason: 'wrong-extension' };
   }
-  const stem = tail.slice(0, -MJS_EXT.length);
+  const stem = tail.slice(0, -ext.length);
   // Same stem gate as install (rejects the reserved hypo-* namespace, Windows
   // device names, and out-of-charset names) so parse and install agree.
   if (!isValidInstallStem(stem)) {
     return { ok: false, reason: 'invalid-stem' };
   }
-  return { ok: true, stem, basename: tail };
+  return { ok: true, stem, basename: tail, interpreter };
 }
 
 /**
@@ -1395,7 +1503,7 @@ export function syncExtensions({
     // uninstall. commands/agents have no sidecar, so their single key is preserved.
     const keys = [`${ext.type}/${inst}`];
     if (ext.type === 'hooks') {
-      keys.push(`${ext.type}/${inst.replace(/\.mjs$/, '.manifest.json')}`);
+      keys.push(`${ext.type}/${hookManifestNameFor(inst)}`);
     }
     for (const key of keys) {
       if (recorded[key] !== undefined && newSHAs[key] === undefined) newSHAs[key] = recorded[key];
@@ -1439,6 +1547,23 @@ export function syncExtensions({
             );
             continue;
           }
+          // The forward and reverse hook-command shapes are mirrors and must never
+          // drift: buildHookCommand/parseCapturableHookCommand only agree when the
+          // install filename's extension matches what the manifest's interpreter
+          // expects. installFile already carries the interpreter-derived extension
+          // when an installName renamed it, so this only ever fires for a
+          // wiki-storage-name hook (no installName) whose file extension disagrees
+          // with its own manifest — e.g. a `.py` file with no `interpreter` (which
+          // defaults to node) or the wrong one. Caught here, before any hard-copy,
+          // the same way a malformed manifest is: never a silent drop, and never a
+          // hook installed under a command its own source cannot run.
+          const interpreter = manifestParsed.manifest.interpreter ?? DEFAULT_HOOK_INTERPRETER;
+          if (!installFile.endsWith(hookExtFor(interpreter))) {
+            result.warnings.push(
+              `${type}/${ext.file}: interpreter "${interpreter}" does not match "${installFile}"'s extension (interpreter-extension-mismatch) — skipping ${ext.name}`,
+            );
+            continue;
+          }
         } else {
           result.warnings.push(`${ext.name}.manifest.json missing — hook will not auto-register`);
         }
@@ -1478,11 +1603,12 @@ export function syncExtensions({
         manifestParsed &&
         manifestParsed.ok
       ) {
-        // P1: derive the sidecar install name from the sibling `.mjs` installFile
-        // so the manifest copy + SHA key follow installName exactly as the hook
-        // file does. For a wiki-authored hook (no installName) installFile is
-        // `ext.file`, so this equals the old `ext.manifestName` (no regression).
-        const installManifestName = installFile.replace(/\.mjs$/, '.manifest.json');
+        // P1: derive the sidecar install name from the sibling installFile (any
+        // interpreter extension) so the manifest copy + SHA key follow
+        // installName exactly as the hook file does. For a wiki-authored hook (no
+        // installName) installFile is `ext.file`, so this equals the old
+        // `ext.manifestName` (no regression).
+        const installManifestName = hookManifestNameFor(installFile);
         const mKey = `${type}/${installManifestName}`;
         const mRes = copyOne({
           srcPath: ext.manifestPath,

--- a/tests/capture.test.mjs
+++ b/tests/capture.test.mjs
@@ -165,6 +165,53 @@ test('hooks skip an invalid installName rather than install under the wiki name'
   });
 });
 
+// IMPR-38: capture rejected every non-node hook. resolveInstallFile is one of
+// the three symmetric build/parse/extension sites this widens.
+suite('capture: resolveInstallFile interpreter widening (IMPR-38)');
+
+test('a python3 installName resolves to .py, a bash installName to .sh', () => {
+  withTmpDir((dir) => {
+    for (const [interpreter, ext] of [
+      ['python3', '.py'],
+      ['bash', '.sh'],
+    ]) {
+      const wiki = extWithManifest(dir, 'hooks', `hypo-ext-h${ext}`, {
+        type: 'hook',
+        event: 'Stop',
+        installName: 'myhook',
+        interpreter,
+      });
+      assert.deepEqual(resolveInstallFile(wiki), { installFile: `myhook${ext}` });
+    }
+  });
+});
+
+test('an absent interpreter defaults to node, byte-identical to pre-IMPR-38 (backward compat)', () => {
+  withTmpDir((dir) => {
+    const ext = extWithManifest(dir, 'hooks', 'hypo-ext-h.mjs', {
+      type: 'hook',
+      event: 'Stop',
+      installName: 'myhook',
+    });
+    assert.deepEqual(resolveInstallFile(ext), { installFile: 'myhook.mjs' });
+  });
+});
+
+test('an unknown interpreter makes the whole manifest malformed, falling back to the wiki name (never a skip on the installName axis)', () => {
+  withTmpDir((dir) => {
+    const ext = extWithManifest(dir, 'hooks', 'hypo-ext-h.mjs', {
+      type: 'hook',
+      event: 'Stop',
+      installName: 'myhook',
+      interpreter: 'perl',
+    });
+    // parseManifest rejects the whole manifest (interpreter is validated the same
+    // place event/matcher/timeout are), so resolveInstallFile takes its
+    // malformed-manifest fallback: the wiki storage name, not a skip+warn.
+    assert.deepEqual(resolveInstallFile(ext), { installFile: 'hypo-ext-h.mjs' });
+  });
+});
+
 suite('capture: parseExtKey (ADR 0061 §8 uninstall key safety)');
 
 const COVERED = ['hooks', 'commands', 'skills', 'agents'];
@@ -181,7 +228,7 @@ test('rejects traversal / separators / wrong extension / unknown type', () => {
   assert.equal(parseExtKey('commands/a/b.md', COVERED), null);
   assert.equal(parseExtKey('commands/a..b.md', COVERED), null);
   assert.equal(parseExtKey('commands/mycmd.txt', COVERED), null);
-  assert.equal(parseExtKey('hooks/x.md', COVERED), null); // hooks want .mjs
+  assert.equal(parseExtKey('hooks/x.md', COVERED), null); // hooks want .mjs/.py/.sh, not .md
   assert.equal(parseExtKey('unknown/x.md', COVERED), null);
   assert.equal(parseExtKey('commands/.hidden.md', COVERED), null);
   assert.equal(parseExtKey('nokey', COVERED), null);
@@ -197,6 +244,21 @@ test('accepts the hook manifest sidecar but only for hooks', () => {
   // removable file (widened destructive surface).
   assert.equal(parseExtKey('commands/x.manifest.json', COVERED), null);
   assert.equal(parseExtKey('agents/x.manifest.json', COVERED), null);
+});
+
+test('accepts a hook install key under any interpreter extension (IMPR-38)', () => {
+  assert.deepEqual(parseExtKey('hooks/myhook.py', COVERED), {
+    type: 'hooks',
+    installFile: 'myhook.py',
+  });
+  assert.deepEqual(parseExtKey('hooks/myhook.sh', COVERED), {
+    type: 'hooks',
+    installFile: 'myhook.sh',
+  });
+  assert.deepEqual(parseExtKey('hooks/myhook.mjs', COVERED), {
+    type: 'hooks',
+    installFile: 'myhook.mjs',
+  });
 });
 
 test('respects the covered-types scope (codex excludes skills/agents)', () => {
@@ -561,6 +623,165 @@ test('installName hook installs mjs, sidecar, and command under the original nam
   });
 });
 
+// IMPR-38: capture manifest widened to carry `interpreter`, and the three
+// symmetric sites (discoverExtensions' extension filter, resolveInstallFile,
+// buildHookCommand) widen together — a python3 hook installs, registers, and
+// is owned exactly like the node case above, just under .py and its own
+// interpreter prefix.
+test('a python3 hook installs the .py, its sidecar, and a python3-prefixed command', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      writeExt(hypoDir, 'hooks', 'hypo-ext-h.py', '#!/usr/bin/env python3\n', {
+        type: 'hook',
+        event: 'PostToolUse',
+        installName: 'mypyhook',
+        interpreter: 'python3',
+      });
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+
+      const copyDir = join(home, '.claude', 'hooks');
+      assert.ok(existsSync(join(copyDir, 'mypyhook.py')), 'hook not installed under installName');
+      assert.ok(
+        existsSync(join(copyDir, 'mypyhook.manifest.json')),
+        'sidecar not installed under installName (must not collide with the .py itself)',
+      );
+
+      const settings = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      const groups = (settings.hooks?.PostToolUse || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('mypyhook.py')),
+      );
+      assert.equal(groups.length, 1, 'exactly one PostToolUse entry expected');
+      assert.equal(
+        groups[0].hooks[0].command,
+        'python3 $HOME/.claude/hooks/mypyhook.py',
+        'command must use the python3 interpreter, not node',
+      );
+
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(
+        pkg.extensions.claude['hooks/mypyhook.py'],
+        'hook SHA key not owned under installName',
+      );
+      assert.ok(
+        pkg.extensions.claude['hooks/mypyhook.manifest.json'],
+        'sidecar SHA key not owned under installName',
+      );
+    });
+  });
+});
+
+// A bash hook needs no installName: discoverExtensions must recognize .sh as a
+// hook extension on its own (the wiki-storage-name path), separately from the
+// installName-driven rename tested above.
+test('a bash hook with no installName installs and registers under its wiki name', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      writeExt(hypoDir, 'hooks', 'hypo-ext-shhook.sh', '#!/usr/bin/env bash\n', {
+        type: 'hook',
+        event: 'Stop',
+        interpreter: 'bash',
+      });
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+
+      const copyDir = join(home, '.claude', 'hooks');
+      assert.ok(existsSync(join(copyDir, 'hypo-ext-shhook.sh')), 'bash hook not hard-copied');
+      const settings = JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8'));
+      const groups = (settings.hooks?.Stop || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('hypo-ext-shhook.sh')),
+      );
+      assert.equal(groups.length, 1);
+      assert.equal(groups[0].hooks[0].command, 'bash $HOME/.claude/hooks/hypo-ext-shhook.sh');
+    });
+  });
+});
+
+// The production regression this was actually about: a wiki-storage-name hook
+// (no installName) whose file extension disagrees with its manifest's
+// interpreter (here, a `.py` file with no `interpreter` field, which defaults
+// to node) must never be hard-copied or registered. Without this guard,
+// forward-sync would install the `.py` under `node ...py`, a command its own
+// reverse parser then refuses (`wrong-extension`) — the exact asymmetry a
+// build/parse mirror must not allow.
+test('a hook whose extension disagrees with its interpreter is skipped with a visible reason, not installed', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      // No `interpreter` field: defaults to node, which wants .mjs, not .py.
+      writeExt(hypoDir, 'hooks', 'hypo-ext-mismatch.py', '#!/usr/bin/env python3\n', {
+        type: 'hook',
+        event: 'Stop',
+      });
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+      const out = JSON.parse(r.stdout);
+
+      const copyDir = join(home, '.claude', 'hooks');
+      assert.ok(
+        !existsSync(join(copyDir, 'hypo-ext-mismatch.py')),
+        'mismatched hook must not be hard-copied',
+      );
+      assert.ok(
+        !existsSync(join(copyDir, 'hypo-ext-mismatch.manifest.json')),
+        'sidecar must not be copied for a hook that was refused',
+      );
+      const settingsPath = join(home, '.claude', 'settings.json');
+      const settingsText = existsSync(settingsPath) ? readFileSync(settingsPath, 'utf-8') : '';
+      assert.ok(!settingsText.includes('mismatch'), 'no settings.json entry for the mismatched hook');
+      assert.ok(
+        out.applied.extensions.warnings.some(
+          (w) => w.includes('interpreter-extension-mismatch') && w.includes('hypo-ext-mismatch'),
+        ),
+        'a distinct, visible skip reason must be reported',
+      );
+    });
+  });
+});
+
+// Interpreter present but still wrong for the extension: python3 does not
+// install a .mjs.
+test('a python3-declared hook over a .mjs file is skipped the same way', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      writeExt(hypoDir, 'hooks', 'hypo-ext-badpair.mjs', '#!/usr/bin/env node\n', {
+        type: 'hook',
+        event: 'Stop',
+        interpreter: 'python3',
+      });
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r.status, 0, r.stderr);
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        !existsSync(join(home, '.claude', 'hooks', 'hypo-ext-badpair.mjs')),
+        'mismatched hook must not be hard-copied',
+      );
+      assert.ok(
+        out.applied.extensions.warnings.some((w) => w.includes('interpreter-extension-mismatch')),
+      );
+    });
+  });
+});
+
 test('duplicate installName skips the whole group (no partial install)', () => {
   withTmpHome((home) => {
     withTmpDir((dir) => {
@@ -832,7 +1053,47 @@ test('round-trip accept: a HOME-relative dir builds a command the parser restore
     assert.ok(parsed.ok, `${stem} should round-trip`);
     assert.equal(parsed.stem, stem);
     assert.equal(parsed.basename, `${stem}.mjs`);
+    assert.equal(parsed.interpreter, 'node');
   }
+});
+
+// IMPR-38: capture rejected every non-node hook. buildHookCommand/
+// parseCapturableHookCommand must widen together (build/parse are mirrors) so a
+// python or bash hook registers and captures under its own interpreter+extension.
+// The one assertion that pins "build and parse can never drift" across the
+// FULL interpreter allowlist, not just node. If a new interpreter is ever added
+// to HOOK_INTERPRETER_EXT without a matching parseCapturableHookCommand branch,
+// this is what catches it: every interpreter's own buildHookCommand output must
+// come back ok:true, with the SAME stem/interpreter, through the strict parser.
+test('round-trip accept: every allowlisted interpreter build/parses under its own extension', () => {
+  const hooksDir = join(HOME, '.claude', 'hooks');
+  for (const [interpreter, ext] of [
+    ['node', '.mjs'],
+    ['python3', '.py'],
+    ['bash', '.sh'],
+  ]) {
+    const command = buildHookCommand(hooksDir, `mycmd${ext}`, interpreter);
+    assert.equal(command, `${interpreter} $HOME/.claude/hooks/mycmd${ext}`);
+    const parsed = parseCapturableHookCommand(command);
+    assert.ok(parsed.ok, `${interpreter} should round-trip`);
+    assert.equal(parsed.stem, 'mycmd');
+    assert.equal(parsed.basename, `mycmd${ext}`);
+    assert.equal(parsed.interpreter, interpreter);
+  }
+});
+
+// This is a unit-level property of the two pure functions, NOT proof that the
+// production forward path is safe: buildHookCommand itself does not validate
+// the installFile/interpreter pairing (see the reasoning at its definition), so
+// on its own it happily builds this exact mismatched command. What actually
+// keeps a mismatched hook out of settings.json is buildExpectedSettingsEntries
+// (and, before any hard-copy, syncExtensions) refusing to call buildHookCommand
+// for a mismatched pair in the first place — covered separately below in
+// "capture: forward-sync installFile integration".
+test('buildHookCommand does not itself validate the pairing; parseCapturableHookCommand is the parser-side backstop', () => {
+  const command = buildHookCommand(join(HOME, '.claude', 'hooks'), 'x.py', 'node');
+  assert.equal(command, `node $HOME/.claude/hooks/x.py`);
+  assert.equal(parseCapturableHookCommand(command).reason, 'wrong-extension');
 });
 
 test('round-trip reject: a dir outside HOME builds an absolute command the parser rejects', () => {
@@ -853,7 +1114,12 @@ suite('capture: parseCapturableHookCommand strict axes');
 
 test('accepts the exact canonical form', () => {
   const parsed = parseCapturableHookCommand('node $HOME/.claude/hooks/mycmd.mjs');
-  assert.deepEqual(parsed, { ok: true, stem: 'mycmd', basename: 'mycmd.mjs' });
+  assert.deepEqual(parsed, {
+    ok: true,
+    stem: 'mycmd',
+    basename: 'mycmd.mjs',
+    interpreter: 'node',
+  });
 });
 
 test('rejects a non-string with a distinct reason', () => {
@@ -877,28 +1143,38 @@ test('rejects CR/LF', () => {
   );
 });
 
-test('rejects a bad node prefix, including double space and tab', () => {
+test('rejects an interpreter outside the allowlist, and a bad prefix shape, including double space and tab', () => {
   assert.equal(
     parseCapturableHookCommand('nodex $HOME/.claude/hooks/x.mjs').reason,
-    'bad-node-prefix',
+    'bad-interpreter-prefix',
   );
   assert.equal(
     parseCapturableHookCommand('/usr/bin/node $HOME/.claude/hooks/x.mjs').reason,
-    'bad-node-prefix',
+    'bad-interpreter-prefix',
+  );
+  // python (no trailing 3) and ruby/perl/sh are all outside HOOK_INTERPRETERS —
+  // this is the allowlist itself, not a shape defect.
+  assert.equal(
+    parseCapturableHookCommand('python $HOME/.claude/hooks/x.py').reason,
+    'bad-interpreter-prefix',
+  );
+  assert.equal(
+    parseCapturableHookCommand('sh $HOME/.claude/hooks/x.sh').reason,
+    'bad-interpreter-prefix',
   );
   assert.equal(
     parseCapturableHookCommand('node  $HOME/.claude/hooks/x.mjs').reason,
-    'bad-node-prefix',
+    'bad-interpreter-prefix',
   ); // double space
   assert.equal(
     parseCapturableHookCommand('node\t$HOME/.claude/hooks/x.mjs').reason,
-    'bad-node-prefix',
+    'bad-interpreter-prefix',
   ); // tab for space
   assert.equal(
     parseCapturableHookCommand('node \t$HOME/.claude/hooks/x.mjs').reason,
-    'bad-node-prefix',
+    'bad-interpreter-prefix',
   ); // space then tab
-  assert.equal(parseCapturableHookCommand('node ').reason, 'bad-node-prefix');
+  assert.equal(parseCapturableHookCommand('node ').reason, 'bad-interpreter-prefix');
 });
 
 test('rejects a path not under $HOME/.claude/hooks (tilde, relative, env prefix, absolute)', () => {
@@ -944,10 +1220,26 @@ test('rejects a nested segment or traversal in the tail', () => {
   );
 });
 
-test('rejects a non-.mjs tail', () => {
-  assert.equal(parseCapturableHookCommand('node $HOME/.claude/hooks/x.js').reason, 'not-mjs');
-  assert.equal(parseCapturableHookCommand('node $HOME/.claude/hooks/x').reason, 'not-mjs');
-  assert.equal(parseCapturableHookCommand('node $HOME/.claude/hooks/x.mjs.bak').reason, 'not-mjs');
+test('rejects a tail whose extension does not match the interpreter', () => {
+  assert.equal(
+    parseCapturableHookCommand('node $HOME/.claude/hooks/x.js').reason,
+    'wrong-extension',
+  );
+  assert.equal(parseCapturableHookCommand('node $HOME/.claude/hooks/x').reason, 'wrong-extension');
+  assert.equal(
+    parseCapturableHookCommand('node $HOME/.claude/hooks/x.mjs.bak').reason,
+    'wrong-extension',
+  );
+  // Right allowlisted interpreter, wrong interpreter's extension — the two are
+  // read together, never independently.
+  assert.equal(
+    parseCapturableHookCommand('python3 $HOME/.claude/hooks/x.mjs').reason,
+    'wrong-extension',
+  );
+  assert.equal(
+    parseCapturableHookCommand('bash $HOME/.claude/hooks/x.py').reason,
+    'wrong-extension',
+  );
 });
 
 test('rejects a stem that fails isValidInstallStem, including the reserved hypo namespace', () => {
@@ -968,6 +1260,10 @@ test('rejects a stem that fails isValidInstallStem, including the reserved hypo 
     'invalid-stem',
   );
   assert.equal(parseCapturableHookCommand('node $HOME/.claude/hooks/.mjs').reason, 'invalid-stem'); // empty stem
+  assert.equal(
+    parseCapturableHookCommand('python3 $HOME/.claude/hooks/hypo-core.py').reason,
+    'invalid-stem',
+  );
 });
 
 suite('capture: scanSettingsHooks defensive walk');
@@ -1107,15 +1403,18 @@ test('lossy command axes each skip with a visible reason and yield no candidate'
   // Each axis uses a UNIQUE basename so the F6 duplicate check never shadows the
   // per-axis reason. None of these is capturable, so nothing is written anywhere.
   const axes = [
-    { command: 'node $HOME/.claude/hooks/argh.mjs --flag', reason: 'not-mjs' }, // extra CLI arg
-    { command: 'FOO=1 node $HOME/.claude/hooks/envh.mjs', reason: 'bad-node-prefix' }, // env prefix
-    { command: 'node $HOME/.claude/hooks/shellh.mjs && echo hi', reason: 'not-mjs' }, // inline shell
-    { command: '/usr/bin/node $HOME/.claude/hooks/absnodeh.mjs', reason: 'bad-node-prefix' }, // non-bare node
+    { command: 'node $HOME/.claude/hooks/argh.mjs --flag', reason: 'wrong-extension' }, // extra CLI arg
+    { command: 'FOO=1 node $HOME/.claude/hooks/envh.mjs', reason: 'bad-interpreter-prefix' }, // env prefix
+    { command: 'node $HOME/.claude/hooks/shellh.mjs && echo hi', reason: 'wrong-extension' }, // inline shell
+    {
+      command: '/usr/bin/node $HOME/.claude/hooks/absnodeh.mjs',
+      reason: 'bad-interpreter-prefix',
+    }, // non-bare node
     { command: 'node $HOME/.claude/hooks/ghosth.mjs', reason: 'unresolved-source' }, // .mjs missing
     { command: 'node $HOME/.config/hooks/outh.mjs', reason: 'path-not-under-home-hooks' }, // path outside
     { command: 'node hooks/relh.mjs', reason: 'path-not-under-home-hooks' }, // relative
     { command: 'node ~/.claude/hooks/tildeh.mjs', reason: 'path-not-under-home-hooks' }, // tilde
-    { command: 'node  $HOME/.claude/hooks/dblh.mjs', reason: 'bad-node-prefix' }, // double space
+    { command: 'node  $HOME/.claude/hooks/dblh.mjs', reason: 'bad-interpreter-prefix' }, // double space
     { command: 'node $HOME/.claude/hooks/crh.mjs\n', reason: 'contains-newline' }, // CRLF
   ];
   const settings = {
@@ -1318,14 +1617,20 @@ test('a symlinked source (non-regular) is refused as unresolved-source', () => {
 
 // Register one canonical hook (a real .mjs source + the exact settings.json form
 // forward-sync emits) so the capture → adopt round-trip can be observed whole.
-function seedCanonicalHook(home, { stem, event = 'PostToolUse', matcher, timeout, body }) {
+function seedCanonicalHook(
+  home,
+  { stem, event = 'PostToolUse', matcher, timeout, body, interpreter = 'node', ext = '.mjs' },
+) {
   const hooksDir = join(home, '.claude', 'hooks');
   mkdirSync(hooksDir, { recursive: true });
-  writeFileSync(join(hooksDir, `${stem}.mjs`), body);
+  writeFileSync(join(hooksDir, `${stem}${ext}`), body);
   const settingsPath = join(home, '.claude', 'settings.json');
   const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {};
   settings.hooks = settings.hooks || {};
-  const hookEntry = { type: 'command', command: `node $HOME/.claude/hooks/${stem}.mjs` };
+  const hookEntry = {
+    type: 'command',
+    command: `${interpreter} $HOME/.claude/hooks/${stem}${ext}`,
+  };
   if (timeout !== undefined) hookEntry.timeout = timeout;
   const group = { hooks: [hookEntry] };
   if (matcher !== undefined) group.matcher = matcher;
@@ -1415,6 +1720,58 @@ test('omits an empty matcher from the reverse-generated manifest', () => {
         ),
       );
       assert.deepEqual(manifest, { type: 'hook', installName: 'nomatch', event: 'PostToolUse' });
+    });
+  });
+});
+
+// IMPR-38: reverse-capture of a python3 hook. The manifest must carry
+// `interpreter: 'python3'` (unlike the node case above, where it is omitted for
+// backward compat) and the wiki storage file keeps the .py extension.
+test('captures a canonical python3 hook, recording interpreter in the manifest', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const body = '#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n';
+      const settingsPath = seedCanonicalHook(home, {
+        stem: 'mypyhook',
+        interpreter: 'python3',
+        ext: '.py',
+        body,
+      });
+
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home);
+      assert.equal(r.status, 0, r.stderr);
+
+      const wikiDir = join(hypoDir, 'extensions', 'hooks');
+      assert.equal(readFileSync(join(wikiDir, 'hypo-ext-mypyhook.py'), 'utf-8'), body);
+      const manifest = JSON.parse(
+        readFileSync(join(wikiDir, 'hypo-ext-mypyhook.manifest.json'), 'utf-8'),
+      );
+      assert.deepEqual(manifest, {
+        type: 'hook',
+        installName: 'mypyhook',
+        event: 'PostToolUse',
+        interpreter: 'python3',
+      });
+
+      const pkg = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
+      assert.ok(pkg.extensions.claude['hooks/mypyhook.py'], 'py key owned');
+      assert.ok(pkg.extensions.claude['hooks/mypyhook.manifest.json'], 'sidecar key owned');
+
+      const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const groups = (after.hooks.PostToolUse || []).filter((g) =>
+        (g.hooks || []).some((h) => (h.command || '').includes('mypyhook.py')),
+      );
+      assert.equal(groups.length, 1, 'no duplicate registration');
+      assert.equal(
+        groups[0].hooks[0].command,
+        'python3 $HOME/.claude/hooks/mypyhook.py',
+        'command char-identical, python3 interpreter preserved',
+      );
     });
   });
 });


### PR DESCRIPTION
# English

## What changed

A captured hook's manifest can now declare an interpreter. `node`, `python3` and
`bash` are accepted, each with one file extension (`.mjs`, `.py`, `.sh`), and the
three places that previously hardcoded `node` and `.mjs` read that value instead:
the strict reverse parser, the command builder, and the type-to-extension map.

A manifest with no interpreter still means `node`, and the command string it
produces is byte for byte what it was before.

## Why

Reverse capture accepted only the literal shape `node $HOME/.claude/hooks/<name>.mjs`.
Measured against a real vault, all 13 registered hooks were refused with
`bad-node-prefix`, which is every hook the user had. The install side was already
able to handle them: `EXT_TYPES` carries `hooks`, and sync does both the file copy
and the settings.json registration. Only the eligibility check was in the way.

There was no manual route around it either. `buildHookCommand` hardcoded `node`,
and the extension map was fixed at `.mjs`, so writing a manifest by hand would
have registered a python hook as `node ....mjs` and it would not have run at all.

## How

The interpreter is an allowlist rather than a free string. This value ends up as
the command in `settings.json`, and a manifest arrives from a vault that syncs
between machines, so an arbitrary string here is arbitrary execution. It is
validated in `parseManifest` before anything downstream reads it, and
`buildHookCommand` throws on a value outside the set rather than trusting its
caller.

The forward builder and the reverse parser are deliberate mirrors, and widening
one alone is what breaks that. Review found exactly this: `discoverExtensions`
finds a hook by file extension and `buildExpectedSettingsEntries` built a command
without checking that the extension agreed with the manifest's interpreter, so a
`.py` file with `interpreter: node` produced `node ....py`, which the reverse
parser then discarded as `wrong-extension`. Forward sync would install and
register a hook that the next capture throws away.

So the interpreter and extension are now enforced as a pair on both sides, and
sync skips a mismatched hook with a visible `interpreter-extension-mismatch`
warning rather than installing a command its own source cannot run.

## Manual verification

    npm test                    1897 passed, 0 failed
    npm run lint                0
    npm run check:tracker-ids   0
    npm run check:pack-surface  0

Each defence was disabled in turn and the pinning assertion checked for red, then
restored and re-verified:

- allowlist bypassed in manifest validation: an unknown interpreter produced the
  install filename `myhookundefined`, caught by the assertion that a malformed
  manifest falls back to the wiki name
- `buildHookCommand` returned to hardcoded `node`: 8 failures, including the
  python3 and bash command assertions and the round-trip test
- default interpreter changed away from `node`: 16 failures, among them
  "an absent interpreter defaults to node, byte-identical" which is the
  backward-compatibility pin

The round-trip assertion is new. It feeds every allowlisted interpreter's built
command back through the parser and requires `ok: true`. Nothing of the sort
existed before, which is why the forward-path asymmetry above survived the first
round of tests.

## Migration notes

None for existing installs. A manifest without an `interpreter` key keeps meaning
`node` and produces an identical command string, so no captured hook is
re-registered or re-copied by this change.

Out of scope: forward-sync does not carry the executable bit, so a vault script
that needs `+x` still arrives as 644. Hooks are unaffected, because they are
registered as `<interpreter> <path>` and never rely on the bit.

# 한국어

## 변경 내용

캡처된 훅의 manifest가 interpreter를 선언할 수 있습니다. `node`, `python3`, `bash`를
받고 각각 확장자가 하나씩(`.mjs`, `.py`, `.sh`) 대응하며, 전에 `node`와 `.mjs`를
하드코딩하던 세 자리가 그 값을 읽습니다. 엄격 역파서, 커맨드 생성기, 타입별 확장자
맵입니다.

interpreter가 없는 manifest는 여전히 `node`를 뜻하고, 만들어지는 커맨드 문자열도 전과
byte 단위로 같습니다.

## 이유

역방향 캡처가 `node $HOME/.claude/hooks/<name>.mjs` 리터럴만 받았습니다. 실제 볼트로
재보니 등록된 훅 13개가 전부 `bad-node-prefix`로 거절됐는데, 그게 사용자가 가진 훅
전부였습니다. 설치 쪽은 이미 처리할 수 있었습니다. `EXT_TYPES`에 `hooks`가 있고 sync가
파일 복사와 settings.json 등록을 둘 다 합니다. 막고 있던 것은 자격 판정 한 곳입니다.

손으로 우회할 길도 없었습니다. `buildHookCommand`가 `node`를 하드코딩하고 확장자 맵이
`.mjs` 고정이라, manifest를 직접 써 넣어도 python 훅이 `node ....mjs`로 등록돼 실행조차
되지 않았습니다.

## 방법

interpreter를 자유 문자열이 아니라 allowlist로 받습니다. 이 값이 결국 `settings.json`의
커맨드가 되고, manifest는 머신 사이를 오가는 볼트에서 옵니다. 여기 임의 문자열이 들어오면
임의 실행입니다. 그래서 하위 소비처가 읽기 전에 `parseManifest`에서 검증하고,
`buildHookCommand`는 호출자를 믿는 대신 집합 밖 값에 throw 합니다.

정방향 생성기와 역방향 파서는 의도된 거울이고, 한쪽만 넓히는 것이 그 관계를 깹니다.
검토가 정확히 그것을 찾았습니다. `discoverExtensions`는 파일 확장자로 훅을 찾고
`buildExpectedSettingsEntries`는 확장자가 manifest의 interpreter와 맞는지 보지 않은 채
커맨드를 만들어서, `interpreter: node`인 `.py` 파일이 `node ....py`를 낳고 역파서가 그것을
`wrong-extension`으로 버렸습니다. 정방향 sync가 설치·등록한 훅을 다음 캡처가 버리는
상태입니다.

이제 interpreter와 확장자를 양쪽에서 짝으로 강제하고, 짝이 안 맞는 훅은 자기 소스가
실행할 수 없는 커맨드로 등록하는 대신 `interpreter-extension-mismatch` 경고를 남기고
건너뜁니다.

## 수동 검증

    npm test                    1897 passed, 0 failed
    npm run lint                0
    npm run check:tracker-ids   0
    npm run check:pack-surface  0

방어를 하나씩 무력화해 단언이 red 인지 보고 원상복구한 뒤 다시 확인했습니다.

- manifest 검증에서 allowlist 우회: 미지의 interpreter가 `myhookundefined` 라는 설치
  파일명을 만들었고, malformed manifest가 위키 이름으로 폴백한다는 단언이 잡았습니다
- `buildHookCommand`를 `node` 하드코딩으로 복귀: 실패 8건, python3·bash 커맨드 단언과
  왕복 테스트 포함
- 기본 interpreter를 `node` 아닌 값으로 변경: 실패 16건, 그중 "absent interpreter는
  node로 기본값, byte 동일"이 하위호환을 고정하는 단언입니다

왕복 단언은 새로 넣었습니다. allowlist의 모든 interpreter에 대해 정방향이 만든 커맨드를
역파서에 그대로 먹여 `ok: true`를 요구합니다. 이런 단언이 없었고, 그래서 위의 정방향
비대칭이 첫 라운드 테스트를 통과해 살아남았습니다.

## 마이그레이션 노트

기존 설치에는 없습니다. `interpreter` 키가 없는 manifest는 계속 `node`를 뜻하고 커맨드
문자열도 같으므로, 이 변경으로 다시 등록되거나 다시 복사되는 캡처 훅은 없습니다.

범위 밖: forward-sync가 실행 비트를 옮기지 않아, `+x`가 필요한 볼트 스크립트는 여전히
644로 도착합니다. 훅은 `<interpreter> <path>`로 등록돼 그 비트에 의존하지 않으므로
영향이 없습니다.

## Changelog

- EN: `hypomnema capture` now handles hooks written in python or bash, not only node. A captured hook records its interpreter, and the command it registers on another machine uses that interpreter. Hooks captured before this keep working unchanged.
- KO: `hypomnema capture`가 node뿐 아니라 python·bash로 작성된 훅도 다룹니다. 캡처된 훅이 자기 interpreter를 기록하고, 다른 머신에 등록되는 커맨드가 그 interpreter를 씁니다. 이전에 캡처한 훅은 그대로 동작합니다.

## Checklist

- [x] `npm test` (1897 passed, 0 failed)
- [x] `npm run lint`, `check:tracker-ids`, `check:pack-surface` (all exit 0)
- [x] Regression proof: each defence disabled in turn, pinning assertion goes red, restored and re-verified
- [x] Codex cross-review before commit; the forward-path asymmetry it found is fixed and now has a round-trip assertion
- [x] No attribution footer, no session URL, no internal tracker ids
- [ ] Live-session QA for the capture path (no hook behaviour changed, but the registration string did)
