### PR TITLE
fix(uninstall): remove the shell rc block and the wiki pre-commit hook that init installs

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import { readRenameMarker, renameMarkerPath, RENAME_MARKER_REL } from './lib/rename-marker.mjs';
-import { resolveGitHooksDir } from './lib/git-hooks-dir.mjs';
+import { resolveGitHooksDir, WIKI_PRE_COMMIT_MARKER_START } from './lib/git-hooks-dir.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import {
   readSyncState,
@@ -506,7 +506,7 @@ function checkGit(hypoDir) {
         ? 'Not installed — run /hypo:init to install .hypoignore guard'
         : 'Not installed, and /hypo:init will not install into this path — point core.hooksPath back inside the repository, or install the guard yourself',
     );
-  } else if (content.includes('# hypo-managed:pre-commit:start')) {
+  } else if (content.includes(WIKI_PRE_COMMIT_MARKER_START)) {
     pass(label, 'Hypomnema .hypoignore guard installed');
   } else {
     warn(label, 'Exists but not managed by Hypomnema — manual git add can bypass .hypoignore');

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -38,7 +38,14 @@ import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { expandHome, resolveHypoRoot } from './lib/hypo-root.mjs';
-import { hooksDirForInstall, unsafeHookTargetReason } from './lib/git-hooks-dir.mjs';
+import {
+  hooksDirForInstall,
+  unsafeHookTargetReason,
+  WIKI_PRE_COMMIT_MARKER_START,
+  WIKI_PRE_COMMIT_MARKER_END,
+  SHELL_MARKER_START,
+  SHELL_MARKER_END,
+} from './lib/git-hooks-dir.mjs';
 import { readCoreHooksConfig } from './lib/core-hooks.mjs';
 import {
   readPkgJson as readPkgJsonSafe,
@@ -748,9 +755,6 @@ function installPkgGitHook(dryRun) {
 
 // ── wiki pre-commit hook ─────────────────────────────────────────────────────
 
-const WIKI_PRE_COMMIT_MARKER_START = '# hypo-managed:pre-commit:start';
-const WIKI_PRE_COMMIT_MARKER_END = '# hypo-managed:pre-commit:end';
-
 // Single-quote escaping prevents shell expansion of special chars (e.g. $HOME, backticks) in path
 function shellSingleQuote(p) {
   return `'${p.replace(/'/g, "'\\''")}'`;
@@ -858,9 +862,6 @@ function installWikiPreCommitHook(hypoDir, dryRun, force, root, lintStrict) {
 }
 
 // ── shell function setup ─────────────────────────────────────────────────────
-
-const SHELL_MARKER_START = '# hypo-managed:shell-setup:start';
-const SHELL_MARKER_END = '# hypo-managed:shell-setup:end';
 
 function shellFunctionBlock() {
   return `${SHELL_MARKER_START}

--- a/scripts/lib/git-hooks-dir.mjs
+++ b/scripts/lib/git-hooks-dir.mjs
@@ -38,6 +38,16 @@ import { execFileSync } from 'child_process';
 import { existsSync, lstatSync, realpathSync, statSync } from 'fs';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'path';
 
+// ── shared install/uninstall markers ────────────────────────────────────────
+// init.mjs writes these when it installs the wiki's git pre-commit hook and
+// the shell rc block; uninstall.mjs reads them back to remove exactly what
+// init created. Defined once here, imported by both, so the two scripts can
+// never drift into recognizing different markers.
+export const WIKI_PRE_COMMIT_MARKER_START = '# hypo-managed:pre-commit:start';
+export const WIKI_PRE_COMMIT_MARKER_END = '# hypo-managed:pre-commit:end';
+export const SHELL_MARKER_START = '# hypo-managed:shell-setup:start';
+export const SHELL_MARKER_END = '# hypo-managed:shell-setup:end';
+
 // Fallback scrub list for git versions without `rev-parse --local-env-vars`.
 // Mirrors scripts/install-git-hooks.mjs, which established this trust model.
 const STATIC_LOCAL_ENV_VARS = [

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -14,6 +14,15 @@
  *   --force-commands     Remove user-modified slash commands instead of preserving them
  *   --force-extensions   Remove user-modified extension files (hypo-ext-*) instead of preserving them
  *   --hooks-dir=<path>   Override Claude hooks directory (default: ~/.claude/hooks)
+ *   --hypo-dir=<path>    Wiki vault to remove the pre-commit hook from (default: auto-resolve,
+ *                        same rules as init/lint/query)
+ *   --shell-config=<path> Shell rc file to strip the shell block from (default: checks both
+ *                        ~/.zshrc and ~/.bashrc, since init may have run under either shell)
+ *
+ * The wiki's git pre-commit hook and the shell rc's `claude()` wrapper function are removed
+ * only when they still carry the marker init.mjs wrote (WIKI_PRE_COMMIT_MARKER_START /
+ * SHELL_MARKER_START, both from ./lib/git-hooks-dir.mjs). A user's own pre-commit hook, a
+ * symlinked hook target, and any rc content outside the marker block are never touched.
  *
  * Extensions: hypo-ext-* hard-copies under
  * ~/.claude/{hooks,commands,skills,agents}/ and ~/.codex/{hooks,commands}/ (with
@@ -23,7 +32,16 @@
  * does not follow them). The wiki source (~/hypomnema/extensions/) is preserved.
  */
 
-import { existsSync, readFileSync, writeFileSync, rmSync, rmdirSync, readdirSync } from 'fs';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  rmdirSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
@@ -48,6 +66,15 @@ import {
   buildHookCommand,
 } from './lib/extensions.mjs';
 import { removeProvenanceSidecar } from './lib/pkg-provenance.mjs';
+import {
+  hooksDirForInstall,
+  unsafeHookTargetReason,
+  WIKI_PRE_COMMIT_MARKER_START,
+  WIKI_PRE_COMMIT_MARKER_END,
+  SHELL_MARKER_START,
+  SHELL_MARKER_END,
+} from './lib/git-hooks-dir.mjs';
+import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -428,6 +455,182 @@ function stripExtensionSettings(settingsPath, hooksDir, apply, ownedCommands = n
   return { stripped };
 }
 
+// ── marker-span validation (shared by both removal paths below) ────────────
+
+// Two independent indexOf() calls cannot tell "well-formed" apart from
+// "duplicated" or "swapped": if a file happens to hold two full copies of the
+// block, indexOf finds only the first END, so slicing [firstStart, firstEnd]
+// leaves the second copy's install behind with no report of it. If END
+// precedes START (a hand-edited or corrupted file), slicing [start, end) with
+// start > end does not error, it silently duplicates whatever sits between
+// them into the "removed" span. Neither this script nor the file it is
+// touching has a way back from either outcome, so a span is only trusted when
+// both markers appear EXACTLY once and START comes before END.
+function countOccurrences(content, needle) {
+  let count = 0;
+  let idx = 0;
+  while ((idx = content.indexOf(needle, idx)) !== -1) {
+    count++;
+    idx += needle.length;
+  }
+  return count;
+}
+
+function findMarkerSpan(content, startMarker, endMarker) {
+  const startCount = countOccurrences(content, startMarker);
+  const endCount = countOccurrences(content, endMarker);
+  if (startCount !== 1 || endCount !== 1) {
+    return {
+      ok: false,
+      reason: `expected exactly one start and one end marker, found ${startCount} start / ${endCount} end`,
+    };
+  }
+  const startIdx = content.indexOf(startMarker);
+  const endIdx = content.indexOf(endMarker);
+  if (!(startIdx < endIdx)) {
+    return { ok: false, reason: 'the end marker appears before the start marker' };
+  }
+  return { ok: true, startIdx, endIdx };
+}
+
+// ── wiki pre-commit hook removal ────────────────────────────────────────────
+
+// Mirrors init.mjs's own resolution (hooksDirForInstall) as the PRIMARY
+// candidate, so this finds the hook wherever init would put it today,
+// including under a core.hooksPath override. A second, best-effort candidate
+// (the vault's plain .git/hooks/pre-commit) is checked too: if core.hooksPath
+// changed after install, the current resolution no longer points at the file
+// init actually wrote, and that file would otherwise never be found. Both
+// candidates go through the same marker/ownership gate below, so widening the
+// search costs nothing in safety, only in how many places we bother to look.
+// A hook that still carries our marker is removed; a user's own pre-commit (no
+// marker), a symlinked/non-regular target, and a hook whose marker is
+// duplicated, swapped, or missing its shebang are all left standing.
+// `pre-commit.bak` (init's --force-commands backup of the user's original
+// hook) is never removed here, only reported so the user knows it exists.
+function removeWikiPreCommitHook(hypoDir, apply) {
+  const result = { removed: [], skipped: [], bakPresent: [] };
+
+  if (!hypoDir || !existsSync(join(hypoDir, 'hypo-config.md'))) {
+    result.skipped.push(`no Hypomnema vault found${hypoDir ? ` at ${hypoDir}` : ''} — nothing to remove`);
+    return result;
+  }
+
+  const candidateDirs = [];
+  const { dir: hooksDir, skip } = hooksDirForInstall(hypoDir);
+  if (hooksDir) candidateDirs.push(hooksDir);
+  else if (skip) result.skipped.push(skip);
+
+  // Best-effort fallback: only when `.git` is a real directory here (a plain
+  // checkout, not a linked worktree's gitdir-pointer FILE, which this join
+  // would misread entirely — resolveGitHooksDir already handles that layout
+  // correctly via the primary candidate above).
+  const legacyGitDir = join(hypoDir, '.git');
+  if (existsSync(legacyGitDir) && statSync(legacyGitDir).isDirectory()) {
+    candidateDirs.push(join(legacyGitDir, 'hooks'));
+  }
+
+  const seen = new Set();
+  for (const dir of candidateDirs) {
+    const hookPath = join(dir, 'pre-commit');
+    // Dedupe by the resolved real path, not the string: the primary candidate
+    // is realpath'd internally (resolveGitHooksDir's canonicalize) while the
+    // legacy join above is not, so the same physical file can arrive under two
+    // different-looking paths. Falling back to the raw path when the file does
+    // not exist is fine — two distinct absent candidates never collide.
+    let key = hookPath;
+    try {
+      key = realpathSync(hookPath);
+    } catch {
+      // leave key as hookPath
+    }
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const bakPath = `${hookPath}.bak`;
+    if (existsSync(bakPath)) result.bakPresent.push(bakPath);
+
+    const unsafe = unsafeHookTargetReason(hookPath);
+    if (unsafe) {
+      result.skipped.push(`${hookPath} (${unsafe})`);
+      continue;
+    }
+    if (!existsSync(hookPath)) continue; // already absent, nothing to report
+
+    let content;
+    try {
+      content = readFileSync(hookPath, 'utf-8');
+    } catch (e) {
+      result.skipped.push(`${hookPath} (cannot read: ${e.code || e.message})`);
+      continue;
+    }
+    if (!content.includes(WIKI_PRE_COMMIT_MARKER_START) || !content.includes(WIKI_PRE_COMMIT_MARKER_END)) {
+      result.skipped.push(`${hookPath} (not managed by Hypomnema — preserving)`);
+      continue;
+    }
+
+    const span = findMarkerSpan(content, WIKI_PRE_COMMIT_MARKER_START, WIKI_PRE_COMMIT_MARKER_END);
+    if (!span.ok) {
+      result.skipped.push(`${hookPath} (${span.reason} — preserving)`);
+      continue;
+    }
+
+    // init writes the marker as the ENTIRE hook body: a bare "#!/bin/sh\n"
+    // right before WIKI_PRE_COMMIT_MARKER_START, nothing after
+    // WIKI_PRE_COMMIT_MARKER_END. A file with no shebang there was never
+    // written by init even if it happens to carry a well-formed marker span
+    // (hand-authored or copy-pasted) — deleting it on marker presence alone
+    // would remove code we do not own. A user who appended their own check
+    // after the block turned this into a file we only partly own. init's own
+    // --force-commands path handles the analogous case by OVERWRITING with
+    // equivalent content (a safe merge); uninstall has no such repair, only
+    // rmSync, so treating "extra content" the same as "fully ours" would
+    // silently delete the user's check with no way back.
+    const before = content.slice(0, span.startIdx);
+    const after = content.slice(span.endIdx + WIKI_PRE_COMMIT_MARKER_END.length);
+    if (!/^#![^\n]*\n$/.test(before)) {
+      result.skipped.push(`${hookPath} (hook carries content before the Hypomnema block — preserving)`);
+      continue;
+    }
+    if (after.trim() !== '') {
+      result.skipped.push(`${hookPath} (hook carries content after the Hypomnema block — preserving)`);
+      continue;
+    }
+
+    if (apply) rmSync(hookPath);
+    result.removed.push(hookPath);
+  }
+
+  return result;
+}
+
+// ── shell function block removal ────────────────────────────────────────────
+
+// init picks ONE rc file at install time from $SHELL (or --shell-config), but
+// $SHELL by uninstall time may point somewhere else, or init may have run in
+// a different shell session altogether — so both common rc files are checked
+// by default rather than guessing one. Only the marker span itself is
+// stripped; every other byte in the file, including surrounding blank lines,
+// is left exactly as it was. A malformed span (duplicated or swapped markers,
+// see findMarkerSpan above) leaves the file completely untouched: an rc file
+// is the user's own, and this script has no backup to restore it from.
+function removeShellFunctionBlock(shellConfigPath, apply) {
+  if (!existsSync(shellConfigPath)) return null;
+  const content = readFileSync(shellConfigPath, 'utf-8');
+  if (!content.includes(SHELL_MARKER_START) && !content.includes(SHELL_MARKER_END)) {
+    return null; // block not present here at all
+  }
+
+  const span = findMarkerSpan(content, SHELL_MARKER_START, SHELL_MARKER_END);
+  if (!span.ok) {
+    return { path: shellConfigPath, removed: false, skipped: span.reason };
+  }
+
+  const updated = content.slice(0, span.startIdx) + content.slice(span.endIdx + SHELL_MARKER_END.length);
+  if (apply) writeFileSync(shellConfigPath, updated);
+  return { path: shellConfigPath, removed: true, skipped: null };
+}
+
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
@@ -437,6 +640,8 @@ function parseArgs(argv) {
     hooksDir: null,
     forceCommands: false,
     forceExtensions: false,
+    hypoDir: null,
+    shellConfig: null,
   };
   for (const arg of argv.slice(2)) {
     if (arg === '--apply') args.apply = true;
@@ -444,6 +649,16 @@ function parseArgs(argv) {
     else if (arg === '--force-commands') args.forceCommands = true;
     else if (arg === '--force-extensions') args.forceExtensions = true;
     else if (arg.startsWith('--hooks-dir=')) args.hooksDir = arg.slice(12);
+    // expandHome mirrors init.mjs's own --hypo-dir/--shell-config parsing
+    // (init.mjs's parseArgs) exactly, reusing the same function from
+    // ./lib/hypo-root.mjs rather than re-deriving it. Uninstall must undo
+    // whatever path init actually wrote to disk, and init resolves a leading
+    // "~/" itself (the shell never does, since the value arrives already
+    // quoted inside "--flag=value"); skipping that step here would silently
+    // fail to find the vault or rc file a user installed with "~/..." to
+    // begin with.
+    else if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
+    else if (arg.startsWith('--shell-config=')) args.shellConfig = expandHome(arg.slice(15));
   }
   return args;
 }
@@ -588,6 +803,20 @@ const claudeSettings = join(HOME, '.claude', 'settings.json');
 const hookResult = removeHookFiles(claudeHooksDir, hookFiles, args.apply);
 const settingsResult = stripSettingsJson(claudeSettings, claudeHooksDir, hookMap, args.apply);
 const commandResult = removeCommands(args.apply, args.forceCommands);
+
+// Wiki-side cleanup: the git pre-commit hook and the shell rc block init.mjs
+// installs outside ~/.claude entirely. Both are independent of --codex/--hooks-dir.
+const hypoDir = args.hypoDir ?? resolveHypoRoot();
+const preCommitResult = removeWikiPreCommitHook(hypoDir, args.apply);
+
+const shellConfigCandidates = args.shellConfig
+  ? [args.shellConfig]
+  : [join(HOME, '.zshrc'), join(HOME, '.bashrc')];
+const shellBlockOutcomes = shellConfigCandidates
+  .map((p) => removeShellFunctionBlock(p, args.apply))
+  .filter(Boolean);
+const shellBlockResults = shellBlockOutcomes.filter((r) => r.removed).map((r) => r.path);
+const shellBlockSkipped = shellBlockOutcomes.filter((r) => !r.removed);
 
 // Extensions. Order matters: remove files first, then strip
 // settings, then surgically clear the per-target SHA map. The SHA strip uses
@@ -736,6 +965,27 @@ if (hookResult.missing.length)
   lines.push(
     `⊘ Already absent (${hookResult.missing.length}):\n${hookResult.missing.map((p) => `  ${p}`).join('\n')}`,
   );
+if (preCommitResult.removed.length)
+  lines.push(
+    `✓ Wiki pre-commit hook ${dryRun ? 'to remove' : 'removed'} (${preCommitResult.removed.length}):\n${preCommitResult.removed.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (preCommitResult.skipped.length)
+  lines.push(
+    `⊘ Wiki pre-commit hook preserved:\n${preCommitResult.skipped.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (preCommitResult.bakPresent.length)
+  lines.push(
+    `ⓘ Pre-commit backup left in place (from --force-commands, never touched by uninstall):\n${preCommitResult.bakPresent.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (shellBlockResults.length)
+  lines.push(
+    `✓ Shell function block ${dryRun ? 'to remove' : 'removed'} (${shellBlockResults.length}):\n${shellBlockResults.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (shellBlockSkipped.length)
+  lines.push(
+    `⊘ Shell function block preserved:\n${shellBlockSkipped.map((r) => `  ${r.path} (${r.skipped})`).join('\n')}`,
+  );
+
 if (settingsResult.error) lines.push(`⚠ ${settingsResult.error}`);
 if (claudeExtSettings.error) lines.push(`⚠ ${claudeExtSettings.error}`);
 if (codexExtSettings.error) lines.push(`⚠ ${codexExtSettings.error}`);
@@ -750,7 +1000,9 @@ if (
   !pkgJsonRemoved &&
   !commandResult.skippedUserModified.length &&
   !extSkippedUserModified.length &&
-  !extSkippedNonRegular.length
+  !extSkippedNonRegular.length &&
+  !preCommitResult.removed.length &&
+  !shellBlockResults.length
 ) {
   lines.push('Nothing to uninstall — Hypomnema does not appear to be installed.');
 }

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -14,6 +14,8 @@ import {
   readFileSync,
   existsSync,
   statSync,
+  lstatSync,
+  symlinkSync,
   cpSync,
   realpathSync,
 } from 'node:fs';
@@ -21,6 +23,7 @@ import { join, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
 import { PROVENANCE_FILENAME } from '../scripts/lib/pkg-provenance.mjs';
+import { hooksDirForInstall } from '../scripts/lib/git-hooks-dir.mjs';
 import {
   HOME,
   HOOKS,
@@ -28,6 +31,7 @@ import {
   SCRIPTS,
   SESSION_TMP_HOME,
   deriveCoreHookBasenames,
+  gitRepo,
   readCoreHooksConfig,
   run,
   runWithHome,
@@ -1451,5 +1455,299 @@ test('--dry-run does not write the provenance sidecar', () => {
       const sidecarPath = join(home, '.claude', 'hooks', PROVENANCE_FILENAME);
       assert.ok(!existsSync(sidecarPath), '--dry-run must not write the provenance sidecar');
     });
+  });
+});
+
+// ── uninstall.mjs: wiki pre-commit hook + shell setup block ──────────────────
+//
+// uninstall.mjs must remove exactly the two vault-adjacent artifacts init.mjs
+// creates outside ~/.claude: the git pre-commit hook and the shell rc block.
+// Neither is a Claude-hooks-dir concern, so these are separate from the
+// --hooks-dir suites above.
+
+suite('uninstall.mjs: wiki pre-commit hook + shell setup');
+
+test('dry-run leaves the wiki pre-commit hook in place; --apply removes it', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    // init's own gitSetup/firstCommit only run --no-git-init-free in every other
+    // test in this file because they need a global git identity this process
+    // does not have. Pre-creating the repo with one sidesteps that and still
+    // exercises the real installWikiPreCommitHook path against a real repo.
+    mkdirSync(hypoDir, { recursive: true });
+    gitRepo(hypoDir);
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell']);
+    assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    const hookPath = join(hooksDir, 'pre-commit');
+    assert.ok(existsSync(hookPath), 'fixture: init must install the pre-commit hook');
+
+    const dryR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`]);
+    assert.equal(dryR.status, 0, `stderr: ${dryR.stderr}`);
+    assert.ok(existsSync(hookPath), 'dry-run must not delete the hook');
+    assert.ok(dryR.stdout.includes(hookPath), 'dry-run report must name the hook it would remove');
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(!existsSync(hookPath), '--apply must remove the Hypomnema-managed hook');
+  });
+});
+
+test('preserves a user pre-commit hook that carries no Hypomnema marker', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    writeFileSync(join(hypoDir, 'hypo-config.md'), '# config');
+    gitRepo(hypoDir);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    mkdirSync(hooksDir, { recursive: true });
+    const hookPath = join(hooksDir, 'pre-commit');
+    const userContent = '#!/bin/sh\necho user hook\n';
+    writeFileSync(hookPath, userContent, { mode: 0o755 });
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(existsSync(hookPath), 'a user pre-commit hook must survive uninstall');
+    assert.equal(readFileSync(hookPath, 'utf-8'), userContent, 'its content must be untouched');
+  });
+});
+
+test('refuses to remove a symlinked pre-commit target', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    writeFileSync(join(hypoDir, 'hypo-config.md'), '# config');
+    gitRepo(hypoDir);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    mkdirSync(hooksDir, { recursive: true });
+    const outside = join(dir, 'outside-target');
+    writeFileSync(outside, '#!/bin/sh\n# hypo-managed:pre-commit:start\nexit 0\n# hypo-managed:pre-commit:end\n');
+    const hookPath = join(hooksDir, 'pre-commit');
+    symlinkSync(outside, hookPath);
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(existsSync(outside), 'the symlink target file must survive');
+    assert.ok(lstatSync(hookPath).isSymbolicLink(), 'the symlink itself must survive, never followed');
+  });
+});
+
+test('reports a pre-commit.bak without touching it', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    gitRepo(hypoDir);
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell']);
+    assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    const bakPath = join(hooksDir, 'pre-commit.bak');
+    const bakContent = '#!/bin/sh\necho original user hook\n';
+    writeFileSync(bakPath, bakContent);
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.equal(readFileSync(bakPath, 'utf-8'), bakContent, 'pre-commit.bak must survive untouched');
+    assert.ok(applyR.stdout.includes('pre-commit.bak'), 'report must mention the backup');
+  });
+});
+
+test('preserves the whole hook when the user appended a line after the Hypomnema block', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    gitRepo(hypoDir);
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell']);
+    assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    const hookPath = join(hooksDir, 'pre-commit');
+    const userLine = '\necho "my own check" && exit 1\n';
+    const withUserLine = readFileSync(hookPath, 'utf-8') + userLine;
+    writeFileSync(hookPath, withUserLine);
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(existsSync(hookPath), 'the hook must survive since it is no longer fully ours');
+    assert.equal(
+      readFileSync(hookPath, 'utf-8'),
+      withUserLine,
+      'the user line appended after the block must be untouched',
+    );
+  });
+});
+
+test('preserves a shebang-less hook even when it carries a well-formed marker span', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    gitRepo(hypoDir);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    mkdirSync(hooksDir, { recursive: true });
+    const hookPath = join(hooksDir, 'pre-commit');
+    // A well-formed marker span with no leading shebang is NOT what init ever
+    // writes (wikiPreCommitContent always emits "#!/bin/sh\n" first), so this
+    // must never be treated as "fully ours" on marker presence alone.
+    const content =
+      '# hypo-managed:pre-commit:start\nsome_users_own_command || exit 1\nexit 0\n# hypo-managed:pre-commit:end\n';
+    writeFileSync(hookPath, content, { mode: 0o755 });
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(existsSync(hookPath), 'a marker span with no shebang must never be deleted');
+    assert.equal(readFileSync(hookPath, 'utf-8'), content, 'its content must be untouched');
+  });
+});
+
+test('still finds and removes the original hook after core.hooksPath moves elsewhere', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    mkdirSync(hypoDir, { recursive: true });
+    gitRepo(hypoDir);
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell']);
+    assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+    const originalHookPath = join(hypoDir, '.git', 'hooks', 'pre-commit');
+    assert.ok(existsSync(originalHookPath), 'fixture: init must install into the plain .git/hooks');
+
+    // Redirect core.hooksPath so the CURRENT resolution no longer points at
+    // the file init actually wrote — the exact drift this fallback exists for.
+    const elsewhere = join(dir, 'elsewhere-hooks');
+    mkdirSync(elsewhere, { recursive: true });
+    const cfg = spawnSync('git', ['config', 'core.hooksPath', elsewhere], { cwd: hypoDir, encoding: 'utf-8' });
+    assert.equal(cfg.status, 0, `git config stderr: ${cfg.stderr}`);
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(
+      !existsSync(originalHookPath),
+      'the original .git/hooks/pre-commit must still be found and removed via the fallback candidate',
+    );
+  });
+});
+
+test('dry-run leaves the shell marker block; --apply strips only that block', () => {
+  withTmpDir((dir) => {
+    const rcPath = join(dir, 'zshrc');
+    const before = 'export PATH=$PATH:/opt/tool\n\nalias ll="ls -la"\n';
+    writeFileSync(rcPath, before);
+
+    const hypoDir = join(dir, 'wiki');
+    const initR = run('init.mjs', [
+      `--hypo-dir=${hypoDir}`,
+      '--no-hooks',
+      '--no-git-init',
+      `--shell-config=${rcPath}`,
+    ]);
+    assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+    const withBlock = readFileSync(rcPath, 'utf-8');
+    assert.ok(
+      withBlock.includes('# hypo-managed:shell-setup:start'),
+      'fixture: init must install the shell block',
+    );
+
+    const dryR = run('uninstall.mjs', [`--hypo-dir=${hypoDir}`, `--shell-config=${rcPath}`]);
+    assert.equal(dryR.status, 0, `stderr: ${dryR.stderr}`);
+    assert.equal(readFileSync(rcPath, 'utf-8'), withBlock, 'dry-run must not modify the rc file');
+
+    const applyR = run('uninstall.mjs', [
+      `--hypo-dir=${hypoDir}`,
+      `--shell-config=${rcPath}`,
+      '--apply',
+    ]);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    const after = readFileSync(rcPath, 'utf-8');
+    assert.ok(!after.includes('hypo-managed:shell-setup'), '--apply must remove the marker block');
+    assert.ok(after.includes('export PATH=$PATH:/opt/tool'), 'the line before the block must survive');
+    assert.ok(after.includes('alias ll="ls -la"'), 'the line after the block must survive');
+  });
+});
+
+test('a swapped marker (END before START) leaves the rc file byte-for-byte untouched', () => {
+  withTmpDir((dir) => {
+    const rcPath = join(dir, 'zshrc');
+    // END literally precedes START — a hand-edited or corrupted file, not
+    // anything init would ever produce. Two bare indexOf() calls would slice
+    // [startIdx, endIdx) with startIdx > endIdx and DUPLICATE this content
+    // instead of raising anything.
+    const swapped =
+      'before\n# hypo-managed:shell-setup:end\nfunction claude() { true; }\n# hypo-managed:shell-setup:start\nafter\n';
+    writeFileSync(rcPath, swapped);
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${join(dir, 'wiki')}`, `--shell-config=${rcPath}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.equal(readFileSync(rcPath, 'utf-8'), swapped, '--apply must not write a single byte to a swapped-marker rc');
+  });
+});
+
+test('a duplicated block (two full START/END pairs) is preserved, not partially stripped', () => {
+  withTmpDir((dir) => {
+    const rcPath = join(dir, 'zshrc');
+    const oneBlock = '# hypo-managed:shell-setup:start\nfunction claude() { true; }\n# hypo-managed:shell-setup:end\n';
+    const duplicated = `${oneBlock}\n${oneBlock}`;
+    writeFileSync(rcPath, duplicated);
+
+    const applyR = run('uninstall.mjs', [`--hypo-dir=${join(dir, 'wiki')}`, `--shell-config=${rcPath}`, '--apply']);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.equal(
+      readFileSync(rcPath, 'utf-8'),
+      duplicated,
+      'a duplicated block must be preserved whole, not have only the first copy stripped',
+    );
+    assert.ok(applyR.stdout.includes('preserved'), 'report must explain the block was preserved');
+  });
+});
+
+test('checks both ~/.zshrc and ~/.bashrc by default, not just $SHELL', () => {
+  withTmpHome((home) => {
+    const fakeBlock =
+      '# hypo-managed:shell-setup:start\nfunction claude() { true; }\n# hypo-managed:shell-setup:end\n';
+    const zshrc = join(home, '.zshrc');
+    const bashrc = join(home, '.bashrc');
+    writeFileSync(zshrc, `# zsh stuff\n\n${fakeBlock}`);
+    writeFileSync(bashrc, `# bash stuff\n\n${fakeBlock}`);
+
+    const applyR = runWithHome('uninstall.mjs', ['--apply'], home);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(
+      !readFileSync(zshrc, 'utf-8').includes('hypo-managed:shell-setup'),
+      '.zshrc block must be stripped even without --shell-config',
+    );
+    assert.ok(
+      !readFileSync(bashrc, 'utf-8').includes('hypo-managed:shell-setup'),
+      '.bashrc block must be stripped even without --shell-config',
+    );
+    assert.ok(readFileSync(zshrc, 'utf-8').includes('# zsh stuff'), '.zshrc other content must survive');
+    assert.ok(readFileSync(bashrc, 'utf-8').includes('# bash stuff'), '.bashrc other content must survive');
+  });
+});
+
+test('--hypo-dir expands a leading ~ the same way init.mjs expands it', () => {
+  withTmpHome((home) => {
+    const hypoDir = join(home, 'vault');
+    mkdirSync(hypoDir, { recursive: true });
+    gitRepo(hypoDir);
+    const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell'], home);
+    assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    const hookPath = join(hooksDir, 'pre-commit');
+    assert.ok(existsSync(hookPath), 'fixture: init must install the pre-commit hook');
+
+    // The shell never expands "~" inside "--flag=value"; only the receiving
+    // script's own expandHome() call does. init.mjs's parseArgs already calls
+    // it (scripts/init.mjs), so uninstall must call the same function or this
+    // literally never resolves to anything on disk.
+    const applyR = runWithHome('uninstall.mjs', ['--hypo-dir=~/vault', '--apply'], home);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(!existsSync(hookPath), '--hypo-dir=~/vault must resolve to the real vault path and remove its hook');
+  });
+});
+
+test('a missing vault is skipped with a reason, not a crash', () => {
+  withTmpHome((home) => {
+    const applyR = runWithHome(
+      'uninstall.mjs',
+      [`--hypo-dir=${join(home, 'no-such-wiki')}`, '--apply'],
+      home,
+    );
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(/vault/i.test(applyR.stdout), 'report must explain why the pre-commit hook was skipped');
   });
 });


### PR DESCRIPTION
# English

## What changed

`uninstall` now removes the two things `init` installs outside `~/.claude`: the `claude()` wrapper block in the user's shell rc, and the `pre-commit` hook in the wiki vault. Two new flags, `--hypo-dir` and `--shell-config`, let you point at either explicitly.

## Why

Removal was not the inverse of installation, and the gap had teeth.

The leftover `pre-commit` hook embeds an absolute path into the package. Move the package or delete it, and every commit in the wiki fails with `MODULE_NOT_FOUND`. You uninstall the tool and your wiki stops accepting commits, with nothing pointing at the cause.

The shell rc block is quieter but the same shape: a `claude()` function calling a hook that is no longer there.

## How

Both removals go through one gate. A marker span is trusted only when `START` and `END` each appear exactly once and `START` precedes `END`, and a hook must still carry its shebang. Anything else is preserved whole, with the reason printed in the report.

That strictness is deliberate. Marker presence alone does not prove the file is ours, and `uninstall` has no repair path the way `init --force-commands` does: it deletes, and there is nothing to fall back to. Cross-review found two concrete ways a looser version corrupted user files. A swapped `END`/`START` sliced backwards and duplicated the user's own bytes into the rc. A doubly-installed block was half-stripped, leaving the second copy behind unreported.

The hook is looked for in two places, deduped by realpath: the resolution `init` itself uses (which follows `core.hooksPath` and linked worktrees), plus the vault's plain `.git/hooks/pre-commit`. A `core.hooksPath` change after install used to strand the hook that `init` actually wrote.

`--hypo-dir` and `--shell-config` expand a leading `~` through the same helper `init` uses. Without that, a vault installed as `~/vault` was never found, which breaks the very property this change exists to establish.

Both rc files (`~/.zshrc` and `~/.bashrc`) are checked by default rather than picking one from `$SHELL`, since `init` may have run under a different shell than the one uninstalling.

The marker strings now live in one module, read by `init`, `uninstall`, and `doctor` alike. There were three copies before this.

Symlinked and non-regular hook targets are never followed or removed. A user's own `pre-commit` without our marker is left alone. `pre-commit.bak` is only reported, never touched. Dry run remains the default and writes nothing.

## Manual verification

Full install and removal cycle in an isolated `HOME`, with `HYPO_DIR` unset so the ambient vault could not be reached:

```
$ printf '# my own rc line\nexport FOO=1\n' > $QA/home/.zshrc
$ env -u HYPO_DIR HOME=$QA/home SHELL=/bin/zsh node scripts/init.mjs --hypo-dir=$QA/home/vault
$ grep -c 'hypo-managed:shell-setup' $QA/home/.zshrc
2
$ test -f $QA/home/vault/.git/hooks/pre-commit && echo yes
yes

$ env -u HYPO_DIR HOME=$QA/home node scripts/uninstall.mjs --hypo-dir=$QA/home/vault
✓ Wiki pre-commit hook to remove (1): .../vault/.git/hooks/pre-commit
✓ Shell function block to remove (1): .../home/.zshrc

$ env -u HYPO_DIR HOME=$QA/home node scripts/uninstall.mjs --apply --hypo-dir=$QA/home/vault
✓ Wiki pre-commit hook removed (1): .../vault/.git/hooks/pre-commit
✓ Shell function block removed (1): .../home/.zshrc

$ grep -c 'hypo-managed:shell-setup' $QA/home/.zshrc
0
$ grep -c 'export FOO=1' $QA/home/.zshrc
1
$ test -f $QA/home/vault/.git/hooks/pre-commit || echo removed
removed
```

Dry run announced both targets and wrote nothing. `--apply` removed both. The rc line the user wrote by hand survived.

Suites: `npm test` 1925 passing, `--file=init` 73, `--file=git-hooks-dir` 14, `--file=doctor` 92, `npm run lint` clean.

## Migration notes

None. Existing installs gain the removals on the next `uninstall`; nothing changes for anyone who does not run it.

---

# 한국어

## 변경 내용

`uninstall` 이 `init` 이 `~/.claude` 밖에 만드는 둘을 제거한다. 셸 rc 의 `claude()` 래퍼 블록과 위키 볼트의 `pre-commit` 훅이다. 자리를 직접 지정하는 `--hypo-dir` 과 `--shell-config` 플래그도 함께 들어간다.

## 이유

제거가 설치의 역이 아니었고, 그 틈이 실제로 문다.

남겨진 `pre-commit` 훅에는 패키지 절대경로가 박혀 있다. 패키지를 옮기거나 지우면 위키의 모든 커밋이 `MODULE_NOT_FOUND` 로 실패한다. 도구를 지웠는데 위키가 커밋을 안 받고, 원인을 가리키는 것은 아무것도 없다.

셸 rc 블록은 더 조용하지만 같은 모양이다. 이제 없는 훅을 부르는 `claude()` 함수가 남는다.

## 방법

두 제거가 같은 게이트를 지난다. `START` 와 `END` 가 각각 정확히 한 번씩 나오고 `START` 가 앞설 때만 그 구간을 우리 것으로 본다. 훅은 shebang 도 있어야 한다. 하나라도 어긋나면 파일을 통째로 보존하고 사유를 리포트에 적는다.

이 엄격함은 의도한 것이다. 마커가 있다는 사실만으로는 그 파일이 우리 것이라는 증명이 안 되고, `uninstall` 에는 `init --force-commands` 같은 복구 경로가 없다. 지우면 끝이다. 교차검토가 느슨한 판본이 사용자 파일을 망가뜨리는 두 경로를 재현했다. `END` 가 `START` 앞에 오면 슬라이스가 거꾸로 잡혀 사용자 자신의 바이트가 rc 에 중복해 들어갔다. 블록이 두 번 설치돼 있으면 첫 것만 지워지고 둘째가 말없이 남았다.

훅은 두 자리에서 찾고 realpath 로 중복을 거른다. `init` 자신이 쓰는 해석(`core.hooksPath` 와 linked worktree 를 따라간다)과, 볼트의 평범한 `.git/hooks/pre-commit` 이다. 설치 후 `core.hooksPath` 가 바뀌면 `init` 이 실제로 쓴 훅을 놓치고 있었다.

`--hypo-dir` 과 `--shell-config` 은 `init` 이 쓰는 그 헬퍼로 앞머리 `~` 를 확장한다. 그게 없으면 `~/vault` 로 설치한 볼트를 영영 못 찾는데, 그것은 이 변경이 세우려는 성질 자체를 깨는 일이다.

rc 는 `$SHELL` 로 하나를 고르지 않고 `~/.zshrc` 와 `~/.bashrc` 를 둘 다 본다. `init` 이 지금 제거하는 셸과 다른 셸에서 돌았을 수 있다.

마커 문자열은 이제 한 모듈에 있고 `init`, `uninstall`, `doctor` 가 같은 값을 읽는다. 전에는 사본이 셋이었다.

심볼릭 링크와 비정규 파일은 따라가지도 지우지도 않는다. 마커 없는 사용자 본인의 `pre-commit` 은 그대로 둔다. `pre-commit.bak` 은 존재만 알리고 건드리지 않는다. dry run 이 여전히 기본이고 아무것도 쓰지 않는다.

## 수동 검증

격리된 `HOME` 에서 설치와 제거를 한 바퀴 돌렸다. 주변 볼트에 닿지 않도록 `HYPO_DIR` 을 함께 걷어냈다.

```
$ printf '# my own rc line\nexport FOO=1\n' > $QA/home/.zshrc
$ env -u HYPO_DIR HOME=$QA/home SHELL=/bin/zsh node scripts/init.mjs --hypo-dir=$QA/home/vault
$ grep -c 'hypo-managed:shell-setup' $QA/home/.zshrc
2
$ test -f $QA/home/vault/.git/hooks/pre-commit && echo yes
yes

$ env -u HYPO_DIR HOME=$QA/home node scripts/uninstall.mjs --hypo-dir=$QA/home/vault
✓ Wiki pre-commit hook to remove (1): .../vault/.git/hooks/pre-commit
✓ Shell function block to remove (1): .../home/.zshrc

$ env -u HYPO_DIR HOME=$QA/home node scripts/uninstall.mjs --apply --hypo-dir=$QA/home/vault
✓ Wiki pre-commit hook removed (1): .../vault/.git/hooks/pre-commit
✓ Shell function block removed (1): .../home/.zshrc

$ grep -c 'hypo-managed:shell-setup' $QA/home/.zshrc
0
$ grep -c 'export FOO=1' $QA/home/.zshrc
1
$ test -f $QA/home/vault/.git/hooks/pre-commit || echo removed
removed
```

dry run 이 두 대상을 예고하고 아무것도 쓰지 않았다. `--apply` 가 둘 다 지웠다. 사용자가 손으로 쓴 rc 줄은 남았다.

스위트: `npm test` 1925 통과, `--file=init` 73, `--file=git-hooks-dir` 14, `--file=doctor` 92, `npm run lint` 통과.

## 마이그레이션 노트

없다. 기존 설치는 다음 `uninstall` 부터 이 제거를 받는다. 실행하지 않는 사람에게는 아무 변화가 없다.

---

## Changelog

- EN: `uninstall` now removes the shell rc block and the wiki `pre-commit` hook that `init` installs, so removal is the inverse of installation (#244).
- KO: `uninstall` 이 `init` 이 만든 셸 rc 블록과 위키 `pre-commit` 훅을 지운다. 제거가 설치의 역이 된다 (#244).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
