### PR TITLE
test(harness): stop a detached worker from racing the temp HOME it writes into

### DIFF
--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -33,9 +33,29 @@ const NONEXISTENT_WIKI = join(tmpdir(), `hypo-no-wiki-${process.pid}`);
 // need a specific HOME use runWithHome() to override.
 const SESSION_TMP_HOME = mkdtempSync(join(tmpdir(), 'hypo-session-home-'));
 
+// A tmp HOME can still be written to while it is being torn down. SessionStart
+// fires a DETACHED version-check worker (hooks/hypo-session-start.mjs, the
+// `spawn(..., { detached: true })` in buildUpdateNotice) that outlives the
+// spawnSync the test used to run the hook, and it writes under
+// <HOME>/.claude/hypomnema/cache. A plain recursive rmSync races that write and
+// dies with ENOTEMPTY, which is a green-or-red coin flip decided by CI load
+// rather than by the code under test. Retrying the unlink is the safety net;
+// the tests that exercise notices also seed a fresh version-check cache so the
+// worker never spawns in the first place. Both are needed: the seed removes the
+// known producer, the retry covers any other late writer.
+//
+// Node backs off LINEARLY on ENOTEMPTY, so these numbers buy 100+200+...+1000,
+// about 5.5s, not one second. That is comfortably past the worker's own 2s
+// network budget, but it is NOT a synchronization primitive: a detached child
+// has no bound on when it is scheduled, and one that starts AFTER the delete
+// succeeded will mkdirSync the HOME back into existence with no retry left to
+// catch it. The seed is what actually removes that case; this only widens the
+// window for writers we have not named.
+const RM_RETRY = { recursive: true, force: true, maxRetries: 10, retryDelay: 100 };
+
 process.on('exit', () => {
   try {
-    rmSync(SESSION_TMP_HOME, { recursive: true, force: true });
+    rmSync(SESSION_TMP_HOME, RM_RETRY);
   } catch {}
 });
 
@@ -90,7 +110,7 @@ function withTmpHome(fn) {
   try {
     fn(dir);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(dir, RM_RETRY);
   }
 }
 

--- a/tests/notifier.test.mjs
+++ b/tests/notifier.test.mjs
@@ -768,10 +768,40 @@ test('doctor: passes when PATH CLI matches/exceeds the active install', () => {
 // back IN by clearing the opt-out vars in the child env (CI failure 2026-06-07).
 const NOTIFY_ON = { CI: '', NO_UPDATE_NOTIFIER: '', HYPO_NO_UPDATE_CHECK: '' };
 
+// Every test that opts notices back IN with NOTIFY_ON must call this before it
+// runs SessionStart. Opting in is what reaches buildUpdateNotice(), which fires
+// a DETACHED version-check worker whenever the cache reads as stale. That worker
+// outlives the spawnSync and keeps writing under <HOME>/.claude/hypomnema/cache,
+// racing the teardown of the HOME it is writing into. Seeding a cache that reads
+// as fresh removes the spawn condition, so the worker never starts.
+//
+// MERGE, never overwrite: this same file also carries the notify-once marks the
+// notices read and write (notifiedFor, pkgRootDriftNotified,
+// pkgRootNullNotified). Replacing it wholesale silently resets the very state a
+// multi-step test is asserting on, which is what the first version of this
+// helper did; an assertion pins that now.
+//
+// No `latest` is recorded, so computeNotice() returns null and no update banner
+// joins the stderr these tests match on. Tests that DO exercise the update
+// notifier seed their own cache with a `latest` and are unaffected.
+function seedFreshVersionCache(home) {
+  const cacheDir = join(home, '.claude', 'hypomnema', 'cache');
+  const cachePath = join(cacheDir, 'version-check.json');
+  mkdirSync(cacheDir, { recursive: true });
+  let cache = {};
+  try {
+    cache = JSON.parse(readFileSync(cachePath, 'utf-8'));
+  } catch {
+    /* first call in this HOME */
+  }
+  writeFileSync(cachePath, JSON.stringify({ ...cache, checkedAt: Date.now() }));
+}
+
 test('session-start (D3): stale PATH sibling surfaces a one-shot notice, then throttles', () => {
   withTmpHome((home) => {
     withFakeCli('1.1.0', ({ binDir }) => {
       seedActivePkg(home, { pkgRoot: home, pkgVersion: '1.2.1' });
+      seedFreshVersionCache(home); // no detached worker; see the helper above
       const payload = JSON.stringify({ cwd: home, session_id: 'sib-test' });
       const first = spawnSync(process.execPath, [join(REPO, 'hooks', 'hypo-session-start.mjs')], {
         input: payload,
@@ -801,6 +831,7 @@ test('session-start (D3): no notice when CLI matches active (no false nag)', () 
   withTmpHome((home) => {
     withFakeCli('9.9.9', ({ binDir }) => {
       seedActivePkg(home, { pkgRoot: home, pkgVersion: '1.2.1' });
+      seedFreshVersionCache(home); // no detached worker; see the helper above
       const r = spawnSync(process.execPath, [join(REPO, 'hooks', 'hypo-session-start.mjs')], {
         input: JSON.stringify({ cwd: home, session_id: 'sib-ok' }),
         encoding: 'utf-8',
@@ -815,6 +846,7 @@ test('session-start (D3): opted out (CI/NO_UPDATE_NOTIFIER) suppresses the sibli
   withTmpHome((home) => {
     withFakeCli('1.1.0', ({ binDir }) => {
       seedActivePkg(home, { pkgRoot: home, pkgVersion: '1.2.1' });
+      seedFreshVersionCache(home); // no detached worker; see the helper above
       const r = spawnSync(process.execPath, [join(REPO, 'hooks', 'hypo-session-start.mjs')], {
         input: JSON.stringify({ cwd: home, session_id: 'sib-optout' }),
         encoding: 'utf-8',
@@ -1333,6 +1365,7 @@ test('resolvePkgRoot: self and a symlink alias of the SAME physical root compare
 suite('ISSUE-70: session-start pkgRoot-drift notice + throttle');
 
 function runSessionStartAt(hookPath, home, sessionId, extraEnv = {}) {
+  seedFreshVersionCache(home);
   return spawnSync(process.execPath, [hookPath], {
     input: JSON.stringify({ cwd: home, session_id: sessionId }),
     encoding: 'utf-8',
@@ -1720,4 +1753,84 @@ test('replay-post-tool-use-rejects-non-http-schemes: file:// / ftp:// / data: �
       `non-http URL contents leaked in stdout: ${r.stdout}`,
     );
   }
+});
+
+// ── detached version-check worker: the spawn condition itself ────────────────
+//
+// SessionStart fires a detached worker when the version-check cache reads as
+// stale. That worker outlives the spawnSync a test used to run the hook and
+// keeps writing under <HOME>/.claude/hypomnema/cache, racing the teardown of
+// the very HOME it is writing into. It cost three simultaneous Node-version CI
+// failures on a run whose only change was a doc edit; the same commit had been
+// green minutes before, and stayed green locally on both 4 and 8 shards.
+//
+// What is pinned here is the CONDITION, not the race. A race cannot be asserted
+// on directly: the outcome depends on which of two processes wins, so a passing
+// run proves nothing. The spawn condition is deterministic, so that is what
+// these two assert, and they only mean something as a PAIR. Alone, "no marker
+// appeared" is indistinguishable from a harness that never triggers the worker
+// at all, which is why the stale case is here as the control.
+suite('detached version-check worker spawn condition');
+
+// Replaces the real worker with one that records that it ran. The fake writes
+// synchronously on startup, so the wait below is for process scheduling only.
+function fakeWorkerInstall(markerPath, fn) {
+  withFakePkgInstall('1.7.0', (root) => {
+    writeFileSync(
+      join(root, 'hooks', 'version-check-fetch.mjs'),
+      `import { writeFileSync } from 'node:fs';\nwriteFileSync(${JSON.stringify(markerPath)}, 'ran');\n`,
+    );
+    fn(root);
+  });
+}
+
+// Synchronous poll: test() does not await, so a promise-based wait would be
+// dropped on the floor and the assertion would pass unconditionally.
+function waitForMarker(markerPath, timeoutMs = 8000) {
+  const sab = new Int32Array(new SharedArrayBuffer(4));
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(markerPath)) return true;
+    Atomics.wait(sab, 0, 0, 50);
+  }
+  return existsSync(markerPath);
+}
+
+test('control: a STALE version-check cache does spawn the detached worker', () => {
+  withTmpHome((home) => {
+    const marker = join(home, 'worker-ran');
+    fakeWorkerInstall(marker, (root) => {
+      seedHypoPkg(home, root);
+      // Deliberately NOT seeding a fresh cache: this is the pre-fix behavior.
+      spawnSync(process.execPath, [join(root, 'hooks', 'hypo-session-start.mjs')], {
+        input: JSON.stringify({ cwd: home, session_id: 'worker-control' }),
+        encoding: 'utf-8',
+        env: { ...process.env, ...NOTIFY_ON, HYPO_DIR: '', HOME: home },
+      });
+      assert.ok(
+        waitForMarker(marker),
+        'the control must actually spawn the worker, otherwise the case below proves nothing',
+      );
+    });
+  });
+});
+
+test('a FRESH version-check cache does not spawn the detached worker', () => {
+  withTmpHome((home) => {
+    const marker = join(home, 'worker-ran');
+    fakeWorkerInstall(marker, (root) => {
+      seedHypoPkg(home, root);
+      // runSessionStartAt seeds the fresh cache; that is the behavior under test.
+      const r = runSessionStartAt(
+        join(root, 'hooks', 'hypo-session-start.mjs'),
+        home,
+        'worker-fresh',
+      );
+      // Check the hook actually ran to completion first. Without this, a hook
+      // that died before reaching buildUpdateNotice() would also leave no
+      // marker, and this assertion would pass while testing nothing.
+      assert.equal(r.status, 0, `hook did not exit cleanly: ${r.stderr}`);
+      assert.ok(!waitForMarker(marker, 3000), 'a fresh cache must leave the worker unspawned');
+    });
+  });
 });


### PR DESCRIPTION
# English

## What changed

Two test-harness changes that stop a detached background process from racing the teardown of the temp `HOME` it is writing into.

The notice tests now seed a version-check cache that reads as fresh, which removes the condition that fires the worker at all. `withTmpHome` and the session-wide temp `HOME` retry their recursive unlink, covering any other late writer.

## Why

`hooks/hypo-session-start.mjs` fires a detached worker to refresh the version-check cache whenever that cache reads as stale. Tests run the hook through `spawnSync`, so the hook itself finishes synchronously, but the detached child outlives it and keeps writing under `<HOME>/.claude/hypomnema/cache`. A test that tears its `HOME` down right after can lose that race, and `rmSync` dies with `ENOTEMPTY`.

This is not hypothetical. On the previous PR, three Node versions failed simultaneously on a push whose only change was a documentation edit. The same commit had been green minutes earlier, and stayed green locally on both 4 and 8 shards. The failing assertion was an unrelated drift-notice test, which is what a teardown race looks like from the outside: the failure lands on whichever test happened to be holding the directory.

Green was decided by CI load rather than by the code under test, which makes the merge gate uninformative in both directions. A red run had to be re-run to find out whether it meant anything.

## How

Two layers, because they cover different things.

Seeding a fresh cache removes the one producer we can name. It is a merge, not an overwrite: the same file also carries the notify-once marks the notices read and write, and the first version of this helper replaced the file wholesale and silently reset the state a multi-step test was asserting on. That mistake is now pinned by an assertion.

Every test that opts notices back in must seed, not just the ones that failed. Opting in is what reaches the code that fires the worker, so the sibling-notifier tests that run the hook directly needed it too; the review caught that they had been left out.

Retrying the unlink is the safety net for any writer we have not named. It is deliberately not sold as more than that. Node backs off linearly on `ENOTEMPTY`, so the settings buy about 5.5 seconds rather than the one second a first reading suggests, which clears the worker's own 2s network budget. But a detached child has no bound on when it is scheduled, and one that starts after the delete already succeeded will recreate the directory with no retry left to catch it. The seed is what removes that case.

## Manual verification

The race itself cannot be asserted on: the outcome depends on which of two processes wins, so a passing run proves nothing about it. What is deterministic is the spawn condition, so that is what the new tests pin, and they only mean something as a pair:

- a control that seeds no cache and confirms the worker **does** spawn (the real worker is swapped for one that records that it ran)
- the fixed path, which seeds a fresh cache and confirms it **does not**

Without the control, "no marker appeared" is indistinguishable from a harness that never triggers the worker at all.

The fresh case also checks the hook exited cleanly. Without that, a hook that died before reaching the code under test would leave no marker either, and the assertion would pass while testing nothing.

Three sabotage runs, all red: removing the cache seed; reverting the merge back to an overwrite (two assertions, one of them the pre-existing drift test whose state the overwrite was destroying); and pointing the hook at a path that does not exist, which the new exit-status check catches.

```
node tests/runner.mjs --file=notifier
node tests/parallel.mjs --shards=8
npm test
npm run lint
```

## Migration notes

None. Test-harness only; nothing here ships.

---

# 한국어

## 변경 내용

테스트 하네스 두 곳을 고쳐, 백그라운드로 떨어져 나간 프로세스가 자기가 쓰고 있는 임시 `HOME` 의 정리와 경합하지 않게 한다.

알림 테스트가 신선하게 읽히는 version-check 캐시를 심어 워커가 뜨는 조건 자체를 없앤다. `withTmpHome` 과 세션 전역 임시 `HOME` 은 재귀 삭제를 재시도해서, 이름을 대지 못한 다른 늦은 쓰기를 덮는다.

## 이유

`hooks/hypo-session-start.mjs` 는 version-check 캐시가 낡게 읽히면 그것을 갱신할 워커를 detached 로 띄운다. 테스트는 훅을 `spawnSync` 로 돌리므로 훅 자체는 동기적으로 끝나지만, 떨어져 나간 자식은 그보다 오래 살아 `<HOME>/.claude/hypomnema/cache` 에 계속 쓴다. 바로 뒤에 `HOME` 을 지우는 테스트는 그 경합에서 질 수 있고, `rmSync` 가 `ENOTEMPTY` 로 죽는다.

가정이 아니다. 직전 PR 에서 문서만 고친 push 에 Node 세 버전이 동시에 실패했다. 같은 커밋이 몇 분 전에는 green 이었고 로컬에서는 4샤드와 8샤드 둘 다 green 이었다. 실패한 단언은 무관한 drift 알림 테스트였는데, 정리 경합은 밖에서 보면 원래 그렇게 생겼다. 마침 그 디렉터리를 쥐고 있던 테스트가 대신 죽는다.

green 여부를 코드가 아니라 CI 부하가 정하고 있었다. 그러면 머지 게이트가 양쪽으로 다 무의미해진다. 빨간 실행이 무슨 뜻인지 알아내려면 다시 돌려 봐야 했다.

## 방법

층이 둘인 이유는 덮는 범위가 다르기 때문이다.

신선한 캐시를 심는 것은 이름을 댈 수 있는 유일한 생산자를 없앤다. 덮어쓰기가 아니라 병합이다. 그 파일은 알림들이 읽고 쓰는 notify-once 마크도 같이 담고 있어서, 이 헬퍼의 첫 판은 파일을 통째로 갈아치우며 여러 단계짜리 테스트가 단언하던 상태를 조용히 지웠다. 그 실수는 이제 단언이 잡는다.

실패한 테스트만이 아니라 알림을 다시 켜는 테스트 전부가 심어야 한다. 알림을 켜는 것이 곧 워커를 띄우는 코드에 닿는 일이라, 훅을 직접 돌리는 sibling 알림 테스트에도 필요했다. 검토가 그 누락을 잡았다.

삭제 재시도는 이름을 대지 못한 쓰기를 위한 안전망이고, 그 이상으로 팔지 않는다. Node 는 `ENOTEMPTY` 에서 선형으로 backoff 하므로 이 설정은 언뜻 보이는 1초가 아니라 약 5.5초를 산다. 워커 자신의 2초 네트워크 예산은 넘긴다. 그러나 detached 자식은 언제 스케줄될지에 상한이 없고, 삭제가 이미 성공한 뒤에 시작한 자식은 디렉터리를 다시 만들어 버려 잡을 재시도가 남아 있지 않다. 그 경우를 없애는 것은 캐시 시드 쪽이다.

## 수동 검증

경합 자체는 단언할 수 없다. 결과가 두 프로세스 중 누가 이기느냐에 달려 있어서 통과한 실행이 그것에 대해 아무것도 증명하지 못한다. 결정적인 것은 워커가 뜨는 조건이고, 새 테스트가 고정하는 것이 그것이다. 그리고 그 둘은 짝일 때만 의미를 갖는다.

- 캐시를 안 심고 워커가 **뜨는지** 확인하는 대조군(진짜 워커를 자기가 돌았다고 기록하는 것으로 바꿔 둔다)
- 신선한 캐시를 심고 **안 뜨는지** 확인하는 고쳐진 경로

대조군이 없으면 "마커가 안 생겼다" 는 애초에 워커를 한 번도 안 띄우는 하네스와 구별되지 않는다.

신선한 캐시 쪽은 훅이 정상 종료했는지도 확인한다. 그게 없으면 검사 대상에 닿기 전에 죽은 훅도 마커를 안 남기므로, 단언이 아무것도 재지 않으면서 통과한다.

무력화 셋을 돌렸고 전부 빨개졌다. 캐시 시드 제거, 병합을 덮어쓰기로 되돌리기(단언 둘, 그중 하나가 덮어쓰기 때문에 상태를 잃던 기존 drift 테스트), 그리고 훅 경로를 없는 파일로 바꾸기(새 종료 상태 확인이 잡는다).

```
node tests/runner.mjs --file=notifier
node tests/parallel.mjs --shards=8
npm test
npm run lint
```

## 마이그레이션 노트

없다. 테스트 하네스만 바뀌고 출하되는 것은 없다.

---

## Changelog

None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed (test-harness only, nothing user-facing)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
