### PR TITLE
fix(close): a question answer opens the gate only on a close phrase and closes it only on a marked reconfirm decline

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -4508,11 +4508,15 @@ export function resolveTranscriptBySessionId(
  *             queue-op; a remove-path queued_command attachment carrying a
  *             close with an audited human producer (origin.kind "human"); a
  *             correlated, non-error AskUserQuestion answer naming a close.
- *   • CLOSE   a fresh user intent that closes the gate: any other genuine user
- *             text that is not a close phrase, `/clear`, `popAll`, a non-close
- *             queued_command, a non-close AskUserQuestion selection, or typed
- *             text matching {@link isCloseRetractionPattern} (the retraction
- *             tripwire).
+ *   • CLOSE   a fresh user intent that closes the gate: `/clear`, `popAll`, a
+ *             non-close queued_command, a decline answering an AskUserQuestion
+ *             whose own prompt carried {@link CLOSE_RECONFIRM_MARK} (ours, so
+ *             the decline rejects OUR close question and nobody else's), or
+ *             typed text matching {@link isCloseRetractionPattern} (the
+ *             retraction tripwire). Two things that used to close no longer do:
+ *             plain typed text that is merely not a close phrase, and an
+ *             ordinary non-close answer to an unmarked question. Both are
+ *             NEUTRAL below.
  *   • NEUTRAL everything the model can produce or the harness injects: system/
  *             sdk replay, isMeta bodies, sidechain, interruptedMessageId
  *             companions, a command-invocation record, assistant,
@@ -4682,6 +4686,17 @@ export function walkCloseGate(transcriptPath) {
   // staleness limit, mitigated the same way: any later live user intent, on any
   // branch, still closes it.
   const askIds = new Set();
+  // Subset of askIds whose tool_use input carries CLOSE_RECONFIRM_MARK, i.e.
+  // it IS our close-reconfirm prompt, not some unrelated question the model
+  // happens to ask around the same time. Same correlation guard
+  // isCloseReconfirmDeclined uses (see its doc comment below), reimplemented
+  // here rather than calling that function: its re-arm rule only recognizes a
+  // typed close phrase, which misses the three new openers this walk already
+  // tracks (a queued /compact, a human-origin queued delivery, an
+  // AskUserQuestion close answer). Driving decline off this walk instead means
+  // any of those already reopens the gate for free, with no separate re-arm
+  // rule to keep in sync.
+  const markedAskIds = new Set();
   let open = false;
   let openedAtIndex = -1;
 
@@ -4744,12 +4759,15 @@ export function walkCloseGate(transcriptPath) {
     }
 
     // Record AskUserQuestion tool_use ids (assistant record, always precedes its
-    // answer in line order).
+    // answer in line order), and separately mark the ones that ARE our
+    // close-reconfirm prompt (input carries CLOSE_RECONFIRM_MARK).
     const content = (o.message ?? o).content;
     if (Array.isArray(content)) {
       for (const b of content) {
         if (!b || typeof b !== 'object' || b.type !== 'tool_use' || !b.id) continue;
-        if (b.name === 'AskUserQuestion') askIds.add(b.id);
+        if (b.name !== 'AskUserQuestion') continue;
+        askIds.add(b.id);
+        if (JSON.stringify(b.input ?? null).includes(CLOSE_RECONFIRM_MARK)) markedAskIds.add(b.id);
       }
     }
 
@@ -4772,7 +4790,20 @@ export function walkCloseGate(transcriptPath) {
     // record from reaching the answer parser. is_error:false AND the host's
     // success marker are required because a malformed AskUserQuestion echoes the
     // raw input back in an is_error result, and the model authors the option
-    // labels. A close selection opens the gate; any other real selection closes it.
+    // labels.
+    //
+    // T5: a close phrase in the answer opens the gate, same as before. But a
+    // decline no longer closes it on its own: only a decline answering a
+    // MARKED prompt (ours, see markedAskIds above) does. Every other answer,
+    // including a non-close, non-decline click and a decline to an unmarked
+    // question, is neutral. The old default (any other real selection closed
+    // the gate) let a reflection question the close skill's own Step 1a asks
+    // mid-procedure cancel the approval that started that procedure: the
+    // model asks something adjacent, the user answers plainly, and the answer
+    // was not a close phrase, so the old rule read it as a change of mind.
+    // The loss this buys: an unmarked question answered with "지금 종료하지
+    // 말아 줘" (a real request to keep going, just not phrased as a decline
+    // to OUR prompt) now passes through neutral instead of closing the gate.
     if (Array.isArray(content) && !isModelReachableRecord(o)) {
       for (const b of content) {
         if (!b || typeof b !== 'object') continue;
@@ -4780,17 +4811,29 @@ export function walkCloseGate(transcriptPath) {
         if (b.is_error === true) continue;
         const s = typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
         if (!/have been answered/.test(s)) continue;
-        let sawAnswer = false;
         let sawClose = false;
+        let sawDecline = false;
         for (const m of s.matchAll(/="([^"]*)"/g)) {
-          sawAnswer = true;
+          // Independent checks, not else-if: a marked prompt's decline option
+          // can itself contain close wording (the model authors the text),
+          // and the decline-wins priority below only works if sawDecline gets
+          // set even when the same string also matches isClosePattern.
           if (isClosePattern(m[1])) sawClose = true;
+          if (CLOSE_RECONFIRM_DECLINE_WORDS.test(m[1])) sawDecline = true;
         }
-        if (sawClose) {
+        // A decline on a MARKED prompt wins over a close match checked on the
+        // same answer. The model authors the option text, and a marked prompt
+        // exists precisely to ask "close now, yes or no", so an answer that
+        // reads as a decline of THAT question must not be overridable by a
+        // close phrase riding along elsewhere in the same answer string. If
+        // the close check ran first, the model could word a decline option to
+        // also contain a close phrase and force the gate open on its own
+        // rejection.
+        if (sawDecline && markedAskIds.has(b.tool_use_id)) {
+          open = false;
+        } else if (sawClose) {
           open = true;
           openedAtIndex = i;
-        } else if (sawAnswer) {
-          open = false;
         }
       }
     }
@@ -4930,6 +4973,16 @@ export function hasPendingBackgroundWork(payload) {
 // reason silently break this correlation with no test to catch it.
 export const CLOSE_RECONFIRM_MARK = '지금 닫기';
 
+// The decline vocabulary shared by walkCloseGate's marked-reconfirm click
+// branch and isCloseReconfirmDeclined below. One constant so the two walks
+// cannot drift into recognizing different words for the same "not now"
+// answer: they stay separate WALKS on purpose (isCloseReconfirmDeclined's
+// re-arm rule only recognizes a typed close phrase, which is too narrow for
+// walkCloseGate's other openers), but the vocabulary they match against is
+// one value, not two copies that a future edit could update in only one
+// place.
+const CLOSE_RECONFIRM_DECLINE_WORDS = /(아직|나중|not\s?yet|later)/i;
+
 /**
  * True iff the LATEST correlated AskUserQuestion answer in the transcript
  * declined an autoclose reconfirm prompt ("아직" / "나중" / "not yet" /
@@ -4975,7 +5028,6 @@ export function isCloseReconfirmDeclined(transcriptPath) {
   } catch {
     return false;
   }
-  const DECLINE = /(아직|나중|not\s?yet|later)/i;
   const askIds = new Set();
   let declined = false;
   for (const line of lines) {
@@ -5024,7 +5076,7 @@ export function isCloseReconfirmDeclined(transcriptPath) {
       if (b.type === 'tool_result' && b.tool_use_id && askIds.has(b.tool_use_id)) {
         const s = typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
         for (const m of s.matchAll(/="([^"]*)"/g)) {
-          if (DECLINE.test(m[1])) declined = true;
+          if (CLOSE_RECONFIRM_DECLINE_WORDS.test(m[1])) declined = true;
         }
       }
     }

--- a/tests/close-signals.test.mjs
+++ b/tests/close-signals.test.mjs
@@ -1382,9 +1382,15 @@ test('AskUserQuestion is_error echo of a close phrase → false', () => {
   });
 });
 
-// A non-close AskUserQuestion selection after a close is a fresh user decision,
-// so it expires the lease (the "still continue" click retracts the close).
-test('close, then a non-close AskUserQuestion selection → false (lease expires)', () => {
+// T5 flip: a non-close AskUserQuestion selection used to expire the lease (the
+// old default closed on ANY non-close click). It no longer does. A reflection
+// question the close skill's own Step 1a asks mid-procedure produced this
+// exact shape, an ordinary click answering an unrelated question, and the old
+// rule read it as the user changing their mind and cancelled the approval that
+// started the procedure. Now only a close phrase in the answer opens the gate,
+// and only a decline answering OUR MARKED close-reconfirm prompt closes it
+// (see the click-axis reconfirm suite below); an ordinary click is neutral.
+test('close, then a non-close AskUserQuestion selection → true (no longer expires the lease)', () => {
   withTmpDir((dir) => {
     const p = writeJsonl(dir, [
       USER(CLOSE),
@@ -1406,7 +1412,7 @@ test('close, then a non-close AskUserQuestion selection → false (lease expires
         },
       },
     ]);
-    assert.equal(isCloseGateOpen(p), false);
+    assert.equal(isCloseGateOpen(p), true);
   });
 });
 
@@ -1748,14 +1754,20 @@ test('empty string and non-string input → false', () => {
   assert.equal(isCloseRetractionPattern(42), false);
 });
 
-// NOT A CHANNEL (removed after review): an AskUserQuestion answer that is not a
-// close still expires the lease, including phrasings no retraction list would have
-// held. This is the fail-closed direction the repo's unknown-enum rule asks for.
-test('a non-close AskUserQuestion answer expires the lease, whatever its wording', () => {
+// T5 flip: this used to pin the fail-closed direction (any non-close answer
+// expires the lease, whatever its wording). That direction is gone; a click
+// axis that closed on any unrecognized answer is exactly the default that let
+// an unrelated mid-procedure question cancel a real approval. Now the answer
+// is neutral unless it names a close, or declines OUR MARKED reconfirm prompt.
+// The loss this buys: '지금 종료하지 말아 줘' is a genuine request to keep
+// going, but it is not a close phrase and this question is not marked, so it
+// now passes through neutral instead of closing, same as the other three
+// unrelated wordings below.
+test('a non-close AskUserQuestion answer on an unmarked question is neutral, whatever its wording', () => {
   withTmpDir((dir) => {
     for (const picked of ['지금 종료하지 말아 줘', '지금 쓴다', '3개', 'whatever']) {
       const p = writeJsonl(dir, [USER(CLOSE), ASK('q'), ANSWER('q', picked)]);
-      assert.equal(isCloseGateOpen(p), false, picked);
+      assert.equal(isCloseGateOpen(p), true, picked);
     }
   });
 });
@@ -1783,6 +1795,170 @@ test('typed non-close text after the approval line still expires the lease', () 
       TYPED('하나만 더 해줘'),
     ]);
     assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+// ── T5: click axis, marked reconfirm decline only ──────────────────────────
+// A close answer still opens the gate exactly as before. The other half of
+// the click axis is new: an answer no longer closes the gate just for not
+// naming a close. Only a decline answering OUR marked close-reconfirm prompt
+// (askCloseReconfirmToolUse, correlated via CLOSE_RECONFIRM_MARK) closes it,
+// and any of the four openers this walk already recognizes reopens it right
+// after, the same as it would after any other close.
+suite('isCloseGateOpen() click axis: marked reconfirm decline only (T5)');
+
+test('a decline answering OUR marked close-reconfirm prompt closes an open gate', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      askCloseReconfirmToolUse('q1'),
+      ANSWER('q1', '아직, 계속'),
+    ]);
+    assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+// A decline that ALSO contains close wording (the model authors the option
+// text, so it could word a decline to carry a close phrase too) must still
+// close: the decline branch is checked first for a marked prompt, and only
+// falls through to the close check when the answer did not decline.
+// Otherwise a marked reconfirm's own "no" option would be a forgeable way to
+// force the gate open on the user's own rejection.
+test('a decline that also carries close wording still closes, on a marked prompt (decline wins)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      askCloseReconfirmToolUse('q1'),
+      ANSWER('q1', '나중에 세션 마무리'),
+    ]);
+    assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+test('an English decline that also carries close wording still closes, on a marked prompt (decline wins)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      askCloseReconfirmToolUse('q1'),
+      ANSWER('q1', 'not yet, wrap up later'),
+    ]);
+    assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+// COVERAGE GAP (found in review): every T5 assertion above starts from an
+// ALREADY-OPEN gate (USER(CLOSE) first), so a neutral answer and an
+// opening answer read the same isCloseGateOpen(p) === true and no assertion
+// tells them apart. A sabotage that made every AskUserQuestion answer open
+// the gate (`if (m[1] !== undefined) sawClose = true;` in place of
+// `if (isClosePattern(m[1])) sawClose = true;`) passed the whole suite
+// green. These three start from a transcript with NO initiation record at
+// all (no typed close, no /compact enqueue, no queued delivery), so a
+// non-close answer opening the gate has nowhere to hide.
+test('no initiation at all, then an UNMARKED non-close AskUserQuestion answer, stays closed (does not open)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [ASK('q'), ANSWER('q', '3개')]);
+    assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+// Being marked (askCloseReconfirmToolUse) grants no opening authority of its
+// own: it only narrows what CLOSES an already-open gate. A non-close,
+// non-decline answer to a marked prompt, with no prior initiation, must stay
+// closed exactly like the unmarked case above.
+test('no initiation at all, then a MARKED non-close non-decline AskUserQuestion answer, stays closed (marked grants no opening authority)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [askCloseReconfirmToolUse('q1'), ANSWER('q1', '3개')]);
+    assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+// The priority flip above is scoped to a MARKED prompt only: markedAskIds.has
+// gates the decline branch, so an unmarked question's close answer is
+// unaffected and still opens the gate exactly as before. This fixture also
+// has NO prior initiation record, so it doubles as the positive twin of the
+// two closed-gate tests above: with no initiation at all, a close-naming
+// answer is what actually opens the gate, nothing else does.
+test('a close answer to an UNMARKED question still opens the gate (priority flip does not touch the opening axis)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [ASK('q'), ANSWER('q', '세션 마무리')]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+// SOURCE SCAN: walkCloseGate and isCloseReconfirmDeclined must match the SAME
+// decline vocabulary, or the two walks quietly drift apart on what counts as
+// "not now". Counting the literal regex text (not calling either function)
+// pins that the pattern is defined once and referenced, not copied.
+test('the reconfirm decline vocabulary regex literal is defined in exactly one place in the source', () => {
+  const src = readFileSync(join(REPO, 'hooks', 'hypo-shared.mjs'), 'utf-8');
+  const literal = '/(아직|나중|not\\s?yet|later)/i';
+  const occurrences = src.split(literal).length - 1;
+  assert.equal(occurrences, 1, 'the decline regex literal must be defined once and shared');
+});
+
+test('the same decline wording answering an UNMARKED question does not close the gate', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [USER(CLOSE), ASK('q'), ANSWER('q', '아직, 계속')]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+test('after a marked decline closes the gate, a typed close phrase reopens it', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      askCloseReconfirmToolUse('q1'),
+      ANSWER('q1', '아직, 계속'),
+      TYPED('세션 마무리 해줘'),
+    ]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+test('after a marked decline closes the gate, a queued /compact reopens it', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      askCloseReconfirmToolUse('q1'),
+      ANSWER('q1', '아직, 계속'),
+      QOP('enqueue', '/compact'),
+    ]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+test('after a marked decline closes the gate, a human-origin queued close delivery reopens it', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      askCloseReconfirmToolUse('q1'),
+      ANSWER('q1', '아직, 계속'),
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: {
+          type: 'queued_command',
+          prompt: '세션 마무리 해줘',
+          origin: { kind: 'human' },
+        },
+      },
+    ]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+test('after a marked decline closes the gate, a fresh AskUserQuestion close answer reopens it', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      askCloseReconfirmToolUse('q1'),
+      ANSWER('q1', '아직, 계속'),
+      ASK('q2'),
+      ANSWER('q2', '세션 마무리 해줘'),
+    ]);
+    assert.equal(isCloseGateOpen(p), true);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

The AskUserQuestion axis of the close gate now opens on a close phrase only, and
closes only on a decline answering a prompt that carried the close-reconfirm
marker. Every other answer is neutral and leaves the gate where it was.

## Why

The old rule was "a close selection opens the gate, any other real selection
closes it". That made the close procedure cancel itself. The close skill asks
reflection questions mid-procedure; the user answers one plainly; the answer is
not a close phrase; the old rule read it as a change of mind and closed the gate
the user had just opened.

Measured on a real transcript (1686 records, an unrelated project):

| record | event | gate |
|---|---|---|
| 1392 | user types a close phrase | open |
| 1426 | model asks an unrelated question about where to file a citation | |
| 1427 | user answers with the recommended option | closed |
| after | apply runs | refused |
| 1505 | model asks again, user picks the close option | open again |

The refusal message said the user had not asked to close. The user had, 35
records earlier. Every session close paid a forced round trip for this.

## How

The decline is judged inside the same walk rather than by calling
`isCloseReconfirmDeclined`. That function's re-arm rule recognizes typed close
text only, so it cannot see the three other openers this walk already tracks (a
queued `/compact`, a human-origin queued delivery, an AskUserQuestion close
answer). Driving the decline off this walk means any of those reopens the gate
with no separate re-arm rule to keep in sync. Only the decline vocabulary is
shared, as one file-scope constant both walks reference, so the two cannot drift
apart on what counts as "not now". A source-scan assertion pins that the literal
appears once.

A decline wins over a close match on the same answer. The model authors the
option labels, so checking close first would let it word a decline option to
carry close wording and force the gate open on its own rejection. Both checks
run independently rather than as an if/else chain, so an option matching both
still registers as a decline.

The loss this buys, stated in the code: an unmarked question answered with a
real request to keep going, phrased as something other than a decline to our own
prompt, now passes through neutral instead of closing the gate.

## Manual verification

The gate walk was run against the deployed copy and a live transcript, not only
against fixtures.

```
# the installed 1.7.3 copy, before this change
node -e 'import("<installed>/hooks/hypo-shared.mjs").then(m => {
  console.log(m.walkCloseGate("<transcript>"));  // { open: true, openedAtIndex: 1506 }
})'
```

Reading the records between 1392 and 1506 showed the close phrase at 1392, the
unrelated question at 1426, and its answer at 1427 as the record that closed the
gate. That is the case this change removes.

Suite results in the branch:

```
node tests/runner.mjs --file=close-signals    # 153 passed, 0 failed
node tests/parallel.mjs --shards=4            # 1989 passed, 0 failed, exit 0
npm run lint                                  # exit 0
node scripts/check-tracker-ids.mjs --all      # exit 0
```

Three regression proofs were run by disabling the change and confirming the
intended assertions turn red, then restoring and confirming the diff was intact:

- reverting the decline priority reddens exactly the two decline-wins tests
- restoring a duplicate of the decline regex reddens exactly the source scan
- removing the close-phrase requirement on opening reddens exactly the two
  closed-gate tests

The third proof initially reddened nothing, which is why the closed-gate
assertions exist: the flipped assertions all started from an already-open gate,
where neutral and opening produce the same value.

## Migration notes

None. The gate is computed from the transcript, so an upgraded install applies
the new rule to its next session with no state to migrate. Sessions already
running keep the copy they started with.

---

# 한국어

## 변경 내용

close 게이트의 AskUserQuestion 축이 이제 close 문구를 담은 응답에만 열리고, 재확인
마커가 붙은 프롬프트의 거절 응답에만 닫힌다. 나머지 응답은 전부 중립이라 게이트를 있던
자리에 둔다.

## 이유

기존 규칙은 "close 선택은 열고, 다른 실제 선택은 전부 닫는다" 였다. 그래서 close 절차가
스스로를 취소했다. close 스킬이 절차 중에 확인 질문을 던지고, 사용자가 거기 평범하게
답하고, 그 답이 close 문구가 아니니, 옛 규칙이 그걸 마음이 바뀐 것으로 읽어 방금 사용자가
연 게이트를 닫았다.

실제 트랜스크립트(1686 레코드, 다른 프로젝트)에서 잰 것이다.

| 레코드 | 무슨 일 | 게이트 |
|---|---|---|
| 1392 | 사용자가 close 문구를 타이핑 | 열림 |
| 1426 | 모델이 인용을 어디 남길지 무관한 질문 | |
| 1427 | 사용자가 권장 선택지로 응답 | 닫힘 |
| 그 뒤 | apply 실행 | 거부 |
| 1505 | 모델이 다시 묻고 사용자가 close 선택 | 다시 열림 |

거부 메시지는 사용자가 close 를 요청하지 않았다고 말했다. 사용자는 35 레코드 앞에서
요청했다. 매 세션 마무리가 이 왕복을 물었다.

## 방법

거절 판정을 `isCloseReconfirmDeclined` 를 부르지 않고 같은 워크 안에서 한다. 그 함수의
re-arm 규칙은 타이핑 close 텍스트만 인정해서, 이 워크가 이미 추적하는 다른 개시 셋(큐에
든 `/compact`, 사람 origin 큐 배달, AskUserQuestion close 응답)을 못 본다. 거절을 이 워크로
몰면 그 셋 중 무엇이든 게이트를 다시 열고, 따로 맞춰 둘 re-arm 규칙이 없다. 공유하는 것은
거절 어휘뿐이고 파일 레벨 상수 하나를 두 워크가 참조하므로, "지금은 아니다" 의 판정
기준이 갈라질 수 없다. 그 리터럴이 한 번만 나오는지는 소스 스캔 단언이 고정한다.

같은 응답에서 거절이 close 보다 우선한다. 선택지 라벨은 모델이 저작하므로, close 를 먼저
보면 거절 선택지에 close 문구를 실어 자기 거절로 게이트를 열게 만들 수 있다. 두 검사를
if/else 사슬이 아니라 각각 독립으로 돌려, 둘 다 맞는 응답도 거절로 잡히게 했다.

감수하는 손실은 코드에 적었다. 표시 없는 질문에 실린, 우리 프롬프트에 대한 거절이 아닌
형태의 계속 요청은 이제 게이트를 닫지 않고 중립으로 지나간다.

## 수동 검증

게이트 워크를 픽스처만이 아니라 배포된 사본과 살아 있는 트랜스크립트에 직접 걸었다.

```
# 이 변경 전의 설치본 1.7.3 사본
node -e 'import("<installed>/hooks/hypo-shared.mjs").then(m => {
  console.log(m.walkCloseGate("<transcript>"));  // { open: true, openedAtIndex: 1506 }
})'
```

1392 와 1506 사이 레코드를 읽어 1392 의 close 문구, 1426 의 무관한 질문, 그리고 게이트를
닫은 레코드가 1427 의 그 응답이라는 것을 확인했다. 이 변경이 없애는 자리가 그것이다.

브랜치에서의 결과다.

```
node tests/runner.mjs --file=close-signals    # 153 passed, 0 failed
node tests/parallel.mjs --shards=4            # 1989 passed, 0 failed, exit 0
npm run lint                                  # exit 0
node scripts/check-tracker-ids.mjs --all      # exit 0
```

회귀 증명 셋을 돌렸다. 변경을 무력화해 의도한 단언이 red 가 되는 것을 보고, 복원해 diff 가
그대로인지 대조했다.

- 거절 우선순위를 되돌리면 거절 우선 테스트 둘만 red 다
- 거절 정규식 사본을 되살리면 소스 스캔 단언만 red 다
- 개시에서 close 문구 요구를 지우면 닫힌 게이트 테스트 둘만 red 다

셋째 증명은 처음에 아무것도 red 로 만들지 못했고, 그래서 닫힌 게이트 단언이 존재한다.
뒤집은 단언들이 전부 이미 열린 게이트에서 출발해서, 중립과 개시가 같은 값을 냈기 때문이다.

## 마이그레이션 노트

없다. 게이트는 트랜스크립트에서 계산하므로, 업그레이드한 설치본은 다음 세션부터 새 규칙을
적용하고 옮길 상태가 없다. 이미 돌고 있는 세션은 시작 시점의 사본을 그대로 쓴다.

---

## Changelog

- EN: The close gate no longer treats an ordinary answer to a mid-procedure question as a change of mind: a question answer opens it only on a close phrase and closes it only on a decline to the close-reconfirm prompt (#252, ADR 0087, ADR 0088).
- KO: close 게이트가 절차 중 질문에 대한 평범한 응답을 마음이 바뀐 것으로 읽지 않는다. 질문 응답은 close 문구에만 게이트를 열고, close 재확인 프롬프트에 대한 거절에만 닫는다 (#252, ADR 0087, ADR 0088).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
