### PR TITLE
fix(sync): carry the executable bit from capture through to the far machine

### DIFF
--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -42,9 +42,10 @@ import {
   unlinkSync,
   renameSync,
   realpathSync,
-  lstatSync,
   openSync,
   closeSync,
+  statSync,
+  chmodSync,
 } from 'fs';
 import { randomBytes } from 'crypto';
 import { join, dirname, relative, sep } from 'path';
@@ -76,6 +77,7 @@ import {
   HOOK_EVENT_ALLOWLIST,
   SKILL_ROOT_FILE,
   EXT_PREFIX,
+  withSrcExecBits,
 } from './lib/extensions.mjs';
 import { readCoreHooksConfig, deriveCoreHookBasenames } from './lib/core-hooks.mjs';
 
@@ -582,13 +584,21 @@ function log(msg) {
 // `${dest}.tmp.${pid}` name was predictable, and writeFileSync on a path someone had
 // already planted a symlink at would follow it straight out of the wiki. O_EXCL fails
 // on an existing path of any kind, symlink included.
-function writeAtomic(dest, buf) {
+// `srcMode`, when given, carries the source file's execute bit onto the wiki
+// copy (openSync's own mode argument is clipped by umask same as writeFileSync,
+// so this still has to be a separate chmod). Omitted for a manifest write: that
+// content is JSON we generated, not a copy of something with a mode worth
+// keeping.
+function writeAtomic(dest, buf, srcMode) {
   const tmp = `${dest}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
   const fd = openSync(tmp, 'wx');
   try {
     writeFileSync(fd, buf);
   } finally {
     closeSync(fd);
+  }
+  if (srcMode != null) {
+    chmodSync(tmp, withSrcExecBits(statSync(tmp).mode, srcMode));
   }
   try {
     renameSync(tmp, dest);
@@ -719,7 +729,8 @@ function writeSkill({ rec, skillRoot, manifestPath, manifest, files, guard, wiki
         madeDirs.add(cur);
       }
     }
-    writeAtomic(destPath, readFileSync(f.srcPath));
+    const buf = readFileSync(f.srcPath);
+    writeAtomic(destPath, buf, statSync(f.srcPath).mode);
     rec.createdFiles.push(destPath);
   }
 }
@@ -812,22 +823,6 @@ function captureOneSkill({ c, extDir, guard, wikiRoot, args, captured, skipped, 
     log(`= ${label}: already captured`);
     captured.push({ ...rec, status: 'already' });
     return;
-  }
-
-  // Content round-trips; the executable bit does not (forward-sync writes with the
-  // default mode). Say so rather than let a captured `scripts/run.sh` arrive
-  // non-executable on the far machine without a word.
-  const execFiles = c.files.filter((f) => {
-    try {
-      return (lstatSync(f.srcPath).mode & 0o111) !== 0;
-    } catch {
-      return false;
-    }
-  });
-  if (execFiles.length > 0) {
-    log(
-      `! ${label}: ${execFiles.length} executable file(s) — content is captured, but the executable bit is not carried by sync`,
-    );
   }
 
   if (!args.dryRun) {
@@ -1055,7 +1050,7 @@ function run(args, { claudeHome = join(HOME, '.claude') } = {}) {
         manifestPrevBuf: existingManifestBuf,
       };
       writeAtomic(manifestPath, JSON.stringify(plan.manifest, null, 2) + '\n');
-      writeAtomic(filePath, srcBuf);
+      writeAtomic(filePath, srcBuf, statSync(c.srcPath).mode);
       created.push(rec);
     }
     captured.push({ ...c, installFile, requiredKeys, status: 'ready' });

--- a/scripts/lib/extensions.mjs
+++ b/scripts/lib/extensions.mjs
@@ -28,6 +28,8 @@ import {
   unlinkSync,
   mkdirSync,
   lstatSync,
+  statSync,
+  chmodSync,
   rmdirSync,
 } from 'fs';
 import { join, dirname, relative, resolve, posix, sep } from 'path';
@@ -894,9 +896,26 @@ export function readExtensionPkgStateNoMutate(pkgPath, target) {
 
 // ── sync orchestration ─────────────────────────────────────────────────────────
 
-function writeFreshAtomic(dest, content) {
+/** Carry only src's execute bits (owner/group/other) onto a mode value; every
+ * other permission bit (dest's own read/write, however umask shaped it) is
+ * left alone. This is the one place forward-sync decides "should this file be
+ * executable", so every writer of dest routes through it. Exported so
+ * capture.mjs's own atomic writer (a captured file's FIRST write into the wiki)
+ * applies the identical rule; the wiki copy must not lose the bit before
+ * forward-sync ever gets a chance to carry it further. */
+export function withSrcExecBits(destMode, srcMode) {
+  return (destMode & ~0o111) | (srcMode & 0o111);
+}
+
+function writeFreshAtomic(dest, content, srcMode) {
   const tmp = `${dest}.tmp.${process.pid}.${Date.now()}`;
   writeFileSync(tmp, content);
+  if (srcMode != null) {
+    // writeFileSync has no mode option that survives umask, so the execute bit
+    // has to be applied explicitly, and before the rename: otherwise dest is
+    // briefly visible with the wrong mode to anything racing this write.
+    chmodSync(tmp, withSrcExecBits(statSync(tmp).mode, srcMode));
+  }
   try {
     renameSync(tmp, dest);
   } catch (err) {
@@ -914,13 +933,19 @@ function writeFreshAtomic(dest, content) {
  * overwrites user-modified / unowned files; without it those are left untouched and
  * surface as drift/conflict. A symlink/non-regular dest is never followed even under
  * force (the isRegularFile guard precedes the force branch).
+ *
+ * The executable bit is not tracked anywhere (no mode column in the SHA map's
+ * ownership model), so src's mode is the only source of truth for it and gets
+ * carried onto dest on every branch that (re)writes it, including the
+ * content-identical `up-to-date` branch below.
  */
 function copyOne({ srcPath, destPath, key, recordedSHA, apply, force }) {
   const srcContent = readFileSync(srcPath);
   const srcSHA = sha256(srcContent);
+  const srcMode = statSync(srcPath).mode;
 
   if (!existsSync(destPath)) {
-    if (apply) writeFreshAtomic(destPath, srcContent);
+    if (apply) writeFreshAtomic(destPath, srcContent, srcMode);
     return { action: 'create', sha: srcSHA };
   }
   if (!isRegularFile(destPath)) {
@@ -933,6 +958,20 @@ function copyOne({ srcPath, destPath, key, recordedSHA, apply, force }) {
   }
   const onDiskSHA = sha256(onDisk);
   if (onDiskSHA === srcSHA) {
+    // Content already matches, but the exec bit can still be stale: this used to
+    // be a pure no-op, which is exactly why a mismatched bit here never healed.
+    // Reported as 'update' (not a new action) so every existing "N to sync" /
+    // "N synced" count and log line already keyed on create/update/force-update
+    // picks it up for free.
+    // ponytail: this also overwrites an exec bit a user deliberately flipped on a
+    // file whose content happens to still match src (chmod -x'd a script they
+    // like read-only). Upgrade path: record mode next to sha in the pkg-json map
+    // so a user's own bit can be told apart from our default and left alone.
+    const destMode = statSync(destPath).mode;
+    if ((destMode & 0o111) !== (srcMode & 0o111)) {
+      if (apply) chmodSync(destPath, withSrcExecBits(destMode, srcMode));
+      return { action: 'update', sha: srcSHA };
+    }
     return { action: 'up-to-date', sha: srcSHA };
   }
   if (recordedSHA && onDiskSHA === recordedSHA) {
@@ -942,7 +981,7 @@ function copyOne({ srcPath, destPath, key, recordedSHA, apply, force }) {
       if (!verify || sha256(verify) !== recordedSHA) {
         return { action: 'skip-changed', sha: recordedSHA };
       }
-      writeFreshAtomic(destPath, srcContent);
+      writeFreshAtomic(destPath, srcContent, srcMode);
     }
     return { action: 'update', sha: srcSHA };
   }
@@ -950,7 +989,7 @@ function copyOne({ srcPath, destPath, key, recordedSHA, apply, force }) {
   if (force) {
     if (apply) {
       writeFreshAtomic(`${destPath}.bak`, onDisk);
-      writeFreshAtomic(destPath, srcContent);
+      writeFreshAtomic(destPath, srcContent, srcMode);
     }
     return { action: 'force-update', sha: srcSHA };
   }

--- a/tests/capture.test.mjs
+++ b/tests/capture.test.mjs
@@ -11,6 +11,8 @@ import {
   existsSync,
   symlinkSync,
   lstatSync,
+  chmodSync,
+  statSync,
 } from 'node:fs';
 import { join, basename } from 'node:path';
 import { test, suite } from './harness.mjs';
@@ -1765,6 +1767,63 @@ test('captures a directory skill, adopts it, and reinstalls it on a second machi
         assert.ok(
           !existsSync(join(home2, '.claude', 'skills', 'hypo-ext-mine')),
           'installs under the original name, not the wiki storage name',
+        );
+      });
+    });
+  });
+});
+
+// Regression: capture's OWN wiki write must not lose the source's executable
+// bit. Before this fix, capture.mjs's writeAtomic always wrote 644, so the wiki
+// copy was wrong from the moment capture created it. The immediate adopt sync
+// then made it worse: its up-to-date branch heals mode FROM the wiki (now the
+// source of truth for forward-sync), and the wiki copy was already wrong, so
+// the heal wrote 644 back onto the user's ORIGINAL local file too.
+test('capture preserves the executable bit end to end: wiki copy, far install, and the original', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      assert.equal(
+        runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home).status,
+        0,
+      );
+      const src = join(home, '.claude', 'skills', 'mine');
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, 'SKILL.md'), '# mine\n');
+      const helper = join(src, 'run.sh');
+      writeFileSync(helper, '#!/bin/sh\necho hi\n');
+      chmodSync(helper, 0o755);
+
+      const r = runWithHome('capture.mjs', [`--hypo-dir=${hypoDir}`, '--all'], home);
+      assert.equal(r.status, 0, r.stderr);
+
+      // (b) the regression this test pins: the original local file must still be
+      // executable after capture + its own adopt sync.
+      const origMode = statSync(helper).mode & 0o777;
+      assert.equal(
+        origMode & 0o111,
+        0o111,
+        `capture must not strip the original file's executable bit, got ${origMode.toString(8)}`,
+      );
+
+      const wikiHelper = join(hypoDir, 'extensions', 'skills', 'hypo-ext-mine', 'run.sh');
+      const wikiMode = statSync(wikiHelper).mode & 0o777;
+      assert.equal(
+        wikiMode & 0o111,
+        0o111,
+        `wiki copy must carry the source's executable bit, got ${wikiMode.toString(8)}`,
+      );
+
+      // (a) a second machine syncing the same wiki must install it executable too.
+      withTmpHome((home2) => {
+        const up = runWithHome('upgrade.mjs', ['--apply', `--hypo-dir=${hypoDir}`], home2);
+        assert.equal(up.status, 0, up.stderr);
+        const farHelper = join(home2, '.claude', 'skills', 'mine', 'run.sh');
+        const farMode = statSync(farHelper).mode & 0o777;
+        assert.equal(
+          farMode & 0o111,
+          0o111,
+          `far install must carry the executable bit, got ${farMode.toString(8)}`,
         );
       });
     });

--- a/tests/extensions.test.mjs
+++ b/tests/extensions.test.mjs
@@ -12,6 +12,8 @@ import {
   readdirSync,
   existsSync,
   symlinkSync,
+  chmodSync,
+  statSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { test, suite } from './harness.mjs';
@@ -100,6 +102,87 @@ test('upgrade-extensions-hard-copy-and-manifest-register', () => {
         settingsAfter,
         settingsBefore,
         'settings.json drifted across idempotent --apply',
+      );
+    });
+  });
+});
+
+// forward-sync must carry a wiki script's executable bit to the install target
+// (the bug this pins: a 755 wiki script always landed 644 on a fresh machine).
+test('forward-sync carries the executable bit on a fresh install (create branch)', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      writeExt(hypoDir, 'hooks', 'hypo-ext-runner.mjs', '#!/usr/bin/env node\n');
+      chmodSync(join(hypoDir, 'extensions', 'hooks', 'hypo-ext-runner.mjs'), 0o755);
+
+      const r = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(r.status, 0, `apply failed: ${r.stderr}`);
+
+      const installed = join(home, '.claude', 'hooks', 'hypo-ext-runner.mjs');
+      const mode = statSync(installed).mode & 0o777;
+      assert.equal(
+        mode & 0o111,
+        0o111,
+        `installed copy must carry the src's 755 exec bit, got ${mode.toString(8)}`,
+      );
+    });
+  });
+});
+
+// The 'up-to-date' branch (content already matches src) used to be a pure no-op:
+// a mode mismatch there was never healed, on any sync, ever. This pins the fix,
+// including that check-mode (no --apply) must count the mismatch as pending work
+// rather than reporting "up to date" while a stale bit sits on disk.
+test('forward-sync heals a stale exec bit when content is already up to date', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+
+      const srcPath = join(hypoDir, 'extensions', 'hooks', 'hypo-ext-stale.mjs');
+      writeExt(hypoDir, 'hooks', 'hypo-ext-stale.mjs', '#!/usr/bin/env node\n');
+      chmodSync(srcPath, 0o755);
+
+      const r1 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(r1.status, 0, `first apply failed: ${r1.stderr}`);
+      const installed = join(home, '.claude', 'hooks', 'hypo-ext-stale.mjs');
+
+      // Simulate a pre-fix install (or a user's own `chmod -x`): identical bytes,
+      // wrong mode.
+      chmodSync(installed, 0o644);
+
+      const check = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json'], home);
+      assert.equal(check.status, 1, `check mode must exit non-zero on pending work: ${check.stderr}`);
+      const checkOut = JSON.parse(check.stdout);
+      assert.equal(
+        checkOut.extensions.needsWork,
+        true,
+        'a mode-only mismatch must count as pending work, not "up to date"',
+      );
+
+      const r2 = runWithHome('upgrade.mjs', [`--hypo-dir=${hypoDir}`, '--json', '--apply'], home);
+      assert.equal(r2.status, 0, `second apply failed: ${r2.stderr}`);
+      const out2 = JSON.parse(r2.stdout);
+      const fixed = out2.applied.extensions.actions.find(
+        (a) => a.file === 'hooks/hypo-ext-stale.mjs',
+      );
+      assert.ok(fixed, 'the mode-only fix must show up in the actions list');
+      assert.equal(
+        fixed.action,
+        'update',
+        'a content-identical mode fix reuses the existing update action, not a new one',
+      );
+
+      const mode = statSync(installed).mode & 0o777;
+      assert.equal(
+        mode & 0o111,
+        0o111,
+        `stale 644 copy must be healed back to executable, got ${mode.toString(8)}`,
       );
     });
   });


### PR DESCRIPTION
# English

## What changed

The executable bit now survives the whole trip: from a local script, into the wiki, and out to every other machine. Both writers on that path take the source mode and apply it before the file becomes visible.

## Why

Capture a `755` helper script into the wiki and it arrived `644` everywhere else. A shell script that is not executable is not a shell script; the far machine gets a file it cannot run, with no error to explain it.

Capture printed a warning about this ("content is captured, but the executable bit is not carried by sync"), which is a strange thing for a tool to say about its own round trip. The warning is gone because the sentence is no longer true.

## How

Two writers dropped the mode, not one. `capture`'s `writeAtomic` lost it on the first write into the wiki, and forward-sync's `writeFreshAtomic` lost it again when installing the wiki copy. Neither took a mode argument at all, so umask decided.

Both now chmod the temp file before the rename, so the destination is never visible with the wrong bits. Only the execute bits travel (`mode & 0o111`); read and write bits keep whatever umask gave them, and setuid/setgid/sticky never move. Manifests and `.bak` backups deliberately pass no mode.

The `up-to-date` branch used to be a pure no-op when content already matched. A file with correct bytes and a stale mode stayed stale forever, on every sync, because nothing ever looked. It now heals the mode and reports it as an `update`, which means check mode counts a mode-only mismatch as pending work instead of claiming everything is current.

Fixing only the second writer would have been worse than the original bug, and cross-review reproduced exactly that. With capture still writing `644`, the new heal read the wiki's wrong mode as truth and wrote `644` back onto the user's original local file. Measured: `before=755 wiki=644 after=644`. The source of truth has to be the source.

Files we do not own stay untouched. Every skip branch returns before any chmod, and a symlink is still refused by the regular-file check.

Nothing is recorded in `hypo-pkg.json`. The SHA map's value schema is validated (`isFlatShaValue` accepts a hex string and nothing else), and widening it would reach into `uninstall`'s ownership judgment. The source mode is readable at every sync, so there is nothing to store. The cost, that a deliberate `chmod -x` on a content-identical file gets undone, is marked in the code with the upgrade path.

## Manual verification

The regression was pinned by reverting, not by passing. Removing only the two `srcMode` arguments at capture's call sites failed with `capture must not strip the original file's executable bit, got 644`, reproducing the cross-review finding exactly. Restored, then `--file=capture` green again at 95.

Suites: `npm test` 1915 passing, `--file=extensions` 75, `--file=capture` 95, `npm run lint` clean, `check:pack-surface` matches the snapshot.

## Migration notes

None. A file already installed with a stale mode is healed on the next sync rather than needing a reinstall, which is the point of the `up-to-date` change.

---

# 한국어

## 변경 내용

실행 비트가 전 구간을 살아서 건넌다. 로컬 스크립트에서 위키로, 위키에서 다른 모든 머신으로. 그 경로의 두 writer 가 원본 mode 를 받아 파일이 보이기 전에 적용한다.

## 이유

`755` 헬퍼 스크립트를 위키로 capture 하면 다른 곳에는 `644` 로 도착했다. 실행 안 되는 셸 스크립트는 셸 스크립트가 아니다. 먼 쪽 머신은 못 돌리는 파일을 받고, 그 이유를 알려 주는 에러는 없다.

capture 가 이걸 경고로 알리고 있었다("content is captured, but the executable bit is not carried by sync"). 도구가 자기 왕복에 대해 할 말로는 이상하다. 그 문장이 이제 참이 아니라서 경고를 걷어냈다.

## 방법

mode 를 흘린 writer 가 하나가 아니라 둘이었다. `capture` 의 `writeAtomic` 이 위키로 넣는 첫 쓰기에서 잃었고, forward-sync 의 `writeFreshAtomic` 이 그 위키 사본을 설치하며 또 잃었다. 둘 다 mode 인자가 아예 없어서 umask 가 정했다.

이제 둘 다 rename 전에 tmp 에 chmod 한다. 목적지가 잘못된 비트로 보이는 창이 없다. 실행 비트만 건너가고(`mode & 0o111`) 읽기·쓰기 비트는 umask 가 준 그대로다. setuid/setgid/sticky 는 옮기지 않는다. manifest 와 `.bak` 백업은 일부러 mode 를 안 넘긴다.

`up-to-date` 분기는 내용이 이미 같으면 아무것도 안 하는 자리였다. 바이트는 맞고 mode 만 어긋난 파일은 아무도 안 보기 때문에 영원히 어긋난 채였다. 이제 mode 를 고치고 그것을 `update` 로 보고한다. check 모드가 mode 만 어긋난 것도 남은 일로 세고, 다 최신이라고 말하지 않는다.

두 번째 writer 만 고쳤으면 원래 버그보다 나빠진다. 교차검토가 그것을 그대로 재현했다. capture 가 여전히 `644` 를 쓰는 상태에서 새 힐링이 위키의 틀린 mode 를 진실로 읽어 사용자의 원본 로컬 파일에 `644` 를 되썼다. 실측은 `before=755 wiki=644 after=644` 였다. 진실의 출처는 출처여야 한다.

우리 것이 아닌 파일은 그대로 둔다. 모든 skip 분기가 chmod 전에 반환하고, 심볼릭 링크는 여전히 정규 파일 검사에서 거부된다.

`hypo-pkg.json` 에는 아무것도 기록하지 않는다. SHA 맵의 값 스키마는 검증을 받고 있고(`isFlatShaValue` 는 hex 문자열만 통과시킨다), 그걸 넓히면 `uninstall` 의 소유 판정까지 번진다. 원본 mode 는 매 sync 마다 읽히므로 저장할 것이 없다. 대가는 내용이 같은 파일에 일부러 건 `chmod -x` 가 되돌려진다는 것이고, 그 사실과 업그레이드 경로를 코드에 표시해 뒀다.

## 수동 검증

회귀는 통과가 아니라 되돌려서 고정했다. capture 호출부의 `srcMode` 인자 둘만 빼자 `capture must not strip the original file's executable bit, got 644` 로 실패했고, 교차검토가 찾은 그것을 그대로 재현했다. 복구한 뒤 `--file=capture` 가 다시 95 로 통과했다.

스위트: `npm test` 1915 통과, `--file=extensions` 75, `--file=capture` 95, `npm run lint` 통과, `check:pack-surface` 스냅샷 일치.

## 마이그레이션 노트

없다. 이미 어긋난 mode 로 깔린 파일은 재설치 없이 다음 sync 에서 고쳐진다. `up-to-date` 변경이 노린 것이 그것이다.

---

## Changelog

- EN: Captured and synced files keep their executable bit end to end, so a `755` script no longer arrives `644` on another machine; a stale mode on an already-installed copy is healed on the next sync (#245).
- KO: capture 하고 sync 한 파일이 실행 비트를 끝까지 지킨다. `755` 스크립트가 다른 머신에 `644` 로 도착하지 않고, 이미 깔린 사본의 어긋난 mode 는 다음 sync 에서 고쳐진다 (#245).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
