### PR TITLE
fix(hooks): trust a hooks copy only when it can prove which package wrote it

### DIFF
--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -38,6 +38,7 @@ import {
   scopeVisible,
   readVisibilityScope,
   pkgRootDriftStatus,
+  PKG_ROOT,
 } from './hypo-shared.mjs';
 import {
   defaultCachePath,
@@ -54,6 +55,9 @@ import {
   pkgRootDriftAlreadyNotified,
   markPkgRootDriftNotified,
   clearPkgRootDriftNotified,
+  pkgRootNullAlreadyNotified,
+  markPkgRootNullNotified,
+  clearPkgRootNullNotified,
 } from './version-check.mjs';
 import { snapshotBase, overwriteTargets } from './base-store.mjs';
 import { listProposals } from './proposal-store.mjs';
@@ -260,6 +264,48 @@ function buildPkgRootDriftNotice() {
       `  Hooks already resolved the correct root for this session — this is a ` +
       `heads-up, not a blocker.\n` +
       `  → run \`/hypo:upgrade --apply\` to bring hypo-pkg.json back in sync.`
+    );
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * PKG_ROOT-null notice. A different failure than the drift banner above:
+ * drift only fires when self-location DID resolve (PKG_ROOT is non-null,
+ * just disagreeing with the cache). This fires when hooks/hypo-shared.mjs's
+ * resolvePkgRoot() came up with nothing at all — self-location failed AND no
+ * verified provenance sidecar covered it — which is exactly the state where
+ * PreCompact's lint/feedback calls silently no-op (they have no root to
+ * shell scripts through). The two conditions cannot both hold in the same
+ * session (drift requires a non-null self-location), so there is no overlap
+ * to arbitrate — they use separate notify-once cache fields regardless, so
+ * neither one depends on that being true forever.
+ *
+ * Same notify-once shape as the drift banner: shown once, cleared as soon as
+ * PKG_ROOT resolves again so a later recurrence re-notifies instead of
+ * staying suppressed by a mark from a different install state.
+ */
+function buildPkgRootNullNotice() {
+  try {
+    const cachePath = defaultCachePath();
+    if (PKG_ROOT) {
+      clearPkgRootNullNotified(cachePath);
+      return '';
+    }
+    if (isOptedOut()) return '';
+    const cache = readCache(cachePath);
+    if (pkgRootNullAlreadyNotified(cache)) return '';
+    markPkgRootNullNotified(cachePath);
+    return (
+      `[Hypomnema] Package root unresolved: this install's hooks cannot locate ` +
+      `their own package, so PreCompact's lint/feedback checks are silently ` +
+      `skipped this session.\n` +
+      `  → run \`hypomnema upgrade --apply\` to sync this install's hook copies ` +
+      `with the current package (the \`/hypo:upgrade --apply\` slash command does ` +
+      `the same thing, where slash commands were installed). \`/hypo:init\` will ` +
+      `NOT fix this — it skips every hook file that already exists.\n` +
+      `  → or run \`hypomnema doctor\` to see what's missing.`
     );
   } catch {
     return '';
@@ -500,16 +546,24 @@ process.stdin.on('end', () => {
     const updateLine = buildUpdateNotice();
     const siblingLine = buildSiblingNotice();
     const pkgDriftLine = buildPkgRootDriftNotice();
-    // The update + stale-sibling + pkgRoot-drift banners must reach the USER.
-    // On a SessionStart hook that exits 0, stderr is invisible in the normal
-    // TUI (only shown on exit 2 / --verbose) and additionalContext is
+    // pkgDriftLine and pkgNullLine can never both be non-empty in the same
+    // session: drift requires PKG_ROOT to have resolved (non-null) via
+    // self-location, while the null notice fires exactly when it did not.
+    // Listed together below on that basis, not because one is chosen over
+    // the other.
+    const pkgNullLine = buildPkgRootNullNotice();
+    // The update + stale-sibling + pkgRoot-drift/null banners must reach the
+    // USER. On a SessionStart hook that exits 0, stderr is invisible in the
+    // normal TUI (only shown on exit 2 / --verbose) and additionalContext is
     // model-only — `systemMessage` is the documented user-visible channel.
     // Route those banners there. They ALSO stay in noticePrefix →
     // additionalContext below, so the model and the user start the session
     // looking at the same state. (The other stderr notices —
     // sync/growth/clear/suggest — are intentionally transcript/--verbose only
     // and out of this banner's scope.)
-    const userMessage = [updateLine, siblingLine, pkgDriftLine].filter(Boolean).join('\n\n');
+    const userMessage = [updateLine, siblingLine, pkgDriftLine, pkgNullLine]
+      .filter(Boolean)
+      .join('\n\n');
     if (userMessage) outExtra = { ...outExtra, systemMessage: userMessage };
     const notices = [
       syncLine,
@@ -519,6 +573,7 @@ process.stdin.on('end', () => {
       updateLine,
       siblingLine,
       pkgDriftLine,
+      pkgNullLine,
     ].filter(Boolean);
     let noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
     if (syncLine) process.stderr.write(`\n\x1b[33m${syncLine}\x1b[0m\n`);
@@ -529,6 +584,7 @@ process.stdin.on('end', () => {
     if (updateLine) process.stderr.write(`\n\x1b[33m${updateLine}\x1b[0m\n`);
     if (siblingLine) process.stderr.write(`\n\x1b[33m${siblingLine}\x1b[0m\n`);
     if (pkgDriftLine) process.stderr.write(`\n\x1b[33m${pkgDriftLine}\x1b[0m\n`);
+    if (pkgNullLine) process.stderr.write(`\n\x1b[33m${pkgNullLine}\x1b[0m\n`);
     const cwd = data.cwd || data.directory || process.cwd();
     const sessionId = data.session_id || 'default';
     const MARKER_FILE = sessionMarkerPath(sessionId);

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -24,7 +24,7 @@ import {
 import { join, relative, basename, dirname, isAbsolute } from 'path';
 import { homedir, hostname, tmpdir } from 'os';
 import { spawnSync } from 'child_process';
-import { randomBytes } from 'crypto';
+import { randomBytes, createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 
 const HOME = homedir();
@@ -149,7 +149,14 @@ function readCachedPkgRoot() {
 // Hypomnema — e.g. `$HOME/package.json` from an unrelated project. This
 // contract answers "is this a real, resolvable directory", not "is this OUR
 // package". Callers that need the latter also require self-containment.
-function isUsablePkgRootLocal(pkgRoot) {
+//
+// Exported so scripts/doctor.mjs can apply the SAME predicate to a sidecar's
+// recorded pkgRoot that readVerifiedProvenancePkgRoot() below applies at
+// runtime — doctor used to hand-roll a thinner name+hash check that a
+// version-less "name":"hypomnema" root would pass while the runtime resolver
+// rejects it, so doctor could PASS a sidecar the runtime treats as null. The
+// import direction stays scripts/ → hooks/, never the reverse.
+export function isUsablePkgRootLocal(pkgRoot) {
   if (typeof pkgRoot !== 'string' || !pkgRoot || !isAbsolute(pkgRoot)) return false;
   try {
     const v = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf-8')).version;
@@ -205,16 +212,25 @@ function candidateContainsRunningModule(candidateRoot, ownRealPath) {
 // candidateContainsRunningModule rejects it: that ancestor's own hooks/
 // subdirectory (if it even has one) is not this file.
 //
-// Bounded walk: up to 6 candidate ancestors above hooks/'s own parent (the
+// Bounded walk: up to 6 candidate ancestors above hooksDir's own parent (the
 // ordinary root sits at the very first one; a few extra levels tolerate an
 // unusual nesting depth). Never throws, fails open to null on any error.
-function selfLocationPkgRoot() {
-  let hooksDir, ownRealPath;
+//
+// Split out from selfLocationPkgRoot() (below) so scripts/doctor.mjs can ask
+// the same question about an ARBITRARY installed hooks directory
+// (~/.claude/hooks, ~/.codex/hooks) instead of only about wherever THIS
+// running module happens to live. doctor needs that to tell "self-location
+// genuinely can't resolve for this install" (the standalone-copy steady
+// state, silence is correct) apart from "self-location would resolve but the
+// provenance sidecar is missing/broken" (a real gap — see CONCERN 4's
+// PKG_ROOT-null-and-silent fix in checkProvenanceSidecar). Exported;
+// scripts/ → hooks/ stays the only allowed import direction.
+export function selfLocationPkgRootFrom(hooksDir) {
+  let ownRealPath;
   try {
-    hooksDir = dirname(fileURLToPath(import.meta.url));
     ownRealPath = realpathSync(join(hooksDir, 'hypo-shared.mjs'));
   } catch {
-    return null; // can't even resolve our own path — nothing to self-contain against
+    return null; // can't even resolve the module at hooksDir — nothing to self-contain against
   }
   try {
     let dir = dirname(hooksDir); // first candidate: the ordinary root, one level above hooks/
@@ -232,16 +248,93 @@ function selfLocationPkgRoot() {
   }
 }
 
+function selfLocationPkgRoot() {
+  let hooksDir;
+  try {
+    hooksDir = dirname(fileURLToPath(import.meta.url));
+  } catch {
+    return null; // can't even resolve our own path
+  }
+  return selfLocationPkgRootFrom(hooksDir);
+}
+
+// Copy-time provenance sidecar (`.hypo-provenance.json`, written next to a
+// standalone-copied hooks/ dir by installHooks/applyHookFiles — see
+// scripts/lib/pkg-provenance.mjs, the writer half of this contract) is the
+// ONLY fallback resolvePkgRoot() gets when self-location can't resolve. The
+// filename and the "hypomnema" name check below must stay byte-identical
+// with scripts/lib/pkg-provenance.mjs — hooks can't import scripts/ (no
+// reaching outside hooks/), so the contract is duplicated, not shared.
+//
+// This is accidental-staleness protection, not a security boundary: any
+// process running as this OS user can edit this JSON file (or hypo-shared.mjs
+// itself) freely. It only catches what installHooks/applyHookFiles left
+// unguarded before this fix — a manual-install hooks/ copy left pointing at
+// an old pkgVersion because a skip-then-refresh-the-cache-anyway sequence
+// (init re-run against an unchanged hooks/ dir) recorded a version the copy
+// on disk never actually became.
+//
+// Producer proof, BOTH required before this pkgRoot is trusted:
+//   - the recorded pkgRoot's package.json "name" must be "hypomnema" (not
+//     merely "some usable versioned package.json" — isUsablePkgRootLocal
+//     alone would accept $HOME/package.json from an unrelated project)
+//   - the recorded hypoSharedSha256 must match the SHA-256 of THIS running
+//     hypo-shared.mjs file — ties the sidecar to the exact copy it was
+//     written next to, so a sidecar surviving a partial re-install (new
+//     hooks/*.mjs dropped in, old sidecar left behind) is rejected rather
+//     than silently trusted.
+//
+// Scope, stated honestly: hypoSharedSha256 pins ONE file — this file. A
+// sidecar surviving a re-install that touched some OTHER hook (e.g.
+// hypo-personal-check.mjs got a new version, hypo-shared.mjs itself didn't
+// change a byte) still passes this check and PKG_ROOT still resolves,
+// because the running module — the one thing this function can verify
+// without cost — never changed. Catching that wider drift needs hashing
+// every file hooks.json wires up, which is too expensive to do on every
+// hook load (this function runs on every single hook invocation); that
+// broader, once-per-`doctor`-run check is `hooksDigest`
+// (scripts/lib/pkg-provenance.mjs's computeHooksDigest, verified by
+// scripts/doctor.mjs), deliberately NOT read here.
+const PROVENANCE_FILENAME = '.hypo-provenance.json';
+const EXPECTED_PKG_NAME = 'hypomnema';
+
+function readVerifiedProvenancePkgRoot(hooksDir) {
+  try {
+    const raw = JSON.parse(readFileSync(join(hooksDir, PROVENANCE_FILENAME), 'utf-8'));
+    const { pkgRoot, hypoSharedSha256 } = raw || {};
+    if (!isUsablePkgRootLocal(pkgRoot)) return null;
+    const producerPkgJson = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf-8'));
+    if (producerPkgJson.name !== EXPECTED_PKG_NAME) return null;
+    if (typeof hypoSharedSha256 !== 'string' || !hypoSharedSha256) return null;
+    const ownHash = createHash('sha256')
+      .update(readFileSync(join(hooksDir, 'hypo-shared.mjs')))
+      .digest('hex');
+    if (ownHash !== hypoSharedSha256) return null;
+    return pkgRoot;
+  } catch {
+    return null;
+  }
+}
+
 // Resolution order: self-location wins whenever it resolves — it is a direct,
 // self-containment-verified fact about the code currently running, not an
 // inference. Only when it cannot resolve (the standalone-copied hooks case
-// above, or a genuine read failure) does the cache get to answer, and only
-// after passing the same usable-root contract as everything else here.
+// above, or a genuine read failure) does the verified provenance sidecar get
+// to answer, checked against the same directory this module is actually
+// running from. The cache (readCachedPkgRoot/hypo-pkg.json) is deliberately
+// NOT a resolution fallback here — a disagreeing provenance sidecar means
+// "stop", not "ask the cache", because the cache is exactly what can be
+// stale (that staleness is this fix's whole premise). readCachedPkgRoot stays
+// in this file only for pkgRootDriftStatus()'s surfacing comparison below.
 function resolvePkgRoot() {
   const self = selfLocationPkgRoot();
   if (self) return self;
-  const cached = readCachedPkgRoot();
-  return isUsablePkgRootLocal(cached) ? cached : null;
+  try {
+    const hooksDir = dirname(fileURLToPath(import.meta.url));
+    return readVerifiedProvenancePkgRoot(hooksDir);
+  } catch {
+    return null;
+  }
 }
 export const PKG_ROOT = resolvePkgRoot();
 
@@ -709,7 +802,10 @@ function gitIgnoresPageUsageCached(hypoDir, sessionId, probeFn = runGitCheckIgno
   if (!probe || (probe.status !== 0 && probe.status !== 1)) {
     if (scoped) {
       try {
-        writeFileSync(cachePath, JSON.stringify({ unavailableUntil: Date.now() + PROBE_BACKOFF_MS }));
+        writeFileSync(
+          cachePath,
+          JSON.stringify({ unavailableUntil: Date.now() + PROBE_BACKOFF_MS }),
+        );
       } catch {
         // non-fatal; the probe just runs again next prompt
       }
@@ -1628,89 +1724,89 @@ export function withFileLock(targetPath, fn, opts = {}) {
   let loggedLiveHolder = false;
   let loggedSteal = false;
   try {
-  for (;;) {
-    try {
-      if (!staged) {
-        try {
-          writeFileSync(tmpPath, String(process.pid), { flag: 'wx' });
-          staged = true;
-        } catch (stageErr) {
-          // Staging fails for the same reason acquisition does — an unwritable
-          // directory — and `openSync(lock,'wx')` used to report exactly that as
-          // EEXIST whenever a lock was already sitting there, sending it down the
-          // contention path. Preserve that: contend if a lock exists, and surface
-          // a genuine write failure otherwise rather than masking it as a timeout.
-          if (!existsSync(lockPath)) throw stageErr;
-          throw Object.assign(new Error('lock-contended'), { code: 'EEXIST' });
-        }
-      }
-      // Kept separate from staging on purpose: EPERM/EMLINK from the link are
-      // real failures, not contention, and must not decay into ELOCKTIMEOUT.
-      linkSync(tmpPath, lockPath);
-      break;
-    } catch (err) {
-      if (err.code !== 'EEXIST') throw err;
-      // Held by another writer. Steal ONLY a demonstrably stale lock; otherwise
-      // wait and eventually time out. The stat and the unlink are handled
-      // separately on purpose: an un-removable stale lock (EACCES/EPERM/EBUSY)
-      // and a fresh lock must both fall through to the timeout check — never
-      // `continue` past it, or an un-unlinkable lock spins forever and violates
-      // the timeoutMs → ELOCKTIMEOUT contract (caller falls to the proposal gate).
-      let stale = false;
+    for (;;) {
       try {
-        // Steal-eligible by age alone; liveness is checked separately below
-        // before we actually act on it.
-        stale = Date.now() - statSync(lockPath).mtimeMs > staleMs;
-      } catch (statErr) {
-        if (statErr.code === 'ENOENT') continue; // lock vanished; retry create now
-        throw statErr; // unexpected stat failure — surface it, don't mask
-      }
-      if (stale) {
-        const holderPid = readLockHolderPid(lockPath);
-        if (holderPid !== null && isPidAlive(holderPid)) {
-          // LIVE holder preempted past staleMs: do NOT steal. Surface it so the
-          // preemption is visible, then fall through to the poll/timeout path
-          // below instead of racing a second writer into the critical section.
-          if (!loggedLiveHolder) {
-            console.error(
-              `[hypomnema] withFileLock: NOT stealing ${lockPath} — holder pid ${holderPid} is still alive past staleMs=${staleMs}`,
-            );
-            loggedLiveHolder = true;
+        if (!staged) {
+          try {
+            writeFileSync(tmpPath, String(process.pid), { flag: 'wx' });
+            staged = true;
+          } catch (stageErr) {
+            // Staging fails for the same reason acquisition does — an unwritable
+            // directory — and `openSync(lock,'wx')` used to report exactly that as
+            // EEXIST whenever a lock was already sitting there, sending it down the
+            // contention path. Preserve that: contend if a lock exists, and surface
+            // a genuine write failure otherwise rather than masking it as a timeout.
+            if (!existsSync(lockPath)) throw stageErr;
+            throw Object.assign(new Error('lock-contended'), { code: 'EEXIST' });
           }
-          stale = false;
-        } else if (!loggedSteal) {
-          // Also once per acquire: an un-removable stale lock re-enters this
-          // branch on every poll, and the steal is one event either way.
-          console.error(
-            `[hypomnema] withFileLock: stealing stale lock ${lockPath}` +
-              (holderPid !== null
-                ? ` (holder pid ${holderPid} is no longer running)`
-                : ' (no readable holder pid — pre-liveness lockfile)'),
-          );
-          loggedSteal = true;
         }
-      }
-      if (stale) {
+        // Kept separate from staging on purpose: EPERM/EMLINK from the link are
+        // real failures, not contention, and must not decay into ELOCKTIMEOUT.
+        linkSync(tmpPath, lockPath);
+        break;
+      } catch (err) {
+        if (err.code !== 'EEXIST') throw err;
+        // Held by another writer. Steal ONLY a demonstrably stale lock; otherwise
+        // wait and eventually time out. The stat and the unlink are handled
+        // separately on purpose: an un-removable stale lock (EACCES/EPERM/EBUSY)
+        // and a fresh lock must both fall through to the timeout check — never
+        // `continue` past it, or an un-unlinkable lock spins forever and violates
+        // the timeoutMs → ELOCKTIMEOUT contract (caller falls to the proposal gate).
+        let stale = false;
         try {
-          unlinkSync(lockPath);
-          continue; // stole it; retry the create immediately
-        } catch (unlinkErr) {
-          if (unlinkErr.code === 'ENOENT') continue; // another stealer won; retry
-          // Cannot remove it: do NOT spin — fall through to timeout/sleep so
-          // acquisition eventually throws ELOCKTIMEOUT instead of hanging.
+          // Steal-eligible by age alone; liveness is checked separately below
+          // before we actually act on it.
+          stale = Date.now() - statSync(lockPath).mtimeMs > staleMs;
+        } catch (statErr) {
+          if (statErr.code === 'ENOENT') continue; // lock vanished; retry create now
+          throw statErr; // unexpected stat failure — surface it, don't mask
         }
+        if (stale) {
+          const holderPid = readLockHolderPid(lockPath);
+          if (holderPid !== null && isPidAlive(holderPid)) {
+            // LIVE holder preempted past staleMs: do NOT steal. Surface it so the
+            // preemption is visible, then fall through to the poll/timeout path
+            // below instead of racing a second writer into the critical section.
+            if (!loggedLiveHolder) {
+              console.error(
+                `[hypomnema] withFileLock: NOT stealing ${lockPath} — holder pid ${holderPid} is still alive past staleMs=${staleMs}`,
+              );
+              loggedLiveHolder = true;
+            }
+            stale = false;
+          } else if (!loggedSteal) {
+            // Also once per acquire: an un-removable stale lock re-enters this
+            // branch on every poll, and the steal is one event either way.
+            console.error(
+              `[hypomnema] withFileLock: stealing stale lock ${lockPath}` +
+                (holderPid !== null
+                  ? ` (holder pid ${holderPid} is no longer running)`
+                  : ' (no readable holder pid — pre-liveness lockfile)'),
+            );
+            loggedSteal = true;
+          }
+        }
+        if (stale) {
+          try {
+            unlinkSync(lockPath);
+            continue; // stole it; retry the create immediately
+          } catch (unlinkErr) {
+            if (unlinkErr.code === 'ENOENT') continue; // another stealer won; retry
+            // Cannot remove it: do NOT spin — fall through to timeout/sleep so
+            // acquisition eventually throws ELOCKTIMEOUT instead of hanging.
+          }
+        }
+        if (Date.now() - start > timeoutMs) {
+          // Tagged so callers can distinguish "could not get the lock" (fall to the
+          // proposal gate) from a real fn() write error (mkdir/openSync/disk-full),
+          // which must NOT be masked as a timeout.
+          const e = new Error(`lock-timeout: ${lockPath}`);
+          e.code = 'ELOCKTIMEOUT';
+          throw e;
+        }
+        sleepSync(pollMs);
       }
-      if (Date.now() - start > timeoutMs) {
-        // Tagged so callers can distinguish "could not get the lock" (fall to the
-        // proposal gate) from a real fn() write error (mkdir/openSync/disk-full),
-        // which must NOT be masked as a timeout.
-        const e = new Error(`lock-timeout: ${lockPath}`);
-        e.code = 'ELOCKTIMEOUT';
-        throw e;
-      }
-      sleepSync(pollMs);
     }
-  }
   } finally {
     // The sibling is only ever a staging file: once linked, the lock IS the
     // link, and on every failure path it must not survive as litter.
@@ -4154,7 +4250,11 @@ const CLOSE_COMMIT_MESSAGE = new RegExp(
  *   is the YYYY-MM-DD captured from the artifact's own heading, or null for a
  *   commit-message match (the caller already has the commit's date).
  */
-export function detectSessionCloseArtifact({ path = null, content = null, commitMessage = null } = {}) {
+export function detectSessionCloseArtifact({
+  path = null,
+  content = null,
+  commitMessage = null,
+} = {}) {
   if (typeof commitMessage === 'string' && CLOSE_COMMIT_MESSAGE.test(commitMessage)) {
     return { matched: true, kind: 'commit-message', date: null };
   }

--- a/hooks/version-check.mjs
+++ b/hooks/version-check.mjs
@@ -430,6 +430,53 @@ export function clearPkgRootDriftNotified(path) {
   }
 }
 
+// ── pkgRoot-null notice ─────────────────────────────────────────────────────
+// A DIFFERENT failure than drift above: drift only ever fires when
+// self-location resolved (PKG_ROOT is non-null, just disagreeing with the
+// cache). This one fires when PKG_ROOT itself resolved to null — self-location
+// failed AND no verified provenance sidecar covered it — the case where
+// PreCompact's lint/feedback calls silently no-op because they have no root to
+// shell scripts through. The two conditions can never both hold in the same
+// session (drift requires a non-null self-location), so there is no "which
+// wins" question in practice, but the two use separate cache fields regardless
+// so neither implementation depends on that being true forever.
+// Boolean (not a pair-key like drift) — the notified state is just "already
+// told them this session's install has no resolvable pkgRoot".
+
+/** Has the PKG_ROOT-null state already been surfaced since it last cleared? */
+export function pkgRootNullAlreadyNotified(cache) {
+  return Boolean(cache && cache.pkgRootNullNotified === true);
+}
+
+/** Record that the PKG_ROOT-null banner was shown (read-merge-write). */
+export function markPkgRootNullNotified(path) {
+  try {
+    const cache = readCache(path) || {};
+    cache.pkgRootNullNotified = true;
+    writeCacheAtomic(path, cache);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Clear a previously-recorded PKG_ROOT-null mark once PKG_ROOT resolves again
+ * (self-location or a verified provenance sidecar). Without this, a null state
+ * that resolves and then recurs later (e.g. the provenance sidecar's hash
+ * binding breaks again after a partial re-install) would stay silently
+ * suppressed forever. Read-merge-write, best-effort.
+ */
+export function clearPkgRootNullNotified(path) {
+  try {
+    const cache = readCache(path);
+    if (!cache || !('pkgRootNullNotified' in cache)) return;
+    delete cache.pkgRootNullNotified;
+    writeCacheAtomic(path, cache);
+  } catch {
+    /* best-effort */
+  }
+}
+
 /**
  * Shared one-line message for the init/upgrade downgrade guard (P). `op` is
  * 'init' or 'upgrade'. Kept here so guard text stays identical across both CLIs.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "scripts/lib/hypo-root.mjs",
     "scripts/lib/page-usage.mjs",
     "scripts/lib/pkg-json.mjs",
+    "scripts/lib/pkg-provenance.mjs",
     "scripts/lib/plugin-detect.mjs",
     "scripts/lib/project-create.mjs",
     "scripts/lib/rename-marker.mjs",

--- a/qa-runs/2026-08-25.md
+++ b/qa-runs/2026-08-25.md
@@ -161,3 +161,56 @@ Hook firing driven by the harness's own events inside a live Claude Code session
 Both this run and the worker fed hooks their event JSON directly, which is the
 same entry point the harness uses, so what remains untested is event delivery and
 ordering, not the hook bodies.
+
+---
+
+# QA run 2026-08-25 (second): ISSUE-80 provenance sidecar (PR #239)
+
+PR #239 changes `hooks/hypo-shared.mjs`, so the deployed-copy behavior it fixes
+cannot be observed from the checkout. The failure being fixed only exists on the
+manual/npm channel, where `installHooks` copies the `.mjs` files alone and
+self-location can never resolve. This run rebuilds that channel in an isolated
+`HOME` and exercises it.
+
+Candidate: `8051a09` on `fix/pkgroot-provenance`.
+Isolated root: a scratch `HOME` with two package copies (`pkg-new` at 1.7.2,
+`pkg-old` at 1.7.0) and a vault under it. Every command ran as
+`HOME=<isolated>`, so the developer's real vault and plugin cache were untouched.
+
+## What was exercised
+
+| #   | Scenario                                                     | Observed                                                                                                    |
+| --- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| 1   | manual `init` from `pkg-new`                                 | sidecar written with all four fields (`pkgRoot`, `pkgVersion`, `hypoSharedSha256`, `hooksDigest`)           |
+| 2   | standalone hooks copy resolves its root                      | `PKG_ROOT` = `pkg-new`                                                                                      |
+| 3   | **the original defect**: cache poisoned to `pkg-old` (1.7.0) | `PKG_ROOT` still `pkg-new`. Before this change the manual channel answered `pkg-old`                        |
+| 4   | sidecar hash broken, cache still pointing at `pkg-old`       | `PKG_ROOT` = `null`. No cache fallback                                                                      |
+| 5   | SessionStart hook fed a real payload                         | the unresolved-root banner actually fired on the deployed copy                                              |
+| 6   | `doctor` against the broken sidecar                          | warns, names the hash mismatch, explains that `PKG_ROOT` will be unresolved                                 |
+| 7   | sidecar restored, one _other_ hook made stale                | `doctor` warns: "1/20 hook file(s) differ from the current package source (e.g. hypo-personal-check.mjs)"   |
+| 8   | runtime with that same stale sibling                         | still resolves. The two-layer split is deliberate: the runtime verifies one file, `doctor` verifies the set |
+
+Scenario 3 is the whole point of the change and it reproduced exactly as
+measured in the earlier session. Scenario 7 is what the aggregate digest was
+added for, and it names the drifted file rather than just reporting a mismatch.
+
+## A defect this run caught that the suite did not
+
+`doctor`'s four new recovery messages were inconsistent: two pointed at
+`hypomnema upgrade --apply` and two at `/hypo:upgrade --apply`. A slash command
+is not guaranteed to exist (`--no-commands` installs skip them), and this is the
+same objection the cross-review raised against the SessionStart banner. Only the
+banner was fixed at the time. All four now use the CLI form.
+
+**The message text is not pinned by any assertion.** `--file=doctor` stayed at
+92 passed both before and after the fix, which is exactly why the inconsistency
+survived unit testing and only surfaced when the output was read by a human.
+The same is true of the sidecar's atomic write: eleven of the twelve sabotage
+runs went red, and the one that did not was `renameSync`, because atomicity
+leaves an identical file behind and a unit test cannot tell the two writes apart.
+
+## Not covered
+
+The banner was verified by feeding the hook a payload and reading its
+`systemMessage`, not by watching it render in a live Claude Code TUI. The
+rendering path (`systemMessage` to terminal) is unchanged by this PR.

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1878,7 +1878,10 @@ function checkProvenanceSidecar(hooksDir, label) {
   try {
     sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
   } catch {
-    warn(label, `${sidecarPath} is not valid JSON — run /hypo:upgrade --apply to rewrite it`);
+    warn(
+      label,
+      `${sidecarPath} is not valid JSON — run \`hypomnema upgrade --apply\` to rewrite it`,
+    );
     return;
   }
 
@@ -1931,7 +1934,7 @@ function checkProvenanceSidecar(hooksDir, label) {
   warn(
     label,
     `${sidecarPath} does not verify (${reasons.join('; ')}) — resolvePkgRoot() will treat ` +
-      `PKG_ROOT as unresolved this session; run /hypo:upgrade --apply to refresh it`,
+      `PKG_ROOT as unresolved this session; run \`hypomnema upgrade --apply\` to refresh it`,
   );
 }
 

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -31,6 +31,8 @@ import {
   detectSessionCloseArtifact,
   localAndUtcDates,
   SESSION_CLOSED_MARKER_STALE_MS,
+  isUsablePkgRootLocal,
+  selfLocationPkgRootFrom,
 } from '../hooks/hypo-shared.mjs';
 import { listProposals } from '../hooks/proposal-store.mjs';
 import {
@@ -50,12 +52,19 @@ import {
   CODEX_TYPES,
 } from './lib/extensions.mjs';
 import { sha256, readFileIfRegular, readPkgJson } from './lib/pkg-json.mjs';
+import {
+  provenancePath,
+  EXPECTED_PKG_NAME,
+  HOOKS_DIGEST_FIELD,
+  computeHooksDigest,
+} from './lib/pkg-provenance.mjs';
 import { resolveCliOnPath, classifyInstall } from '../hooks/version-check.mjs';
 import { isHypomnemaPluginEnabled } from './lib/plugin-detect.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
 const PKG_ROOT = join(SCRIPT_DIR, '..');
+const HOOKS_SRC = join(PKG_ROOT, 'hooks');
 
 // ── install channel ───────────────────────────────────────────────────────────
 //
@@ -320,6 +329,8 @@ function checkHooks(coreManagedByPlugin) {
   } else {
     fail('Hook files installed', `No hook files found in ${claudeHooks} — run /hypo:init`);
   }
+
+  checkProvenanceSidecar(claudeHooks, 'hooks/.hypo-provenance.json');
 }
 
 function checkSettingsJson(coreManagedByPlugin) {
@@ -813,11 +824,9 @@ function deriveCommitProjects(hypoDir, hash) {
   // projects/a/hot.md → projects/b/hot.md rename would silently drop project
   // a from scope — a marker naming only "b" would then wrongly cover the
   // whole commit. -M's tab-separated `status\told\tnew` line carries both.
-  const show = spawnSync(
-    'git',
-    ['-C', hypoDir, 'show', '--name-status', '-M', '--format=', hash],
-    { encoding: 'utf-8' },
-  );
+  const show = spawnSync('git', ['-C', hypoDir, 'show', '--name-status', '-M', '--format=', hash], {
+    encoding: 'utf-8',
+  });
   if (show.status !== 0 || !show.stdout) return [];
   const projects = new Set();
   for (const line of show.stdout.split('\n')) {
@@ -1229,6 +1238,8 @@ function checkCodexPaths() {
       `No hook files found in ${codexHooks} — run /hypo:init --codex`,
     );
   }
+
+  checkProvenanceSidecar(codexHooks, 'Codex hooks/.hypo-provenance.json');
 
   const settingsPath = join(HOME, '.codex', 'settings.json');
   if (!existsSync(settingsPath)) {
@@ -1826,6 +1837,136 @@ function checkStaleSibling() {
   } else {
     pass('PATH CLI vs active install', `v${cli.version} (active v${active.pkgVersion})`);
   }
+}
+
+// ── provenance sidecar (manual/npm channel) ────────────────────────────────────
+//
+// `.hypo-provenance.json` lives next to a standalone-copied hooks/ dir
+// (installHooks/applyHookFiles — scripts/lib/pkg-provenance.mjs) and is what
+// hooks/hypo-shared.mjs's resolvePkgRoot() falls back to when self-location
+// can't resolve. Absent is a normal state whenever there is no INSTALLED
+// hooks/hypo-shared.mjs at `hooksDir` to worry about at all (plugin channel:
+// hooks run straight from CLAUDE_PLUGIN_ROOT, nothing is ever copied here;
+// a truly fresh, never-inited home) — that case stays silent. It is also
+// normal, and stays silent, when hypo-shared.mjs IS installed here but
+// self-locates on its own (a dev checkout whose "hooksDir" happens to be the
+// package's own hooks/, not a copy). The one PRESENT-but-broken and the one
+// ABSENT-but-should-not-be-silent case are both actionable (CONCERN 4):
+//   - present sidecar that fails to verify → WARN, same three-way shape as
+//     checkPkgIntegrity below, never FAIL (a broken sidecar just degrades
+//     PKG_ROOT to null, surfaced live by hypo-session-start.mjs's
+//     PKG_ROOT-null banner, not corrupting anything on disk)
+//   - installed hypo-shared.mjs, self-location fails for it, AND no sidecar
+//     at all → that combination IS "PKG_ROOT is null for every hook running
+//     from here" (resolvePkgRoot() has nothing left to try), so silence here
+//     would hide exactly the state the live banner already warns about
+function checkProvenanceSidecar(hooksDir, label) {
+  const sidecarPath = provenancePath(hooksDir);
+  if (!existsSync(sidecarPath)) {
+    if (existsSync(join(hooksDir, 'hypo-shared.mjs')) && !selfLocationPkgRootFrom(hooksDir)) {
+      warn(
+        label,
+        `no provenance sidecar, and this install's hooks cannot self-locate their ` +
+          `package — PKG_ROOT resolves to null for every hook running from ${hooksDir}; ` +
+          `run \`hypomnema upgrade --apply\` to write one`,
+      );
+    }
+    return;
+  }
+
+  let sidecar;
+  try {
+    sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+  } catch {
+    warn(label, `${sidecarPath} is not valid JSON — run /hypo:upgrade --apply to rewrite it`);
+    return;
+  }
+
+  const { pkgRoot, hypoSharedSha256, [HOOKS_DIGEST_FIELD]: hooksDigest } = sidecar || {};
+
+  // Same predicate the runtime resolver requires (isUsablePkgRootLocal, used
+  // by readVerifiedProvenancePkgRoot in hooks/hypo-shared.mjs) — imported,
+  // not hand-rolled again here, so a version-less "name":"hypomnema" root can
+  // no longer PASS this check while resolvePkgRoot() treats it as null.
+  const usableOk = isUsablePkgRootLocal(pkgRoot);
+
+  let producerName = null;
+  try {
+    producerName = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf-8')).name;
+  } catch {
+    /* pkgRoot missing/unreadable — nameOk stays false below */
+  }
+  const nameOk = producerName === EXPECTED_PKG_NAME;
+
+  let hashOk = false;
+  try {
+    hashOk = sha256(readFileSync(join(hooksDir, 'hypo-shared.mjs'))) === hypoSharedSha256;
+  } catch {
+    /* hooks/hypo-shared.mjs unreadable in its own hooks dir — hashOk stays false */
+  }
+
+  if (usableOk && nameOk && hashOk) {
+    // hooksDigest (BLOCKER A item 3) can still turn this into a warn: it is
+    // folded into the SAME label/check rather than pushed as a second entry,
+    // so a caller reading checks by label (every other check in this file,
+    // and every test asserting on one) sees exactly one verdict per sidecar.
+    const digestIssue = hooksDigestMismatch(hooksDir, hooksDigest);
+    if (!digestIssue) {
+      pass(label, `verified — resolves to ${pkgRoot}`);
+    } else {
+      warn(label, `verified (pkgRoot/hash), but ${digestIssue}`);
+    }
+    return;
+  }
+  const reasons = [];
+  if (!usableOk) {
+    reasons.push(
+      `recorded pkgRoot (${pkgRoot}) is not a usable package root (must be an absolute ` +
+        `path to a directory whose package.json carries a version)`,
+    );
+  }
+  if (!nameOk) reasons.push(`recorded pkgRoot (${pkgRoot}) is not this package`);
+  if (!hashOk)
+    reasons.push('recorded hypoSharedSha256 does not match the installed hypo-shared.mjs');
+  warn(
+    label,
+    `${sidecarPath} does not verify (${reasons.join('; ')}) — resolvePkgRoot() will treat ` +
+      `PKG_ROOT as unresolved this session; run /hypo:upgrade --apply to refresh it`,
+  );
+}
+
+// BLOCKER A item 3: the runtime SHA check above (hashOk) pins ONE file,
+// hypo-shared.mjs — see that function's own hooks/hypo-shared.mjs-side
+// comment for why. This pins every OTHER file hooks.json wires up too, once
+// per `hypomnema doctor` run rather than once per hook load (too expensive
+// to do there — see computeHooksDigest's doc comment in
+// scripts/lib/pkg-provenance.mjs). Skips silently when the sidecar predates
+// this field (an older init/upgrade wrote it before BLOCKER A existed) —
+// there is nothing recorded to compare against, and the runtime never reads
+// this field either, so staying quiet hides nothing the runtime already
+// trusts.
+//
+// Returns null when there is nothing to report (field absent, or digests
+// match), or a ready-to-append reason string naming a few diverged files.
+function hooksDigestMismatch(hooksDir, recordedDigest) {
+  if (typeof recordedDigest !== 'string' || !recordedDigest) return null;
+  const actualDigest = computeHooksDigest(PKG_ROOT, hooksDir);
+  if (actualDigest === null || actualDigest === recordedDigest) return null;
+
+  const allFiles = [...Object.values(HOOK_MAP).flat(), ...SHARED_FILES];
+  const diverged = allFiles.filter((file) => {
+    try {
+      return !readFileSync(join(hooksDir, file)).equals(readFileSync(join(HOOKS_SRC, file)));
+    } catch {
+      return true; // unreadable on either side counts as diverged
+    }
+  });
+  const examples = diverged.slice(0, 3).join(', ');
+  return (
+    `hooksDigest mismatch: ${diverged.length}/${allFiles.length} hook file(s) differ from ` +
+    `the current package source${examples ? ` (e.g. ${examples})` : ''} — run ` +
+    `\`hypomnema upgrade --apply\``
+  );
 }
 
 // ── package integrity ─────────────────────────────────────────────────────────

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -48,6 +48,7 @@ import {
   readFileIfRegular,
 } from './lib/pkg-json.mjs';
 import { syncExtensions } from './lib/extensions.mjs';
+import { writeProvenanceSidecar } from './lib/pkg-provenance.mjs';
 import { templateSchemaVersion } from './lib/template-schema-version.mjs';
 import { classifyInstall, downgradeGuardMessage } from '../hooks/version-check.mjs';
 import {
@@ -458,6 +459,14 @@ function installHooks(targetDir, dryRun) {
     if (!dryRun) copyFileSync(join(HOOKS_SRC, file), dest);
     log('created', dest);
   }
+  // Refresh the provenance sidecar every run, even when every .mjs above was
+  // skipped as already-present: this is the standalone (manual/npm) channel
+  // only (the plugin channel never calls installHooks), and resolvePkgRoot()'s
+  // provenance fallback needs it to track the truth of what is actually on
+  // disk here, not just what a fresh copy left behind. See
+  // hooks/hypo-shared.mjs's readVerifiedProvenancePkgRoot() for the reader.
+  const sidecar = writeProvenanceSidecar(targetDir, PKG_ROOT, PKG_VERSION, HOOKS_SRC, dryRun);
+  if (sidecar) log('created', sidecar);
 }
 
 function mergeSettingsJson(settingsPath, hooksDir, dryRun, hookMap) {

--- a/scripts/lib/pkg-provenance.mjs
+++ b/scripts/lib/pkg-provenance.mjs
@@ -1,0 +1,166 @@
+/**
+ * `.hypo-provenance.json` sidecar: copy-time producer proof for the
+ * standalone (manual/npm) hooks channel.
+ *
+ * hooks/hypo-shared.mjs's resolvePkgRoot() falls back to this file, verified
+ * against its own package name + a SHA-256 of the running hypo-shared.mjs,
+ * whenever self-location can't confirm a package root — the standalone hooks
+ * copy has no package.json alongside it to walk up to, by design (hooks
+ * import only Node built-ins, nothing outside the hooks dir).
+ *
+ * This is accidental-staleness protection, not a security boundary: any
+ * process running as this OS user can edit this JSON file freely, same as it
+ * could edit hooks/hypo-shared.mjs itself. It only guards against the
+ * accidental drift init/upgrade left unguarded before this fix — a hook
+ * file skip (already-present) that still let hypo-pkg.json's cached pointer
+ * move on to a newer version, silently mismatching the code actually copied.
+ *
+ * The filename and the producer-name check ("hypomnema") here must stay
+ * byte-identical with hooks/hypo-shared.mjs's own copy of this contract —
+ * hooks can't import scripts/, so the two sides are duplicated, not shared.
+ */
+
+import { existsSync, readFileSync, writeFileSync, unlinkSync, renameSync } from 'fs';
+import { join } from 'path';
+import { sha256 } from './pkg-json.mjs';
+import { readCoreHooksConfig, deriveCoreHookBasenames } from './core-hooks.mjs';
+
+export const PROVENANCE_FILENAME = '.hypo-provenance.json';
+export const EXPECTED_PKG_NAME = 'hypomnema';
+
+// Field name for the aggregate hook-set hash (BLOCKER A). Exported so
+// scripts/doctor.mjs reads/writes the same key instead of duplicating the
+// string literal — doctor already imports this module for
+// PROVENANCE_FILENAME/EXPECTED_PKG_NAME, so importing one more constant costs
+// nothing and closes the duplication CONCERN 1 flagged for the filename/name
+// pair (those two stay duplicated only because hooks/hypo-shared.mjs can't
+// import this file at all).
+export const HOOKS_DIGEST_FIELD = 'hooksDigest';
+
+/**
+ * Deterministic aggregate hash over every hook file hooks/hooks.json wires up
+ * (every event handler's file plus every `shared` entry) — the exact set
+ * installHooks/applyHookFiles copy, derived from hooks.json itself rather
+ * than hand-listed here so this can never drift from what actually gets
+ * copied. `dir` is read for CONTENT: pass hooksSrcDir at write time (the
+ * package's own hooks/, immediately after files were copied out of it — see
+ * writeProvenanceSidecar) and the installed hooksDir at doctor-check time
+ * (mirrors how hypoSharedSha256 below is written from source but verified
+ * against the installed copy).
+ *
+ * Deliberately NOT what the runtime resolver reads: hooks/hypo-shared.mjs's
+ * readVerifiedProvenancePkgRoot() only ever compares hypoSharedSha256, one
+ * file, because hook modules load on every single hook event and hashing an
+ * entire directory on every load would tax the hot path for a check only
+ * `hypomnema doctor` needs to run once per invocation. This digest is that
+ * doctor-only, directory-wide check: it catches a hooks/ dir where some OTHER
+ * file (e.g. hypo-personal-check.mjs) went stale while hypo-shared.mjs itself
+ * stayed byte-identical, which the single-file SHA the runtime trusts cannot
+ * see at all.
+ *
+ * Sorted basenames, `<file>\n<sha256-of-file-hex>\n` per file concatenated,
+ * then SHA-256 of that string — order and content only, never mtime/size.
+ * Returns null if hooks.json can't be read/parsed or any listed file can't be
+ * read, so a caller can treat "couldn't compute" the same as "nothing to
+ * compare" rather than writing/trusting a bogus digest.
+ */
+export function computeHooksDigest(pkgRoot, dir) {
+  const cfgRes = readCoreHooksConfig(pkgRoot);
+  if (!cfgRes.ok) return null;
+  const files = [...deriveCoreHookBasenames(cfgRes.cfg)].sort();
+  try {
+    let acc = '';
+    for (const file of files) {
+      acc += `${file}\n${sha256(readFileSync(join(dir, file)))}\n`;
+    }
+    return sha256(acc);
+  } catch {
+    return null;
+  }
+}
+
+export function provenancePath(hooksDir) {
+  return join(hooksDir, PROVENANCE_FILENAME);
+}
+
+/**
+ * Write/refresh the sidecar next to a standalone hooks copy at `hooksDir`.
+ * `hooksSrcDir` is the package's own hooks/ (the source hypo-shared.mjs was
+ * just copied FROM) — its content is what gets hashed, since that hash is
+ * what the copy left at `hooksDir` will actually match.
+ *
+ * Callers must invoke this every run that touches — or even just re-verifies
+ * — the hook file set, EVEN when every individual .mjs file was skipped as
+ * already-present. A skipped hook copy that still lets hypo-pkg.json's
+ * pkgVersion move on to a newer release is exactly the bug this sidecar
+ * exists to catch; refreshing it only when files actually changed would
+ * reintroduce that gap under a new name.
+ *
+ * Returns the sidecar path written, or null if the source couldn't be
+ * hashed (leaves any pre-existing sidecar untouched rather than write a
+ * broken one).
+ *
+ * `hooksDigest` (BLOCKER A) is best-effort: computed from the same
+ * `hooksSrcDir`, over the file set hooks.json actually wires up. Unlike
+ * hypoSharedSha256 above, a failure to compute it does not abort the write —
+ * it is a doctor-only freshness signal, not part of the runtime contract
+ * (hooks/hypo-shared.mjs never reads this field), so a sidecar the runtime
+ * can verify should not be withheld just because the digest step failed.
+ */
+export function writeProvenanceSidecar(hooksDir, pkgRoot, pkgVersion, hooksSrcDir, dryRun) {
+  let hypoSharedSha256;
+  try {
+    hypoSharedSha256 = sha256(readFileSync(join(hooksSrcDir, 'hypo-shared.mjs')));
+  } catch {
+    return null;
+  }
+  const hooksDigest = computeHooksDigest(pkgRoot, hooksSrcDir);
+  const dest = provenancePath(hooksDir);
+  const data = {
+    pkgRoot,
+    pkgVersion,
+    hypoSharedSha256,
+    ...(hooksDigest ? { [HOOKS_DIGEST_FIELD]: hooksDigest } : {}),
+    copiedAt: new Date().toISOString(),
+  };
+  if (!dryRun) atomicWriteJson(dest, data);
+  return dest;
+}
+
+// Tmp file in the SAME directory as `dest`, then rename over it (CONCERN 2):
+// a reader (readVerifiedProvenancePkgRoot in hooks/hypo-shared.mjs) that
+// races a plain truncate-then-write can observe a half-written file and
+// JSON.parse throws, degrading PKG_ROOT to null for that hook invocation.
+// Same directory is required for the rename to be atomic — crossing a
+// filesystem boundary would fall back to a non-atomic copy+delete.
+function atomicWriteJson(dest, data) {
+  const tmp = `${dest}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
+  try {
+    renameSync(tmp, dest);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err;
+  }
+}
+
+/** Remove the sidecar at `hooksDir`, if present. Returns the path removed, or null. */
+export function removeProvenanceSidecar(hooksDir, apply) {
+  const dest = provenancePath(hooksDir);
+  if (!existsSync(dest)) return null;
+  if (apply) unlinkSync(dest);
+  return dest;
+}
+
+/** Non-mutating read. Returns the parsed sidecar, or null on absence/corruption. */
+export function readProvenanceSidecar(hooksDir) {
+  try {
+    return JSON.parse(readFileSync(provenancePath(hooksDir), 'utf-8'));
+  } catch {
+    return null;
+  }
+}

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -47,6 +47,7 @@ import {
   hasSymlinkAncestor,
   buildHookCommand,
 } from './lib/extensions.mjs';
+import { removeProvenanceSidecar } from './lib/pkg-provenance.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -510,6 +511,17 @@ function removeHookFiles(hooksDir, hookFiles, apply) {
       missing.push(p);
     }
   }
+  // .hypo-provenance.json (scripts/lib/pkg-provenance.mjs) is written next to
+  // this exact hooksDir by installHooks/applyHookFiles — same lifecycle as the
+  // hook files themselves, so it is removed in the same pass rather than left
+  // behind to describe a package root that no longer has any hooks pointing
+  // through it. Unlike hookFiles above, this is an optional file (only the
+  // manual/npm channel ever writes one) — so, mirroring the loop's own
+  // present/absent split, it is only added to `removed` (dry-run: "to remove")
+  // when it actually exists; a channel that never wrote one gets no line at
+  // all, not a spurious "already absent".
+  const sidecar = removeProvenanceSidecar(hooksDir, apply);
+  if (sidecar) removed.push(sidecar);
   return { removed, missing };
 }
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -53,6 +53,7 @@ import {
   writeDualSkipProvenance,
 } from './lib/pkg-json.mjs';
 import { syncExtensions } from './lib/extensions.mjs';
+import { writeProvenanceSidecar } from './lib/pkg-provenance.mjs';
 import { isHypomnemaPluginEnabled, resolveEnabledPluginRoot } from './lib/plugin-detect.mjs';
 import { classifyInstall, downgradeGuardMessage } from '../hooks/version-check.mjs';
 
@@ -1135,6 +1136,12 @@ if (args.apply) {
       );
     }
     appliedHooks = applyHookFiles(hooks, claudeHooksDir);
+    // Refresh every run managesClaudeCore is true, not only when a stale hook
+    // was actually copied above: applyHookFiles OVERWRITES (never skips) a
+    // stale hook, but even a run that finds every hook already up-to-date
+    // must still keep the sidecar's pkgVersion truthful, same reasoning as
+    // installHooks's own refresh-every-run comment.
+    writeProvenanceSidecar(claudeHooksDir, PKG_ROOT, readVersionAtRoot(PKG_ROOT), HOOKS_SRC, false);
     appliedSettings = applySettingsJson(settings, claudeSettingsPath);
     // applyCommands handles the single atomic hypo-pkg.json write (pkgRoot, version, schema, commands map)
     appliedCommands = applyCommands(commands, args.forceCommands);
@@ -1196,6 +1203,7 @@ if (args.apply) {
       );
     }
     appliedHooksCodex = applyHookFiles(hooksCodex, codexHooksDir);
+    writeProvenanceSidecar(codexHooksDir, PKG_ROOT, readVersionAtRoot(PKG_ROOT), HOOKS_SRC, false);
     appliedSettingsCodex = applySettingsJson(settingsCodex, codexSettingsPath);
   }
   // After applyCommands wrote hypo-pkg.json — merges extensions.<target> alongside.

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -31,6 +31,7 @@ import {
   withTmpDir,
   withTmpHome,
 } from './helpers.mjs';
+import { PROVENANCE_FILENAME, EXPECTED_PKG_NAME } from '../scripts/lib/pkg-provenance.mjs';
 
 // ── doctor.mjs smoke tests ───────────────────────────────────────────────────
 
@@ -860,7 +861,7 @@ test('doctor-close-artifacts: legacy marker with ONLY a flat `project` (no `proj
 // (hooks/hypo-shared.mjs SESSION_CLOSED_MARKER_STALE_MS comment) — a
 // same-day marker for an UNRELATED project must not silence an unapproved
 // close in THIS project. A date-only correlation would wrongly pass this.
-test('doctor-close-artifacts: a DIFFERENT project\'s same-day marker does not mask this project\'s unapproved close → warn', () => {
+test("doctor-close-artifacts: a DIFFERENT project's same-day marker does not mask this project's unapproved close → warn", () => {
   withTmpDir((dir) => {
     baseWiki(dir);
     mkdirSync(join(dir, 'projects', 'project-a'), { recursive: true });
@@ -900,10 +901,14 @@ test('doctor-close-artifacts: a DIFFERENT project\'s same-day marker does not ma
 // case (UTC day ≠ local day) is deterministic regardless of the host's own
 // timezone.
 function runDoctorJsonInTz(dir, tz) {
-  const r = spawnSync(process.execPath, [join(SCRIPTS, 'doctor.mjs'), `--hypo-dir=${dir}`, '--json'], {
-    encoding: 'utf-8',
-    env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME, TZ: tz },
-  });
+  const r = spawnSync(
+    process.execPath,
+    [join(SCRIPTS, 'doctor.mjs'), `--hypo-dir=${dir}`, '--json'],
+    {
+      encoding: 'utf-8',
+      env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME, TZ: tz },
+    },
+  );
   return { r, out: JSON.parse(r.stdout) };
 }
 
@@ -1812,10 +1817,18 @@ test('a well-formed marker → warn naming from/to and a runnable re-run command
     const check = out.find((c) => c.label === 'Incomplete rename');
     assert.ok(check, 'Incomplete rename check not found');
     assert.equal(check.status, 'warn', `expected warn with a marker present: ${check.detail}`);
-    assert.ok(check.detail.includes('pages/foo.md'), `detail must name the from-page: ${check.detail}`);
-    assert.ok(check.detail.includes('pages/bar.md'), `detail must name the to-page: ${check.detail}`);
     assert.ok(
-      /node .*rename\.mjs .*--from=pages\/foo\.md .*--to=pages\/bar\.md .*--apply/.test(check.detail),
+      check.detail.includes('pages/foo.md'),
+      `detail must name the from-page: ${check.detail}`,
+    );
+    assert.ok(
+      check.detail.includes('pages/bar.md'),
+      `detail must name the to-page: ${check.detail}`,
+    );
+    assert.ok(
+      /node .*rename\.mjs .*--from=pages\/foo\.md .*--to=pages\/bar\.md .*--apply/.test(
+        check.detail,
+      ),
       `detail must include an exact runnable re-run command: ${check.detail}`,
     );
   });
@@ -1881,7 +1894,11 @@ test('marker present, from gone, to exists (move finished, marker leftover) → 
     const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
     const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
     assert.ok(check, 'Incomplete rename check not found');
-    assert.equal(check.status, 'warn', `stale-but-finished marker must still warn: ${check.detail}`);
+    assert.equal(
+      check.status,
+      'warn',
+      `stale-but-finished marker must still warn: ${check.detail}`,
+    );
     assert.ok(
       !/re-run/i.test(check.detail),
       `must not suggest a re-run that would fail (--from no longer resolves): ${check.detail}`,
@@ -1933,7 +1950,12 @@ test('marker in a git repo that does NOT ignore .cache/ → doctor appends a git
     writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
     writeFileSync(
       join(dir, '.cache', 'rename-in-progress.json'),
-      JSON.stringify({ mode: 'page', from: 'pages/foo.md', to: 'pages/bar.md', started_at: '2026-08-01T00:00:00.000Z' }),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/foo.md',
+        to: 'pages/bar.md',
+        started_at: '2026-08-01T00:00:00.000Z',
+      }),
     );
     const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
     const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
@@ -1953,7 +1975,12 @@ test('marker in a git repo that DOES ignore .cache/ → no gitignore hint', () =
     writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
     writeFileSync(
       join(dir, '.cache', 'rename-in-progress.json'),
-      JSON.stringify({ mode: 'page', from: 'pages/foo.md', to: 'pages/bar.md', started_at: '2026-08-01T00:00:00.000Z' }),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/foo.md',
+        to: 'pages/bar.md',
+        started_at: '2026-08-01T00:00:00.000Z',
+      }),
     );
     const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
     const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
@@ -1971,12 +1998,287 @@ test('marker in a non-git vault → no gitignore hint, no crash', () => {
     writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
     writeFileSync(
       join(dir, '.cache', 'rename-in-progress.json'),
-      JSON.stringify({ mode: 'page', from: 'pages/foo.md', to: 'pages/bar.md', started_at: '2026-08-01T00:00:00.000Z' }),
+      JSON.stringify({
+        mode: 'page',
+        from: 'pages/foo.md',
+        to: 'pages/bar.md',
+        started_at: '2026-08-01T00:00:00.000Z',
+      }),
     );
     const r = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
-    assert.ok(r.status !== null && r.status <= 1, `doctor must not crash on a non-git vault: ${r.stdout}${r.stderr}`);
+    assert.ok(
+      r.status !== null && r.status <= 1,
+      `doctor must not crash on a non-git vault: ${r.stdout}${r.stderr}`,
+    );
     const check = JSON.parse(r.stdout).find((c) => c.label === 'Incomplete rename');
     assert.equal(check.status, 'warn');
-    assert.ok(!/gitignore/i.test(check.detail), `non-git vault must get no gitignore hint: ${check.detail}`);
+    assert.ok(
+      !/gitignore/i.test(check.detail),
+      `non-git vault must get no gitignore hint: ${check.detail}`,
+    );
+  });
+});
+
+// ── ISSUE-80: provenance sidecar check (scripts/doctor.mjs's checkProvenanceSidecar) ──
+// Absent is a normal, silent state (plugin/dev channels never write one; so does
+// a manual install predating this check). Present is either verified (pass) or
+// broken (warn, never fail — a broken sidecar just degrades PKG_ROOT to null,
+// which the SessionStart PKG_ROOT-null banner surfaces instead).
+suite('doctor.mjs — provenance sidecar check (ISSUE-80)');
+
+test('no sidecar at all (fresh install) → no check reported', () => {
+  withTmpHome((home) => {
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+    assert.equal(check, undefined, 'an absent sidecar must not be reported at all');
+  });
+});
+
+test('a verified sidecar (written by init) → pass', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+      assert.ok(check, 'expected a hooks/.hypo-provenance.json check');
+      assert.equal(check.status, 'pass', `a freshly-written sidecar must verify: ${check.detail}`);
+      assert.match(check.detail, /verified/);
+    });
+  });
+});
+
+test('corrupt sidecar JSON → warn', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const sidecarPath = join(home, '.claude', 'hooks', '.hypo-provenance.json');
+      writeFileSync(sidecarPath, '{not json');
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+      assert.ok(check, 'expected a hooks/.hypo-provenance.json check');
+      assert.equal(check.status, 'warn', `corrupt JSON must warn, not pass/fail: ${check.detail}`);
+      assert.match(check.detail, /not valid JSON/);
+    });
+  });
+});
+
+test('sidecar pkgRoot package.json name != "hypomnema" → warn', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const foreignRoot = mkdtempSync(join(tmpdir(), 'hypo-foreign-root-'));
+      try {
+        writeFileSync(
+          join(foreignRoot, 'package.json'),
+          JSON.stringify({ name: 'not-hypomnema', version: '1.0.0' }),
+        );
+        const sidecarPath = join(home, '.claude', 'hooks', '.hypo-provenance.json');
+        const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+        sidecar.pkgRoot = foreignRoot;
+        writeFileSync(sidecarPath, JSON.stringify(sidecar));
+        const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+        const out = JSON.parse(r.stdout);
+        const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+        assert.ok(check, 'expected a hooks/.hypo-provenance.json check');
+        assert.equal(check.status, 'warn', `a foreign pkgRoot must warn: ${check.detail}`);
+        assert.match(check.detail, /is not this package/);
+      } finally {
+        rmSync(foreignRoot, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+test('sidecar hypoSharedSha256 mismatch → warn', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const sidecarPath = join(home, '.claude', 'hooks', '.hypo-provenance.json');
+      const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+      sidecar.hypoSharedSha256 = 'deadbeef'.repeat(8);
+      writeFileSync(sidecarPath, JSON.stringify(sidecar));
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+      assert.ok(check, 'expected a hooks/.hypo-provenance.json check');
+      assert.equal(check.status, 'warn', `a hash mismatch must warn: ${check.detail}`);
+      assert.match(check.detail, /does not match the installed hypo-shared\.mjs/);
+    });
+  });
+});
+
+test('--codex flag: a verified codex-side sidecar (written by upgrade --apply --codex) → pass', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const upR = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply', '--codex'], home);
+      assert.equal(upR.status, 0, `upgrade --apply --codex failed: ${upR.stderr}`);
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--codex', '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const check = out.find((c) => c.label === 'Codex hooks/.hypo-provenance.json');
+      assert.ok(check, 'expected a Codex hooks/.hypo-provenance.json check');
+      assert.equal(check.status, 'pass', `codex sidecar must verify: ${check.detail}`);
+    });
+  });
+});
+
+// CONCERN 1 (fix/pkgroot-provenance codex review): the sidecar filename and
+// producer-name check are duplicated byte-for-byte between
+// hooks/hypo-shared.mjs (a private const — hooks can't import scripts/) and
+// scripts/lib/pkg-provenance.mjs (the exported source of truth). A source
+// scan, not a shared import, is the only way to bind them: importing
+// hooks/hypo-shared.mjs's PKG_ROOT here would run selfLocationPkgRoot()
+// against THIS test file's own checkout, an unrelated side effect. Follows
+// the same read-source-as-text pattern as tests/proposal-base.test.mjs's
+// "publishes the lock by linking" test.
+test('CONCERN 1: PROVENANCE_FILENAME/EXPECTED_PKG_NAME stay byte-identical between hooks/hypo-shared.mjs and scripts/lib/pkg-provenance.mjs', () => {
+  const sharedSrc = readFileSync(join(REPO, 'hooks', 'hypo-shared.mjs'), 'utf-8');
+  const filenameMatch = sharedSrc.match(/const PROVENANCE_FILENAME = '([^']+)'/);
+  const nameMatch = sharedSrc.match(/const EXPECTED_PKG_NAME = '([^']+)'/);
+  assert.ok(
+    filenameMatch,
+    'hooks/hypo-shared.mjs must define PROVENANCE_FILENAME as a plain string literal',
+  );
+  assert.ok(
+    nameMatch,
+    'hooks/hypo-shared.mjs must define EXPECTED_PKG_NAME as a plain string literal',
+  );
+  assert.equal(
+    filenameMatch[1],
+    PROVENANCE_FILENAME,
+    'sidecar filename diverged between the runtime reader and scripts/lib/pkg-provenance.mjs',
+  );
+  assert.equal(
+    nameMatch[1],
+    EXPECTED_PKG_NAME,
+    'producer-name check diverged between the runtime reader and scripts/lib/pkg-provenance.mjs',
+  );
+});
+
+// ── BLOCKER A: hooksDigest (aggregate hash over every hook.json-wired file) ──
+suite('doctor.mjs — hooksDigest + self-location checks (fix/pkgroot-provenance)');
+
+test('a hook file other than hypo-shared.mjs changed after copy → hooksDigest mismatch names it', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const hooksDir = join(home, '.claude', 'hooks');
+      const target = join(hooksDir, 'hypo-personal-check.mjs');
+      // hypo-shared.mjs itself is untouched — the runtime SHA check alone
+      // would still verify this install; only the aggregate hooksDigest sees
+      // this file drift.
+      writeFileSync(target, readFileSync(target, 'utf-8') + '\n// tampered for test\n');
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+      assert.ok(check, 'expected a hooks/.hypo-provenance.json check');
+      assert.equal(
+        check.status,
+        'warn',
+        `a changed non-hypo-shared hook file must surface as a hooksDigest warn: ${check.detail}`,
+      );
+      assert.match(check.detail, /hooksDigest mismatch/);
+      assert.match(check.detail, /hypo-personal-check\.mjs/);
+    });
+  });
+});
+
+test('sidecar predating hooksDigest (no such field) → doctor skips the digest check silently', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const hooksDir = join(home, '.claude', 'hooks');
+      const sidecarPath = join(hooksDir, '.hypo-provenance.json');
+      const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+      delete sidecar.hooksDigest;
+      writeFileSync(sidecarPath, JSON.stringify(sidecar));
+      // Tamper a hook file too — if the digest check ran anyway, this would warn.
+      const target = join(hooksDir, 'hypo-personal-check.mjs');
+      writeFileSync(target, readFileSync(target, 'utf-8') + '\n// tampered for test\n');
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+      assert.ok(check, 'expected a hooks/.hypo-provenance.json check');
+      assert.equal(
+        check.status,
+        'pass',
+        `a pre-hooksDigest sidecar must still verify on name+hash+usable alone: ${check.detail}`,
+      );
+    });
+  });
+});
+
+test('sidecar pkgRoot package.json has no version → doctor warns, does not PASS', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      const versionlessRoot = mkdtempSync(join(tmpdir(), 'hypo-versionless-root-'));
+      try {
+        writeFileSync(
+          join(versionlessRoot, 'package.json'),
+          JSON.stringify({ name: 'hypomnema' }), // name matches; no "version" field
+        );
+        const sidecarPath = join(home, '.claude', 'hooks', '.hypo-provenance.json');
+        const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+        sidecar.pkgRoot = versionlessRoot;
+        writeFileSync(sidecarPath, JSON.stringify(sidecar));
+        const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+        const out = JSON.parse(r.stdout);
+        const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+        assert.ok(check, 'expected a hooks/.hypo-provenance.json check');
+        assert.equal(
+          check.status,
+          'warn',
+          `a version-less root must not PASS — isUsablePkgRootLocal (the same predicate ` +
+            `the runtime resolver requires) rejects it too: ${check.detail}`,
+        );
+        assert.match(check.detail, /not a usable package root/);
+      } finally {
+        rmSync(versionlessRoot, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+test('hooks installed, self-location fails, no sidecar at all → doctor warns, not silent', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+      // A standalone `init` copy has no package.json alongside it, so
+      // self-location for this hooksDir always fails — same steady state
+      // documented on selfLocationPkgRootFrom in hooks/hypo-shared.mjs.
+      const sidecarPath = join(home, '.claude', 'hooks', '.hypo-provenance.json');
+      rmSync(sidecarPath, { force: true });
+      const r = runWithHome('doctor.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      const out = JSON.parse(r.stdout);
+      const check = out.find((c) => c.label === 'hooks/.hypo-provenance.json');
+      assert.ok(
+        check,
+        'an installed-but-unresolvable hook copy with no sidecar must not stay silent',
+      );
+      assert.equal(check.status, 'warn', `must not stay silent: ${check.detail}`);
+      assert.match(check.detail, /PKG_ROOT resolves to null/);
+    });
   });
 });

--- a/tests/extensions.test.mjs
+++ b/tests/extensions.test.mjs
@@ -3531,3 +3531,24 @@ test('uninstall-extensions-skips-non-regular-symlink', () => {
     });
   });
 });
+
+// ISSUE-80: uninstall must remove the `.hypo-provenance.json` sidecar
+// installHooks writes next to ~/.claude/hooks (scripts/lib/pkg-provenance.mjs)
+// — same lifecycle as the hook files it sits beside. A leftover sidecar after
+// uninstall would describe a package root no hooks point through any more.
+test('uninstall-removes-provenance-sidecar-with-hooks', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const sidecarPath = join(home, '.claude', 'hooks', '.hypo-provenance.json');
+      assert.ok(existsSync(sidecarPath), 'pre-state: init must write the provenance sidecar');
+
+      const un = runWithHome('uninstall.mjs', ['--apply'], home);
+      assert.equal(un.status, 0, `uninstall failed: ${un.stderr}\n${un.stdout}`);
+      assert.ok(!existsSync(sidecarPath), 'uninstall must remove the provenance sidecar');
+    });
+  });
+});

--- a/tests/fixtures/npm-pack.files.json
+++ b/tests/fixtures/npm-pack.files.json
@@ -324,6 +324,10 @@
     "exec": false
   },
   {
+    "path": "scripts/lib/pkg-provenance.mjs",
+    "exec": false
+  },
+  {
     "path": "scripts/lib/plugin-detect.mjs",
     "exec": false
   },

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -5,6 +5,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   mkdirSync,
   mkdtempSync,
@@ -19,8 +20,10 @@ import {
 import { join, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
+import { PROVENANCE_FILENAME } from '../scripts/lib/pkg-provenance.mjs';
 import {
   HOME,
+  HOOKS,
   REPO,
   SCRIPTS,
   SESSION_TMP_HOME,
@@ -1353,4 +1356,100 @@ test('--help option list matches every flag parseArgs actually recognizes', () =
     [...recognized].sort(),
     `--help's option list must exactly match the flags parseArgs recognizes.\nlisted:     ${JSON.stringify([...listed].sort())}\nrecognized: ${JSON.stringify([...recognized].sort())}`,
   );
+});
+
+// ── ISSUE-80: installHooks writes/refreshes the provenance sidecar ────────────
+// `.hypo-provenance.json` (scripts/lib/pkg-provenance.mjs) is what
+// hooks/hypo-shared.mjs's resolvePkgRoot() falls back to on a standalone
+// (manual/npm) hooks copy once self-location can't resolve. installHooks is
+// the writer for the manual/npm channel's ~/.claude/hooks.
+suite('init.mjs — provenance sidecar (ISSUE-80)');
+
+function repoHypoSharedSha256() {
+  return createHash('sha256')
+    .update(readFileSync(join(HOOKS, 'hypo-shared.mjs')))
+    .digest('hex');
+}
+
+test('installHooks writes a provenance sidecar that verifies against this package', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const r = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-commands', '--no-shell', '--no-git-init'],
+        home,
+      );
+      assert.equal(r.status, 0, `init failed: ${r.stderr}`);
+
+      const sidecarPath = join(home, '.claude', 'hooks', PROVENANCE_FILENAME);
+      assert.ok(existsSync(sidecarPath), 'installHooks must write the provenance sidecar');
+      const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+      assert.equal(sidecar.pkgRoot, REPO, 'sidecar pkgRoot must point at this package');
+      assert.equal(
+        sidecar.hypoSharedSha256,
+        repoHypoSharedSha256(),
+        'sidecar hash must match the hypo-shared.mjs actually copied',
+      );
+    });
+  });
+});
+
+// The whole point of the fix: a re-run where every hooks/*.mjs file is
+// already-present (and therefore skipped, per scripts/init.mjs's own
+// installHooks comment) must still refresh the sidecar, not leave a stale
+// one behind. copiedAt is a fresh timestamp per write, so it changing across
+// runs is the observable proof the sidecar was actually rewritten, not just
+// left untouched because the hook files themselves were untouched.
+test('a second init run, with every hook file skipped as already-present, still refreshes the sidecar', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const args = [`--hypo-dir=${hypoDir}`, '--no-commands', '--no-shell', '--no-git-init'];
+      const first = runWithHome('init.mjs', args, home);
+      assert.equal(first.status, 0, `first init failed: ${first.stderr}`);
+      const sidecarPath = join(home, '.claude', 'hooks', PROVENANCE_FILENAME);
+      const afterFirst = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+
+      const second = runWithHome('init.mjs', args, home);
+      assert.equal(second.status, 0, `second init failed: ${second.stderr}`);
+      assert.match(
+        second.stdout,
+        /skipped/i,
+        `second run must report the hook files as skipped (already-present): ${second.stdout}`,
+      );
+      const afterSecond = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+      assert.equal(
+        afterSecond.pkgRoot,
+        REPO,
+        'the refreshed sidecar must still point at the current package',
+      );
+      assert.equal(
+        afterSecond.hypoSharedSha256,
+        repoHypoSharedSha256(),
+        'the refreshed sidecar must still hash-match the current hypo-shared.mjs',
+      );
+      assert.notEqual(
+        afterSecond.copiedAt,
+        afterFirst.copiedAt,
+        'a skip-everything re-run must still rewrite the sidecar (fresh copiedAt), not leave it untouched',
+      );
+    });
+  });
+});
+
+test('--dry-run does not write the provenance sidecar', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const r = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--dry-run', '--no-commands', '--no-shell', '--no-git-init'],
+        home,
+      );
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      const sidecarPath = join(home, '.claude', 'hooks', PROVENANCE_FILENAME);
+      assert.ok(!existsSync(sidecarPath), '--dry-run must not write the provenance sidecar');
+    });
+  });
 });

--- a/tests/notifier.test.mjs
+++ b/tests/notifier.test.mjs
@@ -5,6 +5,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   mkdtempSync,
   mkdirSync,
@@ -948,10 +949,7 @@ suite('ISSUE-70: pkgRoot self-location vs cache (resolvePkgRoot / pkgRootDriftSt
 function seedHypoPkg(home, pkgRoot) {
   const claudeDir = join(home, '.claude');
   mkdirSync(claudeDir, { recursive: true });
-  writeFileSync(
-    join(claudeDir, 'hypo-pkg.json'),
-    JSON.stringify({ pkgRoot, pkgVersion: '1.0.0' }),
-  );
+  writeFileSync(join(claudeDir, 'hypo-pkg.json'), JSON.stringify({ pkgRoot, pkgVersion: '1.0.0' }));
 }
 
 // A pkgRoot usable per isUsablePkgRootLocal (hooks/hypo-shared.mjs): absolute
@@ -959,6 +957,28 @@ function seedHypoPkg(home, pkgRoot) {
 function seedUsableRoot(root, version = '1.7.0') {
   mkdirSync(root, { recursive: true });
   writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'hypomnema', version }));
+}
+
+// SHA-256 of a standalone hooks copy's hypo-shared.mjs — identical bytes to
+// HOOKS/hypo-shared.mjs since standaloneHooksCopy() does a plain cpSync.
+function hypoSharedSha256(hooksSrc = HOOKS) {
+  return createHash('sha256')
+    .update(readFileSync(join(hooksSrc, 'hypo-shared.mjs')))
+    .digest('hex');
+}
+
+// Writes `.hypo-provenance.json` (scripts/lib/pkg-provenance.mjs's contract)
+// next to a standalone hooks copy at `hooksDir`. Defaults produce a sidecar
+// that VERIFIES; pass overrides to build a rejection case.
+function seedProvenance(hooksDir, overrides = {}) {
+  const data = {
+    pkgRoot: overrides.pkgRoot,
+    pkgVersion: overrides.pkgVersion ?? '1.7.0',
+    hypoSharedSha256:
+      'hypoSharedSha256' in overrides ? overrides.hypoSharedSha256 : hypoSharedSha256(),
+    copiedAt: new Date().toISOString(),
+  };
+  writeFileSync(join(hooksDir, '.hypo-provenance.json'), JSON.stringify(data));
 }
 
 // Copies just hooks/ into a throwaway tmp dir, so a hook running FROM that
@@ -1050,10 +1070,13 @@ test('resolvePkgRoot: hypo-pkg.json missing or corrupt never throws (self-locati
   });
 });
 
-test('resolvePkgRoot: self-location unresolvable (standalone-copied hooks, mirrors the npm/manual deploy) → status unknown, falls back to a usable cache', () => {
+test('resolvePkgRoot: self-location unresolvable (standalone-copied hooks, mirrors the npm/manual deploy), no provenance sidecar → status unknown, PKG_ROOT null (BLOCKER 1: no cache fallback)', () => {
   withTmpHome((home) => {
     const standaloneDir = standaloneHooksCopy();
     try {
+      // A usable, up-to-date cache exists — the OLD behavior (pre-fix) would
+      // have adopted it. The new policy is self → verified provenance → null,
+      // full stop: the cache is never consulted for resolution any more.
       const usableCache = join(home, 'cached-root');
       seedUsableRoot(usableCache);
       seedHypoPkg(home, usableCache);
@@ -1061,8 +1084,8 @@ test('resolvePkgRoot: self-location unresolvable (standalone-copied hooks, mirro
       assert.equal(r.status.status, 'unknown');
       assert.equal(
         r.PKG_ROOT,
-        usableCache,
-        'falls back to the (usable) cache when self-location cannot resolve',
+        null,
+        'no provenance sidecar and self-location unresolvable → null, even with a usable cache present',
       );
     } finally {
       rmSync(standaloneDir, { recursive: true, force: true });
@@ -1070,39 +1093,142 @@ test('resolvePkgRoot: self-location unresolvable (standalone-copied hooks, mirro
   });
 });
 
-test('resolvePkgRoot: cache contract — an unusable cached pkgRoot (no package.json, or relative) is never returned, even with self-location unresolvable', () => {
+test('resolvePkgRoot: self-location unresolvable + valid provenance sidecar → PKG_ROOT resolves to the sidecar pkgRoot', () => {
   withTmpHome((home) => {
     const standaloneDir = standaloneHooksCopy();
     try {
-      const hooksSharedPath = join(standaloneDir, 'hooks', 'hypo-shared.mjs');
-
-      // (a) existing directory, no package.json at all
-      const bareDir = join(home, 'cached-dir-no-package-json');
-      mkdirSync(bareDir, { recursive: true });
-      seedHypoPkg(home, bareDir);
-      let r = probePkgRoot(home, hooksSharedPath);
-      assert.equal(r.PKG_ROOT, null, 'a cached dir with no package.json must not be returned');
+      const provenanceRoot = join(home, 'provenance-root');
+      seedUsableRoot(provenanceRoot);
+      const hooksDir = join(standaloneDir, 'hooks');
+      seedProvenance(hooksDir, { pkgRoot: provenanceRoot });
+      const r = probePkgRoot(home, join(hooksDir, 'hypo-shared.mjs'));
       assert.equal(r.status.status, 'unknown');
-
-      // (b) relative cached pkgRoot — must never be adopted
-      seedHypoPkg(home, '.');
-      r = probePkgRoot(home, hooksSharedPath);
-      assert.equal(r.PKG_ROOT, null, 'a relative cached pkgRoot must not be returned');
-
-      // (c) package.json present but missing a version field
-      const versionlessRoot = join(home, 'versionless-root');
-      mkdirSync(versionlessRoot, { recursive: true });
-      writeFileSync(join(versionlessRoot, 'package.json'), JSON.stringify({ name: 'hypomnema' }));
-      seedHypoPkg(home, versionlessRoot);
-      r = probePkgRoot(home, hooksSharedPath);
-      assert.equal(r.PKG_ROOT, null, 'a cached package.json without a version must not be usable');
+      assert.equal(
+        r.PKG_ROOT,
+        provenanceRoot,
+        'a verified provenance sidecar must resolve PKG_ROOT',
+      );
     } finally {
       rmSync(standaloneDir, { recursive: true, force: true });
     }
   });
 });
 
-test('resolvePkgRoot: self-containment — an UNRELATED versioned package.json two levels above a standalone hooks copy is rejected → status unknown, falls back to cache', () => {
+test('resolvePkgRoot: self-location succeeds → self wins even when the provenance sidecar points somewhere else', () => {
+  withFakePkgInstall('1.7.0', (realRoot) => {
+    withTmpHome((home) => {
+      // The sidecar is never even consulted once self-location resolves — a
+      // disagreeing (or outright garbage) sidecar must not change the answer.
+      const elsewhere = join(home, 'provenance-elsewhere');
+      seedUsableRoot(elsewhere);
+      seedProvenance(join(realRoot, 'hooks'), { pkgRoot: elsewhere });
+      const r = probePkgRoot(home, join(realRoot, 'hooks', 'hypo-shared.mjs'));
+      assert.equal(
+        r.PKG_ROOT,
+        realRoot,
+        'self-location must win over a disagreeing provenance sidecar',
+      );
+    });
+  });
+});
+
+// BLOCKER 2 producer proof, both halves. Neither a name mismatch nor a hash
+// mismatch may resolve — and, per BLOCKER 1, neither falls back to the cache.
+test('resolvePkgRoot: provenance producer proof — pkgRoot package.json "name" must be "hypomnema", else null', () => {
+  withTmpHome((home) => {
+    const standaloneDir = standaloneHooksCopy();
+    try {
+      const foreignRoot = join(home, 'foreign-root');
+      mkdirSync(foreignRoot, { recursive: true });
+      writeFileSync(
+        join(foreignRoot, 'package.json'),
+        JSON.stringify({ name: 'not-hypomnema', version: '1.7.0' }),
+      );
+      const hooksDir = join(standaloneDir, 'hooks');
+      seedProvenance(hooksDir, { pkgRoot: foreignRoot });
+      // A usable cache is present too — must still not be adopted (BLOCKER 1).
+      seedHypoPkg(home, foreignRoot);
+      const r = probePkgRoot(home, join(hooksDir, 'hypo-shared.mjs'));
+      assert.equal(
+        r.PKG_ROOT,
+        null,
+        'a provenance pkgRoot whose package.json name != "hypomnema" must be rejected',
+      );
+    } finally {
+      rmSync(standaloneDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('resolvePkgRoot: provenance producer proof — hypoSharedSha256 must match the running hypo-shared.mjs, else null', () => {
+  withTmpHome((home) => {
+    const standaloneDir = standaloneHooksCopy();
+    try {
+      const provenanceRoot = join(home, 'provenance-root');
+      seedUsableRoot(provenanceRoot);
+      const hooksDir = join(standaloneDir, 'hooks');
+      seedProvenance(hooksDir, { pkgRoot: provenanceRoot, hypoSharedSha256: 'deadbeef'.repeat(8) });
+      // A usable cache is present too — this is the assertion that pins
+      // BLOCKER 1: a hash mismatch must NOT fall back to the cache.
+      seedHypoPkg(home, provenanceRoot);
+      const r = probePkgRoot(home, join(hooksDir, 'hypo-shared.mjs'));
+      assert.equal(
+        r.PKG_ROOT,
+        null,
+        'a hypoSharedSha256 mismatch must reject the sidecar and must NOT fall back to the cache',
+      );
+    } finally {
+      rmSync(standaloneDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('resolvePkgRoot: provenance contract — unusable pkgRoot shapes (missing/relative/versionless) and missing/corrupt sidecar all resolve to null, never throw', () => {
+  withTmpHome((home) => {
+    const standaloneDir = standaloneHooksCopy();
+    try {
+      const hooksDir = join(standaloneDir, 'hooks');
+      const hooksSharedPath = join(hooksDir, 'hypo-shared.mjs');
+
+      // (a) no sidecar at all
+      let r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(r.PKG_ROOT, null, 'no sidecar → null');
+
+      // (b) corrupt JSON
+      writeFileSync(join(hooksDir, '.hypo-provenance.json'), '{not json');
+      r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(r.PKG_ROOT, null, 'corrupt sidecar JSON → null, not a throw');
+
+      // (c) sidecar pkgRoot points at a dir with no package.json
+      const bareDir = join(home, 'bare-dir-no-package-json');
+      mkdirSync(bareDir, { recursive: true });
+      seedProvenance(hooksDir, { pkgRoot: bareDir });
+      r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(r.PKG_ROOT, null, 'sidecar pkgRoot with no package.json → null');
+
+      // (d) sidecar pkgRoot is relative — must never be adopted
+      seedProvenance(hooksDir, { pkgRoot: '.' });
+      r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(r.PKG_ROOT, null, 'a relative sidecar pkgRoot must not be returned');
+
+      // (e) sidecar pkgRoot's package.json has no version field
+      const versionlessRoot = join(home, 'versionless-root');
+      mkdirSync(versionlessRoot, { recursive: true });
+      writeFileSync(join(versionlessRoot, 'package.json'), JSON.stringify({ name: 'hypomnema' }));
+      seedProvenance(hooksDir, { pkgRoot: versionlessRoot });
+      r = probePkgRoot(home, hooksSharedPath);
+      assert.equal(
+        r.PKG_ROOT,
+        null,
+        'a sidecar pkgRoot package.json without a version must not be usable',
+      );
+    } finally {
+      rmSync(standaloneDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('resolvePkgRoot: self-containment — an UNRELATED versioned package.json two levels above a standalone hooks copy is rejected → status unknown, PKG_ROOT null (no cache fallback)', () => {
   withTmpHome((home) => {
     // codex repro shape: hooks copied standalone (no package.json alongside),
     // but some ANCESTOR above it happens to carry its own, unrelated, perfectly
@@ -1122,6 +1248,9 @@ test('resolvePkgRoot: self-containment — an UNRELATED versioned package.json t
       mkdirSync(nestedHooksDir, { recursive: true });
       cpSync(HOOKS, nestedHooksDir, { recursive: true });
 
+      // A usable cache is present too — must still not be adopted (BLOCKER 1:
+      // resolution is self → verified provenance → null, cache is never a
+      // resolution fallback), and no provenance sidecar was written here.
       const usableCache = join(home, 'cached-root');
       seedUsableRoot(usableCache);
       seedHypoPkg(home, usableCache);
@@ -1132,7 +1261,11 @@ test('resolvePkgRoot: self-containment — an UNRELATED versioned package.json t
         'unknown',
         'an unrelated-but-usable ancestor package.json must never be adopted as self-location',
       );
-      assert.equal(r.PKG_ROOT, usableCache, 'must fall back to the cache, not the unrelated package');
+      assert.equal(
+        r.PKG_ROOT,
+        null,
+        'must not fall back to the cache, nor adopt the unrelated package',
+      );
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -1150,7 +1283,10 @@ test('resolvePkgRoot: self-containment — an ancestor with A hooks/hypo-shared.
       // actually running.
       writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'x', version: '9.9.9' }));
       mkdirSync(join(root, 'hooks'), { recursive: true });
-      writeFileSync(join(root, 'hooks', 'hypo-shared.mjs'), '// foreign stub, not the real module\n');
+      writeFileSync(
+        join(root, 'hooks', 'hypo-shared.mjs'),
+        '// foreign stub, not the real module\n',
+      );
 
       // The REAL running module lives nested one level deeper, so `root` is
       // an ancestor the walk will actually reach and test.
@@ -1158,6 +1294,7 @@ test('resolvePkgRoot: self-containment — an ancestor with A hooks/hypo-shared.
       mkdirSync(nestedHooksDir, { recursive: true });
       cpSync(HOOKS, nestedHooksDir, { recursive: true });
 
+      // A usable cache is present too — must still not be adopted (BLOCKER 1).
       const usableCache = join(home, 'cached-root');
       seedUsableRoot(usableCache);
       seedHypoPkg(home, usableCache);
@@ -1168,7 +1305,7 @@ test('resolvePkgRoot: self-containment — an ancestor with A hooks/hypo-shared.
         'unknown',
         'an ancestor with A hooks/hypo-shared.mjs, but not THIS one, must not be adopted',
       );
-      assert.equal(r.PKG_ROOT, usableCache);
+      assert.equal(r.PKG_ROOT, null, 'must not fall back to the cache');
     } finally {
       rmSync(base, { recursive: true, force: true });
     }

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -14,10 +14,12 @@ import {
   existsSync,
   symlinkSync,
   unlinkSync,
+  cpSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createProject, substituteTokens, insertHotRow } from '../scripts/lib/project-create.mjs';
+import { writeProvenanceSidecar, provenancePath } from '../scripts/lib/pkg-provenance.mjs';
 import {
   buildProjectSuggestionLine,
   findBackfillCandidate,
@@ -2214,7 +2216,7 @@ test('session-start surfaces a conflict-unresolved entry with half-merged-tree g
 // into the clean-conflict "committed and safe" reassurance — that claim is
 // not known to hold for an unrecognized op — nor assert the conflict-
 // unresolved branch's "the abort failed", which is equally unverified here.
-test('session-start treats an unrecognized conflict-* op as unresolved, without either conflict branch\'s claim', () => {
+test("session-start treats an unrecognized conflict-* op as unresolved, without either conflict branch's claim", () => {
   withGrowthWiki((dir) => {
     mkdirSync(join(dir, '.cache'), { recursive: true });
     writeFileSync(
@@ -2229,7 +2231,10 @@ test('session-start treats an unrecognized conflict-* op as unresolved, without 
     const r = runStart(dir);
     const ctx = JSON.parse(r.stdout).additionalContext || '';
     assert.ok(ctx.includes('remote diverged'), `unknown-conflict notice missing: ${ctx}`);
-    assert.ok(/unresolved/.test(ctx), `unknown-conflict must say to treat it as unresolved: ${ctx}`);
+    assert.ok(
+      /unresolved/.test(ctx),
+      `unknown-conflict must say to treat it as unresolved: ${ctx}`,
+    );
     assert.ok(
       !/your local work is committed/i.test(ctx),
       `unknown-conflict must NOT borrow the clean-conflict "committed" claim: ${ctx}`,
@@ -2256,7 +2261,10 @@ test('session-start emits no conflict/half-merged guidance for an unrelated op (
     const r = runStart(dir);
     const ctx = JSON.parse(r.stdout).additionalContext || '';
     assert.ok(ctx.includes('last sync failed'), `generic sync notice missing: ${ctx}`);
-    assert.ok(!ctx.includes('remote diverged'), `unrelated op must not get conflict wording: ${ctx}`);
+    assert.ok(
+      !ctx.includes('remote diverged'),
+      `unrelated op must not get conflict wording: ${ctx}`,
+    );
     assert.ok(!/half-merged/.test(ctx), `unrelated op must not get half-merged wording: ${ctx}`);
   });
 });
@@ -2300,9 +2308,7 @@ test('session-start and doctor render the same wording family for every sync-sta
         JSON.stringify({ timestamp: '2026-06-19T00:00:00Z', op, error: 'x', host: 'test' }) + '\n',
       );
       const startCtx = JSON.parse(runStart(dir).stdout).additionalContext || '';
-      const doctorOut = JSON.parse(
-        run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']).stdout,
-      );
+      const doctorOut = JSON.parse(run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']).stdout);
       const doctorDetail = doctorOut.find((c) => c.label === 'Sync state')?.detail || '';
 
       const cls = classifySyncOp(op);
@@ -3100,4 +3106,120 @@ test('replay-session-start-drops-stale-clear-marker: >7 day marker is discarded'
     assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `stale marker must not fire: ${ctx}`);
     assert.ok(!existsSync(p), 'stale marker must be cleaned up');
   });
+});
+
+// ── ISSUE-80: PKG_ROOT-null notice (hypo-session-start.mjs's buildPkgRootNullNotice) ──
+//
+// The banner fires only when hooks/hypo-shared.mjs's resolvePkgRoot() itself
+// resolves to null — self-location must fail. Running the hook straight from
+// HOOKS (this checkout) always self-locates, so these tests run it from a
+// standalone COPY of hooks/ instead (mirrors the npm/manual deploy shape
+// notifier.test.mjs's resolvePkgRoot suite uses), with no --codex/plugin
+// involved: just a bare `cp hooks/ elsewhere`.
+suite('hypo-session-start.mjs — PKG_ROOT-null notice (ISSUE-80)');
+
+// The banner (like the update notifier / sibling notice) honors isOptedOut(),
+// which the CI runner's own CI=true would otherwise suppress — opt back IN by
+// clearing the opt-out vars in the child env (same pattern as notifier.test.mjs's
+// NOTIFY_ON).
+const NOTIFY_ON = { CI: '', NO_UPDATE_NOTIFIER: '', HYPO_NO_UPDATE_CHECK: '' };
+
+function standaloneHooksCopy() {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-standalone-hooks-'));
+  cpSync(HOOKS, join(dir, 'hooks'), { recursive: true });
+  return join(dir, 'hooks');
+}
+
+function runStandaloneSessionStart(hooksDir, home, extraEnv = {}) {
+  return spawnSync(process.execPath, [join(hooksDir, 'hypo-session-start.mjs')], {
+    input: JSON.stringify({ cwd: home, session_id: 'pkgroot-null-test' }),
+    encoding: 'utf-8',
+    env: { ...process.env, ...NOTIFY_ON, HYPO_DIR: '', HOME: home, ...extraEnv },
+  });
+}
+
+test('PKG_ROOT null (no provenance sidecar): the banner fires once, then throttles on a re-run', () => {
+  const standaloneDir = standaloneHooksCopy();
+  try {
+    const home = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-null-home-'));
+    try {
+      const first = runStandaloneSessionStart(standaloneDir, home);
+      assert.match(first.stderr, /Package root unresolved/, `stderr: ${first.stderr}`);
+      const out = JSON.parse(first.stdout);
+      assert.match(out.systemMessage || '', /Package root unresolved/);
+      assert.match(out.additionalContext || '', /Package root unresolved/);
+
+      // Same PKG_ROOT-null state, same session cache under the same HOME →
+      // notify-once must suppress the second showing.
+      const second = runStandaloneSessionStart(standaloneDir, home);
+      assert.doesNotMatch(
+        second.stderr,
+        /Package root unresolved/,
+        'a second run in the same unresolved state must not re-notify',
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  } finally {
+    rmSync(dirname(standaloneDir), { recursive: true, force: true });
+  }
+});
+
+test('PKG_ROOT resolving again clears the mark, so a later recurrence re-notifies', () => {
+  const standaloneDir = standaloneHooksCopy();
+  try {
+    const home = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-null-recur-home-'));
+    try {
+      const first = runStandaloneSessionStart(standaloneDir, home);
+      assert.match(first.stderr, /Package root unresolved/, `stderr: ${first.stderr}`);
+
+      // PKG_ROOT resolves (a verified provenance sidecar now covers this
+      // standalone copy) → clearPkgRootNullNotified() must run, and this run
+      // itself carries no notice (PKG_ROOT is non-null here).
+      writeProvenanceSidecar(standaloneDir, REPO, '0.0.0-test', HOOKS, false);
+      const resolved = runStandaloneSessionStart(standaloneDir, home);
+      assert.doesNotMatch(
+        resolved.stderr,
+        /Package root unresolved/,
+        'a run where PKG_ROOT resolves must carry no PKG_ROOT-null notice',
+      );
+
+      // PKG_ROOT goes null again (sidecar removed) → the mark was cleared
+      // above, so this must re-notify rather than stay silently suppressed.
+      unlinkSync(provenancePath(standaloneDir));
+      const recurred = runStandaloneSessionStart(standaloneDir, home);
+      assert.match(
+        recurred.stderr,
+        /Package root unresolved/,
+        `a recurrence after the mark was cleared must re-notify: ${recurred.stderr}`,
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  } finally {
+    rmSync(dirname(standaloneDir), { recursive: true, force: true });
+  }
+});
+
+test('opt-out (CI=true) suppresses the PKG_ROOT-null notice', () => {
+  const standaloneDir = standaloneHooksCopy();
+  try {
+    const home = mkdtempSync(join(tmpdir(), 'hypo-pkgroot-null-optout-home-'));
+    try {
+      const r = spawnSync(process.execPath, [join(standaloneDir, 'hypo-session-start.mjs')], {
+        input: JSON.stringify({ cwd: home, session_id: 'pkgroot-null-optout' }),
+        encoding: 'utf-8',
+        env: { ...process.env, HYPO_DIR: '', HOME: home, CI: 'true' },
+      });
+      assert.doesNotMatch(
+        r.stderr,
+        /Package root unresolved/,
+        `opted-out (CI=true) must suppress the notice: ${r.stderr}`,
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  } finally {
+    rmSync(dirname(standaloneDir), { recursive: true, force: true });
+  }
 });

--- a/tests/upgrade.test.mjs
+++ b/tests/upgrade.test.mjs
@@ -5,6 +5,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   mkdtempSync,
   mkdirSync,
@@ -20,6 +21,7 @@ import { tmpdir } from 'node:os';
 import { parseSchemaVocab } from '../scripts/lib/schema-vocab.mjs';
 import { isHypomnemaPluginEnabled } from '../scripts/lib/plugin-detect.mjs';
 import { writeDualSkipProvenance } from '../scripts/lib/pkg-json.mjs';
+import { PROVENANCE_FILENAME } from '../scripts/lib/pkg-provenance.mjs';
 import { test, suite } from './harness.mjs';
 import {
   HOME,
@@ -1531,4 +1533,70 @@ test('registry root usable at write time: writes the correction and returns true
   } finally {
     rmSync(registryDir, { recursive: true, force: true });
   }
+});
+
+// ── ISSUE-80: --apply refreshes the provenance sidecar (scripts/lib/pkg-provenance.mjs) ──
+suite('upgrade.mjs — provenance sidecar refresh (ISSUE-80)');
+
+function repoHypoSharedSha256() {
+  return createHash('sha256')
+    .update(readFileSync(join(HOOKS, 'hypo-shared.mjs')))
+    .digest('hex');
+}
+
+test('--apply refreshes a corrupted claude-side provenance sidecar (scripts/upgrade.mjs:1144)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const sidecarPath = join(home, '.claude', 'hooks', PROVENANCE_FILENAME);
+      assert.ok(existsSync(sidecarPath), 'pre-state: init must have written the sidecar');
+      // Corrupt it so a real regression (upgrade never touching it) is
+      // distinguishable from "it happened to already be correct".
+      writeFileSync(sidecarPath, '{not json');
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(r.status, 0, `upgrade --apply failed: ${r.stderr}`);
+
+      const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+      assert.equal(sidecar.pkgRoot, REPO, '--apply must rewrite the sidecar pkgRoot');
+      assert.equal(
+        sidecar.hypoSharedSha256,
+        repoHypoSharedSha256(),
+        '--apply must rewrite the sidecar hash to match the installed hypo-shared.mjs',
+      );
+    });
+  });
+});
+
+// scripts/upgrade.mjs:1206 mirrors the same write for the codex hooks
+// directory, but only under `if (args.codex)`. --codex has no dependency
+// on a codex CLI actually being installed (applyHookFiles mkdirSync's the
+// target unconditionally), so the fixture just needs the flag.
+test('--apply --codex writes the provenance sidecar into the codex hooks dir (scripts/upgrade.mjs:1206)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply', '--codex'], home);
+      assert.equal(r.status, 0, `upgrade --apply --codex failed: ${r.stderr}`);
+
+      const codexSidecarPath = join(home, '.codex', 'hooks', PROVENANCE_FILENAME);
+      assert.ok(
+        existsSync(codexSidecarPath),
+        '--apply --codex must write the codex-side provenance sidecar',
+      );
+      const sidecar = JSON.parse(readFileSync(codexSidecarPath, 'utf-8'));
+      assert.equal(sidecar.pkgRoot, REPO, 'codex sidecar pkgRoot must point at this package');
+      assert.equal(
+        sidecar.hypoSharedSha256,
+        repoHypoSharedSha256(),
+        'codex sidecar hash must match the installed hypo-shared.mjs',
+      );
+    });
+  });
 });


### PR DESCRIPTION
# English

## What changed

A standalone hooks copy (the npm / manual install channel) now records where it came from, and the runtime trusts that record only when the copy can prove the package wrote it. `resolvePkgRoot()` resolves in this order: self-location, then a verified provenance sidecar, then `null`. The stale global cache is no longer a fallback.

The sidecar (`.hypo-provenance.json`) is written next to the copied hooks by `init` and `upgrade`, checked by `doctor`, and removed by `uninstall`. When no root resolves at all, SessionStart says so once instead of leaving the session silently degraded.

## Why

On the npm / manual install channel, nothing could catch a stale package root. Self-location is structurally impossible there: `installHooks` copies only the `.mjs` files, with no `package.json` beside them to walk up to, so the check that requires the running module to live inside the candidate root can never succeed. Resolution then fell through to `~/.claude/hypo-pkg.json`, which records a `pkgVersion` that nobody read.

Measured directly, with two differently-versioned packages under a temp HOME and a manual hooks copy pointed at the older one: the plugin channel resolved to the new package, the manual channel resolved to the old one, and no code noticed the disagreement. The manual channel had 1.7.1 installed and was running 1.7.0's `scripts/`. The same staleness was present on a real machine.

The `init` re-run path is what makes this stick. It skips hook files that already exist, then updates `hypo-pkg.json` anyway, cementing a pairing that was never true.

## How

Adoption requires two independent proofs, not just a usable-looking root:

- the recorded root's `package.json` `name` must be this package, so an unrelated versioned `package.json` cannot be adopted
- the recorded SHA-256 must match the `hypo-shared.mjs` that is actually running, tying the sidecar to the exact copy it was written beside

A mismatch resolves to `null` rather than falling back to the cache. Falling back would let the same stale cache re-select the same wrong root, which is the failure being fixed.

**This is accidental-staleness protection, not a security boundary.** Any process running as this OS user can edit the sidecar, exactly as it could edit `hypo-shared.mjs` itself. Hooks use Node built-ins only and cannot build a privilege boundary within one UID. The comments say so at both ends.

Two layers, split by cost. The runtime verifies one file, because hook modules load on every hook event and hashing a directory on every load would tax the hot path. `doctor` verifies the whole set through an aggregate digest over the files `hooks.json` actually wires up, which catches a directory where some other hook went stale while `hypo-shared.mjs` stayed byte-identical.

The writer lives in `scripts/lib/`, the reader in `hooks/`. Hooks cannot import `scripts/`, so the filename and producer-name constants are duplicated rather than shared, and a source-scanning test now fails if the two ever drift apart.

## Manual verification

Done, in an isolated `HOME` that rebuilds the manual/npm channel this change exists for: two package copies (1.7.2 and 1.7.0) plus a standalone hooks copy. Recorded in `qa-runs/2026-08-25.md`.

The defect reproduced and is fixed. With the cache poisoned to point at the older package, the manual channel now answers the correct root; before this change it answered the stale one. Breaking the sidecar hash resolves to `null` rather than falling back to that cache. The SessionStart banner fired on the deployed copy, not just in a unit test. `doctor` named the drifted file when one *other* hook was made stale while `hypo-shared.mjs` stayed identical, and the runtime still resolved, which is the two-layer split behaving as designed.

That run caught a defect the suite did not: `doctor`'s four new recovery messages were split between the CLI form and a slash command, and a slash command is not guaranteed to exist. Fixed in the follow-up commit. `--file=doctor` stayed at 92 passed before and after, which is why it survived unit testing.

What the suite does cover, run locally:

```
npm test                          # 1910 passed, 0 failed
node tests/parallel.mjs --shards=8 # 1910 passed, 0 failed
npm run lint                      # 0 errors
npm run check:pack-surface        # 134 files, 0 closure violations
npm run check:tracker-ids
npm run format:check
```

Twelve defenses were each disabled in turn to confirm the new assertions actually fail without them. Eleven produced a red. One did not: the sidecar is written through a temp file and `renameSync`, and no assertion pins that. Atomicity leaves the resulting file identical, so a unit test cannot tell the two writes apart. The exposure is small (a reader catching a torn write fails to parse and resolves to `null`, which is the fail-open path already), but it is worth stating plainly that this one property rests on review rather than on a test.

## Migration notes

None required. Installs predating this change have no sidecar; the runtime treats that as unresolved rather than as an error, and the next `hypomnema upgrade --apply` writes one. `doctor` skips the digest check on a sidecar written before that field existed, so an older sidecar does not produce a spurious warning.

---

# 한국어

## 변경 내용

단독 복사된 훅 사본(npm 및 수동 설치 채널)이 자기가 어디서 왔는지를 기록하고, 런타임은 그 사본이 어느 패키지가 썼는지 증명할 수 있을 때만 그 기록을 믿는다. `resolvePkgRoot()` 의 순서는 자기위치, 검증된 provenance sidecar, 그다음 `null` 이다. 낡은 전역 캐시는 더 이상 폴백이 아니다.

sidecar(`.hypo-provenance.json`)는 `init` 과 `upgrade` 가 복사된 훅 옆에 쓰고, `doctor` 가 점검하고, `uninstall` 이 지운다. 아무 루트도 해석되지 않으면 SessionStart 가 한 번 알린다. 세션이 조용히 반쪽으로 도는 일이 없어진다.

## 이유

npm 및 수동 설치 채널에서는 낡은 패키지 루트를 아무도 잡지 못했다. 그 채널에서 자기위치 판정은 구조적으로 불가능하다. `installHooks` 가 `.mjs` 만 복사하고 그 옆에 거슬러 올라갈 `package.json` 을 두지 않으므로, 실행 중인 모듈이 후보 루트 안에 있어야 한다는 조건이 성립할 수 없다. 그래서 해석이 `~/.claude/hypo-pkg.json` 으로 흘렀는데, 거기 적힌 `pkgVersion` 을 읽는 코드가 없었다.

임시 HOME 아래에 버전이 다른 두 패키지와 옛 쪽을 가리키는 수동 훅 사본을 두고 직접 쟀다. 플러그인 채널은 새 패키지를, 수동 채널은 옛 패키지를 답했고 그 불일치를 알아채는 코드가 없었다. 수동 채널은 1.7.1 이 설치돼 있는데 1.7.0 의 `scripts/` 를 실행하고 있었다. 실사용 머신에서도 같은 낡음이 확인됐다.

이것을 고착시키는 것은 `init` 재실행 경로다. 이미 있는 훅 파일을 건너뛴 뒤 `hypo-pkg.json` 은 그대로 갱신해서, 한 번도 참인 적 없는 짝을 확정한다.

## 방법

채택 조건은 "쓸 만해 보이는 루트" 가 아니라 서로 독립인 증명 둘이다.

- 기록된 루트의 `package.json` `name` 이 이 패키지여야 한다. 무관한 프로젝트의 버전 붙은 `package.json` 이 채택되지 않는다
- 기록된 SHA-256 이 지금 실행 중인 `hypo-shared.mjs` 와 일치해야 한다. sidecar 를 그것이 쓰인 바로 그 사본에 결박한다

어긋나면 캐시로 내려가지 않고 `null` 로 끝난다. 폴백하면 같은 낡은 캐시가 같은 잘못된 루트를 다시 고르는데, 그것이 지금 고치려는 실패다.

**보안 경계가 아니라 우발적 낡음 방지다.** 이 OS 사용자로 도는 프로세스는 sidecar 를 얼마든지 고칠 수 있고, 그건 `hypo-shared.mjs` 자체를 고칠 수 있는 것과 같다. 훅은 Node 내장만 쓰므로 같은 UID 안에서 권한 경계를 세울 수 없다. 양쪽 주석에 그렇게 적어 뒀다.

비용을 기준으로 층을 갈랐다. 런타임은 파일 하나만 검증한다. 훅 모듈은 매 훅 이벤트마다 로드되므로 디렉터리 전체를 해시하면 뜨거운 경로에 세금을 매기는 셈이다. `doctor` 는 `hooks.json` 이 실제로 엮는 파일들에 대한 집계 해시로 전체를 검증하고, `hypo-shared.mjs` 는 그대로인데 다른 훅만 낡은 디렉터리를 잡아낸다.

라이터는 `scripts/lib/` 에, 리더는 `hooks/` 에 있다. 훅이 `scripts/` 를 import 할 수 없어 파일명과 생산자 이름 상수가 공유가 아니라 중복인데, 둘이 갈리면 소스를 읽어 대조하는 테스트가 빨개진다.

## 수동 검증

했다. 이 변경이 존재하는 이유인 수동 및 npm 채널을 격리된 `HOME` 에 다시 세웠다. 패키지 사본 둘(1.7.2 와 1.7.0)과 단독 복사된 훅 사본이다. 기록은 `qa-runs/2026-08-25.md` 에 있다.

결함이 재현됐고 고쳐졌다. 캐시를 옛 패키지로 오염시킨 상태에서 수동 채널이 옳은 루트를 답한다. 이 변경 전에는 낡은 쪽을 답했다. sidecar 해시를 깨면 그 캐시로 내려가지 않고 `null` 로 끝난다. SessionStart 배너는 단위 테스트가 아니라 배포된 사본에서 실제로 발화했다. `hypo-shared.mjs` 는 그대로인데 다른 훅 하나만 낡게 만들었더니 `doctor` 가 그 파일을 지목했고 런타임은 여전히 해석했다. 의도한 층 분리가 그대로 동작한다.

그 실행이 스위트가 못 잡은 결함을 하나 잡았다. `doctor` 의 새 복구 메시지 넷이 CLI 형태와 슬래시 커맨드로 갈려 있었는데, 슬래시 커맨드는 있으리라는 보장이 없다. 후속 커밋에서 고쳤다. `--file=doctor` 는 고치기 전후로 92 passed 그대로였고, 그래서 단위 테스트를 빠져나갔다.

스위트가 덮는 부분은 로컬에서 다 돌렸다.

```
npm test                          # 1910 passed, 0 failed
node tests/parallel.mjs --shards=8 # 1910 passed, 0 failed
npm run lint                      # 0 errors
npm run check:pack-surface        # 134 files, 0 closure violations
npm run check:tracker-ids
npm run format:check
```

방어 열둘을 하나씩 무력화해 새 단언이 정말 그것 없이는 실패하는지 확인했다. 열하나가 빨개졌다. 하나는 아니었다. sidecar 를 임시 파일과 `renameSync` 로 쓰는데 그것을 고정하는 단언이 없다. 원자성은 결과 파일이 동일해서 단위 테스트가 두 쓰기를 구별하지 못한다. 노출은 작다(찢어진 쓰기를 읽은 리더는 parse 에 실패해 `null` 로 떨어지고, 그건 이미 fail open 경로다). 다만 이 성질 하나가 테스트가 아니라 검토에 기대고 있다는 것은 분명히 적어 둔다.

## 마이그레이션 노트

필요 없다. 이 변경 이전에 설치된 것들은 sidecar 가 없는데, 런타임은 그것을 오류가 아니라 미해석으로 다루고 다음 `hypomnema upgrade --apply` 가 하나 쓴다. `doctor` 는 해당 필드가 생기기 전에 쓰인 sidecar 에서는 digest 검사를 건너뛰므로 옛 sidecar 가 헛경고를 내지 않는다.

---

## Changelog

- EN: The npm and manual install channels now detect a stale package root instead of silently running an older release's scripts: a hooks copy is trusted only when it can prove which package wrote it, and an unresolvable root is surfaced once at session start rather than degrading the session in silence.
- KO: npm 및 수동 설치 채널이 낡은 패키지 루트를 잡아낸다. 예전에는 옛 릴리스의 scripts 를 조용히 실행했다. 훅 사본은 어느 패키지가 썼는지 증명할 수 있을 때만 신뢰하고, 루트가 해석되지 않으면 세션 시작에 한 번 알린다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (QA run recorded in `qa-runs/2026-08-25.md`; no README/ARCHITECTURE surface changed)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
