### PR TITLE
fix(close): say whether the commit ran, and let check resolve the project apply would use

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -153,13 +153,13 @@ The result JSON includes a `stage` field when `ok: false`. Branch on it:
 | `post-apply-lint` | The payload introduced an error-level lint blocker in a payload file (malformed body / bad frontmatter), or lint crashed. | Fix the offending content in the payload, then re-run. (Broken wikilinks are W4 warnings — not gated.) |
 | `post-apply-verification+lint` | Both above. | Fix both; re-run. |
 
-Once `ok: true`, report:
+Once `ok: true`, report from the result JSON's `applied` and `skipped` arrays together, not `applied` alone. `applied` lists only the fields this run actually wrote bytes for; `skipped` lists the fields that already matched what was on disk (a re-run of an already-applied payload). An idempotent re-run legitimately reports `applied: []`, and that is success, not a failure to report on: check `skipped` for the same 4-6 entries instead. Read `committed` the same way: `true` covers both a real commit and the case where nothing needed staging (a full no-op re-run); `false` means the commit itself ran and failed (see `markerSkipReason`); `null` means apply never reached the commit step at all, because `ok` was already false (an authority refusal before any write, or a verification/lint failure, or a withheld conflict, per `stage`). `null` does NOT mean nothing was written: `applied` can be non-empty (bytes landed on disk) while `committed` stays `null`, because those bytes were never staged into git.
 
-- ✓ session-state.md applied
-- ✓ hot.md (project + root) applied
-- ✓ session-log entry appended
+- ✓ session-state.md applied (or already current, per `skipped`)
+- ✓ hot.md (project + root) applied (or already current)
+- ✓ session-log entry appended (or already present)
 - ✓ open-questions applied (or skipped if unchanged)
-- ✓ log.md entry appended
+- ✓ log.md entry appended (or already present)
 - ✓ post-apply lint clean
 - **marker written?** (required check): if `markerWritten: true`, report "session-close marker written"; if `markerWritten: false`, report "session-close marker NOT written (reason: `<markerSkipReason>`)" and do NOT declare the session "closed" or "complete". A missing marker means the Stop-chain is still open; recover per the `markerSkipReason` branch below.
 

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -109,6 +109,7 @@ import {
   scopeVisible,
   readVisibilityScope,
   withFileLock,
+  extractTouchedWikiFilesWithTrust,
 } from '../hooks/hypo-shared.mjs';
 import { hashContent, readBaseEntry, advanceBase } from '../hooks/base-store.mjs';
 import { writeProposal } from '../hooks/proposal-store.mjs';
@@ -225,6 +226,35 @@ function requireProjectDir(args, slug) {
   }
 }
 
+// When the global gate's own discovery (hot.md pointer table + today
+// close-activity scan, both in hypo-shared.mjs) comes back with NO project at
+// all, a real apply never hits that dead end: it is handed `payload.project`
+// directly and never infers. --check-session-close has no payload, so its one
+// remaining authoritative signal is the same session's own transcript — which
+// project's files did THIS session actually touch. Reusing the exact
+// evidence-resolution helper the widened-lint-scope path already trusts here
+// keeps this a single inference vocabulary (touched wiki files), not a second
+// one: the difference is only which project-shaped question gets asked of it.
+// Never guessed: a transcript touching zero or more than one project's files
+// leaves the check exactly as unresolved as it was before this fallback.
+function deriveTouchedProject(hypoDir, transcriptPath) {
+  if (!transcriptPath) return null;
+  const { files, trusted } = extractTouchedWikiFilesWithTrust(transcriptPath, hypoDir);
+  // `trusted:false` means the walk itself may be incomplete (a missing/unreadable
+  // transcript, or a line that failed to parse). A truncated line could have named
+  // a SECOND project the walk never saw, so treating this Set as "the whole
+  // truth" would resolve a single-project reading off a scope that is only
+  // single-project because part of it is missing, exactly the ambiguity this
+  // fallback exists to refuse rather than guess through.
+  if (!trusted) return null;
+  const slugs = new Set();
+  for (const f of files) {
+    const m = /^projects\/([^/]+)\//.exec(f);
+    if (m && existsSync(join(hypoDir, 'projects', m[1]))) slugs.add(m[1]);
+  }
+  return slugs.size === 1 ? [...slugs][0] : null;
+}
+
 // ── session-close check (spec §5.2.7 / §8.3) ────────────────────────
 // Mirrors the hard gate in hypo-personal-check.mjs so the /hypo:crystallize
 // flow can self-verify before /compact triggers PreCompact.
@@ -261,7 +291,7 @@ function runSessionCloseCheck(args) {
     args.transcriptPath ||
     (args.sessionId ? resolveTranscriptBySessionId(args.sessionId) : null) ||
     null;
-  const status = precompactGateStatus(args.hypoDir, {
+  let status = precompactGateStatus(args.hypoDir, {
     ...(args.project
       ? { projectOverride: args.project }
       : checkTranscript
@@ -276,7 +306,30 @@ function runSessionCloseCheck(args) {
     // enforcement lives in the PreCompact/Stop hooks, which carry payload.cwd).
     ...(args.sessionCwd && !args.project ? { sessionCwd: args.sessionCwd } : {}),
   });
+
+  // check/apply divergence (2026-08-25 QA): a real apply never hits discovery
+  // dead-ends because payload.project is required input, not an inference. This
+  // check has no payload, so when discovery finds NO project at all (not even
+  // the recency fallback), it retries scoped to whatever single project this
+  // session's own transcript shows it touching. This is a diagnostic estimate,
+  // not a preview of what a real apply will do: a payload's `project` field is
+  // whatever the caller puts there and can legitimately name a project the
+  // transcript never mentions. Only fires on a fully unresolved global result,
+  // and only on a TRUSTED single-project reading (see deriveTouchedProject): an
+  // already-successful discovery, an ambiguous/empty transcript, or one the walk
+  // could not fully read is left untouched rather than guessed at.
+  let inferredProject = null;
+  if (!args.project && !status.close.project) {
+    inferredProject = deriveTouchedProject(args.hypoDir, checkTranscript);
+    if (inferredProject) {
+      status = precompactGateStatus(args.hypoDir, {
+        projectOverride: inferredProject,
+        ...(args.sessionId ? { sessionId: args.sessionId } : {}),
+      });
+    }
+  }
   const close = status.close;
+  const scopedProject = args.project || inferredProject;
 
   // When a --session-id is supplied, report whether THIS session's
   // per-session marker (the Stop-chain completion signal) exists. This is a
@@ -301,8 +354,8 @@ function runSessionCloseCheck(args) {
   // log-only marker governs the session, the gate runs in log-only mode and the
   // --project override is IGNORED — surface that rather than implying X was
   // checked (it was not).
-  const logOnlyWon = args.project != null && markerObj?.scope === 'log-only';
-  const scope = args.project ? (logOnlyWon ? 'log-only' : 'project') : 'global';
+  const logOnlyWon = scopedProject != null && markerObj?.scope === 'log-only';
+  const scope = scopedProject ? (logOnlyWon ? 'log-only' : 'project') : 'global';
 
   if (args.json) {
     console.log(
@@ -325,9 +378,13 @@ function runSessionCloseCheck(args) {
           skipped: status.skipped,
           // scope is additive; `global` keeps prior semantics for existing readers
           scope,
-          ...(args.project
+          ...(scopedProject
             ? {
-                scoped_project: args.project,
+                scoped_project: scopedProject,
+                // Distinguishes a user-typed --project from this check picking one
+                // for itself off the transcript — a reader should not mistake the
+                // latter for an explicit ask (see deriveTouchedProject above).
+                ...(inferredProject ? { project_inferred_from_transcript: true } : {}),
                 ...(logOnlyWon ? { project_override_ignored: true } : {}),
               }
             : {}),
@@ -340,13 +397,20 @@ function runSessionCloseCheck(args) {
     process.exit(status.ok ? 0 : 1);
   }
 
+  // Label the scoped project by how it was chosen — an explicit --project reads
+  // as a flag the caller typed; an inferred one reads as this check's own guess
+  // off the transcript, so a reader does not credit the caller with an ask
+  // nobody made.
+  const scopedProjectLabel = args.project
+    ? `--project=${args.project}`
+    : `project=${scopedProject} (inferred from the session transcript, no --project given)`;
   if (logOnlyWon) {
     console.log(
-      `Note: a log-only session-closed marker governs session ${args.sessionId}, so the gate ran in log-only mode and --project=${args.project} was IGNORED (no project was checked).\n`,
+      `Note: a log-only session-closed marker governs session ${args.sessionId}, so the gate ran in log-only mode and ${scopedProjectLabel} was IGNORED (no project was checked).\n`,
     );
   } else if (scope === 'project') {
     console.log(
-      `Note: --project=${args.project} — this is a PROJECT-SCOPED diagnostic, not the global /compact gate. A green result means only ${args.project} is close-complete; another project can still block /compact.\n`,
+      `Note: ${scopedProjectLabel} — this is a PROJECT-SCOPED diagnostic, not the global /compact gate. A green result means only ${scopedProject} is close-complete; another project can still block /compact.\n`,
     );
   }
 
@@ -398,8 +462,8 @@ function runSessionCloseCheck(args) {
     // Do NOT claim global compact-readiness (the whole point of the narrow).
     console.log(
       status.ok
-        ? `✓ ${args.project} is close-complete (project-scoped). This is NOT a global /compact guarantee — run \`--check-session-close\` without --project for that.`
-        : `✗ ${args.project} is not close-complete — resolve the ✗ items above.`,
+        ? `✓ ${scopedProject} is close-complete (project-scoped). This is NOT a global /compact guarantee — run \`--check-session-close\` without --project for that.`
+        : `✗ ${scopedProject} is not close-complete — resolve the ✗ items above.`,
     );
   } else {
     console.log(
@@ -1043,7 +1107,10 @@ function applySessionClose(args) {
       stage: 'no-user-close-signal',
       reason: closeAuth.reason,
       applied: [],
-      committed: false,
+      // `null`, not `false`: this refusal fires before the commit step is ever
+      // reached (see the general result's own `committed` contract below).
+      // `false` is reserved for a commit that actually ran and failed.
+      committed: null,
       error: closeAuth.error,
     };
     console.log(
@@ -1103,7 +1170,9 @@ function applySessionClose(args) {
       stage: 'session-id-mismatch',
       error: msg,
       applied: [],
-      committed: false,
+      // `null`, not `false` — refused before the commit step, same contract as
+      // the `no-user-close-signal` refusal above.
+      committed: null,
     };
     console.log(args.json ? JSON.stringify(out, null, 2) : `✗ ${msg}`);
     process.exit(1);
@@ -1734,6 +1803,10 @@ function applySessionClose(args) {
   // but silently.
   let markerWritten = false;
   let markerSkipReason = null;
+  // Hoisted so the result JSON below can report it: `null` when this apply never
+  // reached the commit step at all (ok:false before the writes were even
+  // verified), distinct from a commit that ran and reported `committed:false`.
+  let commitOutcome = null;
   if (ok && args.sessionId) {
     // IO stays lazy so this preserves the exact side-effect order (codex design
     // review): commit first (the only mutation), then resolve the
@@ -1749,7 +1822,6 @@ function applySessionClose(args) {
     // apply's stage+commit. A lock-timeout is treated exactly like any other
     // commit failure below (skip the marker, surface the reason) rather than
     // crashing the apply.
-    let commitOutcome;
     try {
       commitOutcome = withFileLock(vaultCommitLockTarget(args.hypoDir), () =>
         commitWikiChanges(args.hypoDir, appliedPaths),
@@ -1843,6 +1915,19 @@ function applySessionClose(args) {
     date,
     applied,
     skipped,
+    // Was the general-shape sibling of the two early-refusal `committed:null`
+    // fields (no-user-close-signal / session-id-mismatch), which this path never
+    // carried before: a reader of `applied:[]` on a no-op re-run had no
+    // `committed` value to check against and no way to tell it apart from a run
+    // that never reached the commit step. `null` here means exactly that: `ok`
+    // came back false before the commit ever ran (see `stage` for which check
+    // failed: post-apply-verification, post-apply-lint, or proposal-pending). It
+    // does NOT mean nothing was written — an overwrite/append can already be on
+    // disk (see `applied` / `appliedUncommitted`) while `committed` stays `null`.
+    // `true` covers both an actual commit and the legitimate "nothing to stage"
+    // no-op (commitWikiChanges' own contract, see hooks/hypo-shared.mjs); `false`
+    // is a real commit failure, surfaced together with markerSkipReason below.
+    committed: commitOutcome ? commitOutcome.committed : null,
     // Targets withheld: an overwrite drifted from this session's observed base, or
     // an append could not take the file lock in time (`kind: 'append'`). Two
     // channels resolve these, and `proposals` vs `conflicts[].kind` are the sole

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -490,6 +490,145 @@ test('--check-session-close (no --project): JSON scope is global, no scoped_proj
   });
 });
 
+// ── check/apply project-resolution divergence (2026-08-25 QA) ──────────────
+// A real apply never infers: payload.project is required input, so a
+// same-vault apply resolves a brand-new project (no session-state.md, no
+// hot.md row, no log.md entry yet) trivially. --check-session-close carries no
+// payload, so with no --project it depends entirely on
+// sessionCloseGlobalStatus's own discovery (hot.md pointer table + today
+// close-activity scan), and that discovery has nothing to find for a project
+// this fresh. The transcript is the one signal check can still reach for.
+//
+// This fallback is a diagnostic estimate, not a preview of what a real apply
+// will do. A payload's `project` field is whatever the caller puts in it; it
+// can legitimately name a project the transcript never mentions. These tests
+// pin the check's own behavior in isolation (resolve on a trustworthy
+// single-project transcript, stay unresolved on an ambiguous or untrustworthy
+// one) — none of them assert that check and a real apply would agree, because
+// that is not a guarantee this fallback makes.
+suite('crystallize --check-session-close: project inference (2026-08-25 QA divergence)');
+
+function seedUndiscoverableProject(dir, slug) {
+  mkdirSync(join(dir, 'projects', slug), { recursive: true });
+  writeFileSync(join(dir, 'projects', slug, 'index.md'), '---\ntitle: index\n---\n');
+  spawnSync('git', ['-C', dir, 'add', '-A']);
+  spawnSync('git', ['-C', dir, 'commit', '-q', '-m', `seed ${slug}`]);
+  spawnSync('git', ['-C', dir, 'push', '-q', 'origin', 'HEAD']);
+}
+
+function toolUseTranscript(dir, files) {
+  const transcript = join(dir, '.cache', 'transcript.jsonl');
+  mkdirSync(join(dir, '.cache'), { recursive: true });
+  writeFileSync(
+    transcript,
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: files.map((f) => ({
+          type: 'tool_use',
+          name: 'Write',
+          input: { file_path: join(dir, f) },
+        })),
+      },
+    }) + '\n',
+  );
+  return transcript;
+}
+
+test('check with no --project and no evidence resolves nothing (matches the QA repro)', () => {
+  withSyncedWiki((dir) => {
+    seedUndiscoverableProject(dir, 'hook-qa');
+    const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.project, null, `discovery alone must not find a project this fresh: ${r.stdout}`);
+    assert.ok(
+      out.missing.includes('hot.md (no active project in pointer table)'),
+      `must reproduce the exact QA message: ${JSON.stringify(out.missing)}`,
+    );
+  });
+});
+
+test('check with --transcript-path, single-project transcript: resolves via the transcript fallback (diagnostic, not an apply preview)', () => {
+  withSyncedWiki((dir) => {
+    seedUndiscoverableProject(dir, 'hook-qa');
+    const transcript = toolUseTranscript(dir, ['projects/hook-qa/index.md']);
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      `--transcript-path=${transcript}`,
+      '--json',
+    ]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.project, 'hook-qa', `check must resolve hook-qa via the transcript: ${r.stdout}`);
+    assert.equal(out.scope, 'project', 'an inferred project is a scoped diagnostic, like --project');
+    assert.equal(out.scoped_project, 'hook-qa');
+    assert.equal(
+      out.project_inferred_from_transcript,
+      true,
+      'must be labeled as inferred, not mistaken for a caller-typed --project',
+    );
+  });
+});
+
+test('check with a transcript touching two different projects still refuses to guess', () => {
+  withSyncedWiki((dir) => {
+    seedUndiscoverableProject(dir, 'alpha');
+    seedUndiscoverableProject(dir, 'beta');
+    const transcript = toolUseTranscript(dir, ['projects/alpha/index.md', 'projects/beta/index.md']);
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      `--transcript-path=${transcript}`,
+      '--json',
+    ]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.project, null, 'an ambiguous transcript must stay unresolved, not guessed at');
+    assert.equal(out.scope, 'global');
+    assert.ok(!('scoped_project' in out), 'no scoped_project when the fallback declines to guess');
+  });
+});
+
+// A transcript whose readable lines name exactly one project, but that also
+// carries a line the JSONL walk cannot parse, is not a trustworthy single-
+// project reading: the unreadable line could have named a second project the
+// walk never saw. extractTouchedWikiFilesWithTrust flags this as
+// `trusted:false`, and the fallback must refuse it exactly like a genuinely
+// ambiguous transcript, not resolve on the partial Set it did manage to read.
+test('check with a transcript that reads single-project but has a corrupt line stays unresolved (trusted:false)', () => {
+  withSyncedWiki((dir) => {
+    seedUndiscoverableProject(dir, 'hook-qa');
+    const transcript = join(dir, '.cache', 'transcript.jsonl');
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    const validLine = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            name: 'Write',
+            input: { file_path: join(dir, 'projects', 'hook-qa', 'index.md') },
+          },
+        ],
+      },
+    });
+    writeFileSync(transcript, `${validLine}\nnot valid json {{{\n`);
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--check-session-close',
+      `--transcript-path=${transcript}`,
+      '--json',
+    ]);
+    const out = JSON.parse(r.stdout);
+    assert.equal(
+      out.project,
+      null,
+      `an untrustworthy walk must not be read as a complete single-project scope: ${r.stdout}`,
+    );
+    assert.equal(out.scope, 'global');
+    assert.ok(!('scoped_project' in out), 'no scoped_project when the transcript walk cannot be trusted');
+  });
+});
+
 test('--mark-session-closed --project=<absent> → exit 1 before the gate (existence check)', () => {
   withCleanWiki((dir) => {
     const r = run('crystallize.mjs', [
@@ -1854,7 +1993,8 @@ test('--apply-session-close --session-id with an unresolvable transcript → ref
     assert.equal(out.ok, false);
     assert.equal(out.reason, 'transcript-unresolved');
     assert.deepEqual(out.applied, []);
-    assert.equal(out.committed, false);
+    // `null`, not `false`: refused before the commit step is ever reached.
+    assert.equal(out.committed, null, 'refused before the commit step ever ran');
     assert.equal(gitHead(dir), headBefore, 'refused before any write → no new commit');
     assert.equal(
       readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8'),
@@ -1981,7 +2121,8 @@ test('IMPR-15: no-user-close-signal → after an AskUserQuestion 세션 마무�
         `expected the no-signal reason (not transcript-unresolved): ${JSON.stringify(o1)}`,
       );
       assert.deepEqual(o1.applied, []);
-      assert.equal(o1.committed, false);
+      // `null`, not `false`: refused before the commit step is ever reached.
+      assert.equal(o1.committed, null, 'refused before the commit step ever ran');
       assert.equal(gitHead(dir), headBefore, 'refused before any write → no new commit');
       assert.equal(
         readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8'),

--- a/tests/crystallize-apply.test.mjs
+++ b/tests/crystallize-apply.test.mjs
@@ -35,6 +35,34 @@ import {
 
 suite('crystallize.mjs --apply-session-close (#38)');
 
+// The 2026-08-03 QA gap this closes: `applied: []` alone cannot tell an
+// already-applied no-op re-run apart from a run that failed before writing
+// anything. `skipped` (pre-existing) names every field that matched disk;
+// `committed` (newly surfaced on this path, previously only present on the
+// two early-refusal branches) tells apart a commit that ran and found
+// nothing to stage (`true`) from one that never ran at all (`null`, a
+// verification/lint failure) or that ran and failed (`false`).
+test('a second apply of an unchanged payload: applied:[], skipped names every field, committed:true', () => {
+  withWiki(null, (dir, today) => {
+    const payload = payloadForCleanWiki(dir, today);
+    const first = runApply(dir, payload);
+    const firstOut = JSON.parse(first.stdout);
+    assert.equal(firstOut.ok, true, `first apply must succeed: ${first.stdout}`);
+
+    const second = runApply(dir, payload);
+    const out = JSON.parse(second.stdout);
+    assert.equal(out.ok, true, `second apply must still succeed: ${second.stdout}`);
+    assert.deepEqual(out.applied, [], 'nothing new to write on an identical re-run');
+    assert.ok(
+      ['sessionState', 'projectHot', 'rootHot', 'sessionLog', 'log'].every((k) =>
+        out.skipped.some((s) => s.startsWith(k)),
+      ),
+      `skipped must name every field the payload carries: ${JSON.stringify(out.skipped)}`,
+    );
+    assert.equal(out.committed, true, 'nothing to stage is still a successful commit outcome');
+  });
+});
+
 // FEAT-11 T5 fail-safe: drives the REAL close path (not a worker reimplementation
 // of append). Pre-hold a fresh lock on the daily shard so crystallize's append
 // cannot acquire it → the close must withhold to proposal-pending WITHOUT touching
@@ -586,7 +614,9 @@ test('payload.sessionId ≠ --session-id → session-id-mismatch, zero bytes', (
       `stage must be session-id-mismatch: ${r.stdout}`,
     );
     assert.deepEqual(out.applied, [], 'nothing may be reported applied');
-    assert.equal(out.committed, false, 'nothing may be committed');
+    // `null`, not `false`: this refusal fires before the commit step is ever
+    // reached. `false` is reserved for a commit that ran and failed.
+    assert.equal(out.committed, null, 'refused before the commit step ever ran');
     const tracked = spawnSync('git', ['diff', '--quiet'], { cwd: dir });
     assert.equal(tracked.status, 0, 'no committed file may be modified on reject');
     const after = existsSync(shard) ? readFileSync(shard, 'utf-8') : '';

--- a/tests/proposal-base.test.mjs
+++ b/tests/proposal-base.test.mjs
@@ -2537,7 +2537,8 @@ test('no --session-id → apply is refused before any write (no legacy escape ha
     assert.notEqual(r.status, 0, 'omitting --session-id must not succeed');
     assert.equal(out.reason, 'session-id-required');
     assert.deepEqual(out.applied, []);
-    assert.equal(out.committed, false);
+    // `null`, not `false`: refused before the commit step is ever reached.
+    assert.equal(out.committed, null, 'refused before the commit step ever ran');
     assert.equal(gitHead(dir), headBefore, 'refused before any write → no new commit');
     assert.equal(
       readFileSync(t4ProjectHot(dir), 'utf-8'),


### PR DESCRIPTION
# English

## What changed

The result of `--apply-session-close` now says whether the commit ran, and `--check-session-close` can resolve the project a real close would act on instead of giving up.

## Why

Two ways a close told you nothing about what it had just done.

**A re-applied payload reports `applied: []`.** That looks identical to a run that wrote nothing at all. In an August 3 session, `ok:true` with `markerWritten:true` and `applied:[]` left no way to tell an idempotent no-op from a run that failed to write, so the result JSON was abandoned and the answer reconstructed by grepping five files' frontmatter and reading `git log -1`. Idempotency exists to make re-running safe; if the re-run's result cannot be read, that safety is never confirmed.

**Check and apply disagreed about which project was closing.** On the same vault, check said `(unresolved)` and refused, while apply named `hook-qa` and wrote the files. A check that answers about a different project than the apply it precedes is not answering the question it was asked. The reverse is worse: a check that clears project A while apply writes to B means the user approved something other than what happened.

## How

The `applied` fix is not where the tracker predicted. `applied` and `skipped` have split written from unchanged since the first implementation. What was missing is `committed`, present only on the two early-refusal branches. It is now on the general path, with three states: `true` for a commit that ran (including one that legitimately had nothing to stage), `false` for a commit that failed, `null` for never reaching that step. The two refusals that turn back before attempting a commit now report `null`, which is what they always meant; the tests that pinned them as `false` were updated to the corrected contract rather than deleted.

The divergence is not two implementations drifting. It is one of them never inferring. Apply takes the project as explicit input from the payload. Check has no payload, so it depends entirely on shared discovery, which needs a pointer-table row or same-day close activity. A project whose only artifact is its `index.md` has neither.

Check now falls back to the session transcript when discovery finds nothing, and it refuses to guess in two ways. Zero projects touched, or two, leaves it exactly as unresolved as before. An untrusted transcript does the same: a missing, unreadable, or partly unparsable one may be hiding the second project that would have made the answer ambiguous, so a lone survivor is not evidence. That trust distinction already existed in the helper; the first version of this change read its file list and dropped the flag sitting next to it, which cross-review caught.

## Manual verification

Each assertion was proven by disabling only the line it aims at, and by confirming nothing else went red.

Removing `if (!trusted) return null;` fails exactly one assertion, the one checking that a transcript which reads single-project but carries a corrupt line stays unresolved. Reverting the two refusal branches from `null` back to `false` fails exactly one, the session-id mismatch case that means the commit was never attempted.

That method matters here. Earlier in this work a looser disablement produced a red count that could only be explained by killing code outside the change, and the assertions it appeared to validate turned out to measure nothing.

Suites: `npm test` 1940 passing, `--file=close-global` 135, `--file=crystallize-apply` 29, `--file=proposal-base` 133, `npm run lint` clean.

## Migration notes

None for the fallback. The `committed` change is additive on the general path; on the two refusal branches a consumer reading `false` will now see `null`, and no production reader of that field exists.

---

# 한국어

## 변경 내용

`--apply-session-close` 의 결과가 커밋이 돌았는지를 말한다. 그리고 `--check-session-close` 가 포기하는 대신 실제 close 가 다룰 프로젝트를 찾아낸다.

## 이유

close 가 방금 한 일에 대해 아무것도 알려 주지 않는 길이 둘 있었다.

**재적용한 payload 는 `applied: []` 를 낸다.** 그것은 아무것도 안 쓴 실행과 모양이 같다. 8월 3일 세션에서 `ok:true` 에 `markerWritten:true`, `applied:[]` 조합만으로는 멱등 no-op 인지 쓰기에 실패한 것인지 가릴 수 없었고, 결국 결과 JSON 을 버리고 파일 다섯 개의 frontmatter 를 grep 하고 `git log -1` 을 읽어 답을 재구성했다. 멱등성은 재실행을 안전하게 만들려고 있는데, 그 재실행의 결과를 읽을 수 없으면 안전이 확인되지 않는다.

**check 와 apply 가 어느 프로젝트를 닫는지에 대해 다른 답을 냈다.** 같은 볼트에서 check 는 `(unresolved)` 라며 거절했고 apply 는 `hook-qa` 를 지목해 파일을 썼다. 자기가 앞서는 apply 와 다른 프로젝트에 대해 답하는 check 는 물어본 질문에 답한 것이 아니다. 반대 방향이 더 나쁘다. check 가 프로젝트 A 를 통과시키고 apply 가 B 에 쓰면, 사용자가 승인한 것과 벌어진 일이 다르다.

## 방법

`applied` 쪽 수정은 트래커가 예상한 자리가 아니었다. `applied` 와 `skipped` 는 첫 구현부터 written 과 unchanged 를 갈라 왔다. 빠져 있던 것은 `committed` 이고, 그것은 조기 거절 두 분기에만 있었다. 이제 일반 경로에도 있고 세 상태를 가진다. `true` 는 커밋이 돌았다(정당하게 stage 할 것이 없던 경우 포함), `false` 는 커밋이 실패했다, `null` 은 그 단계에 도달하지 못했다. 커밋을 시도하기 전에 돌아서는 두 거절은 이제 `null` 을 내는데, 그것이 원래 뜻하던 바다. 그 둘을 `false` 로 고정하던 테스트는 지우지 않고 정정된 계약을 고정하도록 고쳤다.

두 명령이 갈린 것은 구현이 둘이어서가 아니다. **한쪽이 추론을 아예 안 하기 때문이다.** apply 는 프로젝트를 payload 에서 명시적 입력으로 받는다. check 는 payload 가 없어 공유 discovery 에 전적으로 의존하고, 그것은 포인터 테이블 행이나 당일 close 활동을 요구한다. 산출물이 `index.md` 하나뿐인 프로젝트는 둘 다 없다.

이제 discovery 가 아무것도 못 찾으면 check 가 세션 트랜스크립트로 물러선다. 그리고 두 방향으로 추측을 거부한다. 건드린 프로젝트가 0개거나 2개면 전과 똑같이 unresolved 로 둔다. 신뢰할 수 없는 트랜스크립트도 마찬가지다. 없거나, 못 읽거나, 일부가 파싱 안 되는 트랜스크립트는 답을 모호하게 만들었을 두 번째 프로젝트를 숨기고 있을 수 있어서, 홀로 살아남은 하나는 증거가 아니다. 그 신뢰 구분은 이미 helper 안에 있었는데, 이 변경의 첫 판본이 파일 목록만 읽고 그 옆의 플래그를 흘렸고 교차검토가 그것을 잡았다.

## 수동 검증

단언마다 그것이 겨눈 줄만 무력화해 증명했고, 다른 것이 red 가 되지 않는지도 확인했다.

`if (!trusted) return null;` 을 지우면 정확히 한 단언이 실패한다. 단일 프로젝트로 읽히지만 손상된 줄을 가진 트랜스크립트가 unresolved 로 남는지 재는 그것이다. 두 거절 분기를 `null` 에서 `false` 로 되돌리면 정확히 한 단언이 실패한다. 커밋을 시도조차 안 했다는 뜻의 session-id 불일치 경우다.

이 방식이 여기서 중요하다. 이 작업 앞부분에서 더 느슨한 무력화가 변경 밖 코드까지 죽였을 때만 설명되는 red 개수를 냈고, 그것이 검증해 주는 듯 보이던 단언들은 실제로 아무것도 재지 않고 있었다.

스위트: `npm test` 1940 통과, `--file=close-global` 135, `--file=crystallize-apply` 29, `--file=proposal-base` 133, `npm run lint` 통과.

## 마이그레이션 노트

fallback 쪽은 없다. `committed` 는 일반 경로에서는 추가이고, 두 거절 분기에서는 `false` 를 읽던 소비자가 이제 `null` 을 본다. 그 필드를 읽는 production 소비자는 없다.

---

## Changelog

- EN: A close result now reports whether the commit ran (`committed`), so a re-applied payload's empty `applied` list is no longer indistinguishable from a run that wrote nothing; `--check-session-close` also resolves the project from the session transcript when nothing else identifies it, and stays unresolved rather than guessing when the evidence is ambiguous or untrusted (#249).
- KO: close 결과가 커밋이 돌았는지를 `committed` 로 보고한다. 재적용한 payload 의 빈 `applied` 가 아무것도 안 쓴 실행과 더는 구분 불가능하지 않다. `--check-session-close` 는 다른 단서가 없을 때 세션 트랜스크립트로 프로젝트를 찾고, 증거가 모호하거나 신뢰할 수 없으면 추측하지 않고 unresolved 로 남는다 (#249).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
