### PR TITLE
fix(close): let a Stop hook's own write advance the base it just invalidated

### DIFF
--- a/hooks/hypo-hot-rebuild.mjs
+++ b/hooks/hypo-hot-rebuild.mjs
@@ -19,6 +19,7 @@ import {
   deriveRootLogEntries,
   recordTouchedPaths,
 } from './hypo-shared.mjs';
+import { advanceBase, hashContent } from './base-store.mjs';
 
 const HOT_PATH = join(HYPO_DIR, 'hot.md');
 const GROWTH_CACHE = join(HYPO_DIR, '.cache', 'last-session-growth.json');
@@ -73,7 +74,7 @@ function parsePointerRows(content) {
 }
 
 /** @returns {boolean} true when hot.md was actually rewritten. */
-function rebuild() {
+function rebuild(sessionId) {
   if (!existsSync(HOT_PATH)) return false;
 
   const current = readFileSync(HOT_PATH, 'utf-8');
@@ -116,6 +117,25 @@ ${tableRows}
 
   if (canonical !== current) {
     writeFileSync(HOT_PATH, canonical);
+    // This write bypasses the Write/Edit tool, so hypo-auto-stage's
+    // PostToolUse-based advanceBaseForWrite never sees it (see the file-header
+    // comment above). Without advancing the base here, this session's own
+    // rewrite of hot.md looks -- at close time -- exactly like a DIFFERENT
+    // session having edited it, and the observed-base guard in crystallize.mjs
+    // parks a false conflict against this session's own work. Mirrors
+    // crystallize.mjs's overwrite(): advanceBase right after the write that
+    // made it true.
+    //
+    // No session_id on stdin (empty/malformed payload): advanceBase is a
+    // no-op without a snapshot anyway, so this stays silent-safe like before
+    // this fix -- just observable on stderr instead of a guess.
+    if (sessionId) {
+      advanceBase(HYPO_DIR, sessionId, 'hot.md', hashContent(canonical));
+    } else {
+      process.stderr.write(
+        '[hypo-hot-rebuild] no session_id on stdin; base not advanced for hot.md\n',
+      );
+    }
     return true;
   }
   return false;
@@ -134,7 +154,7 @@ function emitGrowth() {
 
 let hotWritten = false;
 try {
-  hotWritten = rebuild();
+  hotWritten = rebuild(sessionId);
 } catch (err) {
   process.stderr.write(`[hypo-hot-rebuild] error: ${err?.message ?? String(err)}\n`);
 }

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -29,6 +29,13 @@ import {
   readSyncLastSuccess,
   classifySyncOp,
 } from '../hooks/hypo-shared.mjs';
+import {
+  snapshotBase,
+  readBaseEntry,
+  advanceBase,
+  hashContent,
+  overwriteTargets,
+} from '../hooks/base-store.mjs';
 import { test, suite } from './harness.mjs';
 import {
   HOME,
@@ -42,10 +49,12 @@ import {
   formatGrowthMetrics,
   hypoIsClean,
   markerPath,
+  payloadForCleanWiki,
   peekTouchedPaths,
   precompactGateStatus,
   recordTouchedPaths,
   run,
+  runApply,
   runFirstPrompt,
   runStop,
   syncRemote,
@@ -54,6 +63,7 @@ import {
   withGrowthWiki,
   withSyncedWiki,
   withTmpDir,
+  withWiki,
   writeMarker,
 } from './helpers.mjs';
 
@@ -189,6 +199,127 @@ test('markdown link row is silently excluded when mixed with a valid wikilink ro
     assert.ok(
       !result.includes('bad-project'),
       'markdown link row must be excluded from rebuilt output',
+    );
+  });
+});
+
+suite('hypo-hot-rebuild.mjs — same-session base advance (root hot.md drift fix)');
+
+// hot-rebuild rewrites hot.md with a direct writeFileSync, which
+// hypo-auto-stage's PostToolUse-based advanceBaseForWrite never sees (it only
+// fires for a Write/Edit/MultiEdit TOOL call). Before this fix, that write
+// left the session's observed base for hot.md pointing at the pre-rebuild
+// bytes, so a later --apply-session-close with the (correct, post-rebuild)
+// content parked as a false 'base-mismatch' conflict against its own
+// session's edit.
+//
+// The stale row seeded below has nothing to do with a date rollover (it is a
+// deliberately wrong literal date), so this pins the general case: ANY
+// same-day rewrite hot-rebuild makes must still keep the base in sync, not
+// only one triggered by the calendar turning over at midnight.
+test('hot-rebuild advances this session base to the bytes it just wrote, so a matching apply does not park', () => {
+  withWiki(
+    (dir, today) => {
+      const rootHotPath = join(dir, 'hot.md');
+      writeFileSync(
+        rootHotPath,
+        readFileSync(rootHotPath, 'utf-8').replace(
+          `| test-project | ${today} |`,
+          '| test-project | 2000-01-01 |',
+        ),
+      );
+    },
+    (dir, today) => {
+      const sid = 'sess-hotrebuild-advance';
+      snapshotBase(dir, sid, overwriteTargets('test-project'));
+      const baseBefore = readBaseEntry(dir, sid, 'hot.md');
+      assert.equal(baseBefore.state, 'hash', 'snapshotBase must have recorded a base for hot.md');
+
+      const r = runStop('hypo-hot-rebuild.mjs', dir, { session_id: sid });
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+
+      const disk = readFileSync(join(dir, 'hot.md'), 'utf-8');
+      assert.ok(
+        disk.includes(`| test-project | ${today} |`),
+        'hot-rebuild must have corrected the stale row',
+      );
+
+      // Assertion 1: the base now matches what hot-rebuild actually wrote.
+      const baseAfter = readBaseEntry(dir, sid, 'hot.md');
+      assert.equal(
+        baseAfter.hash,
+        hashContent(disk),
+        'hot-rebuild must advance this session base to the bytes it just wrote',
+      );
+      assert.notEqual(baseAfter.hash, baseBefore.hash, 'the base must have MOVED off the stale snapshot');
+
+      // Assertion 2: an apply carrying VALID BUT BYTE-DISTINCT content (one
+      // trailing newline off disk, the exact shape that reproduced the false
+      // park during the investigation) actually reaches the base check
+      // instead of short-circuiting on it. A payload byte-identical to disk
+      // would hit crystallize.mjs's idempotent skip BEFORE the base is ever
+      // consulted, so it would pass here even with a stale base and prove
+      // nothing about the advance this test exists to pin.
+      const proposed = disk.endsWith('\n') ? disk.slice(0, -1) : `${disk}\n`;
+      const payload = payloadForCleanWiki(dir, today);
+      payload.rootHot = { content: proposed };
+      const r2 = runApply(dir, payload, { sessionId: sid });
+      const out = JSON.parse(r2.stdout);
+      assert.equal(out.ok, true, `apply must not park: ${r2.stdout}`);
+      assert.deepEqual(out.conflicts ?? [], [], `no conflict expected: ${r2.stdout}`);
+      assert.ok(
+        (out.applied ?? []).some((a) => a.includes('rootHot')),
+        `rootHot must have gone through the base check and been written, not merely skipped: ${r2.stdout}`,
+      );
+    },
+  );
+});
+
+test('hot-rebuild leaves the base untouched when the file is already canonical (no write, no advance)', () => {
+  withTmpDir((dir) => {
+    // Byte-exact match to rebuild()'s own canonical template (hooks/hypo-hot-
+    // rebuild.mjs), computed the same way it computes `today` (UTC, not
+    // local), so canonical === current and this hook is a true no-op. Reusing
+    // buildCleanWikiTree()'s simpler hot.md here would NOT be a no-op: its
+    // shape already differs structurally from the canonical template, so
+    // rebuild() would always rewrite it regardless of date.
+    const rebuildToday = new Date().toISOString().slice(0, 10);
+    writeFileSync(
+      join(dir, 'hot.md'),
+      `---\ntitle: Hot Cache — Pointer\ntype: reference\nupdated: ${rebuildToday}\ntags: [wiki, operations]\n---\n\n` +
+        `# Hot Cache\n\n> Read at session start → navigate to the relevant project session-state.md and hot.md.\n` +
+        `> Update at session close: project session-state.md, project hot.md, and this file's "Active Projects" table.\n\n` +
+        `## Active Projects\n\n| Project | Last Session | Hot Cache |\n|---|---|---|\n` +
+        `| my-project | ${rebuildToday} | [[projects/my-project/hot]] |\n\n` +
+        `## Session Start Checklist\n\n1. Check this file for the relevant project link\n` +
+        `2. Read \`projects/<name>/session-state.md\` for next tasks if it exists\n` +
+        `3. Read \`projects/<name>/hot.md\` for project background\n`,
+    );
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+
+    const sid = 'sess-hotrebuild-noop';
+    snapshotBase(dir, sid, ['hot.md']);
+    // Force the recorded base to a SENTINEL that is deliberately wrong (not
+    // the disk hash). If the fixture's base already matched disk (as a plain
+    // snapshot would, since disk is already canonical here), a stray
+    // advanceBase call outside the write branch would just re-record the
+    // SAME hash and this assertion would pass for the wrong reason -- it
+    // would never actually observe a call that fires when it should not.
+    // With a sentinel, any advanceBase call is forced to overwrite it with
+    // the real disk hash, which this assertion can tell apart from "untouched".
+    const SENTINEL_HASH = 'sentinel-does-not-match-disk';
+    advanceBase(dir, sid, 'hot.md', SENTINEL_HASH);
+    const baseBefore = readBaseEntry(dir, sid, 'hot.md');
+    assert.equal(baseBefore.hash, SENTINEL_HASH, 'sentinel must be in place before the hook runs');
+
+    const r = runStop('hypo-hot-rebuild.mjs', dir, { session_id: sid });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+
+    const baseAfter = readBaseEntry(dir, sid, 'hot.md');
+    assert.equal(
+      baseAfter.hash,
+      SENTINEL_HASH,
+      'a no-op rebuild must not touch the observed base (advanceBase must not fire outside the write branch)',
     );
   });
 });


### PR DESCRIPTION
# English

## What changed

`hypo-hot-rebuild` now advances the observed base for `hot.md` right after its own write, in the same branch as that write.

## Why

Closing a session parked the root `hot.md` as a conflict while the proposed content and the file on disk were byte-for-byte identical. The guard was reading a base that this very session had made stale.

The hook rewrites `hot.md` from a Stop hook with a direct `writeFileSync`. That bypasses the Write/Edit tools, so the PostToolUse path that advances the base never sees it, and nothing else advanced it either. At close time the observed-base guard compared the session's own rewrite against a base snapshotted before it, and reported it as someone else's edit. The user sees a conflict they cannot resolve, because there is no other party.

## How

The advance sits immediately after the write, inside `if (canonical !== current)`, mirroring what the close path already does after its own write. A rebuild that changes nothing writes nothing and advances nothing. Without a session id on stdin the write still happens and the advance is skipped, which is the old behavior, now visible on stderr rather than silent.

Two earlier explanations for this were wrong, and both are worth recording because each looked convincing.

The first said the hook rewrites `hot.md` on every Stop. It does not; it compares first and returns early when the bytes match.

The second said this only bites after midnight, when the date inside the rebuilt content changes. A scenario with no date rollover reproduces the same park: any change to the pointer table is enough, and a project's own `updated:` field moving is enough to cause one.

Note what does not explain it either. A byte-identical payload never parks, even with a stale base, because the idempotent skip runs before the base check. Staleness alone is not the story, which is why the fix targets the base rather than that comparison.

## Manual verification

The regression is pinned by reverting, not by passing.

Moving the advance outside the write branch makes the no-op assertion fail: the sentinel hash it seeds is overwritten with the real disk hash. That assertion previously passed even with a stray advance, because the fixture's base hash already equalled the canonical hash; seeding a deliberate sentinel is what gives it teeth.

Deleting the advance entirely makes the apply assertion fail with `stage: proposal-pending`, `reason: base-mismatch`, reproducing the original park.

Suites: `npm test` 1930 passing, `--file=session-hooks` 151, `npm run lint` clean.

One full-suite run during this work reported a single unrelated failure in the feedback area, under heavy load from several concurrent suites (466s wall). The same suite passes at 132s on the same commit, and the feedback area passes in isolation at 105. The condition was not pinned down, so this is recorded as observed rather than diagnosed.

## Migration notes

None. The base is per-session state; existing sessions get the correct behavior on their next rebuild.

---

# 한국어

## 변경 내용

`hypo-hot-rebuild` 가 자기 쓰기 직후에 `hot.md` 의 관찰 base 를 전진시킨다. 그 쓰기와 같은 분기 안이다.

## 이유

세션을 닫을 때 루트 `hot.md` 가 충돌로 파킹됐는데, 제안한 내용과 디스크의 파일이 바이트 단위로 같았다. 가드가 읽은 base 를 낡게 만든 것이 바로 그 세션 자신이었다.

이 훅은 Stop 훅에서 `writeFileSync` 로 `hot.md` 를 직접 고쳐 쓴다. Write/Edit 도구를 거치지 않으므로 base 를 전진시키는 PostToolUse 경로가 그것을 못 보고, 다른 무엇도 전진시키지 않았다. close 시점에 관찰-base 가드는 세션 자신의 재작성을 그 전에 찍힌 base 와 비교하고 남의 편집이라고 보고했다. 사용자는 풀 수 없는 충돌을 본다. 상대가 없기 때문이다.

## 방법

전진은 쓰기 바로 뒤 `if (canonical !== current)` 안에 있다. close 경로가 자기 쓰기 뒤에 이미 하는 것과 같은 형태다. 아무것도 안 바꾸는 재작성은 쓰지도 전진시키지도 않는다. stdin 에 세션 id 가 없으면 쓰기는 그대로 하고 전진만 건너뛴다. 예전과 같은 동작이고, 이제 조용하지 않고 stderr 에 보인다.

이 결함의 원인으로 적혔던 설명 둘이 틀렸다. 둘 다 그럴듯했기 때문에 기록해 둔다.

첫째는 훅이 Stop 마다 `hot.md` 를 다시 쓴다는 것이었다. 그렇지 않다. 먼저 비교하고 바이트가 같으면 일찍 반환한다.

둘째는 자정을 넘겨 재작성 내용 안의 날짜가 바뀔 때만 문다는 것이었다. 날짜가 안 넘어가는 시나리오가 같은 파킹을 재현한다. 포인터 테이블이 바뀌기만 하면 되고, 어떤 프로젝트의 `updated:` 하나가 움직여도 그렇게 된다.

설명이 안 되는 것도 적어 둔다. 바이트가 같은 payload 는 base 가 낡아도 파킹되지 않는다. 멱등 스킵이 base 검사보다 먼저 돌기 때문이다. base 가 낡았다는 사실만으로는 이야기가 완성되지 않고, 그래서 이 수정이 겨눈 것은 그 비교가 아니라 base 다.

## 수동 검증

회귀는 통과가 아니라 되돌려서 고정했다.

전진을 쓰기 분기 밖으로 옮기면 no-op 단언이 실패한다. 그 단언이 심어 둔 sentinel 해시가 실제 디스크 해시로 덮인다. 이 단언은 전에는 전진이 새어 나가도 통과했다. 픽스처의 base 해시가 이미 canonical 해시와 같았기 때문이다. 일부러 어긋나는 sentinel 을 심는 것이 이 단언에 이빨을 준다.

전진을 통째로 지우면 apply 단언이 `stage: proposal-pending`, `reason: base-mismatch` 로 실패한다. 원래의 파킹이 그대로 재현된다.

스위트: `npm test` 1930 통과, `--file=session-hooks` 151, `npm run lint` 통과.

작업 중 전체 스위트 한 번에서 feedback 영역의 무관한 실패 1건이 나왔다. 여러 스위트가 동시에 도는 무거운 부하에서였다(466초). 같은 커밋이 132초에서는 통과하고, feedback 영역 단독 실행도 105건 통과다. 조건을 특정하지 못했으므로 진단이 아니라 관측으로 적는다.

## 마이그레이션 노트

없다. base 는 세션별 상태이고, 기존 세션은 다음 재작성부터 올바른 동작을 받는다.

---

## Changelog

- EN: Closing a session no longer parks the root `hot.md` as a false conflict against the session's own Stop-hook rewrite (#246).
- KO: 세션을 닫을 때 루트 `hot.md` 가 그 세션 자신의 Stop 훅 재작성을 상대로 가짜 충돌을 내지 않는다 (#246).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
