### PR TITLE
refactor(lib): extract the shared slug resolver used by rename and lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "scripts/lib/project-create.mjs",
     "scripts/lib/rename-marker.mjs",
     "scripts/lib/schema-vocab.mjs",
+    "scripts/lib/slug-resolver.mjs",
     "scripts/lib/template-schema-version.mjs",
     "scripts/lib/wd-match.mjs",
     "scripts/lib/wikilink.mjs",

--- a/scripts/lib/slug-resolver.mjs
+++ b/scripts/lib/slug-resolver.mjs
@@ -1,0 +1,181 @@
+// scripts/lib/slug-resolver.mjs — shared slug resolution, extracted from
+// lint.mjs and rename.mjs so a future consumer does not grow its own copy.
+//
+// Exposes TWO modes, deliberately not folded into one:
+//
+//   - existence-check (lint)         — buildSlugMap: a Set, membership only.
+//     Fast, but cannot say WHICH page owns a form or whether it is shared.
+//   - collision-aware owner (rename) — buildFormIndex + classifyTarget +
+//     newTargetFor: a form → Set<rel> map, so a caller can tell an
+//     unambiguous resolution from a shared one and refuse to auto-rewrite
+//     the latter.
+//
+// Folding these into one structure would be a regression: lint only needs to
+// know a link resolves to SOMETHING, while rename must refuse to touch a link
+// whose form is shared by more than one page. Collectors stay separate too —
+// lint's target universe is pages/projects/journal plus root .md and
+// sources/* (collectLinkTargets, still in lint.mjs); rename scans the whole
+// vault root and treats journal/session-log/weekly/archive/postmortems and
+// sources/* as immutable link SOURCES (preservationClass, below).
+//
+// Masking, link-body parsing, and the immutability/realpath-containment rules
+// travel with owner mode because rename's rewrite pipeline needs all of them
+// together: mask non-wikilink regions, parse a link body, classify it against
+// the form index, and refuse a target that resolves outside the vault.
+
+import { lstatSync, realpathSync } from 'fs';
+import { dirname, sep } from 'path';
+import { slugForms } from './wikilink.mjs';
+
+// ── existence-check slug map (lint mode) ────────────────────────────────────
+// `extraTargets` are link-target-only slugs (root *.md, sources/*) that
+// resolve wikilinks but are not themselves linted — added verbatim, with NO
+// derived basename/dir-relative aliases, so they can't mask an unrelated
+// broken link.
+export function buildSlugMap(pages, extraTargets = []) {
+  const map = new Set();
+  for (const { rel } of pages) {
+    const noExt = rel.replace(/\.md$/, '').replace(/\\/g, '/');
+    const { full, bare, dirRel } = slugForms(noExt);
+    map.add(full);
+    map.add(bare);
+    if (dirRel) map.add(dirRel);
+  }
+  for (const t of extraTargets) map.add(t);
+  return map;
+}
+
+// ── collision-aware form index (owner mode) ─────────────────────────────────
+export const dirRelForm = (slug) => slugForms(slug).dirRel;
+
+// Unlike buildSlugMap above (a Set that silently dedups collisions), owner
+// mode needs to KNOW when a form is shared, so it maps each form to the SET
+// of page rels that expose it. Precedence forms per page: full noExt slug,
+// bare basename, dir-relative (drop the leading scan-dir segment).
+export function buildFormIndex(pages) {
+  const index = new Map(); // form → Set<rel>
+  const add = (form, rel) => {
+    if (!form) return;
+    if (!index.has(form)) index.set(form, new Set());
+    index.get(form).add(rel);
+  };
+  for (const p of pages) {
+    add(p.slug, p.rel);
+    // sources/* are full-slug-only link targets, exactly as lint's
+    // collectLinkTargets treats them: a bare `[[name]]` must NOT resolve to a
+    // source file. Adding their bare/dir-relative aliases here would make a
+    // real page's bare link look ambiguous and skip a legitimate rewrite.
+    if (/(^|\/)sources(\/|$)/.test(p.rel)) continue;
+    add(p.bare, p.rel);
+    add(dirRelForm(p.slug), p.rel);
+  }
+  return index;
+}
+
+// Classify a link target against the from-page. Returns the form KIND when
+// the target points at from-page, plus whether that form is ambiguous
+// (shared with another page → unsafe to auto-rewrite).
+export function classifyTarget(target, fromPage, formIndex) {
+  const owners = formIndex.get(target);
+  if (!owners || !owners.has(fromPage.rel)) return { kind: null, ambiguous: false };
+  const ambiguous = owners.size > 1;
+  let kind = null;
+  if (target === fromPage.slug) kind = 'full';
+  else if (target === dirRelForm(fromPage.slug)) kind = 'dirrel';
+  else if (target === fromPage.bare) kind = 'bare';
+  return { kind, ambiguous };
+}
+
+// The new target string for a matched form kind — same kind, new page.
+export function newTargetFor(kind, toPage) {
+  if (kind === 'full') return toPage.slug;
+  if (kind === 'dirrel') return dirRelForm(toPage.slug) ?? toPage.bare;
+  return toPage.bare; // bare
+}
+
+// ── wikilink masking (owner mode) ───────────────────────────────────────────
+// Blank out fenced code, inline code, and HTML comments WITHOUT changing
+// length, so a [[ref]] match index in the mask aligns with the same index in
+// the source. Rewriting then edits the source at those exact spans, never
+// touching a link that only appears inside a code sample.
+export function maskNonWikilinkRegions(content) {
+  let out = content;
+  out = out.replace(/^[ \t]{0,3}```[\s\S]*?^[ \t]{0,3}```/gm, (m) => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/^[ \t]{0,3}~~~[\s\S]*?^[ \t]{0,3}~~~/gm, (m) => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/``[^`\n]*``/g, (m) => ' '.repeat(m.length));
+  out = out.replace(/`[^`\n]*`/g, (m) => ' '.repeat(m.length));
+  return out;
+}
+
+// Parse the inside of a `[[ ... ]]` into { target, suffix } where suffix is
+// the alias/anchor tail to preserve verbatim (including a table-escaped
+// `\|`). The target capture stops before an optional `\` preceding the
+// `|`/`#` delimiter, matching lint's extractor exactly.
+export function splitLinkBody(body) {
+  const m = body.match(/^([^|#\\]+?)(\\?[|#][\s\S]*)?$/);
+  if (!m) return null;
+  return { target: m[1].trim(), suffix: m[2] || '' };
+}
+
+// ── preservation class of a link-source path (owner mode) ──────────────────
+// Two distinct reasons a file is normally skipped as a link SOURCE, kept
+// separate because directory-mode renames treat them differently:
+//
+//   'timerecord' — append-only snapshots (journal / session-log / weekly /
+//      archive / postmortems + root log.md). Rewriting a [[old]] inside a
+//      past entry would falsify that moment.
+//   'sources'    — sources/* immutable CAPTURED material. Never rewritten,
+//      not even inside a moved subtree.
+//
+// Matches a path SEGMENT so `pages/journal/x.md` and
+// `projects/p/session-log/y.md` both qualify. Returns null for ordinary live
+// pages.
+export function preservationClass(rel) {
+  const p = rel.replace(/\\/g, '/');
+  if (/(^|\/)sources(\/|$)/.test(p)) return 'sources';
+  if (p === 'log.md') return 'timerecord';
+  if (/(^|\/)(journal|session-log|weekly|archive|postmortems)(\/|$)/.test(p)) return 'timerecord';
+  return null;
+}
+
+// A rename elsewhere in the vault must never churn a frozen snapshot or a
+// source — both preservation classes count as a preserved link SOURCE.
+export function isPreservedSource(rel) {
+  return preservationClass(rel) !== null;
+}
+
+// ── realpath containment (owner mode) ───────────────────────────────────────
+// Verify a path resolves, following any symlink ANCESTOR, to a location
+// inside the real vault root. A lexical ../-check cannot catch this: a
+// symlinked directory that is lexically in-vault can still resolve outside
+// it. The destination may not exist, so the deepest existing prefix is
+// resolved (its realpath is where a write would actually land). Fail-closed:
+// returns false on any resolution error.
+//
+// The walk uses lstat (NOT existsSync) so a DANGLING symlink prefix is
+// detected as present-but-unresolvable rather than skipped as absent —
+// otherwise the walk would step past it to an in-vault parent and wrongly
+// report containment.
+export function realContainedInVault(absPath, realRoot) {
+  let probe = absPath;
+  for (;;) {
+    let exists = true;
+    try {
+      lstatSync(probe);
+    } catch {
+      exists = false;
+    }
+    if (exists) break;
+    const parent = dirname(probe);
+    if (parent === probe) return false;
+    probe = parent;
+  }
+  let real;
+  try {
+    real = realpathSync(probe); // follows links; throws on a dangling symlink
+  } catch {
+    return false;
+  }
+  return real === realRoot || real.startsWith(realRoot + sep);
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -30,8 +30,9 @@ import {
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
 import { FAILURE_TYPE_ENUM } from './lib/failure-type.mjs';
-import { collectPagesLint, collectPagesLinkable, slugForms } from './lib/wikilink.mjs';
+import { collectPagesLint, collectPagesLinkable } from './lib/wikilink.mjs';
 import { parseFrontmatter, SEQUENCE_ENTRY_RE } from './lib/frontmatter.mjs';
+import { buildSlugMap } from './lib/slug-resolver.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -176,28 +177,9 @@ const TYPE_ENUM_FIELDS = {
 };
 
 // ── page collector ────────────────────────────────────────────────────────────
-
-// ── slug map ─────────────────────────────────────────────────────────────────
-
-// `extraTargets` are link-target-only slugs (root *.md, sources/*) that resolve
-// wikilinks but are not themselves linted — added verbatim, with NO derived
-// basename/dir-relative aliases, so they can't mask an unrelated broken link.
-function buildSlugMap(pages, extraTargets = []) {
-  const map = new Set();
-  for (const { rel } of pages) {
-    const noExt = rel.replace(/\.md$/, '').replace(/\\/g, '/');
-    // full slug + bare basename + dir-relative alias (drop the leading scan-dir
-    // segment so the convention link [[learnings/foo]] resolves to
-    // pages/learnings/foo.md). slugForms returns dirRel=null when the slug has no
-    // `/` (a page directly under a scan dir has no extra segment to drop).
-    const { full, bare, dirRel } = slugForms(noExt);
-    map.add(full);
-    map.add(bare);
-    if (dirRel) map.add(dirRel);
-  }
-  for (const t of extraTargets) map.add(t);
-  return map;
-}
+//
+// buildSlugMap (existence-check mode) now lives in ./lib/slug-resolver.mjs,
+// shared with rename.mjs's collision-aware owner mode.
 
 // Link-target-only slugs: files that are valid wikilink destinations but are
 // NOT linted themselves. Root-level *.md (hot.md / log.md / hypo-guide.md /

--- a/scripts/rename.mjs
+++ b/scripts/rename.mjs
@@ -48,11 +48,22 @@ import {
   chmodSync,
   rmSync,
 } from 'fs';
-import { join, basename, dirname, normalize, isAbsolute, sep } from 'path';
+import { join, basename, dirname, normalize, isAbsolute } from 'path';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore } from './lib/hypo-ignore.mjs';
-import { collectPagesRename, slugForms } from './lib/wikilink.mjs';
+import { collectPagesRename } from './lib/wikilink.mjs';
 import { RENAME_MARKER_REL, renameMarkerPath, readRenameMarker } from './lib/rename-marker.mjs';
+import {
+  dirRelForm,
+  buildFormIndex,
+  classifyTarget,
+  newTargetFor,
+  maskNonWikilinkRegions,
+  splitLinkBody,
+  preservationClass,
+  isPreservedSource,
+  realContainedInVault,
+} from './lib/slug-resolver.mjs';
 
 // ── arg parsing ───────────────────────────────────────────────────────────────
 
@@ -69,108 +80,16 @@ function parseArgs(argv) {
   return args;
 }
 
-// ── preservation class of a link-source path ───────────────────────────────────
-// Two distinct reasons a file is normally skipped as a link SOURCE, kept separate
-// because directory mode treats them differently (codex design BLOCKER):
-//
-//   'timerecord' — append-only snapshots (journal / session-log / weekly / archive
-//      / postmortems + root log.md). Rewriting a [[old]] inside a past entry would
-//      falsify that moment. BUT a directory move relocates the whole subtree, so a
-//      time-record INSIDE the moved subtree that links a moving sibling must update
-//      that intra-subtree path label (the page genuinely moved); see runDirectory.
-//
-//   'sources'    — sources/* immutable CAPTURED material. Never rewritten, not even
-//      inside a moved subtree: a directory move must not claim ownership over the
-//      bytes of an external source we transcribed verbatim.
-//
-// Matches a path SEGMENT so `pages/journal/x.md` and `projects/p/session-log/y.md`
-// both qualify. Returns null for ordinary live pages.
-function preservationClass(rel) {
-  const p = rel.replace(/\\/g, '/');
-  if (/(^|\/)sources(\/|$)/.test(p)) return 'sources';
-  if (p === 'log.md') return 'timerecord';
-  if (/(^|\/)(journal|session-log|weekly|archive|postmortems)(\/|$)/.test(p)) return 'timerecord';
-  return null;
-}
-
-// Single-page mode preserves BOTH classes as link sources (unchanged behavior): a
-// rename elsewhere in the vault must never churn a frozen snapshot or a source.
-function isPreservedSource(rel) {
-  return preservationClass(rel) !== null;
-}
-
-// ── slug-form index (resolution with collision detection) ──────────────────────
-// Unlike lint's buildSlugMap (a Set that silently dedups collisions), rename
-// needs to KNOW when a form is shared, so it maps each form → the set of page
-// rels that expose it. precedence forms per page: full noExt slug, bare
-// basename, dir-relative (drop the leading scan-dir segment).
-const dirRelForm = (slug) => slugForms(slug).dirRel;
-
-function buildFormIndex(pages) {
-  const index = new Map(); // form → Set<rel>
-  const add = (form, rel) => {
-    if (!form) return;
-    if (!index.has(form)) index.set(form, new Set());
-    index.get(form).add(rel);
-  };
-  for (const p of pages) {
-    add(p.slug, p.rel);
-    // sources/* are full-slug-only link targets, exactly as lint's
-    // collectLinkTargets treats them: a bare `[[name]]` must NOT resolve to a
-    // source file. Adding their bare/dir-relative aliases here would make a real
-    // page's bare link look ambiguous and skip a legitimate rewrite.
-    if (/(^|\/)sources(\/|$)/.test(p.rel)) continue;
-    add(p.bare, p.rel);
-    add(dirRelForm(p.slug), p.rel);
-  }
-  return index;
-}
-
-// Classify a link target against the from-page. Returns the form KIND when the
-// target points at from-page, plus whether that form is ambiguous (shared with
-// another page → unsafe to auto-rewrite).
-function classifyTarget(target, fromPage, formIndex) {
-  const owners = formIndex.get(target);
-  if (!owners || !owners.has(fromPage.rel)) return { kind: null, ambiguous: false };
-  const ambiguous = owners.size > 1;
-  let kind = null;
-  if (target === fromPage.slug) kind = 'full';
-  else if (target === dirRelForm(fromPage.slug)) kind = 'dirrel';
-  else if (target === fromPage.bare) kind = 'bare';
-  return { kind, ambiguous };
-}
-
-// The new target string for a matched form kind — same kind, new page.
-function newTargetFor(kind, toPage) {
-  if (kind === 'full') return toPage.slug;
-  if (kind === 'dirrel') return dirRelForm(toPage.slug) ?? toPage.bare;
-  return toPage.bare; // bare
-}
-
-// ── wikilink masking (mirror lint.mjs stripNonWikilinkRegions) ──────────────────
-// Blank out fenced code, inline code, and HTML comments WITHOUT changing length,
-// so a [[ref]] match index in the mask aligns with the same index in the source.
-// Rewriting then edits the source at those exact spans, never touching a link
-// that only appears inside a code sample.
-function maskNonWikilinkRegions(content) {
-  let out = content;
-  out = out.replace(/^[ \t]{0,3}```[\s\S]*?^[ \t]{0,3}```/gm, (m) => m.replace(/[^\n]/g, ' '));
-  out = out.replace(/^[ \t]{0,3}~~~[\s\S]*?^[ \t]{0,3}~~~/gm, (m) => m.replace(/[^\n]/g, ' '));
-  out = out.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ' '));
-  out = out.replace(/``[^`\n]*``/g, (m) => ' '.repeat(m.length));
-  out = out.replace(/`[^`\n]*`/g, (m) => ' '.repeat(m.length));
-  return out;
-}
-
-// Parse the inside of a `[[ ... ]]` into { target, suffix } where suffix is the
-// alias/anchor tail to preserve verbatim (including a table-escaped `\|`). The
-// target capture stops before an optional `\` preceding the `|`/`#` delimiter,
-// matching lint's extractor exactly.
-function splitLinkBody(body) {
-  const m = body.match(/^([^|#\\]+?)(\\?[|#][\s\S]*)?$/);
-  if (!m) return null;
-  return { target: m[1].trim(), suffix: m[2] || '' };
-}
+// ── preservation class of a link-source path, form index, masking, and link-body
+// parsing (preservationClass / isPreservedSource / dirRelForm / buildFormIndex /
+// classifyTarget / newTargetFor / maskNonWikilinkRegions / splitLinkBody) now
+// live in ./lib/slug-resolver.mjs, shared with lint.mjs's existence-check mode.
+// Directory mode's own notes on the two preservation classes: 'timerecord' is
+// skipped as a link SOURCE outside the moved subtree, but a time-record INSIDE
+// the moved subtree that links a moving sibling must update that intra-subtree
+// path label (the page genuinely moved); see runDirectory. 'sources' is never
+// rewritten even inside a moved subtree: a directory move must not claim
+// ownership over the bytes of an external source transcribed verbatim.
 
 // Rewrite every inbound reference to fromPage in `content`. Returns
 // { content, rewrites, ambiguous } where rewrites/ambiguous list the links
@@ -316,7 +235,9 @@ function guardExistingMarker(args, thisMarker) {
     );
   }
   const same =
-    marker.mode === thisMarker.mode && marker.from === thisMarker.from && marker.to === thisMarker.to;
+    marker.mode === thisMarker.mode &&
+    marker.from === thisMarker.from &&
+    marker.to === thisMarker.to;
   if (!same) {
     fail(
       args,
@@ -468,40 +389,10 @@ function rewriteContentDir(content, movedByRel, formIndex, aliasPreserve) {
   return { content: out, rewrites, ambiguous };
 }
 
-// Verify a path resolves — following any symlink ANCESTOR — to a location inside
-// the real vault root. A lexical ../-check cannot catch this: `projects/link/new`
-// where `projects/link` → /tmp/outside is lexically in-vault, yet renameSync would
-// follow the symlink and write across the vault boundary. The destination may not
-// exist, so the deepest existing prefix is resolved (its realpath is where a write
-// would actually land). Fail-closed: returns false on any resolution error.
-//
-// The walk uses lstat (NOT existsSync) so a DANGLING symlink prefix is detected as
-// present-but-unresolvable rather than skipped as absent — otherwise the walk would
-// step past it to an in-vault parent and wrongly report containment, letting an
-// external rewrite land before renameSync crashes on the dangling target.
-function realContainedInVault(absPath, realRoot) {
-  let probe = absPath;
-  // Walk up to the deepest path component that exists as a link-or-real entry.
-  for (;;) {
-    let exists = true;
-    try {
-      lstatSync(probe);
-    } catch {
-      exists = false;
-    }
-    if (exists) break;
-    const parent = dirname(probe);
-    if (parent === probe) return false;
-    probe = parent;
-  }
-  let real;
-  try {
-    real = realpathSync(probe); // follows links; throws on a dangling symlink
-  } catch {
-    return false;
-  }
-  return real === realRoot || real.startsWith(realRoot + sep);
-}
+// realContainedInVault now lives in ./lib/slug-resolver.mjs (imported above),
+// reused as-is: `projects/link/new` where `projects/link` → /tmp/outside is
+// lexically in-vault, yet renameSync would follow the symlink and write
+// across the vault boundary, which is exactly what it guards against below.
 
 // The destination's deepest existing ancestor must be a directory. Otherwise
 // mkdirSync(dirname, {recursive}) fails with ENOTDIR — but only AFTER the inbound
@@ -760,7 +651,10 @@ function runDirectory(args, fromDirRel, ignorePatterns) {
       // instead of an unsafe write-then-remove fallback; every write above is
       // already atomic, so a re-run picks up cleanly.
       if (err.code !== 'EXDEV') throw err;
-      fail(args, `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`);
+      fail(
+        args,
+        `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`,
+      );
     }
     clearRenameMarker(args);
     moved = true;
@@ -974,7 +868,10 @@ function run(args) {
         // removes. fromPage.path still holds the valid (possibly rewritten)
         // body, so a re-run picks up cleanly once the device issue is gone.
         if (err.code !== 'EXDEV') throw err;
-        fail(args, `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`);
+        fail(
+          args,
+          `--from and --to ended up on different filesystems mid-run — refusing an unsafe fallback move.`,
+        );
       }
     }
     clearRenameMarker(args);

--- a/tests/fixtures/npm-pack.files.json
+++ b/tests/fixtures/npm-pack.files.json
@@ -348,6 +348,10 @@
     "exec": false
   },
   {
+    "path": "scripts/lib/slug-resolver.mjs",
+    "exec": false
+  },
+  {
     "path": "scripts/lib/template-schema-version.mjs",
     "exec": false
   },

--- a/tests/slug-resolver.test.mjs
+++ b/tests/slug-resolver.test.mjs
@@ -1,0 +1,110 @@
+// tests/slug-resolver.test.mjs
+//
+// One area, one file, one selection unit per suite. Tests inside a suite may
+// build on each other; suites may not — that is what lets the runner shard.
+//
+// rename-wikilink.test.mjs and lint.test.mjs already pin the extracted
+// behavior through the CLI (spawned rename.mjs / lint.mjs processes). These
+// tests exercise scripts/lib/slug-resolver.mjs directly, in-process, so a
+// future consumer (e.g. an OKF export walker) has its own contract to build
+// against instead of only an indirect CLI guarantee.
+
+import assert from 'node:assert/strict';
+import { realpathSync, symlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  buildSlugMap,
+  buildFormIndex,
+  classifyTarget,
+  newTargetFor,
+  dirRelForm,
+  maskNonWikilinkRegions,
+  splitLinkBody,
+  preservationClass,
+  isPreservedSource,
+  realContainedInVault,
+} from '../scripts/lib/slug-resolver.mjs';
+import { test, suite } from './harness.mjs';
+import { withTmpDir } from './helpers.mjs';
+
+suite('slug-resolver.mjs');
+
+test('existence-check mode: buildSlugMap adds full/bare/dir-relative forms plus verbatim extraTargets', () => {
+  const pages = [{ rel: 'pages/learnings/foo.md' }];
+  const map = buildSlugMap(pages, ['sources/bar']);
+  assert.ok(map.has('pages/learnings/foo'), 'full slug');
+  assert.ok(map.has('foo'), 'bare basename');
+  assert.ok(map.has('learnings/foo'), 'dir-relative alias');
+  assert.ok(map.has('sources/bar'), 'extraTarget kept verbatim');
+  // extraTargets get no derived aliases (a bare form could mask a real broken link).
+  assert.ok(!map.has('bar'), 'extraTarget must not gain a derived bare alias');
+});
+
+test('collision-aware owner mode: a bare form shared by two pages is reported ambiguous, the unique dir-relative form is not', () => {
+  const pages = [
+    { rel: 'pages/x/foo.md', slug: 'pages/x/foo', bare: 'foo' },
+    { rel: 'pages/y/foo.md', slug: 'pages/y/foo', bare: 'foo' },
+  ];
+  const formIndex = buildFormIndex(pages);
+  const fromPage = pages[0];
+  const toPage = { rel: 'pages/x/baz.md', slug: 'pages/x/baz', bare: 'baz' };
+
+  const bare = classifyTarget('foo', fromPage, formIndex);
+  assert.equal(bare.kind, 'bare');
+  assert.equal(bare.ambiguous, true, 'bare form shared by two pages must be ambiguous');
+
+  const dirRel = classifyTarget(dirRelForm(fromPage.slug), fromPage, formIndex);
+  assert.equal(dirRel.kind, 'dirrel');
+  assert.equal(dirRel.ambiguous, false, 'dir-relative form is unique, safe to rewrite');
+  assert.equal(newTargetFor(dirRel.kind, toPage), 'x/baz');
+});
+
+test('collision-aware owner mode: sources/* pages get no bare/dir-relative alias in the form index', () => {
+  const pages = [{ rel: 'sources/report.md', slug: 'sources/report', bare: 'report' }];
+  const formIndex = buildFormIndex(pages);
+  assert.ok(formIndex.has('sources/report'), 'full slug indexed');
+  assert.ok(!formIndex.has('report'), 'bare basename must not resolve to a source');
+});
+
+test('maskNonWikilinkRegions blanks a fenced code block without changing length', () => {
+  const content = 'see [[a]]\n```\n[[b]]\n```\nsee [[c]]';
+  const masked = maskNonWikilinkRegions(content);
+  assert.equal(masked.length, content.length, 'masking must preserve length for index alignment');
+  assert.ok(masked.includes('[[a]]') && masked.includes('[[c]]'), 'real links survive masking');
+  assert.ok(!masked.includes('[[b]]'), 'fenced link is blanked');
+});
+
+test('splitLinkBody separates target from alias/anchor suffix', () => {
+  assert.deepEqual(splitLinkBody('foo|alias text'), { target: 'foo', suffix: '|alias text' });
+  assert.deepEqual(splitLinkBody('foo#sec'), { target: 'foo', suffix: '#sec' });
+  assert.deepEqual(splitLinkBody('foo'), { target: 'foo', suffix: '' });
+});
+
+test('preservationClass / isPreservedSource classify time records and immutable sources', () => {
+  assert.equal(preservationClass('journal/2026-01-01.md'), 'timerecord');
+  assert.equal(preservationClass('log.md'), 'timerecord');
+  assert.equal(preservationClass('sources/report.md'), 'sources');
+  assert.equal(preservationClass('pages/foo.md'), null);
+  assert.equal(isPreservedSource('journal/2026-01-01.md'), true);
+  assert.equal(isPreservedSource('pages/foo.md'), false);
+});
+
+test('realContainedInVault accepts an in-vault path and rejects a symlink escape', () => {
+  withTmpDir((vault) => {
+    withTmpDir((outside) => {
+      const realRoot = realpathSync(vault);
+      assert.equal(
+        realContainedInVault(join(vault, 'pages', 'foo.md'), realRoot),
+        true,
+        'an ordinary in-vault path is contained',
+      );
+      const link = join(vault, 'escape');
+      symlinkSync(outside, link);
+      assert.equal(
+        realContainedInVault(join(link, 'new.md'), realRoot),
+        false,
+        'a symlinked ancestor pointing outside the vault must not be contained',
+      );
+    });
+  });
+});


### PR DESCRIPTION
# English

## What changed

The slug resolution code that `rename.mjs` and `lint.mjs` each carried a private
copy of now lives in one module, `scripts/lib/slug-resolver.mjs`. Both callers
import from it. No behavior changes.

## Why

Two copies of one rule drift apart. A correction to the masking logic, the
immutable-source classification, or the realpath containment check in one file
never reaches the other, and nothing in the suite reports the gap: both copies
pass their own tests while disagreeing with each other.

## How

The module exposes two modes, because the two callers want different answers to
the same question.

| caller | mode | takes |
|---|---|---|
| `lint.mjs` | existence check | `buildSlugMap` only. Any hit is a collision. |
| `rename.mjs` | collision aware owner | the form index plus the masking, immutable source, and realpath containment helpers its rewrite pipeline needs. |

The collectors stay separate rather than being merged into one configurable
walk. `lint` scans pages, projects, journal and the root plus sources targets;
`rename` scans the root and skips preserved sources. Folding those into one
function with a flag would put `rename`'s rules one boolean away from `lint`,
which is the coupling this split exists to avoid.

`scripts/graph.mjs` has a third variant. It is deliberately left alone here.

The functions moved byte for byte. Nothing was rewritten in transit, so the
security relevant parts (masking length preservation, the symlink escape
rejection in containment) are the same code in a new file.

Because the new file lives under `scripts/`, it also has to be named in the
`files` allowlist in `package.json` and in the pack surface snapshot. That
allowlist has no negation entry, so a new file simply does not ship until it is
listed, and the failure is silent: product code that never reaches an installed
copy with nothing reporting it.

## Manual verification

This is an extraction, so there is no new defense to disable. The check that
matters is whether it is a move rather than a copy.

```
# no local definition survives in either caller
for fn in buildSlugMap buildFormIndex classifyTarget newTargetFor \
          maskNonWikilinkRegions splitLinkBody preservationClass \
          isPreservedSource realContainedInVault dirRelForm; do
  grep -ln "^function $fn" scripts/rename.mjs scripts/lint.mjs
done          # no output

grep -n "slug-resolver" scripts/rename.mjs scripts/lint.mjs
# lint.mjs:35   import { buildSlugMap } from './lib/slug-resolver.mjs';
# rename.mjs:66 } from './lib/slug-resolver.mjs';
```

Pass counts before and after the extraction are identical, which is the point
for a refactor: 45 for rename, 136 for lint. The 7 in the new suite are new
tests of the module itself, counted separately.

```
node tests/runner.mjs --file=rename-wikilink   # 45 passed, 0 failed  (45 before)
node tests/runner.mjs --file=lint              # 136 passed, 0 failed (136 before)
node tests/runner.mjs --file=slug-resolver     # 7 passed, 0 failed   (new)
node tests/parallel.mjs --shards=4             # 1984 passed, 0 failed, exit 0
npm run lint                                   # exit 0
node scripts/check-pack-surface.mjs            # exit 0, 136 files
node scripts/check-tracker-ids.mjs --all       # exit 0
```

## Migration notes

None. No public surface moved and no vault state is involved.

---

# 한국어

## 변경 내용

`rename.mjs` 와 `lint.mjs` 가 각자 사본으로 들고 있던 slug 해석 코드를 모듈 하나
(`scripts/lib/slug-resolver.mjs`)로 모았다. 두 호출부가 거기서 import 한다. 동작은
바뀌지 않는다.

## 이유

한 규칙의 사본 둘은 갈라진다. 마스킹 로직이나 immutable source 분류, realpath containment
검사를 한쪽에서 고쳐도 다른 쪽에 안 닿고, 스위트는 그 어긋남을 보고하지 않는다. 두 사본이
서로 어긋난 채로 각자의 테스트를 통과하기 때문이다.

## 방법

두 호출부가 같은 질문에 다른 답을 원하므로 모듈이 두 모드를 노출한다.

| 호출부 | 모드 | 가져가는 것 |
|---|---|---|
| `lint.mjs` | 존재 검사 | `buildSlugMap` 하나. 걸리면 곧 충돌이다. |
| `rename.mjs` | 충돌 인지 소유자 | form index 와 rewrite 파이프라인이 쓰는 마스킹, immutable source, realpath containment 헬퍼들. |

콜렉터는 설정 가능한 워크 하나로 합치지 않고 그대로 분리해 둔다. `lint` 는 pages, projects,
journal 과 root 및 sources 타깃을 훑고, `rename` 은 root 를 훑되 preserved sources 를
건너뛴다. 이걸 플래그 하나 달린 함수로 접으면 `rename` 의 규칙이 `lint` 에서 불리언 하나
거리에 놓인다. 이 분리가 피하려는 결합이 정확히 그것이다.

`scripts/graph.mjs` 에 세 번째 변종이 있다. 여기서는 일부러 손대지 않았다.

함수들은 바이트 단위로 옮겼다. 옮기면서 다시 쓴 것이 없으므로, 보안에 관계된 부분(마스킹의
길이 보존, containment 의 symlink 탈출 거절)은 새 파일에 있는 같은 코드다.

새 파일이 `scripts/` 아래라서 `package.json` 의 `files` 허용목록과 pack surface 스냅샷에도
이름을 올려야 한다. 그 허용목록에는 부정 항목이 없어서, 새 파일은 적기 전까지 그냥 출하되지
않는다. 그리고 그 실패가 조용하다. 제품 코드가 설치본에 영영 안 닿는데 아무도 그걸 말해 주지
않는다.

## 수동 검증

추출이라 무력화할 새 방어가 없다. 여기서 중요한 검사는 이것이 복사가 아니라 이동인가다.

```
# 두 호출부 어디에도 지역 정의가 남지 않았다
for fn in buildSlugMap buildFormIndex classifyTarget newTargetFor \
          maskNonWikilinkRegions splitLinkBody preservationClass \
          isPreservedSource realContainedInVault dirRelForm; do
  grep -ln "^function $fn" scripts/rename.mjs scripts/lint.mjs
done          # 출력 없음

grep -n "slug-resolver" scripts/rename.mjs scripts/lint.mjs
# lint.mjs:35   import { buildSlugMap } from './lib/slug-resolver.mjs';
# rename.mjs:66 } from './lib/slug-resolver.mjs';
```

추출 전후의 통과 수가 같다. 리팩터에서는 그게 요점이다. rename 45, lint 136 이다. 새 스위트의
7 은 모듈 자체를 재는 새 테스트라 따로 센다.

```
node tests/runner.mjs --file=rename-wikilink   # 45 passed, 0 failed  (이전 45)
node tests/runner.mjs --file=lint              # 136 passed, 0 failed (이전 136)
node tests/runner.mjs --file=slug-resolver     # 7 passed, 0 failed   (신규)
node tests/parallel.mjs --shards=4             # 1984 passed, 0 failed, exit 0
npm run lint                                   # exit 0
node scripts/check-pack-surface.mjs            # exit 0, 136 files
node scripts/check-tracker-ids.mjs --all       # exit 0
```

## 마이그레이션 노트

없다. 공개 표면이 움직이지 않았고 볼트 상태도 관여하지 않는다.

---

## Changelog

- EN: None (internal refactor, no user-visible behavior change).
- KO: 없음 (내부 리팩터, 사용자에게 보이는 동작 변화 없음).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
