### PR TITLE
chore(release): v1.7.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "hypo",
       "source": "./",
       "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "homepage": "https://github.com/sk-lim19f/Hypomnema"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hypo",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "LLM-native personal wiki system — session-aware knowledge base for Claude Code",
   "author": {
     "name": "sk-lim19f",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Hypomnema are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.3] - 2026-08-27
+
+### Bug Fixes
+
+#### English
+
+- A close result now reports whether the commit ran (`committed`), so a re-applied payload's empty `applied` list is no longer indistinguishable from a run that wrote nothing; `--check-session-close` also resolves the project from the session transcript when nothing else identifies it, and stays unresolved rather than guessing when the evidence is ambiguous or untrusted. ([#249](https://github.com/sk-lim19f/Hypomnema/pull/249))
+- Lint now checks the vault-root files a session close overwrites, so a broken wikilink written by close is caught by the lint that runs right after it instead of only by `doctor`. ([#248](https://github.com/sk-lim19f/Hypomnema/pull/248))
+- A session can finish closing while another session sharing the same vault still has uncommitted work; only files the closing session is accountable for block its marker, and the rest are listed as a notice. ([#247](https://github.com/sk-lim19f/Hypomnema/pull/247))
+- Closing a session no longer parks the root `hot.md` as a false conflict against the session's own Stop-hook rewrite. ([#246](https://github.com/sk-lim19f/Hypomnema/pull/246))
+- Captured and synced files keep their executable bit end to end, so a `755` script no longer arrives `644` on another machine; a stale mode on an already-installed copy is healed on the next sync. ([#245](https://github.com/sk-lim19f/Hypomnema/pull/245))
+- `uninstall` now removes the shell rc block and the wiki `pre-commit` hook that `init` installs, so removal is the inverse of installation. ([#244](https://github.com/sk-lim19f/Hypomnema/pull/244))
+
+#### 한국어
+
+- close 결과가 커밋이 돌았는지를 `committed` 로 보고한다. 재적용한 payload 의 빈 `applied` 를 아무것도 쓰지 않은 실행과 구별할 수 있다. `--check-session-close` 는 다른 단서가 없으면 세션 트랜스크립트에서 프로젝트를 찾고, 증거가 모호하거나 신뢰할 수 없으면 추측하지 않고 unresolved 로 남는다. ([#249](https://github.com/sk-lim19f/Hypomnema/pull/249))
+- lint 가 세션 close 가 덮어쓰는 볼트 루트 파일도 검사한다. close 가 쓴 깨진 wikilink 를 `doctor` 만이 아니라 그 직후 도는 lint 가 잡는다. ([#248](https://github.com/sk-lim19f/Hypomnema/pull/248))
+- 같은 볼트를 쓰는 다른 세션에 미커밋 작업이 남아 있어도 이 세션은 close 를 끝낼 수 있다. 마커를 막는 것은 닫는 세션이 책임지는 파일뿐이고 나머지는 notice 로 나열된다. ([#247](https://github.com/sk-lim19f/Hypomnema/pull/247))
+- 세션을 닫을 때 루트 `hot.md` 가 그 세션 자신의 Stop 훅 재작성을 상대로 가짜 충돌을 내지 않는다. ([#246](https://github.com/sk-lim19f/Hypomnema/pull/246))
+- capture 하고 sync 한 파일이 실행 비트를 끝까지 지킨다. `755` 스크립트가 다른 머신에 `644` 로 도착하지 않고, 이미 설치된 사본의 어긋난 mode 는 다음 sync 에서 고쳐진다. ([#245](https://github.com/sk-lim19f/Hypomnema/pull/245))
+- `uninstall` 이 `init` 이 만든 셸 rc 블록과 위키 `pre-commit` 훅을 지운다. 제거가 설치의 역이 된다. ([#244](https://github.com/sk-lim19f/Hypomnema/pull/244))
+
 ## [1.7.2] - 2026-08-26
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypomnema",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypomnema",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "bin": {
         "hypomnema": "scripts/init.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypomnema",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "LLM-native personal wiki system for Claude Code",
   "type": "module",
   "license": "MIT",

--- a/templates/hypo-config.md
+++ b/templates/hypo-config.md
@@ -1,7 +1,7 @@
 ---
 title: Hypomnema Config
 type: config
-version: "1.7.2"
+version: "1.7.3"
 created: YYYY-MM-DD
 ---
 


### PR DESCRIPTION
# English

## What changed

Cuts the v1.7.3 patch release. Bumps the version across `package.json`,
`package-lock.json`, `.claude-plugin/plugin.json`,
`.claude-plugin/marketplace.json`, and `templates/hypo-config.md`, and adds the
`## [1.7.3]` section to `CHANGELOG.md` covering the six bug fixes merged since
v1.7.2 (#244, #245, #246, #247, #248, #249).

## Why

Four of the six fixes in this range are in the session-close path, and all
four remove friction a user hits on every close: a base that the session's own
Stop hook invalidated, a marker gate that demanded a clean working tree across
the whole vault, a lint scope that missed the files close itself overwrites, and
a close result that could not say whether its commit ran. Those fixes have been on `main` since they
merged but reach nobody until a release carries them, because installs resolve
hooks from the published plugin package rather than from the checkout.

## How

Followed the release checklist in `docs/CONTRIBUTING.md`. Patch releases are
exempt from the vault spec-document step, so this PR touches only the
version-carrying files and the changelog. No README edits: the READMEs describe
current behavior, not version history.

The `CHANGELOG.md` section was drafted with `scripts/collect-changelog.mjs
--strict` from the merged PRs' `## Changelog` blocks, then edited by hand. The
collector emits both an inline `(#N)` and a trailing link per entry; the
inline duplicate was dropped to match the shape of the 1.7.1 and 1.7.2
sections. Those two sections also omit the `### Changelog` index and the
`Contributors:` line, so this one does too.

## Manual verification

No hook, shared-module, or template code changed in this PR, so the usual
real-session hook verification does not apply. The full local gate set was run
in a clean worktree with `npm ci`:

```
npm test                   # 1945 passed, 0 failed (262.1s), exit 0
npm run lint               # 0 error(s), 285 warning(s), exit 0
npm run check:versions     # exit 0
npm run check:bilingual    # exit 0
npm run smoke:plugin       # exit 0
npm run smoke-pack         # exit 0
npm run check:tracker-ids  # exit 0
```

The tag rehearsal (`check-bilingual --tag`, `check-versions --tag`,
`check-tracker-ids --tag`, `npm publish --dry-run`) runs after this PR merges,
against the annotated tag on the merge commit.

## Migration notes

None. This is a patch release with no schema, config, or vault-layout change.
Installed copies pick it up through the normal plugin or npm update path.

---

# 한국어

## 변경 내용

v1.7.3 패치 릴리스를 낸다. `package.json`, `package-lock.json`,
`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
`templates/hypo-config.md` 의 버전을 올리고, v1.7.2 이후 머지된 버그 픽스 여섯 건
(#244, #245, #246, #247, #248, #249)을 담은 `## [1.7.3]` 절을 `CHANGELOG.md` 에 추가한다.

## 이유

이 구간의 여섯 중 넷이 세션 close 경로에 있고, 그 넷 모두 사용자가 close 를 할 때마다
겪는 마찰이다. 세션 자신의 Stop 훅이 무효화하던 base, 볼트 전체의 워킹트리 청결을 요구하던
마커 게이트, close 자신이 덮어쓰는 파일을 못 보던 lint 범위, 그리고 커밋이 돌았는지 말하지
못하던 close 결과다.
이 수정들은 머지된 시점부터 `main` 에 있었지만 릴리스가 실어 나르기 전까지 아무에게도
닿지 않는다. 설치본은 훅을 체크아웃이 아니라 배포된 플러그인 패키지에서 찾기 때문이다.

## 방법

`docs/CONTRIBUTING.md` 의 릴리스 체크리스트를 따랐다. 패치 릴리스는 볼트 스펙 문서 단계가
면제라, 이 PR 이 건드리는 것은 버전을 담은 파일들과 changelog 뿐이다. README 는 고치지 않는다.
README 는 지금의 동작을 기술하지 버전 이력을 담지 않는다.

`CHANGELOG.md` 절은 `scripts/collect-changelog.mjs --strict` 로 머지된 PR 들의
`## Changelog` 블록에서 초안을 뽑고 손으로 다듬었다. 수집기는 항목마다 문장 안 `(#N)` 과
끝의 링크를 둘 다 내는데, 1.7.1 과 1.7.2 절의 형태에 맞춰 문장 안 중복을 뺐다. 그 두 절이
`### Changelog` 인덱스와 `Contributors:` 줄도 쓰지 않아 이번 절도 따랐다.

## 수동 검증

이 PR 은 훅도 공유 모듈도 템플릿도 바꾸지 않으므로 실제 세션 훅 검증은 해당이 없다.
`npm ci` 를 돌린 깨끗한 worktree 에서 로컬 게이트 전부를 실행했다.

```
npm test                   # 1945 passed, 0 failed (262.1s), exit 0
npm run lint               # 0 error(s), 285 warning(s), exit 0
npm run check:versions     # exit 0
npm run check:bilingual    # exit 0
npm run smoke:plugin       # exit 0
npm run smoke-pack         # exit 0
npm run check:tracker-ids  # exit 0
```

태그 리허설(`check-bilingual --tag`, `check-versions --tag`,
`check-tracker-ids --tag`, `npm publish --dry-run`)은 이 PR 이 머지된 뒤 머지 커밋에 단
annotated 태그를 상대로 돈다.

## 마이그레이션 노트

None. 스키마도 설정도 볼트 레이아웃도 바뀌지 않는 패치 릴리스다. 설치본은 평소의 플러그인
또는 npm 업데이트 경로로 받는다.

---

## Changelog

None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
