### PR TITLE
feat(close): order close approval against the recorded resolution

### DIFF
--- a/hooks/close-gate-store.mjs
+++ b/hooks/close-gate-store.mjs
@@ -34,6 +34,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { walkCloseGate } from './hypo-shared.mjs';
 
 /** `<hypoDir>/.cache/close-gate/<session-id>.json`. */
 export function closeGatePath(hypoDir, sessionId) {
@@ -303,4 +304,132 @@ export function readResolution(hypoDir, sessionId, rawTranscript) {
   return verified
     ? { closedAtIndex: parsed.closedAtIndex, prefixMatches: true }
     : { closedAtIndex: REJECTED_INDEX, prefixMatches: false };
+}
+
+/**
+ * The one gate a consumer needs when the caller is about to WRITE the wiki
+ * or WRITE the marker: does this session's transcript, taken together with
+ * any recorded resolution, currently authorize a close? This is the
+ * composite `walkCloseGate` + `readResolution` such a caller should use
+ * instead of wiring the two together itself.
+ *
+ * Three rules, in order:
+ *   1. No open in the transcript at all (`walkCloseGate(...).open` is
+ *      false) → reject. There is nothing to check a resolution against.
+ *   2. A recorded resolution exists and its prefix hash still matches this
+ *      transcript's bytes through the resolved record → pass only when the
+ *      open found in step 1 happened STRICTLY AFTER that record
+ *      (`openedAtIndex >= closedAtIndex`). The two sides of that comparison
+ *      use DIFFERENT bases on purpose, not by accident: `openedAtIndex` is
+ *      `walkCloseGate`'s 0-based position in its record array, while
+ *      `closedAtIndex` is `resolutionStamp`'s 1-based COUNT of records
+ *      resolved. A count of N records resolved (positions 0..N-1 spent)
+ *      means position N is the first UNRESOLVED one — so `openedAtIndex
+ *      (N) >= closedAtIndex (N)` lands exactly on the next fresh record,
+ *      not on the one the resolution already consumed. Reusing this
+ *      comparison anywhere else requires reusing this base mismatch too;
+ *      the new-open tests in the test file below pin this exact boundary,
+ *      so DO NOT "fix" the operator to `>` — that would move the boundary
+ *      off by one in the other direction. An open that does not clear the
+ *      boundary is the signal already spent; it does not authorize a
+ *      second apply.
+ *   3. The recorded resolution's prefix hash does NOT match (the
+ *      transcript was rewritten before the resolved record) → reject,
+ *      distinctly from rule 2, because the fix is different: rule 2 asks
+ *      for a fresh close phrase, rule 3 says the evidence itself cannot be
+ *      trusted.
+ *   (No resolution record at all — `readResolution`'s `NO_CONSTRAINT` — is
+ *   not a fourth rule: it is the absence of rule 2's and rule 3's
+ *   precondition, so an open from step 1 passes with nothing further to
+ *   check.)
+ *
+ * `open` in the return value is `walkCloseGate`'s own verdict (rule 1),
+ * unfiltered by the resolution check — a consumer that wants to know
+ * "did the user say close at all, resolution aside" reads this field.
+ * `ok` is the full three-rule verdict.
+ *
+ * NOT every `isCloseGateOpen` caller should switch to this. Writing bytes is
+ * not the test: `--mark-session-closed` writes a file too (the marker), and
+ * it still belongs on `isCloseGateOpen`. The real criterion is which close
+ * event a call is transacting FOR. `verifyCloseAuthority` and
+ * `hypo-close-guard.mjs` each gate a NEW authorization request: a write
+ * that has not happened yet, standing on whatever close signal the
+ * transcript currently carries — so a resolution recorded by an EARLIER
+ * close must retire that old signal before a new one is trusted again.
+ * `runMarkSessionClosed` (crystallize.mjs's standalone
+ * `--mark-session-closed`) is different in kind: it is the FOLLOW-UP
+ * RECOVERY of a close that, per the resolution file itself, has ALREADY
+ * happened (a successful apply is what wrote that resolution in the first
+ * place). Gating that recovery on `closeGateStatus` would make an apply's
+ * own success permanently block its one legitimate repair path — its
+ * `openedAtIndex` comes from the same transcript snapshot the resolution
+ * was just stamped FROM, so it can never clear the boundary rule 2 needs,
+ * and a marker withheld by a commit failure could never be recovered
+ * without a brand-new close phrase the user has no reason to type twice.
+ * tests/close-hooks-gate.test.mjs's test C
+ * ("crystallize.mjs:754 (runMarkSessionClosed) stays on isCloseGateOpen")
+ * pins exactly this: it withholds a marker via a real commit failure, fixes
+ * the commit by hand with NO new close signal, and asserts the recovery run
+ * still succeeds; swapping :754 to `closeGateStatus` turns that test red.
+ * As of this writing the two callers that gate a NEW request are
+ * `verifyCloseAuthority` (crystallize.mjs, before any wiki byte is written)
+ * and `hypo-close-guard.mjs`'s PreToolUse intercept (before a
+ * Write/Edit/MultiEdit on a close-artifact file lands); every path that
+ * recovers or reports on an ALREADY-recorded close (`runMarkSessionClosed`,
+ * and the post-apply diagnostic that reports whether the transcript carried
+ * a signal) reads `isCloseGateOpen` directly, on purpose, and should keep
+ * doing so.
+ *
+ * @param {{transcriptPath: string|null, hypoDir: string, sessionId: string|null}} args
+ * @returns {{ok: boolean, open: boolean, reason: string|null}}
+ */
+export function closeGateStatus({ transcriptPath, hypoDir, sessionId }) {
+  const { open, openedAtIndex } = walkCloseGate(transcriptPath ?? null);
+  if (!open) {
+    return {
+      ok: false,
+      open: false,
+      reason:
+        'no-open: this session carries no close signal in its transcript yet — ' +
+        'ask the user whether they actually want to close before treating this as one.',
+    };
+  }
+
+  let rawTranscript = null;
+  try {
+    rawTranscript = transcriptPath ? readFileSync(transcriptPath) : null;
+  } catch {
+    rawTranscript = null; // unreadable at the moment of the check; readResolution treats this as unverifiable, not absent
+  }
+  const { closedAtIndex, prefixMatches } = readResolution(hypoDir, sessionId, rawTranscript);
+
+  if (closedAtIndex === null) {
+    // NO_CONSTRAINT: no valid resolution record exists for this session, so
+    // the open found above is unconstrained.
+    return { ok: true, open: true, reason: null };
+  }
+  if (prefixMatches === false) {
+    // Checked ahead of the index comparison on purpose, even though
+    // REJECTED_INDEX already makes `openedAtIndex >= closedAtIndex` fail on
+    // its own arithmetic: the point here is the DISTINCT reason string, not
+    // the pass/fail outcome.
+    return {
+      ok: false,
+      open: true,
+      reason:
+        'transcript-rewrite-detected: the recorded resolution no longer matches this ' +
+        "transcript's history — treat this session's prior resolution as untrustworthy " +
+        'and confirm the close with the user again.',
+    };
+  }
+  if (openedAtIndex >= closedAtIndex) {
+    return { ok: true, open: true, reason: null };
+  }
+  return {
+    ok: false,
+    open: true,
+    reason:
+      'no-new-open-since-resolution: this session already resolved its last close signal — ' +
+      'a fresh close phrase from the user is needed before this can pass again.',
+  };
 }

--- a/hooks/hypo-close-guard.mjs
+++ b/hooks/hypo-close-guard.mjs
@@ -103,11 +103,11 @@ import { relative } from 'path';
 import {
   HYPO_DIR,
   detectSessionCloseArtifact,
-  isCloseGateOpen,
   isGateSkipped,
   touchedPathsPath,
   withFileLock,
 } from './hypo-shared.mjs';
+import { closeGateStatus } from './close-gate-store.mjs';
 
 const CLOSE_ARTIFACT_BASENAMES = new Set(['session-state.md', 'hot.md']);
 // Mirrors hypo-auto-stage.mjs's WRITE_TOOLS: the tools that replace file bytes.
@@ -215,7 +215,22 @@ try {
     process.exit(0);
   }
 
-  if (isCloseGateOpen(input.transcript_path ?? null)) {
+  const gateStatus = closeGateStatus({
+    transcriptPath: input.transcript_path ?? null,
+    hypoDir: HYPO_DIR,
+    sessionId: input.session_id ?? null,
+  });
+  // F4: without session_id, closeGateStatus's own readResolution can never
+  // look up THIS session's close-gate/<id>.json, so a PRIOR close this exact
+  // session already resolved would silently read back as unconstrained (rule
+  // 1's raw transcript open, none of the resolution check rules 2/3 add) —
+  // the same T6-before behavior this whole file exists to close. Real
+  // PreToolUse input always carries session_id (measured), so this branch is
+  // a defensive fail-closed for a shape that should not occur, not the
+  // everyday path: an absent session_id forces an ask on top of whatever
+  // closeGateStatus itself found, rather than letting "cannot verify" read
+  // as "verified clean" the way an unchecked `gateStatus.ok` would.
+  if (gateStatus.ok && input.session_id) {
     process.exit(0);
   }
 
@@ -224,6 +239,11 @@ try {
     : structuralHit
       ? `both session-state.md and hot.md are being rewritten this session`
       : `this write reads as a close announcement (마감/종료 wording)`;
+  // gateStatus.reason is null when gateStatus.ok is true — the missing-
+  // session_id branch above is the only way to reach here with ok:true, so
+  // name that gap explicitly instead of printing a literal "(null)".
+  const gateReason =
+    gateStatus.reason ?? 'no session_id — cannot verify against a recorded resolution';
 
   console.log(
     JSON.stringify({
@@ -233,8 +253,8 @@ try {
         permissionDecision: 'ask',
         permissionDecisionReason:
           `[WIKI CLOSE GUARD] ${rel} — ${why}, but no user close signal was seen ` +
-          `in this session. Confirm with the user before writing: did they actually ` +
-          `ask to close the session?\n` +
+          `in this session (${gateReason}). Confirm with the user before writing: did they ` +
+          `actually ask to close the session?\n` +
           `To bypass: set HYPO_SKIP_GATE=1`,
       },
     }),

--- a/scripts/crystallize.mjs
+++ b/scripts/crystallize.mjs
@@ -113,7 +113,7 @@ import {
 } from '../hooks/hypo-shared.mjs';
 import { hashContent, readBaseEntry, advanceBase } from '../hooks/base-store.mjs';
 import { writeProposal } from '../hooks/proposal-store.mjs';
-import { recordGateClosed, resolutionStamp } from '../hooks/close-gate-store.mjs';
+import { recordGateClosed, resolutionStamp, closeGateStatus } from '../hooks/close-gate-store.mjs';
 
 // This script's own absolute path. Used to print copy-pasteable recovery
 // commands as `node <SELF_SCRIPT> ...` rather than a bare `crystallize` bin,
@@ -939,7 +939,7 @@ const CLOSE_REFUSAL_HELP = [
  *   { ok: false, reason, error }   reason: session-id-required | transcript-unresolved
  *                                          | no-user-close-signal
  */
-function verifyCloseAuthority(sessionId) {
+function verifyCloseAuthority(sessionId, hypoDir) {
   if (!sessionId) {
     return {
       ok: false,
@@ -962,13 +962,15 @@ function verifyCloseAuthority(sessionId) {
         `authority here.`,
     };
   }
-  if (!isCloseGateOpen(transcript)) {
+  const gateStatus = closeGateStatus({ transcriptPath: transcript, hypoDir, sessionId });
+  if (!gateStatus.ok) {
     return {
       ok: false,
       reason: 'no-user-close-signal',
       error:
         "session-close apply refused before any wiki write or commit: this session's transcript " +
-        'carries no user close signal. The user did not ask to close.',
+        'carries no user close signal. The user did not ask to close. ' +
+        `Gate detail: ${gateStatus.reason}`,
     };
   }
   return { ok: true };
@@ -1101,7 +1103,9 @@ function applySessionClose(args) {
   // Only a payload-bearing call can write. A payload-less one falls through to the
   // "payload is required" error below without touching a byte, so gating it here
   // would just replace one refusal with a less accurate one.
-  const closeAuth = args.payload ? verifyCloseAuthority(args.sessionId) : { ok: true };
+  const closeAuth = args.payload
+    ? verifyCloseAuthority(args.sessionId, args.hypoDir)
+    : { ok: true };
   if (!closeAuth.ok) {
     const out = {
       ok: false,
@@ -1886,6 +1890,16 @@ function applySessionClose(args) {
       transcriptResolved: !!closeTranscript,
       // Scan the signal only when the gate passed AND a transcript resolved —
       // isCloseGateOpen never runs earlier than the original nested `else if`.
+      // Reads the raw walkCloseGate open, not closeGateStatus: this apply's
+      // OWN recordGateClosed call above already ran with this transcript's
+      // full record count as closedAtIndex, and openedAtIndex can never reach
+      // or pass a count taken from the very same transcript (see
+      // closeGateStatus's doc comment) — so gating this diagnostic on .ok
+      // would read false on every apply, unconditionally, not just a stale
+      // one. This field asks a narrower question than closeGateStatus
+      // answers: "did the transcript carry a close signal", not "is this
+      // apply itself still authorized" (verifyCloseAuthority already settled
+      // that, before any byte was written).
       hasUserSignal: gateOk && !!closeTranscript && isCloseGateOpen(closeTranscript),
     });
     markerSkipReason = decision.skipReason;

--- a/tests/close-gate-store.test.mjs
+++ b/tests/close-gate-store.test.mjs
@@ -10,6 +10,7 @@ import { test, suite } from './harness.mjs';
 import { withTmpDir } from './helpers.mjs';
 import {
   closeGatePath,
+  closeGateStatus,
   readResolution,
   recordGateClosed,
   resolutionStamp,
@@ -454,5 +455,159 @@ test('readResolution: a verified match stays a verified match across a JSON roun
     assert.equal(naiveConsumerAllows(after, stamp.index), true);
     assert.equal(naiveConsumerAllows(verified, stamp.index - 1), false);
     assert.equal(naiveConsumerAllows(after, stamp.index - 1), false);
+  });
+});
+
+// --- T6: closeGateStatus — the composite walkCloseGate + readResolution gate
+// every consumer should call instead of wiring the two together itself ---
+
+// A genuine typed close-phrase user record, in the same JSONL shape a real
+// transcript carries (see helpers.mjs's seedCloseTranscript, which uses the
+// same phrase against the real transcript resolver).
+const CLOSE_TEXT = '세션 마무리 해줘';
+function closeRecord(text = CLOSE_TEXT) {
+  return JSON.stringify({ type: 'user', message: { role: 'user', content: text } });
+}
+
+/** Writes JSONL records (already-stringified lines) to a fresh transcript
+ * file under `dir` and returns its path. */
+function writeTranscript(dir, ...lines) {
+  const path = join(dir, `transcript-${Math.random().toString(36).slice(2, 10)}.jsonl`);
+  writeFileSync(path, lines.join('\n') + '\n');
+  return path;
+}
+
+suite('close-gate-store: closeGateStatus (T6, the composite gate)');
+
+test('(a) an open with no recorded resolution passes', () => {
+  withTmpDir((hypoDir) => {
+    const transcriptPath = writeTranscript(hypoDir, closeRecord());
+    const result = closeGateStatus({ transcriptPath, hypoDir, sessionId: SESSION });
+    assert.equal(result.ok, true);
+    assert.equal(result.open, true);
+  });
+});
+
+test('(b) a resolved close with no NEW open since the resolution is rejected', () => {
+  withTmpDir((hypoDir) => {
+    const transcriptText = closeRecord() + '\n';
+    const stamp = resolutionStamp(Buffer.from(transcriptText, 'utf-8'));
+    assert.equal(recordGateClosed(hypoDir, SESSION, stamp), true);
+
+    // Same bytes, no fresh close phrase appended since the resolution.
+    const transcriptPath = writeTranscript(hypoDir, closeRecord());
+    const result = closeGateStatus({ transcriptPath, hypoDir, sessionId: SESSION });
+    assert.equal(result.ok, false);
+    assert.equal(result.open, true, 'the transcript itself still opens — only the gate rejects');
+    assert.match(result.reason, /no-new-open-since-resolution/);
+  });
+});
+
+test('(c) a resolved close followed by a fresh close phrase passes', () => {
+  withTmpDir((hypoDir) => {
+    const transcriptText = closeRecord() + '\n';
+    const stamp = resolutionStamp(Buffer.from(transcriptText, 'utf-8'));
+    recordGateClosed(hypoDir, SESSION, stamp);
+
+    // A second, later close phrase — a fresh user decision after the resolution.
+    const transcriptPath = writeTranscript(hypoDir, closeRecord(), closeRecord());
+    const result = closeGateStatus({ transcriptPath, hypoDir, sessionId: SESSION });
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, null);
+  });
+});
+
+test('(d) a prefix-hash mismatch (transcript rewritten ahead of the resolved record) is rejected', () => {
+  withTmpDir((hypoDir) => {
+    const transcriptText = closeRecord() + '\n';
+    const stamp = resolutionStamp(Buffer.from(transcriptText, 'utf-8'));
+    recordGateClosed(hypoDir, SESSION, stamp);
+
+    // A record inserted AHEAD of the resolved one shifts every byte the
+    // resolution's hash was computed over — a rewrite, not an append.
+    const transcriptPath = writeTranscript(
+      hypoDir,
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+      closeRecord(),
+    );
+    const result = closeGateStatus({ transcriptPath, hypoDir, sessionId: SESSION });
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /transcript-rewrite-detected/);
+  });
+});
+
+test('(e) polarity invariant: a forged resolution file never passes MORE than an absent one does', () => {
+  const forgedPayloads = [
+    { open: true },
+    { granted: true },
+    { humanTurnAt: new Date(Date.now() + 86_400_000).toISOString() }, // future
+    { fresh: true },
+  ];
+  // A transcript that never opens the gate at all — rule 1 of closeGateStatus
+  // must reject it before ever reading a resolution file, so this is the ONE
+  // shape where "no file" is NOT already the maximally permissive baseline
+  // (withoutFile is false here, not true). A forged permissive-looking key
+  // like {open:true} making withFile true here is exactly the bug this test
+  // exists to catch — the earlier version of this test only ever exercised a
+  // transcript that already passed on its own, where withoutFile is always
+  // true and `withFile <= withoutFile` cannot fail for ANY withFile value.
+  const NEUTRAL_TEXT = JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content: 'hello, not a close phrase' },
+  });
+
+  for (const payload of forgedPayloads) {
+    withTmpDir((hypoDir) => {
+      writeRawFile(hypoDir, SESSION, payload);
+
+      // Direct assertion on the mechanism, not just the outcome: the forged
+      // file must read back as the exact same NO_CONSTRAINT shape an absent
+      // file gives, regardless of which permissive-looking key it carries.
+      const transcriptForRead = Buffer.from(closeRecord() + '\n', 'utf-8');
+      assert.deepEqual(
+        readResolution(hypoDir, SESSION, transcriptForRead),
+        { closedAtIndex: null, prefixMatches: null },
+        `forged payload must read as NO_CONSTRAINT: ${JSON.stringify(payload)}`,
+      );
+
+      const openPath = writeTranscript(hypoDir, closeRecord());
+      const withFileOpen = closeGateStatus({
+        transcriptPath: openPath,
+        hypoDir,
+        sessionId: SESSION,
+      }).ok;
+      assert.equal(
+        withFileOpen,
+        true,
+        `an open transcript with only a forged (no-constraint) file must still pass: ${JSON.stringify(payload)}`,
+      );
+
+      const noOpenPath = writeTranscript(hypoDir, NEUTRAL_TEXT);
+      const withFileNoOpen = closeGateStatus({
+        transcriptPath: noOpenPath,
+        hypoDir,
+        sessionId: SESSION,
+      }).ok;
+      assert.equal(
+        withFileNoOpen,
+        false,
+        `a forged file must not open a gate the transcript itself never opened: ${JSON.stringify(payload)}`,
+      );
+    });
+  }
+
+  // Baseline: no resolution file at all, same two transcript shapes. Both
+  // scenarios above must match this exactly (open → true, no-open → false).
+  withTmpDir((hypoDir) => {
+    const openPath = writeTranscript(hypoDir, closeRecord());
+    assert.equal(
+      closeGateStatus({ transcriptPath: openPath, hypoDir, sessionId: SESSION }).ok,
+      true,
+    );
+    const noOpenPath = writeTranscript(hypoDir, NEUTRAL_TEXT);
+    assert.equal(
+      closeGateStatus({ transcriptPath: noOpenPath, hypoDir, sessionId: SESSION }).ok,
+      false,
+    );
   });
 });

--- a/tests/close-hooks-gate.test.mjs
+++ b/tests/close-hooks-gate.test.mjs
@@ -18,6 +18,7 @@ import {
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
+import { recordGateClosed, resolutionStamp } from '../hooks/close-gate-store.mjs';
 import {
   HOME,
   HOOKS,
@@ -28,6 +29,7 @@ import {
   payloadForCleanWiki,
   peekTouchedPaths,
   recordTouchedPaths,
+  resolveTranscriptBySessionId,
   run,
   runApply,
   runHook,
@@ -1508,6 +1510,222 @@ test('a non-clear SessionEnd reason records nothing', () => {
       assert.equal(existsSync(gatePath), false, 'a non-clear reason must not record a resolution');
     } finally {
       cleanup();
+    }
+  });
+});
+
+// ── T6: consumer wiring, not the judge function itself ─────────────────────
+//
+// tests/close-gate-store.test.mjs's (a)-(e) call closeGateStatus directly, so
+// they pass whether or not any real caller ever wires it in. The two tests
+// below observe THROUGH the two production call sites instead
+// (verifyCloseAuthority via --apply-session-close, hypo-close-guard.mjs via
+// PreToolUse), so a revert of either wiring — reading `.open` instead of
+// `.ok`, or dropping the call entirely — turns one of these red. Each was
+// confirmed red against the exact neutralization it pins, then restored.
+
+suite('close-gate resolution wiring (T6, consumer gating)');
+
+test('A) verifyCloseAuthority: a resolved close refuses a re-run with no fresh signal, before any byte is written', () => {
+  withCleanWiki((wiki) => {
+    const today = todayLocal();
+    const projDir = join(wiki, 'projects', 'test-project');
+    const payload = {
+      project: 'test-project',
+      date: today,
+      sessionState: { content: readFileSync(join(projDir, 'session-state.md'), 'utf-8') },
+      projectHot: { content: readFileSync(join(projDir, 'hot.md'), 'utf-8') },
+      rootHot: { content: readFileSync(join(wiki, 'hot.md'), 'utf-8') },
+      sessionLog: { entry: `## [${today}] first close\n` },
+      log: { entry: `## [${today}] session | test-project — first close\n` },
+    };
+    const sessionId = 's-t6-verify-authority';
+
+    // Seed the transcript ourselves (not via runApply's auto-seed) so it
+    // survives between calls instead of being deleted by runApply's own
+    // cleanup after the first one — the second and third calls need to see
+    // the SAME session's growing transcript.
+    const cleanupTranscript = seedCloseTranscript(sessionId);
+    try {
+      // 1) A close signal exists, no resolution recorded yet → apply succeeds
+      // (its own success is what records the resolution — see the T3 suite
+      // above).
+      const first = runApply(wiki, payload, { sessionId });
+      const firstOut = JSON.parse(first.stdout);
+      assert.equal(firstOut.ok, true, `first apply must succeed: ${first.stdout}\n${first.stderr}`);
+
+      // 2) Same session, same transcript, no fresh close phrase since the
+      // resolution → verifyCloseAuthority must refuse before any write. The
+      // payload carries DIFFERENT projectHot bytes than the first apply
+      // wrote, on purpose: reusing the same payload would make a rejected
+      // apply and a silently-successful no-op write indistinguishable on
+      // disk (F3 — same bytes either way), so the disk-untouched assertion
+      // below actually needs bytes that would visibly land if the gate did
+      // not hold.
+      const hotBefore = readFileSync(join(projDir, 'hot.md'), 'utf-8');
+      const second = runApply(
+        wiki,
+        { ...payload, projectHot: { content: `${hotBefore}\nsecond close, must never land.\n` } },
+        { sessionId },
+      );
+      const secondOut = JSON.parse(second.stdout);
+      assert.notEqual(second.status, 0, 'a reused, already-resolved signal must not re-authorize');
+      assert.equal(secondOut.ok, false);
+      assert.equal(secondOut.reason, 'no-user-close-signal');
+      assert.match(
+        secondOut.error,
+        /no-new-open-since-resolution/,
+        `the refusal must name the specific gate reason: ${secondOut.error}`,
+      );
+      assert.deepEqual(secondOut.applied, [], 'a refused authority check must write nothing');
+      assert.equal(
+        secondOut.committed,
+        null,
+        'a refused authority check must not attempt a commit',
+      );
+      assert.equal(
+        readFileSync(join(projDir, 'hot.md'), 'utf-8'),
+        hotBefore,
+        'the refused apply must not touch disk',
+      );
+
+      // 3) Pair assertion: a fresh close phrase appended to the SAME
+      // transcript authorizes the re-run.
+      const transcriptPath = resolveTranscriptBySessionId(
+        sessionId,
+        join(SESSION_TMP_HOME, '.claude', 'projects'),
+      );
+      writeFileSync(
+        transcriptPath,
+        readFileSync(transcriptPath, 'utf-8') +
+          JSON.stringify({ type: 'user', message: { role: 'user', content: '세션 마무리 해줘' } }) +
+          '\n',
+      );
+      const third = runApply(wiki, payload, { sessionId });
+      const thirdOut = JSON.parse(third.stdout);
+      assert.equal(thirdOut.ok, true, `a fresh close signal must re-authorize: ${third.stdout}`);
+    } finally {
+      cleanupTranscript();
+    }
+  });
+});
+
+test('B) hypo-close-guard.mjs: a resolved close with no new open re-asks, and names the specific gate rejection', () => {
+  withCleanWiki((wiki) => {
+    const sessionId = 's-t6-guard-wiring';
+    const transcriptPath = join(wiki, `transcript-${sessionId}.jsonl`);
+    writeFileSync(
+      transcriptPath,
+      JSON.stringify({ type: 'user', message: { role: 'user', content: '세션 마무리 해줘' } }) +
+        '\n',
+    );
+    const stdin = {
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: join(wiki, 'projects', 'test-project', 'hot.md'),
+        content: '**2026-08-04(1번째 세션): 세션을 마감했다.**',
+      },
+    };
+
+    // 1) A close signal exists, no resolution recorded → the guard passes
+    // silently (the `ok` path).
+    const before = runHook('hypo-close-guard.mjs', stdin, { HYPO_DIR: wiki });
+    assert.equal(
+      before.stdout.trim(),
+      '',
+      `an open, unresolved close must pass silently: ${before.stdout}`,
+    );
+
+    // 2) Record a resolution against these exact bytes; no new open since.
+    recordGateClosed(wiki, sessionId, resolutionStamp(readFileSync(transcriptPath)));
+
+    const after = runHook('hypo-close-guard.mjs', stdin, { HYPO_DIR: wiki });
+    assert.notEqual(after.stdout.trim(), '', 'a resolved close with no new open must re-ask');
+    const out = JSON.parse(after.stdout);
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'ask');
+    assert.match(
+      out.hookSpecificOutput.permissionDecisionReason,
+      /no-new-open-since-resolution/,
+      `the ask reason must name the specific gate rejection: ${out.hookSpecificOutput.permissionDecisionReason}`,
+    );
+  });
+});
+
+test('C) crystallize.mjs:754 (runMarkSessionClosed) stays on isCloseGateOpen: a commit-failed marker still recovers with NO new close signal', () => {
+  withCleanWiki((wiki) => {
+    // Same commit-failure fixture as the T3 suite above: force the vault's
+    // own commit to fail, so apply succeeds (ok:true, resolution recorded by
+    // its own success) but the marker is withheld (commit-failed).
+    const hooksDir = join(wiki, '.git', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    const hookPath = join(hooksDir, 'pre-commit');
+    writeFileSync(hookPath, '#!/bin/sh\nexit 1\n');
+    chmodSync(hookPath, 0o755);
+
+    const today = todayLocal();
+    const projDir = join(wiki, 'projects', 'test-project');
+    const payload = {
+      project: 'test-project',
+      date: today,
+      sessionState: { content: readFileSync(join(projDir, 'session-state.md'), 'utf-8') },
+      projectHot: { content: readFileSync(join(projDir, 'hot.md'), 'utf-8') },
+      rootHot: { content: readFileSync(join(wiki, 'hot.md'), 'utf-8') },
+      sessionLog: { entry: `## [${today}] test session\n` },
+      log: { entry: `## [${today}] session | test-project\n` },
+    };
+    const sessionId = 's-t6-mark-recovery';
+    const cleanupTranscript = seedCloseTranscript(sessionId);
+    try {
+      const applyResult = runApply(wiki, payload, { sessionId });
+      const applyOut = JSON.parse(applyResult.stdout);
+      assert.equal(
+        applyOut.ok,
+        true,
+        `apply must still succeed on a commit failure: ${applyResult.stdout}\n${applyResult.stderr}`,
+      );
+      assert.equal(
+        applyOut.markerWritten,
+        false,
+        'the marker must be withheld on a commit failure',
+      );
+      assert.ok(
+        /^commit-failed:/.test(applyOut.markerSkipReason || ''),
+        `expected a commit-failed skip reason, got ${JSON.stringify(applyOut.markerSkipReason)}`,
+      );
+      const markerPath = join(wiki, '.cache', `session-closed-${sessionId}.marker`);
+      assert.equal(existsSync(markerPath), false, 'no marker must exist yet');
+
+      // The person fixes the commit failure by hand and lands the payload's
+      // own writes (commands/crystallize.md's documented recovery for
+      // `commit-failed:` — fix the git issue, then re-run). No new close
+      // phrase enters the transcript: this is recovering the SAME close, not
+      // requesting a new one.
+      unlinkSync(hookPath);
+      spawnSync('git', ['add', '-A'], { cwd: wiki });
+      spawnSync('git', ['commit', '-q', '-m', 'recover commit-failed close'], { cwd: wiki });
+
+      // This is the decision F1/F2 pin: :754 must stay isCloseGateOpen, not
+      // closeGateStatus, or this recovery run would refuse itself against
+      // the resolution its own first apply just recorded.
+      const markResult = run('crystallize.mjs', [
+        `--hypo-dir=${wiki}`,
+        '--mark-session-closed',
+        `--session-id=${sessionId}`,
+        '--project=test-project',
+        '--json',
+      ]);
+      const markOut = JSON.parse(markResult.stdout);
+      assert.equal(
+        markResult.status,
+        0,
+        `the recovery marker write must succeed with no new close signal: ${markResult.stdout}\n${markResult.stderr}`,
+      );
+      assert.equal(markOut.ok, true);
+      assert.ok(existsSync(markerPath), 'the marker must land on the recovery run');
+    } finally {
+      cleanupTranscript();
     }
   });
 });

--- a/tests/proposal-base.test.mjs
+++ b/tests/proposal-base.test.mjs
@@ -2496,23 +2496,50 @@ test('same session closing twice does not raise a false-positive against its own
   // The ONLY test that fails when advanceBase is removed. A single apply passes
   // either way, which is exactly why this exists:
   // [[pages/learnings/mutation-check-invariants-a-passing-suite-cannot-see]]
+  //
+  // T6: verifyCloseAuthority now gates on closeGateStatus, which refuses a
+  // REUSED transcript once this session has already resolved a close against
+  // it (the same evidence cannot authorize a second apply with no fresh user
+  // signal). So this test seeds the transcript itself, outside t4Apply's
+  // auto-seed/cleanup, and appends a genuine second close phrase before the
+  // second apply — exactly the evidence a real second close of the same
+  // session would carry. The base-store invariant this test pins (self-conflict
+  // without advanceBase) is otherwise untouched.
   withWiki(null, (dir, today) => {
     snapshotBase(dir, 's-twice', overwriteTargets(T4_PROJECT));
     const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
 
-    const first = `${observed}\nfirst close.\n`;
-    const a = t4Apply(dir, t4Payload(dir, today, first, 'first close'), 's-twice');
-    assert.deepEqual(a.out.conflicts, [], 'first close writes cleanly');
-    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), first);
+    const cleanupTranscript = seedCloseTranscript('s-twice');
+    try {
+      const first = `${observed}\nfirst close.\n`;
+      const a = t4Apply(dir, t4Payload(dir, today, first, 'first close'), 's-twice');
+      assert.deepEqual(a.out.conflicts, [], 'first close writes cleanly');
+      assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), first);
 
-    const second = `${observed}\nsecond close, same session.\n`;
-    const b = t4Apply(dir, t4Payload(dir, today, second, 'second close'), 's-twice');
-    assert.deepEqual(
-      b.out.conflicts,
-      [],
-      'without advanceBase the session diffs against its own stale base and self-conflicts',
-    );
-    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), second);
+      // A fresh close phrase, appended after the first apply already resolved
+      // the transcript through the record above it.
+      const transcriptPath = resolveTranscriptBySessionId(
+        's-twice',
+        join(SESSION_TMP_HOME, '.claude', 'projects'),
+      );
+      writeFileSync(
+        transcriptPath,
+        readFileSync(transcriptPath, 'utf-8') +
+          JSON.stringify({ type: 'user', message: { role: 'user', content: '세션 마무리 해줘' } }) +
+          '\n',
+      );
+
+      const second = `${observed}\nsecond close, same session.\n`;
+      const b = t4Apply(dir, t4Payload(dir, today, second, 'second close'), 's-twice');
+      assert.deepEqual(
+        b.out.conflicts,
+        [],
+        'without advanceBase the session diffs against its own stale base and self-conflicts',
+      );
+      assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), second);
+    } finally {
+      cleanupTranscript();
+    }
   });
 });
 
@@ -2832,7 +2859,11 @@ test('publishes the lock by linking a complete file, never by creating an empty 
   // after a crash between the link and its cleanup the staging name and the lock
   // are one inode — writing the former would rewrite the live lock.
   assert.match(acquire, /randomBytes\(/, 'the staging name is per-call random');
-  assert.match(acquire, /flag: 'wx'/, 'the staging write is exclusive, never onto an existing file');
+  assert.match(
+    acquire,
+    /flag: 'wx'/,
+    'the staging write is exclusive, never onto an existing file',
+  );
 });
 
 // A directory we cannot write to is not the same event as a lock someone else


### PR DESCRIPTION
# English

## What changed

`closeGateStatus` in `hooks/close-gate-store.mjs` now orders a transcript's close
signal against the resolution a successful apply records, and two callers move
onto it: `verifyCloseAuthority`, which runs before any wiki byte is written, and
the PreToolUse guard that intercepts writes to close artifacts.

Two other callers deliberately stay on the raw `isCloseGateOpen` check. Rejections
now carry which of the three rules refused, and three tests observe the wiring
through the consumers.

## Why

A close signal could be spent twice. Every gate re-read the transcript and asked
only "did the user say close", so the same phrase kept authorizing writes long
after the close it belonged to had finished. Re-running an apply with no fresh
signal went through as if the user had just asked.

Users also could not tell two refusals apart. "You never asked to close" and
"that close was already spent" need different responses, and both printed the
same sentence.

## How

Writing bytes is not the criterion for which gate a caller belongs on, since the
standalone marker entrypoint writes a file too. What separates them is which
close a call is transacting for.

A new authorization stands on whatever signal the transcript carries now, so an
older resolution must retire it first. The standalone `--mark-session-closed`
entrypoint is instead the follow-up repair of a close that already happened: a
successful apply is what wrote that resolution, and its `openedAtIndex` comes
from the same transcript snapshot the resolution was stamped from, so it can
never clear the ordering rule. Gating that path would leave a marker withheld by
a commit failure with no way back. The apply's own diagnostic field is the same
case, reading the record it just wrote.

Three tests observe this through the consumers rather than the judge. A unit test
of `closeGateStatus` passes whether or not anything calls it, so it cannot tell
that the wiring is still there.

## Manual verification

Neutralisation, run three times against the full suite. Each one turns exactly
its own test red and nothing else:

```
scripts/crystallize.mjs:965  .ok -> .open          2003 passed, 1 failed  (test A)
hooks/hypo-close-guard.mjs   .ok -> .open          2003 passed, 1 failed  (test B)
scripts/crystallize.mjs:754  -> closeGateStatus    2003 passed, 1 failed  (test C)
```

Before this branch all three left the suite at 2004 passed, 0 failed.

```
npm test                          exit 0   2004 passed, 0 failed
npm run lint                      exit 0   0 errors
node scripts/check-pack-surface.mjs   exit 0
node scripts/check-tracker-ids.mjs --all   exit 0
npx prettier --check <changed>    clean
```

A live-session hook QA run is not in this PR. The spec's final task already
covers the six live-session scenarios for this feature as one pass, and running a
T6-only QA now would repeat it there.

## Migration notes

None. The resolution store already ships; this PR only changes which callers read
it. An installed copy with no resolution file behaves exactly as before, because
an absent record is read as no constraint.

---

# 한국어

## 변경 내용

`hooks/close-gate-store.mjs` 의 `closeGateStatus` 가 트랜스크립트의 close 신호를
apply 성공이 남긴 해결 기록과 순서로 대조한다. 소비처 둘이 그 함수로 옮겼다.
위키 바이트를 쓰기 전에 도는 `verifyCloseAuthority`, 그리고 close 대상 파일 쓰기를
가로채는 PreToolUse 가드다.

나머지 소비처 둘은 원시 `isCloseGateOpen` 에 그대로 둔다. 거절이 이제 세 규칙 중
무엇이 막았는지를 싣고, 배선을 소비처를 통해 관측하는 시험 셋이 붙는다.

## 이유

close 신호가 두 번 쓰일 수 있었다. 모든 게이트가 트랜스크립트를 다시 읽어
"사용자가 close 라고 했나" 만 물었으므로, 그 신호가 속한 close 가 끝난 뒤에도 같은
문장이 계속 쓰기를 인가했다. 새 신호 없이 apply 를 다시 돌려도 방금 요청한 것처럼
통과했다.

거절 둘을 사용자가 구별할 수도 없었다. "close 를 요청한 적이 없다" 와 "그 close 는
이미 소비됐다" 는 해야 할 일이 다른데 같은 문장이 나왔다.

## 방법

어느 게이트에 속하는지를 가르는 기준은 "바이트를 쓰느냐" 가 아니다. 마커 전용
진입점도 파일을 쓴다. 가르는 것은 그 호출이 어느 close 를 위한 거래인가다.

새 인가는 지금 트랜스크립트가 담고 있는 신호 위에 서므로, 앞선 해결 기록이 그
신호를 먼저 물러나게 해야 한다. `--mark-session-closed` 는 반대로 이미 일어난
close 의 후속 복구다. 그 해결 기록을 쓴 것이 apply 성공 자신이고, 그 자리의
`openedAtIndex` 는 해결 기록이 찍힌 것과 같은 트랜스크립트 스냅샷에서 오므로 순서
규칙을 절대 넘을 수 없다. 그 경로를 막으면 커밋 실패로 보류된 마커에 돌아올 길이
없다. apply 자신의 진단 필드도 같은 경우로, 방금 쓴 기록을 다시 읽는다.

시험 셋은 판정 함수가 아니라 소비처를 통해 관측한다. `closeGateStatus` 의 단위
시험은 그 함수를 아무도 안 불러도 통과하므로 배선이 남아 있는지 못 잰다.

## 수동 검증

무력화를 전체 스위트에 세 번 걸었다. 각각 자기 시험 하나만 red 로 만들고 다른 것은
건드리지 않는다.

```
scripts/crystallize.mjs:965  .ok -> .open          2003 passed, 1 failed  (시험 A)
hooks/hypo-close-guard.mjs   .ok -> .open          2003 passed, 1 failed  (시험 B)
scripts/crystallize.mjs:754  -> closeGateStatus    2003 passed, 1 failed  (시험 C)
```

이 브랜치 전에는 셋 다 2004 passed, 0 failed 였다.

```
npm test                          exit 0   2004 passed, 0 failed
npm run lint                      exit 0   에러 0
node scripts/check-pack-surface.mjs   exit 0
node scripts/check-tracker-ids.mjs --all   exit 0
npx prettier --check <변경 파일>   clean
```

실세션 훅 QA 는 이 PR 에 없다. 스펙의 마지막 태스크가 이 기능의 실세션 시나리오
여섯을 한 번에 도는 것으로 이미 잡혀 있어서, T6 만 따로 QA 하면 거기서 다시 돈다.

## 마이그레이션 노트

없다. 해결 기록 저장소는 이미 출하돼 있고 이 PR 은 그것을 읽는 소비처만 바꾼다.
해결 기록 파일이 없는 설치본은 이전과 똑같이 동작한다. 기록 부재는 제약 없음으로
읽히기 때문이다.

---

## Changelog

- EN: Close approval is now checked against the resolution a successful apply records, so a spent close phrase can no longer re-authorize a later write, and a refusal says which rule stopped it (#254, ADR 0087, ADR 0088)
- KO: close 승인을 apply 성공이 남긴 해결 기록과 대조한다. 이미 소비된 close 문장이 이후의 쓰기를 다시 인가하지 못하고, 거절이 어느 규칙에 막혔는지 말한다 (#254, ADR 0087, ADR 0088)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
