### PR TITLE
fix(close): scope the marker gate's cleanliness check to what this session owns

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -445,6 +445,72 @@ export function hypoIsClean(dir = HYPO_DIR) {
   }
 }
 
+/**
+ * Repo-relative POSIX paths with uncommitted changes (tracked or untracked) in
+ * `dir`. Reuses the SAME `-z` rename-aware porcelain parsing as
+ * commitWikiChanges (PR #222): a rename or copy emits `to\0from`, and both
+ * sides count as dirty (a rename's source still shows staged until the rename
+ * itself lands). This is the read-only half of that fix's pathspec boundary:
+ * commitWikiChanges narrows what gets COMMITTED to a caller-supplied scope;
+ * this narrows what counts as a BLOCKER the same way, for precompactGateStatus
+ * to attribute dirty files to the session that owns them instead of the whole
+ * shared working tree.
+ *
+ * Paths are normalized to be relative to `dir` itself, NOT to the git
+ * repository's top level: `git -C <dir> status --porcelain` prints paths
+ * relative to the repo TOP LEVEL even under `-C` (verified empirically: a
+ * vault nested under `<repo>/vault/` reports `vault/hot.md`, not `hot.md`).
+ * Every other path this file compares against (closeAccountableScope,
+ * closeFileTargetsGlobal, extractTouchedWikiFiles) is `dir`-relative, so
+ * without this normalization a nested vault's OWN files would never match
+ * its own scope and every one of them would look foreign (codex pre-commit
+ * review BLOCKER 2). `git rev-parse --show-prefix` gives exactly the prefix
+ * to strip; a dirty path that does not start with it lives outside the
+ * vault entirely (the rest of a bigger host repo) and is dropped, never
+ * "mine".
+ *
+ * @returns {string[]} dirty paths relative to `dir`, or `[]` on any git
+ *   failure (the caller already has its own git-status result via
+ *   hypoIsClean and treats that failure as an unconditional blocker; an
+ *   empty return here just means "cannot attribute", not "clean").
+ */
+function gitDirtyFiles(dir) {
+  const prefixRes = spawnSync('git', ['-C', dir, 'rev-parse', '--show-prefix'], {
+    encoding: 'utf-8',
+  });
+  if (prefixRes.status !== 0) return []; // can't resolve the repo → cannot attribute
+  const prefix = (prefixRes.stdout || '').trim();
+
+  const porcelain = spawnSync('git', ['-C', dir, 'status', '--porcelain', '-uall', '-z'], {
+    encoding: 'utf-8',
+  });
+  if (porcelain.status !== 0) return [];
+  const out = [];
+  const records = (porcelain.stdout || '').split('\0');
+  const toDirRelative = (f) => {
+    if (!f) return null;
+    if (!prefix) return f; // dir IS the repo top level, nothing to strip
+    return f.startsWith(prefix) ? f.slice(prefix.length) : null; // outside the vault
+  };
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i];
+    if (!rec) continue;
+    const xy = rec.slice(0, 2);
+    const file = rec.slice(3); // destination path for a rename/copy
+    const isRenameOrCopy = xy[0] === 'R' || xy[1] === 'R' || xy[0] === 'C' || xy[1] === 'C';
+    let fromFile = null;
+    if (isRenameOrCopy) {
+      i++;
+      fromFile = records[i] || null;
+    }
+    const rel = toDirRelative(file);
+    if (rel) out.push(rel);
+    const relFrom = toDirRelative(fromFile);
+    if (relFrom) out.push(relFrom);
+  }
+  return out;
+}
+
 export function hotMdIsClean(dir = HYPO_DIR) {
   const hotPath = dir === HYPO_DIR ? HOT_PATH : join(dir, 'hot.md');
   if (!existsSync(hotPath)) return { clean: true };
@@ -3281,22 +3347,32 @@ function toHypoRel(absPath, hypoDir) {
 }
 
 /**
- * Repo-relative POSIX paths of wiki files this session edited via direct
- * Edit/Write/MultiEdit/NotebookEdit tool_use. Returns a Set; empty when the
- * transcript is missing/unreadable (callers decide the fallback). A per-line
- * JSON parse error skips that line only (transcripts occasionally truncate).
+ * Same walk as extractTouchedWikiFiles, but also reports whether the walk can
+ * be TRUSTED as a complete enumeration: `trusted: false` when the transcript
+ * is missing, unreadable, or contains a line that failed to parse (transcripts
+ * occasionally truncate mid-write). `extractTouchedWikiFiles` collapses all of
+ * that to an empty/partial Set, indistinguishable from "this session touched
+ * nothing", which is fine for lint's existing debt-partition (a false notice is not a
+ * false pass), but NOT fine for an attribution-sensitive caller like
+ * precompactGateStatus's git-scope check: treating an untrustworthy empty Set
+ * as "nothing to widen" would let a session's own dirty file, invisible only
+ * because its transcript could not be read, pass as someone else's foreign
+ * debt (codex pre-commit review BLOCKER 1).
+ *
+ * @returns {{files: Set<string>, trusted: boolean}}
  */
-export function extractTouchedWikiFiles(transcriptPath, hypoDir) {
+export function extractTouchedWikiFilesWithTrust(transcriptPath, hypoDir) {
   const out = new Set();
   if (!transcriptPath || typeof transcriptPath !== 'string' || !existsSync(transcriptPath)) {
-    return out;
+    return { files: out, trusted: false };
   }
   let raw;
   try {
     raw = readFileSync(transcriptPath, 'utf-8');
   } catch {
-    return out;
+    return { files: out, trusted: false };
   }
+  let trusted = true;
   for (const line of raw.split('\n')) {
     const t = line.trim();
     if (!t) continue;
@@ -3304,6 +3380,7 @@ export function extractTouchedWikiFiles(transcriptPath, hypoDir) {
     try {
       entry = JSON.parse(t);
     } catch {
+      trusted = false; // a truncated/corrupt line: the walk may be incomplete
       continue;
     }
     for (const fp of extractTranscriptToolFilePaths(entry)) {
@@ -3311,7 +3388,19 @@ export function extractTouchedWikiFiles(transcriptPath, hypoDir) {
       if (rel) out.add(rel);
     }
   }
-  return out;
+  return { files: out, trusted };
+}
+
+/**
+ * Repo-relative POSIX paths of wiki files this session edited via direct
+ * Edit/Write/MultiEdit/NotebookEdit tool_use. Returns a Set; empty when the
+ * transcript is missing/unreadable (callers decide the fallback). A per-line
+ * JSON parse error skips that line only (transcripts occasionally truncate).
+ * A caller that needs to tell "genuinely empty" apart from "could not fully
+ * enumerate" wants extractTouchedWikiFilesWithTrust instead.
+ */
+export function extractTouchedWikiFiles(transcriptPath, hypoDir) {
+  return extractTouchedWikiFilesWithTrust(transcriptPath, hypoDir).files;
 }
 
 /**
@@ -3539,20 +3628,89 @@ export function precompactGateStatus(hypoDir, opts = {}) {
   const marker = opts.sessionId ? readSessionClosedMarker(hypoDir, opts.sessionId) : null;
   const logOnly = opts.logOnly === true || marker?.scope === 'log-only';
 
-  // 1. wiki git state. Uncommitted changes (real unsaved work) BLOCK:
-  //    they are human-fixable. Unpushed commits (ahead) DEMOTE to a notice: push is
+  // Paths this session is accountable for at THIS close: the same signals the
+  // lint partition below already trusts for exactly this question ("is this
+  // file mine or pre-existing debt"), hoisted so the git check (step 1) can
+  // partition on it too. Base = the mandatory close-target files (opts.lintScope
+  // override, else the log-only shared root files, else one project's close
+  // files under projectOverride, else every today-active project's); widened by
+  // every file this session's transcript shows it editing directly.
+  const closeAccountableScope = new Set(
+    opts.lintScope ||
+      (logOnly
+        ? ['hot.md', 'log.md']
+        : opts.projectOverride
+          ? closeFileTargetsForProject(hypoDir, opts.projectOverride)
+          : closeFileTargetsGlobal(hypoDir)),
+  );
+  // Trust signal for the git-scope check below (codex pre-commit review
+  // BLOCKER 1): closeAccountableScope's mandatory-files base is always
+  // reliable, but the transcript widening that catches an ad hoc page this
+  // session edited is only as good as the transcript. No opts.transcriptPath
+  // at all, an unreadable file, or a line that fails to parse all mean the
+  // widened scope may be under-inclusive, NOT that this session touched
+  // nothing extra. Only a fully-read, fully-parsed transcript earns
+  // sessionTouchTrusted:true. A single tool_use with no file_path does NOT
+  // lower trust: most tool_use blocks (Read, Bash, Grep, ...) never carry one
+  // and that is expected, not corruption, so treating it as untrustworthy
+  // would make almost every real transcript untrusted and defeat the scoping
+  // this fix exists to add.
+  let sessionTouchTrusted = false;
+  if (opts.transcriptPath) {
+    const widened = extractTouchedWikiFilesWithTrust(opts.transcriptPath, hypoDir);
+    sessionTouchTrusted = widened.trusted;
+    for (const f of widened.files) closeAccountableScope.add(f);
+  }
+
+  // 1. wiki git state. Uncommitted changes (real unsaved work) BLOCK, but only
+  //    the ones inside closeAccountableScope, and only when sessionTouchTrusted
+  //    (above) says that scope can actually be trusted: a session's own scoped
+  //    auto-commit (commitWikiChanges, PR #222) can leave the working tree
+  //    non-empty when a DIFFERENT session sharing this vault still has its own
+  //    file dirty, the 2026-08-03 multi-session block. That dirty file is
+  //    human-fixable by whoever owns it, not by this session, so it demotes to
+  //    a notice (listed by path, never silently dropped) instead of refusing
+  //    this session's marker. A dirty file THIS session owns still blocks
+  //    unconditionally (fail-closed is unchanged for scope this session
+  //    actually touched), and so does an unattributable state: a git failure
+  //    gitDirtyFiles can't enumerate (dirty.length === 0 despite
+  //    git.uncommitted === true), OR a scope we cannot trust
+  //    (!sessionTouchTrusted) both fall back to the original unscoped blocker:
+  //    "cannot attribute" is not "clean".
+  //    Unpushed commits (ahead) DEMOTE to a notice regardless of scope: push is
   //    automatic (auto-commit Stop hook) and its failures are already non-fatal, so
   //    "ahead" is a transient sync state, not a human-fixable blocker. Demoting it
   //    here (the shared gate) keeps the marker == compact-ready invariant:
   //    a committed-but-unpushed close marks AND compacts, instead of the close writer
   //    committing its own payload and then being blocked by its own (unpushed) commit.
   const git = hypoIsClean(hypoDir);
-  if (git.uncommitted) blockers.push({ type: 'git', reason: git.reason });
-  else if (git.ahead)
+  if (git.uncommitted) {
+    const dirty = gitDirtyFiles(hypoDir);
+    if (dirty.length === 0 || !sessionTouchTrusted) {
+      blockers.push({ type: 'git', reason: git.reason });
+    } else {
+      const mine = dirty.filter((f) => closeAccountableScope.has(posixPath(f)));
+      const foreign = dirty.filter((f) => !closeAccountableScope.has(posixPath(f)));
+      if (mine.length > 0) {
+        blockers.push({
+          type: 'git',
+          reason: `uncommitted changes in ${hypoDir}: ${mine.join(', ')}`,
+        });
+      }
+      for (const f of foreign) {
+        notices.push({
+          type: 'git',
+          file: f,
+          reason: `uncommitted changes outside this session's scope: ${f}`,
+        });
+      }
+    }
+  } else if (git.ahead) {
     notices.push({
       type: 'git-sync',
       reason: `unpushed commits in ${hypoDir} (push deferred to Stop hook)`,
     });
+  }
 
   // 2. root hot.md structure
   const hot = hotMdIsClean(hypoDir);
@@ -3762,25 +3920,13 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       const parsed = JSON.parse(r.stdout);
       const allErrors = parsed.errors || [];
       const allW8 = (parsed.warns || []).filter((w) => w.id === 'W8');
-      // log-only base scope = the shared root files only (hot.md / log.md) — NOT
-      // closeFileTargetsGlobal, which would fold the active/phantom project's
-      // mandatory files in and re-introduce the cross-project attribution. The
-      // session's own transcript-touched files are still added below (a log-only
-      // session is accountable for the wiki files it actually edited).
-      // Lint scope: explicit opts.lintScope wins; else log-only uses the shared
-      // root files only; else projectOverride narrows to that one project's close
-      // files (matching the narrowed close status above); else the global set.
-      const scope = new Set(
-        opts.lintScope ||
-          (logOnly
-            ? ['hot.md', 'log.md']
-            : opts.projectOverride
-              ? closeFileTargetsForProject(hypoDir, opts.projectOverride)
-              : closeFileTargetsGlobal(hypoDir)),
-      );
-      if (opts.transcriptPath && existsSync(opts.transcriptPath)) {
-        for (const f of extractTouchedWikiFiles(opts.transcriptPath, hypoDir)) scope.add(f);
-      }
+      // Lint scope = closeAccountableScope, hoisted above step 1 so the git
+      // check can partition on the same "is this mine" answer. See that
+      // hoisted comment for what feeds it (opts.lintScope override, else
+      // log-only's shared root files, else one project's close files under
+      // projectOverride, else the global set, widened by transcript-touched
+      // files).
+      const scope = closeAccountableScope;
       const part = partitionLintScope(allErrors, scope);
       if (part.blocking.length > 0) {
         blockers.push({

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -1179,7 +1179,7 @@ test('uncommitted wiki + conditional close phrase, no decline → reconfirm bloc
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
       {
         type: 'user',
         message: { role: 'user', content: '구현 완료하면 세션 마무리하자' },
@@ -1221,7 +1221,7 @@ test('a correlated "아직, 계속" decline suppresses the reconfirm → continu
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
       { type: 'user', message: { role: 'user', content: '구현 완료하면 세션 마무리하자' } },
       askCloseReconfirmToolUse('q1'),
       {
@@ -1296,7 +1296,7 @@ test('decline label variants ("나중에" / "later") also suppress (label-drift 
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
       { type: 'user', message: { role: 'user', content: '구현 완료하면 세션 마무리하자' } },
       askCloseReconfirmToolUse('q1'),
       {
@@ -1334,7 +1334,7 @@ test('genuine close-now + uncommitted, no decline → still reconfirm block (no 
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
       { type: 'user', message: { role: 'user', content: '다 끝났으면 세션 마무리하자' } },
     ]);
     const r = runAutoMinimal(dir, {
@@ -1501,7 +1501,7 @@ test('absent background_tasks + uncommitted → in-flight fails open, git alone 
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: {} }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
       { type: 'user', message: { role: 'user', content: '오늘은 이만 마무리하자' } },
     ]);
     // No background_tasks key at all in the payload.
@@ -1580,8 +1580,12 @@ test('--mark-session-closed with failing gate → exit 1, no marker', () => {
 // while close work is still uncommitted.
 test('--mark-session-closed with ok gate but dirty git → exit 1, no marker (ADR Q2 regression)', () => {
   withWiki(null, (dir) => {
-    // Introduce uncommitted change AFTER buildCleanWikiTree's commit.
-    writeFileSync(join(dir, 'untracked.md'), 'dirty\n');
+    // Introduce uncommitted change AFTER buildCleanWikiTree's commit. `hot.md`
+    // is always inside the git-blocker's accountable scope (see
+    // precompactGateStatus's closeAccountableScope), unlike an arbitrary root
+    // file, so dirtying it still proves THIS session's own uncommitted work
+    // blocks unconditionally under the multi-session scoping added below.
+    appendFileSync(join(dir, 'hot.md'), '\ndirty\n');
     const r = run('crystallize.mjs', [
       `--hypo-dir=${dir}`,
       '--mark-session-closed',
@@ -2465,7 +2469,10 @@ test('--log-only: active project not closed today → marker written, project:nu
 // log-only is NOT a global-gate bypass: git must still be clean.
 test('--log-only: dirty git still blocks (not a global bypass)', () => {
   withWiki(null, (dir) => {
-    writeFileSync(join(dir, 'untracked.md'), 'dirty\n');
+    // hot.md is in the log-only base scope (['hot.md', 'log.md']) unconditionally,
+    // so dirtying it still proves the git blocker fires for the session's own
+    // scope, not merely for any dirty file in the vault.
+    appendFileSync(join(dir, 'hot.md'), '\ndirty\n');
     const r = run('crystallize.mjs', [
       `--hypo-dir=${dir}`,
       '--mark-session-closed',

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   rmSync,
   writeFileSync,
+  appendFileSync,
   readFileSync,
   existsSync,
   symlinkSync,
@@ -2635,13 +2636,204 @@ test('precompactGateStatus: ahead-only → NO git blocker, has git-sync notice',
   });
 });
 
-test('precompactGateStatus: uncommitted change → git blocker (unchanged)', () => {
+// BASE-SCOPE test: hot.md is in closeFileTargetsGlobal unconditionally, with
+// or without a transcript, so this proves only that a dirty file INSIDE the
+// deterministic base scope always blocks. It does NOT exercise the
+// transcript-trust gate below (a broken trust check cannot turn this test
+// red, because hot.md never depends on it) -- that is what the two
+// attribution-unknown tests further down are for, using pages/mine.md, a
+// file that enters scope ONLY via a trusted transcript.
+test('precompactGateStatus: uncommitted change in the base scope (hot.md) → git blocker', () => {
   withSyncedWiki((dir) => {
-    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    appendFileSync(join(dir, 'hot.md'), '\ndirty\n');
     const gate = precompactGateStatus(dir, { claudeHome: join(dir, '.claude-none') });
     assert.ok(
       (gate.blockers || []).some((b) => b.type === 'git'),
-      `uncommitted work must still be a git blocker: ${JSON.stringify(gate.blockers)}`,
+      `uncommitted work in the base scope must still be a git blocker: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+// 2026-08-03 multi-session incident: this session's own scoped commit
+// (commitWikiChanges, PR #222) can leave the working tree non-empty when a
+// DIFFERENT session sharing the same vault still has its own file dirty. That
+// file is human-fixable by whoever owns it, not by this session, so it must
+// not refuse THIS session's close.
+test('precompactGateStatus: uncommitted change OUTSIDE this session\'s scope → notice, not a git blocker', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'unrelated-session.md'), "# another session's own edit\n");
+    // The partition only fires with a TRUSTED transcript (codex pre-commit
+    // review BLOCKER 1): a readable, fully-parseable transcript that shows
+    // this session editing hot.md only, never unrelated-session.md, is what
+    // earns the demotion below. Without a transcript the gate must fall back
+    // to the unscoped blocker instead (see the two attribution-unknown tests
+    // further down).
+    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const transcript = join(tdir, 't.jsonl');
+    writeFileSync(
+      transcript,
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'hot.md') } }] },
+      }) + '\n',
+    );
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      transcriptPath: transcript,
+    });
+    assert.ok(
+      !(gate.blockers || []).some((b) => b.type === 'git'),
+      `a foreign session's dirty file must NOT be a git blocker: ${JSON.stringify(gate.blockers)}`,
+    );
+    assert.ok(
+      (gate.notices || []).some(
+        (n) => n.type === 'git' && n.file === 'unrelated-session.md',
+      ),
+      `the foreign dirty file must still be listed by name in notices: ${JSON.stringify(gate.notices)}`,
+    );
+  });
+});
+
+// ATTRIBUTION-UNKNOWN tests (codex pre-commit review BLOCKER 1):
+// extractTouchedWikiFiles collapses "no transcript" and "genuinely touched
+// nothing" into the same empty Set, so a naive partition would let this
+// session's OWN dirty file get demoted to a notice just because there was
+// nothing to widen the scope with. pages/mine.md is deliberately OUTSIDE the
+// base scope (unlike hot.md above) -- it can only ever enter
+// closeAccountableScope via a trusted transcript widening, so it is the one
+// file that actually exercises the `sessionTouchTrusted` gate: deleting
+// `|| !sessionTouchTrusted` from the git check turns THESE two tests red
+// without touching the base-scope test above.
+test('precompactGateStatus: no transcript at all → a transcript-only-scope file still blocks (not demoted)', () => {
+  withSyncedWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'mine.md'), '# wip\n');
+    const gate = precompactGateStatus(dir, { claudeHome: join(dir, '.claude-none') });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `no transcript means unattributable, which must still block: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+test('precompactGateStatus: transcript with a corrupt line → a transcript-only-scope file still blocks', () => {
+  withSyncedWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'mine.md'), '# wip\n');
+    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const transcript = join(tdir, 't.jsonl');
+    // One well-formed line plus one truncated (mid-write) line: the walk
+    // still returns SOME files, but must not be trusted as complete.
+    writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'log.md') } }] },
+        }),
+        '{"type": "assistant", "message": {"content": [{"trunc',
+      ].join('\n') + '\n',
+    );
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      transcriptPath: transcript,
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `a corrupt transcript line means the scope cannot be trusted, which must still block: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+// codex pre-commit review BLOCKER 2: `git -C <dir> status --porcelain` prints
+// paths relative to the repo TOP LEVEL, not to `dir`, even under `-C`. A
+// vault living under a bigger host repo (`<repo>/vault/`) would report its
+// own `hot.md` as `vault/hot.md`, which never matches the vault-relative
+// `hot.md` in closeAccountableScope, so the session's OWN dirty file would
+// look foreign and pass. A trusted (parseable) transcript is required here so
+// the partition actually runs instead of falling back to the unscoped
+// blocker on attribution-unknown grounds.
+test('precompactGateStatus: vault nested under a bigger git repo, my hot.md dirty → still a git blocker', () => {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-nested-'));
+  try {
+    const vault = join(base, 'vault');
+    mkdirSync(vault, { recursive: true });
+    spawnSync('git', ['init', '-q'], { cwd: base });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: base });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: base });
+    writeFileSync(
+      join(vault, 'hot.md'),
+      '---\ntitle: Hot\nupdated: today\n---\n## Active Projects\n\n| Project | Last Session | Hot Cache |\n|---|---|---|\n',
+    );
+    writeFileSync(join(vault, 'log.md'), '# Log\n');
+    writeFileSync(join(base, 'host-repo-file.md'), '# unrelated content living outside the vault\n');
+    spawnSync('git', ['add', '-A'], { cwd: base });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: base });
+    appendFileSync(join(vault, 'hot.md'), '\ndirty\n');
+    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const transcript = join(tdir, 't.jsonl');
+    writeFileSync(
+      transcript,
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(vault, 'log.md') } }] },
+      }) + '\n',
+    );
+    const gate = precompactGateStatus(vault, {
+      claudeHome: join(vault, '.claude-none'),
+      transcriptPath: transcript,
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `hot.md dirty in a nested vault must still block (top-level path prefix bug): ${JSON.stringify(gate.blockers)}`,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// A rename touches TWO porcelain records (`to\0from`, see gitDirtyFiles); the
+// destination lands in scope here (session-state.md is a mandatory close
+// file), so the blocker must fire even though the change is carried as a
+// rename, not a plain modification.
+test('precompactGateStatus: a renamed file landing in scope → still a git blocker', () => {
+  withSyncedWiki((dir) => {
+    mkdirSync(join(dir, 'projects', 'demo'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'demo', 'draft.md'), '# draft session-state\n'.repeat(20));
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed draft']);
+    spawnSync('git', [
+      '-C',
+      dir,
+      'mv',
+      'projects/demo/draft.md',
+      'projects/demo/session-state.md',
+    ]);
+    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const transcript = join(tdir, 't.jsonl');
+    writeFileSync(
+      transcript,
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Write',
+              input: { file_path: join(dir, 'projects', 'demo', 'session-state.md') },
+            },
+          ],
+        },
+      }) + '\n',
+    );
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      transcriptPath: transcript,
+      projectOverride: 'demo',
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `a renamed file landing in scope must still block: ${JSON.stringify(gate.blockers)}`,
     );
   });
 });


### PR DESCRIPTION
# English

## What changed

The close marker gate no longer demands a globally clean working tree. It partitions dirty files: the ones this session is accountable for still block, the ones outside that scope demote to a notice listing them by path.

## Why

Two sessions sharing one vault could not both finish.

A session committed its own twelve files with an explicit pathspec, pushed, and asked for its close marker. The gate refused, because a different session working in the same vault still had one file dirty. The refusing condition had nothing to do with the session being refused.

The waiting session cannot resolve this. Committing or stashing someone else's in-progress work is precisely the boundary it must not cross. Its Stop chain stays open, and the skill correctly refuses to report a session as closed while the marker is missing, so it simply cannot finish.

## How

`hypoIsClean` still answers "is anything dirty". A new enumeration answers "which files", and the gate compares that list against the scope this session is accountable for: the mandatory close targets plus the files its transcript shows it editing.

Two ways that partition could quietly pass real work through, both surfaced in cross-review with reproductions:

**Losing attribution is not the same as owning nothing.** A missing transcript, an unreadable one, and a single unparsable line all produced an empty scope, indistinguishable from a session that genuinely touched nothing. The fallback only fired when git listed no files at all, so a file this session had edited could land in the notice bucket. Trust is now a separate signal. When it is absent the partition is skipped entirely and the original unscoped blocker stands.

**`git status --porcelain` reports paths from the repository top level, not from the directory given to `-C`.** A vault nested inside a larger repository yields `vault/hot.md` where the scope holds `hot.md`, so every file the session owned read as foreign. Paths are normalized through `rev-parse --show-prefix`; anything outside that prefix is dropped, and a failed `rev-parse` returns nothing, which routes to the unscoped blocker.

Unpushed commits keep their existing demotion to a notice, unchanged by this work.

## Manual verification

Each assertion was proven by disabling only the code it aims at, and by checking that nothing else went red.

Removing `|| !sessionTouchTrusted` fails exactly the two assertions that use a transcript-only file, and leaves the base-scope and foreign-file assertions passing. Pinning the computed prefix to `''` while leaving `rev-parse` itself intact fails only the nested-vault assertion. Dropping the destination path of a rename record fails only the rename assertion.

That targeting matters here. The first version of these tests dirtied `hot.md`, which is in the base scope unconditionally, so it blocked whether the trust gate existed or not: the assertion passed while measuring nothing. The reproduction that cross-review supplied used a file reachable only through a trusted transcript, and the assertions now use that shape.

Suites: `npm test` 1933 passing, `--file=session-hooks` 154, `--file=close-global` 131, `npm run lint` clean.

## Migration notes

None. The gate's decision changes only for dirty files outside the closing session's scope, which previously blocked and now surface as a notice.

---

# 한국어

## 변경 내용

close 마커 게이트가 워킹트리 전역 청결을 더는 요구하지 않는다. dirty 파일을 가른다. 이 세션이 책임지는 것은 여전히 막고, 그 스코프 밖은 파일명을 나열한 notice 로 낮춘다.

## 이유

한 볼트를 나눠 쓰는 두 세션이 둘 다 끝낼 수 없었다.

어떤 세션이 자기 파일 열둘을 경로를 명시해 커밋하고 push 한 뒤 close 마커를 요청했다. 게이트가 거절했다. 같은 볼트에서 일하던 **다른** 세션이 파일 하나를 아직 dirty 하게 두고 있었기 때문이다. 거절의 조건이 거절당한 세션과 아무 관계가 없다.

기다리는 쪽은 이것을 풀 수 없다. 남이 작업 중인 것을 커밋하거나 stash 하는 것은 넘지 말아야 할 바로 그 경계다. Stop 체인이 열린 채 남고, 마커가 없는 동안 스킬은 세션을 닫혔다고 보고하지 않는 것이 옳으므로, 그 세션은 그냥 끝날 수가 없다.

## 방법

`hypoIsClean` 은 여전히 "무엇이든 dirty 한가" 에 답한다. 새 열거가 "어느 파일인가" 에 답하고, 게이트는 그 목록을 이 세션이 책임지는 스코프와 대조한다. 스코프는 마감 대상 파일에 트랜스크립트가 보여 주는 이 세션의 편집 파일을 더한 것이다.

그 파티션이 진짜 작업을 조용히 통과시킬 수 있는 길 둘이 교차검토에서 재현과 함께 드러났다.

**귀속을 잃은 것과 가진 게 없는 것은 다르다.** 트랜스크립트가 없을 때, 못 읽을 때, 파싱 실패 줄이 하나 섞였을 때가 전부 빈 스코프를 냈고, 그것은 정말 아무것도 안 건드린 세션과 구분되지 않았다. fallback 은 git 이 파일을 하나도 안 낼 때만 돌았으므로, 이 세션이 편집한 파일이 notice 쪽으로 떨어질 수 있었다. 이제 신뢰가 별도 신호다. 신뢰가 없으면 파티션을 아예 안 걸고 원래의 전역 블로커가 선다.

**`git status --porcelain` 은 `-C` 로 준 디렉터리가 아니라 저장소 top-level 기준 경로를 낸다.** 더 큰 저장소 안에 든 볼트는 스코프가 `hot.md` 를 들고 있을 때 `vault/hot.md` 를 내므로, 그 세션이 가진 파일이 전부 남의 것으로 읽혔다. 경로를 `rev-parse --show-prefix` 로 정규화하고, 그 prefix 밖은 버린다. `rev-parse` 가 실패하면 아무것도 안 돌려주고, 그러면 전역 블로커로 간다.

push 안 된 커밋이 notice 로 낮아지는 기존 동작은 이 변경과 무관하게 그대로다.

## 수동 검증

단언마다 그것이 겨눈 코드만 무력화해 증명했고, 다른 것이 red 가 되지 않는지도 함께 봤다.

`|| !sessionTouchTrusted` 를 지우면 트랜스크립트로만 들어오는 파일을 쓰는 단언 **둘만** 실패하고 베이스 스코프 단언과 foreign 단언은 통과한다. `rev-parse` 는 그대로 두고 계산된 prefix 만 `''` 로 고정하면 nested-vault 단언 하나만 실패한다. rename 레코드의 목적지 경로를 버리면 rename 단언 하나만 실패한다.

이 조준이 여기서 중요하다. 이 테스트들의 첫 판본은 `hot.md` 를 dirty 하게 만들었는데, 그 파일은 무조건 베이스 스코프 안이라 신뢰 게이트가 있든 없든 막혔다. **단언은 통과하면서 아무것도 재지 않았다.** 교차검토가 준 재현은 신뢰 가능한 트랜스크립트로만 닿을 수 있는 파일을 썼고, 단언도 이제 그 형태를 쓴다.

스위트: `npm test` 1933 통과, `--file=session-hooks` 154, `--file=close-global` 131, `npm run lint` 통과.

## 마이그레이션 노트

없다. 게이트의 판정이 달라지는 것은 닫는 세션의 스코프 밖 dirty 파일뿐이고, 그것은 전에 막던 것이 이제 notice 로 드러난다.

---

## Changelog

- EN: A session can finish closing while another session sharing the same vault still has uncommitted work; only files the closing session is accountable for block its marker, and the rest are listed as a notice (#247).
- KO: 같은 볼트를 쓰는 다른 세션에 미커밋 작업이 남아 있어도 이 세션은 close 를 끝낼 수 있다. 마커를 막는 것은 닫는 세션이 책임지는 파일뿐이고 나머지는 notice 로 나열된다 (#247).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
