### PR TITLE
docs(readme): stop telling readers that /hypo:debate does not exist

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -289,7 +289,7 @@ PostToolUse 훅 둘은 matcher 없이 등록되고 각자 tool_name으로 거릅
 
 ### Claude Agent Skills
 
-합성이 핵심인 명령어 6개(`ingest`, `query`, `crystallize`, `lint`, `verify`, `graph`)는 `skills/<name>/SKILL.md`로도 등록돼 있습니다. 대화 내용이 해당 스킬의 `description`과 맞으면 Claude Agent Skills 메커니즘이 슬래시 명령 없이도 자동으로 호출합니다. 일곱 번째 스킬인 `debate`는 대응하는 슬래시 커맨드가 따로 없습니다. 세 단계(심문, 검증, 종합)로 구조화된 검토를 실행해 위키 주장을 재검증하거나 되돌리기 어려운 결정을 ADR로 굳힙니다. 명령어를 정확히 몰라도 하려는 일을 말로 적으면 됩니다.
+합성이 핵심인 명령어 6개(`ingest`, `query`, `crystallize`, `lint`, `verify`, `graph`)는 `skills/<name>/SKILL.md`로도 등록돼 있습니다. 대화 내용이 해당 스킬의 `description`과 맞으면 Claude Agent Skills 메커니즘이 슬래시 명령 없이도 자동으로 호출합니다. 일곱 번째인 `debate`는 스킬로만 있습니다. `commands/` 아래에 파일이 없지만 플러그인이 `skills/`도 함께 싣기 때문에 `/hypo:debate`는 나머지와 똑같이 동작합니다. 세 단계(심문, 검증, 종합)로 구조화된 검토를 실행해 위키 주장을 재검증하거나 되돌리기 어려운 결정을 ADR로 굳힙니다. 위 명령어 표에 없는 것은 그 표가 `commands/` 아래 파일을 세기 때문이지 칠 수 있는 것을 세기 때문이 아닙니다. 명령어를 정확히 몰라도 하려는 일을 말로 적으면 됩니다.
 
 | 이렇게 말하면 | 트리거되는 스킬 |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Every maintenance command also runs from a plain shell, which is what you need w
 
 ### Claude Agent Skills
 
-The six synthesis-heavy commands (`ingest`, `query`, `crystallize`, `lint`, `verify`, `graph`) are also exposed as Claude Agent Skills in `skills/<name>/SKILL.md`, so they auto-trigger when the conversation matches their description, with no slash command required. A seventh skill, `debate`, has no slash-command counterpart: it runs a structured three-phase review (interrogate, verify, synthesize) to re-verify a wiki claim or harden a hard-to-reverse decision into an ADR.
+The six synthesis-heavy commands (`ingest`, `query`, `crystallize`, `lint`, `verify`, `graph`) are also exposed as Claude Agent Skills in `skills/<name>/SKILL.md`, so they auto-trigger when the conversation matches their description, with no slash command required. A seventh, `debate`, is a skill only: it has no file under `commands/`, but the plugin loads `skills/` too, so `/hypo:debate` works like the rest. It runs a structured three-phase review (interrogate, verify, synthesize) to re-verify a wiki claim or harden a hard-to-reverse decision into an ADR. It is absent from the command tables above because those count the files under `commands/`, not what you can type.
 
 | Say this | Skill it triggers |
 |---|---|


### PR DESCRIPTION
# English

## What changed

One sentence in the Claude Agent Skills paragraph, in both READMEs. It said `debate` has no slash-command counterpart; it says now that `debate` is a skill without a file under `commands/`, and that `/hypo:debate` works anyway.

## Why

The old wording was true of the directory and false of the user. `commands/` holds no `debate.md`, so counting files gives "no slash command". But `.claude-plugin/plugin.json` loads `"skills": "./skills/"` next to `"commands": "./commands/"`, and `skills/debate/SKILL.md` opens with `You are running /hypo:debate`. A reader who wanted that review would conclude it was unavailable and never type the thing that runs it.

All seven skills address themselves as `/hypo:<name>`. Six of them also have a file under `commands/`, so their wording was accidentally correct. `debate` is the single place where counting files and counting what a user can type give different answers, and the README reported the first as if it were the second.

This was caught by a reader asking why the command table has no `debate`, after a three-lens review of the same file had passed over it. Worth naming: the fact check verified "no slash-command counterpart" against `commands/` and marked it true, which is what the sentence literally claims. Checking a claim as written cannot catch a claim that is measuring the wrong thing.

## How

The tables are unchanged. Their two row counts (nine and seven) sum to the sixteen files under `commands/`, and that correspondence is more useful than a tenth row would be. The paragraph now states why `debate` is absent from them, so the gap is explained rather than misleading.

## Manual verification

```
ls commands/ | wc -l                                    # 16, no debate.md
ls skills/                                              # 7, includes debate
grep -o "You are running \`[^\`]*\`" skills/*/SKILL.md   # all seven say /hypo:<name>
npx prettier --check README.md README.ko.md
npm run check:tracker-ids
grep -c "—\|–" README.md README.ko.md                   # 0 and 0
```

Both files remain 460 lines.

## Migration notes

None. Documentation only.

---

# 한국어

## 변경 내용

Claude Agent Skills 문단의 문장 하나를 두 README 에서 고쳤다. `debate` 에 대응하는 슬래시 커맨드가 없다고 적혀 있던 것을, `commands/` 아래에 파일이 없는 스킬이며 그래도 `/hypo:debate` 는 동작한다고 바꿨다.

## 이유

옛 문구는 디렉터리에 대해서는 참이고 사용자에 대해서는 거짓이었다. `commands/` 에 `debate.md` 가 없으니 파일을 세면 "슬래시 커맨드 없음" 이 나온다. 그러나 `.claude-plugin/plugin.json` 은 `"commands": "./commands/"` 옆에 `"skills": "./skills/"` 를 함께 싣고, `skills/debate/SKILL.md` 의 첫 줄은 `You are running /hypo:debate` 다. 그 검토가 필요했던 사람은 쓸 수 없다고 판단하고, 정작 그것을 실행하는 것을 한 번도 쳐 보지 않게 된다.

일곱 스킬이 전부 자기를 `/hypo:<name>` 으로 부른다. 그중 여섯은 `commands/` 아래에 파일도 있어서 문구가 우연히 맞았다. `debate` 만이 파일을 세는 것과 사용자가 칠 수 있는 것을 세는 것이 다른 답을 내는 자리이고, README 는 앞의 것을 뒤의 것인 양 보고했다.

이건 같은 파일을 세 렌즈로 검토하고도 지나친 뒤에, 명령어 표에 `debate` 가 왜 없냐는 물음에서 잡혔다. 적어 둘 만하다. 사실 검토는 "슬래시 커맨드 대응이 없다" 를 `commands/` 로 확인하고 참으로 표시했다. 문장이 문자 그대로 주장하는 바가 그것이기 때문이다. **쓰인 대로 주장을 검증하는 방식은 애초에 틀린 것을 재고 있는 주장을 잡지 못한다.**

## 방법

표는 그대로 뒀다. 두 표의 행 수(아홉과 일곱)를 더하면 `commands/` 아래 파일 열여섯과 맞고, 그 대응이 열 번째 행보다 쓸모 있다. 문단이 `debate` 가 표에 없는 이유를 이제 밝히므로, 빈자리가 오해가 아니라 설명된 상태가 된다.

## 수동 검증

```
ls commands/ | wc -l                                    # 16, debate.md 없음
ls skills/                                              # 7, debate 포함
grep -o "You are running \`[^\`]*\`" skills/*/SKILL.md   # 일곱 전부 /hypo:<name>
npx prettier --check README.md README.ko.md
npm run check:tracker-ids
grep -c "—\|–" README.md README.ko.md                   # 둘 다 0
```

두 파일 모두 460줄 그대로다.

## 마이그레이션 노트

없다. 문서만 바뀐다.

---

## Changelog

- EN: The README no longer says `/hypo:debate` has no slash command. It does have one: the plugin loads `skills/` as well as `commands/`, so the review runs like any other `/hypo:*` command even though it has no file under `commands/`.
- KO: README 가 더 이상 `/hypo:debate` 에 슬래시 커맨드가 없다고 말하지 않는다. 있다. 플러그인이 `commands/` 와 함께 `skills/` 도 싣기 때문에, `commands/` 아래에 파일이 없어도 다른 `/hypo:*` 명령과 똑같이 실행된다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
