### PR TITLE
fix(lint): scan the close targets that live outside pages, projects and journal

### DIFF
--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -19,7 +19,7 @@
 import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { join, extname, basename } from 'path';
 import { resolveHypoRootInfo, checkVaultOrExit, expandHome } from './lib/hypo-root.mjs';
-import { SESSION_STATE_NEXT_HEADINGS } from '../hooks/hypo-shared.mjs';
+import { SESSION_STATE_NEXT_HEADINGS, closeFileTargetsGlobal } from '../hooks/hypo-shared.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import {
   parseSchemaVocab,
@@ -553,6 +553,50 @@ const pageDirs = parseSchemaPageDirs(args.hypoDir);
 const validTypes = new Set([...VALID_TYPES, ...parseSchemaTypes(args.hypoDir)]);
 
 for (const page of pages) lintPage(page, slugMap, tagVocab, pageDirs, validTypes);
+
+// W4 (broken-wikilink only, NOT the full lintPage) for close's root-level
+// write targets that fall outside pages/projects/journal: hot.md and log.md
+// today. closeFileTargetsGlobal is the one list of what close writes
+// (hooks/hypo-shared.mjs), reused here instead of re-derived, so a future
+// close target is covered automatically. Only the entries NOT already under
+// a scanDir are new; closeFileTargetsGlobal's projects/<slug>/* entries are
+// already linted in full above.
+//
+// Why link-only and not the full lintPage: measured, not assumed. On the
+// packaged templates/ (hot.md type:reference, log.md type:log, both declared
+// in templates/SCHEMA.md's taxonomy), full lintPage on both files comes back
+// completely clean, so "these types trip W2" is not the reason to hold back.
+// The real reason is that live vaults do not all match the template. A vault
+// whose SCHEMA.md predates the `log` type row (or has none) gets a fresh
+// "Unknown type: log" W2 the moment log.md is run through lintPage, and a
+// vault whose root log.md predates the frontmatter convention entirely (no
+// leading `---` block at all, confirmed against a real maintainer vault)
+// gets a fresh "No frontmatter found" W1. Both W1 and W2 are in
+// STRICT_PROMOTE_IDS, so under --strict a vault that lint has always passed
+// would start failing on a file whose content this fix never touched. Full
+// lintPage stays reserved for pages/projects/journal, where every file was
+// already being linted before this change and there is no such newly-exposed
+// vault. W4 itself stays warn-only outside --strict, and postApply
+// (crystallize.mjs) gates only on errors, so this addition can add a new
+// warning to a close's lint output but can never fail one.
+const closeRootTargets = [...closeFileTargetsGlobal(args.hypoDir)].filter(
+  (f) => !f.startsWith('pages/') && !f.startsWith('projects/') && !f.startsWith('journal/'),
+);
+for (const rel of closeRootTargets) {
+  const full = join(args.hypoDir, rel);
+  if (!existsSync(full) || isScanIgnored(full, args.hypoDir, ignorePatterns)) continue;
+  let content;
+  try {
+    content = readFileSync(full, 'utf-8');
+  } catch {
+    continue;
+  }
+  for (const link of extractWikilinks(content)) {
+    if (!slugMap.has(link)) {
+      issue('warn', rel, `Broken wikilink: [[${link}]]`, null, 'W4');
+    }
+  }
+}
 
 // W8: design-history.md stale relative to session-log.md. Emitted once per
 // project (not per page) — runs outside the page loop. POSIX-separated path

--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -1347,7 +1347,7 @@ function lintWiki(files) {
     const broken = out.warns
       .filter((w) => /Broken wikilink/.test(w.message))
       .map((w) => (w.message.match(/\[\[(.+?)\]\]/) || [])[1]);
-    return { broken, errors: out.errors, status: r.status };
+    return { broken, errors: out.errors, warns: out.warns, status: r.status };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -1560,6 +1560,105 @@ test('dir-relative collision across scan dirs resolves when a real file matches'
     !broken.includes('x/foo'),
     `collision key must resolve when a real file exists: ${JSON.stringify(broken)}`,
   );
+});
+
+// ── root close targets (hot.md / log.md) get W4-only scanning ───────────────
+// closeFileTargetsGlobal (hooks/hypo-shared.mjs) says a session close writes
+// root hot.md and log.md, but the three scanDirs (pages/projects/journal)
+// never covered the vault root, so a broken wikilink close itself just wrote
+// there passed lint clean while doctor caught it. See CLAUDE.md's hook-table
+// caveat for why hooks/hypo-shared.mjs, not docs, is the source of truth here.
+suite('lint.mjs root close-target scan (hot.md / log.md)');
+
+test('a broken wikilink in root log.md is caught (not just by doctor)', () => {
+  const { broken } = lintWiki({
+    'log.md': '---\ntitle: Activity Log\ntype: log\nupdated: 2026-06-08\n---\n\nsee [[projects/ghost/hot]]\n',
+  });
+  assert.ok(
+    broken.includes('projects/ghost/hot'),
+    `root log.md broken link must be reported: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('a broken wikilink in root hot.md is caught (not just by doctor)', () => {
+  const { broken } = lintWiki({
+    'hot.md': '---\ntitle: Hot Cache\ntype: reference\nupdated: 2026-06-08\n---\n\nsee [[projects/ghost/hot]]\n',
+  });
+  assert.ok(
+    broken.includes('projects/ghost/hot'),
+    `root hot.md broken link must be reported: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('root log.md: a broken link is caught AND a real link resolves in the same run (no false positive)', () => {
+  // A single vacuous "broken is empty" read passes whether or not the new loop
+  // runs at all (log.md unscanned → no warns either way). Asserting the broken
+  // and the real link together only holds if the loop actually ran: a disabled
+  // loop reports the real link as clean by omission, but ALSO drops the
+  // broken one, so this specific pairing only passes with the loop alive.
+  const { broken } = lintWiki({
+    'log.md':
+      '---\ntitle: Activity Log\ntype: log\nupdated: 2026-06-08\n---\n\nreal [[pages/target]], ghost [[projects/ghost/hot]]\n',
+    'pages/target.md': wlPage('reference', '# Target'),
+  });
+  assert.ok(
+    broken.includes('projects/ghost/hot'),
+    `the broken link must still be reported: ${JSON.stringify(broken)}`,
+  );
+  assert.ok(
+    !broken.includes('pages/target'),
+    `the real link target must resolve, not just go unmentioned: ${JSON.stringify(broken)}`,
+  );
+});
+
+test('root log.md still gets no full lintPage treatment (its non-VALID_TYPES type stays silent)', () => {
+  // log.md's `type: log` is not declared in VOCAB_SCHEMA's taxonomy (it has no
+  // Page Type Taxonomy table), so parseSchemaTypes() contributes nothing and
+  // validTypes falls back to the hardcoded VALID_TYPES list, which does not
+  // include `log`. If lintPage ran on this file, that would raise a W2 "Unknown
+  // type" WARN, not an error, so checking `errors` alone proves nothing; this
+  // reads `warns` directly to prove the type check never ran at all.
+  const { warns } = lintWiki({
+    'log.md': '---\ntitle: Activity Log\ntype: log\nupdated: 2026-06-08\n---\n\nno links here\n',
+  });
+  assert.ok(
+    !warns.some((w) => w.file === 'log.md'),
+    `root log.md must not be run through full lintPage: ${JSON.stringify(warns)}`,
+  );
+});
+
+test('.hyposcanignore flips the same broken link from reported to unscanned', () => {
+  // A single ignored-and-clean run would pass even with the new loop deleted
+  // entirely (log.md never in scope either way). Running the SAME file both
+  // with and without the ignore entry, and asserting the warn flips, only
+  // holds if the loop is both alive and honoring isScanIgnored.
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-wl-'));
+  try {
+    writeFileSync(join(dir, 'SCHEMA.md'), VOCAB_SCHEMA);
+    writeFileSync(
+      join(dir, 'log.md'),
+      '---\ntitle: Activity Log\ntype: log\nupdated: 2026-06-08\n---\n\nsee [[projects/ghost/hot]]\n',
+    );
+    const runLint = () => {
+      const r = spawnSync(
+        process.execPath,
+        [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${dir}`, '--json'],
+        {
+          encoding: 'utf-8',
+          maxBuffer: 64 * 1024 * 1024,
+          env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME },
+        },
+      );
+      return JSON.parse(r.stdout).warns.some(
+        (w) => w.file === 'log.md' && /Broken wikilink/.test(w.message),
+      );
+    };
+    assert.equal(runLint(), true, 'before .hyposcanignore: the broken link must be reported');
+    writeFileSync(join(dir, '.hyposcanignore'), 'log.md\n');
+    assert.equal(runLint(), false, 'after .hyposcanignore: log.md must be skipped entirely');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 suite('fix #49: findDesignHistoryStale()');


### PR DESCRIPTION
# English

## What changed

Lint now also visits the close targets that live outside `pages`, `projects` and `journal`, and checks them for broken wikilinks.

## Why

A session close wrote a broken wikilink into the vault's root `log.md`, and the lint that runs immediately after that same write reported no issues:

```
"lint": { "postApply": { "ok": true, "errors": [], "warnCount": 0 } }
```

`doctor`, at the same moment, reported it:

```
⚠ Broken wiki links — 1 broken: log.md → [[projects/hook-qa/hot]]
```

The two disagreed because lint walked exactly three directories, and `log.md` is in none of them while being one of the files close overwrites. A gate that cannot see what the thing it gates just wrote is not a gate.

## How

The list of close targets comes from the same place close reads it, rather than being restated here, so a new target starts being checked without a second edit. Targets already under the three walked directories are filtered out, so nothing is scanned twice. The ignore rules apply to the new targets through the same helper the existing walk uses.

Only the broken-wikilink rule runs on them. That looks arbitrary until you measure it, so it was measured. The packaged templates lint clean under a full check. A vault whose SCHEMA predates the `log` type gets an unknown-type warning. This maintainer's own `log.md` has no frontmatter block at all, which raises a missing-frontmatter warning. Both of those promote to errors under `--strict`, so running the full check here would fail vaults that pass today, for reasons unrelated to what this change is for. The link rule adds exactly the class of problem `doctor` already reported and nothing else.

That leaves the frontmatter of those root files unchecked, and it is worth stating plainly rather than leaving implied: close overwrites `hot.md` wholesale, and nothing verifies its frontmatter survived. Closing that gap needs a design that does not break vaults which currently pass, so it is deliberately not attempted here.

## Manual verification

The failure was reproduced first, in an isolated `HOME` with a hand-built vault: `lint --json` returned `{"ok":true,"errors":[],"warns":[],"total":0}` on a root `log.md` holding a link to a page that does not exist, while `doctor` on the same vault reported it.

Cross-review then caught the first version of the tests asserting nothing. Three of five passed with the new scan removed entirely: one checked only `errors` while the warning it meant to rule out is a warn, and two asserted the absence of a warning, which is equally true when nothing is scanned at all. Removing the scan now fails four of five, and the fifth is an absence proof that is expected to hold either way.

On the real vault this surfaces 13 broken links in `log.md` that lint could not see before. Two were fixed (a singular/plural directory typo and a missing path prefix, both with the target file present); the rest are recorded rather than guessed at, since `log.md` is an append-only session record and a link to a page that was later deleted is a fact about that session.

Suites: `npm test` 1940 passing, `--file=lint` 136, `npm run lint` clean. Scan cost on a 300-page fixture moves from 0.24-0.26s to 0.25-0.28s across three runs each.

## Migration notes

None, though vaults with pre-existing broken links in their root files will see new warnings on the next lint. They are warnings, not errors, and were already reported by `doctor`.

---

# 한국어

## 변경 내용

lint 가 `pages`, `projects`, `journal` 밖에 있는 close 대상 파일도 방문해 깨진 wikilink 를 검사한다.

## 이유

세션 close 가 볼트 루트 `log.md` 에 깨진 wikilink 를 썼는데, 그 쓰기 직후에 도는 lint 가 문제 없다고 보고했다.

```
"lint": { "postApply": { "ok": true, "errors": [], "warnCount": 0 } }
```

같은 시점에 `doctor` 는 그것을 보고했다.

```
⚠ Broken wiki links — 1 broken: log.md → [[projects/hook-qa/hot]]
```

둘이 갈린 이유는 lint 가 딱 세 디렉터리만 훑는데 `log.md` 가 그중 어디에도 없고, 동시에 close 가 덮어쓰는 파일 중 하나이기 때문이다. **자기가 게이트하는 것이 방금 쓴 내용을 못 보는 게이트는 게이트가 아니다.**

## 방법

close 대상 목록을 여기서 다시 적지 않고 close 가 읽는 그 자리에서 가져온다. 그래서 새 대상이 생기면 여기를 또 고치지 않아도 검사에 들어온다. 이미 세 디렉터리 아래인 대상은 걸러 두 번 스캔되지 않게 했다. ignore 규칙은 기존 순회가 쓰는 그 helper 를 그대로 태워 적용한다.

그 파일들에는 깨진 wikilink 규칙만 돌린다. 그냥 보면 자의적이라 실제로 재 봤다. 패키지 템플릿은 전체 검사로도 깨끗하다. SCHEMA 가 `log` 타입보다 오래된 볼트는 unknown-type 경고가 뜬다. 유지보수자 본인의 `log.md` 는 **프론트매터 블록 자체가 없어** missing-frontmatter 경고가 뜬다. 둘 다 `--strict` 에서 에러로 승격되므로, 여기서 전체 검사를 돌리면 지금 통과하는 볼트가 이 변경과 무관한 이유로 실패한다. 링크 규칙은 `doctor` 가 이미 보고하던 그 종류만 더하고 그 이상은 안 한다.

그러면 그 루트 파일들의 프론트매터는 여전히 검사 밖으로 남는데, 함의로 두지 말고 밝혀 둔다. close 는 `hot.md` 를 통째로 덮어쓰고, 그 프론트매터가 살아남았는지는 아무도 확인하지 않는다. 그 갭을 메우려면 지금 통과하는 볼트를 안 깨는 설계가 필요해서 여기서는 일부러 손대지 않는다.

## 수동 검증

결함을 먼저 재현했다. 격리된 `HOME` 에서 손으로 만든 볼트에 없는 페이지를 가리키는 링크를 루트 `log.md` 에 넣으니 `lint --json` 이 `{"ok":true,"errors":[],"warns":[],"total":0}` 을 냈고, 같은 볼트에서 `doctor` 는 그것을 보고했다.

그다음 교차검토가 **첫 판본의 테스트가 아무것도 안 잰다**는 것을 잡았다. 다섯 중 셋이 새 스캔을 통째로 지워도 통과했다. 하나는 `errors` 만 봤는데 배제하려던 경고가 warn 이었고, 둘은 경고의 부재를 단언했는데 그것은 아무것도 안 스캔해도 참이다. 지금은 스캔을 지우면 다섯 중 넷이 실패하고, 나머지 하나는 어느 쪽이든 성립해야 하는 부재 증명이다.

실제 볼트에서는 lint 가 전에 못 보던 깨진 링크 13건이 `log.md` 에서 드러났다. 둘은 고쳤다(단복수 오타와 경로 접두 누락, 둘 다 대상 파일이 실재). 나머지는 추측하지 않고 기록으로 남겼다. `log.md` 는 append-only 세션 기록이고, 나중에 지워진 페이지를 가리키는 링크는 그 세션에 대한 사실이기 때문이다.

스위트: `npm test` 1940 통과, `--file=lint` 136, `npm run lint` 통과. 300-page 픽스처에서 스캔 비용은 3회씩 재서 0.24-0.26s 에서 0.25-0.28s 로 움직였다.

## 마이그레이션 노트

없다. 다만 루트 파일에 이미 깨진 링크가 있던 볼트는 다음 lint 에서 새 경고를 본다. 에러가 아니라 경고이고 `doctor` 는 이미 보고하고 있던 것이다.

---

## Changelog

- EN: Lint now checks the vault-root files a session close overwrites, so a broken wikilink written by close is caught by the lint that runs right after it instead of only by `doctor` (#248).
- KO: lint 가 세션 close 가 덮어쓰는 볼트 루트 파일도 검사한다. close 가 쓴 깨진 wikilink 를 `doctor` 만이 아니라 그 직후 도는 lint 가 잡는다 (#248).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
