### PR TITLE
chore: release v1.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "hypo",
       "source": "./",
       "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "homepage": "https://github.com/sk-lim19f/Hypomnema"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hypo",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "LLM-native personal wiki system — session-aware knowledge base for Claude Code",
   "author": {
     "name": "sk-lim19f",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Hypomnema are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-08-26
+
+### Bug Fixes
+
+#### English
+
+- The npm and manual install channels now detect a stale package root instead of silently running an older release's scripts: a hooks copy is trusted only when it can prove which package wrote it, and an unresolvable root is surfaced once at session start rather than degrading the session in silence. ([#239](https://github.com/sk-lim19f/Hypomnema/pull/239))
+
+#### 한국어
+
+- npm 및 수동 설치 채널이 낡은 패키지 루트를 잡아낸다. 예전에는 옛 릴리스의 scripts 를 조용히 실행했다. 훅 사본은 어느 패키지가 썼는지 증명할 수 있을 때만 신뢰하고, 루트가 해석되지 않으면 세션 시작에 한 번 알린다. ([#239](https://github.com/sk-lim19f/Hypomnema/pull/239))
+
+### Chores
+
+#### English
+
+- The README now matches the code. Seven false statements were corrected (including a backwards description of the recommended install path and a privacy glob that was inverted), and five behaviors that surprise a new user are documented for the first time: `init` edits your shell rc, it installs a `pre-commit` hook into the wiki repo, `uninstall` removes neither, the default ignore patterns match substrings and can swallow ordinary pages, and cloning an existing wiki onto a second machine has a flag that was never mentioned. ([#241](https://github.com/sk-lim19f/Hypomnema/pull/241))
+
+#### 한국어
+
+- README 가 코드와 맞게 됐다. 거짓 일곱 가지를 고쳤고(권장 설치 경로가 거꾸로 적힌 것, 프라이버시 글로브가 뒤집힌 것 포함), 처음 쓰는 사람을 놀라게 하는 동작 다섯 가지를 처음으로 문서화했다. `init` 이 셸 rc 를 고친다는 것, 위키 저장소에 `pre-commit` 훅을 설치한다는 것, `uninstall` 이 둘 다 안 지운다는 것, 기본 ignore 패턴이 부분일치라 평범한 페이지를 삼킬 수 있다는 것, 그리고 두 번째 기기로 기존 위키를 가져오는 플래그가 있다는 것이다. ([#241](https://github.com/sk-lim19f/Hypomnema/pull/241))
+
 ## [1.7.1] - 2026-08-25
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypomnema",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypomnema",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "bin": {
         "hypomnema": "scripts/init.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypomnema",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "LLM-native personal wiki system for Claude Code",
   "type": "module",
   "license": "MIT",

--- a/templates/hypo-config.md
+++ b/templates/hypo-config.md
@@ -1,7 +1,7 @@
 ---
 title: Hypomnema Config
 type: config
-version: "1.7.1"
+version: "1.7.2"
 created: YYYY-MM-DD
 ---
 


### PR DESCRIPTION
# English

## What changed

Version bump to 1.7.2 across the five version-carrying files and the lockfile, plus the CHANGELOG section assembled from the merged PRs' Changelog blocks.

Three PRs ship in this release: a provenance record that lets a hooks copy prove which package wrote it (#239), a test-harness fix for a detached worker racing its own temp HOME (#240), and a README corrected against the code (#241).

## Why

The release exists for #239. On the npm and manual install channel nothing could catch a stale package root, because self-location is structurally impossible there and resolution fell through to a cache whose recorded version nobody read. An install carrying 1.7.1 was measured running 1.7.0's scripts.

## How

Followed the checklist in `docs/CONTRIBUTING.md`. Patch release, so the vault spec-doc steps (0 and 8) are exempt.

## Manual verification

All nine local gates pass:

```
npm test                   # 1912 passed, 0 failed
npm run lint               # 0 errors
npm run check:versions     # all files agree on 1.7.2
npm run check:bilingual    # CHANGELOG [1.7.2] carries both sub-blocks
npm run smoke:plugin       # commands 16, skills 7, hook targets 15, shared 5
npm run smoke-pack         # packed tarball installs and resolves
npm run check:tracker-ids
npm run check:pack-surface # 134 files, 0 closure violations
npx prettier --check
```

`smoke:plugin` reporting 15 hook targets is worth noting: the README said 14 until #241, and the table was missing a row rather than merely a count.

The hook change in #239 had a real-session QA run in an isolated `HOME`, recorded in `qa-runs/2026-08-25.md`. The defect reproduced there and is fixed: with the cache poisoned to the older package, the manual channel now answers the correct root.

The tag rehearsal (`check-bilingual --tag`, `check-versions --tag`, `check-tracker-ids --tag`, `npm publish --dry-run`) runs after this merges, against the annotated tag.

## Migration notes

None. Installs predating #239 carry no provenance record; the runtime treats that as unresolved rather than as an error, and the next `hypomnema upgrade --apply` writes one.

---

# 한국어

## 변경 내용

버전을 1.7.2 로 올린다. 버전을 지닌 파일 다섯과 lockfile, 그리고 머지된 PR 들의 Changelog 블록에서 모은 CHANGELOG 섹션이다.

이 릴리스에 담기는 PR 은 셋이다. 훅 사본이 어느 패키지가 썼는지 증명하게 하는 출처 기록(#239), 떨어져 나간 워커가 자기 임시 HOME 정리와 경합하던 테스트 하네스 수정(#240), 그리고 코드에 맞춰 고친 README(#241)다.

## 이유

이 릴리스는 #239 때문에 나간다. npm 및 수동 설치 채널에서는 낡은 패키지 루트를 아무도 잡지 못했다. 그 채널에서 자기위치 판정이 구조적으로 불가능해 해석이 캐시로 흘렀는데, 거기 적힌 버전을 읽는 코드가 없었다. 1.7.1 이 설치된 곳이 1.7.0 의 scripts 를 실행하는 것을 직접 쟀다.

## 방법

`docs/CONTRIBUTING.md` 의 체크리스트를 따랐다. 패치 릴리스라 볼트 spec 문서 단계(0번과 8번)는 면제다.

## 수동 검증

로컬 게이트 아홉이 전부 통과한다.

```
npm test                   # 1912 passed, 0 failed
npm run lint               # 0 errors
npm run check:versions     # 모든 파일이 1.7.2 로 일치
npm run check:bilingual    # CHANGELOG [1.7.2] 가 두 하위 블록을 다 가짐
npm run smoke:plugin       # commands 16, skills 7, hook targets 15, shared 5
npm run smoke-pack         # 패킹된 tarball 이 설치되고 해석됨
npm run check:tracker-ids
npm run check:pack-surface # 134 files, 0 closure violations
npx prettier --check
```

`smoke:plugin` 이 훅 타깃을 15로 보고하는 것은 적어 둘 만하다. #241 전까지 README 는 14라고 적었고, 숫자만 틀린 게 아니라 표에서 행 하나가 빠져 있었다.

#239 의 훅 변경은 격리된 `HOME` 에서 실세션 QA 를 거쳤고 기록은 `qa-runs/2026-08-25.md` 에 있다. 거기서 결함이 재현됐고 고쳐졌다. 캐시를 옛 패키지로 오염시킨 상태에서 수동 채널이 옳은 루트를 답한다.

태그 리허설(`check-bilingual --tag`, `check-versions --tag`, `check-tracker-ids --tag`, `npm publish --dry-run`)은 이 PR 이 머지된 뒤 annotated 태그를 대상으로 돌린다.

## 마이그레이션 노트

없다. #239 이전에 설치된 것들은 출처 기록이 없는데, 런타임은 그것을 오류가 아니라 미해석으로 다루고 다음 `hypomnema upgrade --apply` 가 하나 쓴다.

---

## Changelog

None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
