### PR TITLE
fix(uninstall): remove the shell rc block and the wiki pre-commit hook that init installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,14 +257,23 @@ jobs:
           node-version: 20
       - name: Dry-run reports DRY RUN
         run: |
+          # --hooks-dir only scopes the ~/.claude/hooks removal; it does not
+          # bound the rc-block / wiki-pre-commit-hook cleanup, which lives
+          # outside ~/.claude entirely. Without --keep-shell/--keep-wiki-hook
+          # this run would read the runner's real ~/.bashrc and scan its real
+          # $HOME for a vault, since this job never sandboxes HOME.
           out=$(node scripts/uninstall.mjs \
-            --hooks-dir=/tmp/no-hooks-$RANDOM)
+            --hooks-dir=/tmp/no-hooks-$RANDOM \
+            --keep-shell \
+            --keep-wiki-hook)
           echo "$out" | grep -q '\[DRY RUN'
       - name: Apply mode exits 0 when nothing is installed
         run: |
           node scripts/uninstall.mjs \
             --apply \
-            --hooks-dir=/tmp/no-hooks-$RANDOM
+            --hooks-dir=/tmp/no-hooks-$RANDOM \
+            --keep-shell \
+            --keep-wiki-hook
 
   hypo-absent:
     name: Hypo-absent (Node ${{ matrix.node-version }})

--- a/README.ko.md
+++ b/README.ko.md
@@ -74,9 +74,9 @@ hypomnema
 
 > 어느 경로든 첫 실행 뒤에는 Claude Code를 재시작(또는 새 세션 열기)해야 새 훅과 슬래시 커맨드가 반영됩니다.
 
-> `init`은 `~/.zshrc`(또는 `~/.bashrc`)에 `claude()` 셸 함수도 추가합니다. `# hypo-managed:shell-setup:start`와 `:end` 마커 사이에 들어가며, `cd`만 한 세션에도 프로젝트 컨텍스트가 주입되게 합니다. `--no-shell`로 건너뛰거나 `--shell-config=<path>`로 대상 파일을 바꿀 수 있습니다. `uninstall`은 이 블록을 지우지 않으니 마커 사이 줄을 직접 지우세요.
+> `init`은 `~/.zshrc`(또는 `~/.bashrc`)에 `claude()` 셸 함수도 추가합니다. `# hypo-managed:shell-setup:start`와 `:end` 마커 사이에 들어가며, `cd`만 한 세션에도 프로젝트 컨텍스트가 주입되게 합니다. `--no-shell`로 건너뛰거나 `--shell-config=<path>`로 대상 파일을 바꿀 수 있습니다. `uninstall --apply`는 이 블록을 지웁니다(기본으로 `~/.zshrc`와 `~/.bashrc` 둘 다 확인하고, `--shell-config`로 지정한 파일이 있으면 그것만 봅니다). 다만 마커를 손으로 편집해서 중복되거나 순서가 뒤바뀐 상태라면, 무엇을 지워야 할지 안전하게 판단할 수 없으므로 블록을 그대로 둡니다.
 
-> `init`은 위키 저장소에 pre-commit 훅도 설치합니다(`<위키>/.git/hooks/pre-commit`, `# hypo-managed:pre-commit:*` 마커). `.hypoignore`에 걸리는 파일이 스테이지되면 커밋을 막습니다. 해당 파일을 unstage 하거나 `git commit --no-verify`로 우회하세요. 이 훅에는 설치된 패키지의 절대 경로가 박히므로, Hypomnema를 옮기거나 재설치했다면 `hypomnema init`을 다시 돌려 경로를 갱신해야 합니다. 그러지 않으면 위키의 모든 커밋이 실패합니다. `uninstall`은 이 파일을 지우지 않습니다.
+> `init`은 위키 저장소에 pre-commit 훅도 설치합니다(`<위키>/.git/hooks/pre-commit`, `# hypo-managed:pre-commit:*` 마커). `.hypoignore`에 걸리는 파일이 스테이지되면 커밋을 막습니다. 해당 파일을 unstage 하거나 `git commit --no-verify`로 우회하세요. 이 훅에는 설치된 패키지의 절대 경로가 박히므로, Hypomnema를 옮기거나 재설치했다면 `hypomnema init`을 다시 돌려 경로를 갱신해야 합니다. 그러지 않으면 위키의 모든 커밋이 실패합니다. `uninstall --apply`는 이 훅을 지웁니다. 위키 위치는 `init`과 같은 방식으로 찾고, `--hypo-dir=<path>`로 직접 지정할 수도 있습니다. 다만 마커는 있지만 그 바깥에 다른 내용이 붙은 훅처럼 더 이상 온전히 Hypomnema 소유가 아닌 훅은 손대지 않고 그대로 둡니다.
 
 > 두 번째 기기에서는 그냥 `hypomnema`를 돌리지 마세요. 원격과 무관한 새 위키가 만들어집니다. 기존 위키를 클론하는 쪽을 쓰세요. `hypomnema --from-remote=<git-url>`이 위키 루트로 클론한 뒤 실제 Hypomnema 위키인지 확인하고, 새 git 히스토리를 만들지 않은 채 훅과 슬래시 커맨드만 설치합니다. 대상 디렉터리가 이미 있으면 거부합니다.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ hypomnema
 
 `hypomnema` (or `hypomnema --help` for flags) scaffolds the wiki and installs hooks. It also copies the slash command files to `~/.claude/commands/hypo/`, so `/hypo:*` works inside Claude Code afterwards. Later `hypomnema upgrade` runs use per-file SHA tracking, so anything you hand-edited stays put.
 
-`init` also appends a `claude()` shell function to `~/.zshrc` or `~/.bashrc`, marked between `# hypo-managed:shell-setup:start` and `:end`, so a cd-only session still gets project context. Pass `--no-shell` to skip it, or `--shell-config=<path>` to target a different file. `uninstall` does not remove this block; delete the marked lines by hand.
+`init` also appends a `claude()` shell function to `~/.zshrc` or `~/.bashrc`, marked between `# hypo-managed:shell-setup:start` and `:end`, so a cd-only session still gets project context. Pass `--no-shell` to skip it, or `--shell-config=<path>` to target a different file. `uninstall --apply` removes this block (checking both `~/.zshrc` and `~/.bashrc` by default, or the file named by `--shell-config`); it leaves the block untouched if a hand-edit has since duplicated or reordered the markers, since it has no safe way to guess what you meant.
 
 > Either path: restart Claude Code (or open a new session) after the first run so the new hooks and slash commands are picked up.
 
@@ -384,7 +384,7 @@ Place a `hypo-config.md` at the wiki root to make it portable across machines wi
 
 `.hypoignore` controls which paths the hooks ignore (default: `*.pdf`, `*.zip`, `*.pem`, `.env*`, `*credentials*`, `*secret*`, `*token*`, `*password*`, `*passwd*`, …). Edit it directly; there is no privacy mode flag. One file, one source of truth.
 
-> `init` also installs a pre-commit hook into the wiki repo at `<wiki>/.git/hooks/pre-commit`, marked `# hypo-managed:pre-commit:*`. It refuses any commit that stages a path matching `.hypoignore`; unstage the file, or override with `git commit --no-verify`. The hook embeds the absolute path of the installed package, so if you move or reinstall Hypomnema, re-run `hypomnema init` to repoint it or every wiki commit will fail. `uninstall` leaves this file in place.
+> `init` also installs a pre-commit hook into the wiki repo at `<wiki>/.git/hooks/pre-commit`, marked `# hypo-managed:pre-commit:*`. It refuses any commit that stages a path matching `.hypoignore`; unstage the file, or override with `git commit --no-verify`. The hook embeds the absolute path of the installed package, so if you move or reinstall Hypomnema, re-run `hypomnema init` to repoint it or every wiki commit will fail. `uninstall --apply` removes this hook, resolving the vault the same way `init` does (`--hypo-dir=<path>` to override); it only removes a hook that still carries the marker and no content outside it, so a hook you have since edited by hand is left in place.
 
 > The credential-style patterns above are substring globs, so an ordinary page such as `pages/oauth-token-refresh.md` is matched too: it is never injected by any hook, and the wiki pre-commit hook refuses to commit it. If you write about these topics, narrow the patterns or rename the page.
 

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -8,14 +8,19 @@ You are running `/hypo:uninstall`. Remove Hypomnema from this machine.
 
 - Removes Hypomnema hook files from `~/.claude/hooks/` (and optionally `~/.codex/hooks/`)
 - Strips Hypomnema entries from `~/.claude/settings.json`, leaving all other hooks untouched
-- **Dry-run by default** — shows what would be removed without making any changes
+- Removes the `claude()` shell function block from `~/.zshrc` and/or `~/.bashrc` (whichever carries the marker `init` wrote; use `--shell-config=<path>` to target a different file)
+- Removes the marked pre-commit hook from the wiki repo (`<wiki>/.git/hooks/pre-commit`); resolve a non-default wiki with `--hypo-dir=<path>`
+- Removes tracked slash commands, extension hard-copies, and `~/.claude/hypo-pkg.json` when nothing user-modified is left behind
+- Every removal above is marker- or SHA-gated: a block or file you have since hand-edited is reported and left in place, never guessed at
+- **The wiki content itself (pages, journal, sources under the vault root) is never deleted, only the git hook and shell block Hypomnema installed**
+- **Dry-run by default**: shows what would be removed without making any changes
 
 ---
 
 ## Step 1 — Confirm intent
 
 Say:
-> "This will remove Hypomnema hooks from your system. Your wiki files are NOT deleted.
+> "This will remove Hypomnema's hooks, slash commands, the claude() shell function block, and the wiki's pre-commit hook. Your wiki content (pages, journal, sources) is NOT deleted.
 > Run in dry-run mode first to preview changes? [yes]"
 
 Default: yes (dry-run first)
@@ -44,11 +49,18 @@ If no → abort and confirm nothing was changed.
 node ${CLAUDE_PLUGIN_ROOT}/scripts/uninstall.mjs --apply
 ```
 
-If the user also wants Codex hooks removed, append `--codex`.
+If the user also wants Codex hooks removed, append `--codex`. Other flags worth knowing about:
+- `--hypo-dir=<path>`: the wiki whose pre-commit hook gets removed, if it is not the default-resolved one
+- `--shell-config=<path>`: the single rc file to strip the shell block from, instead of checking both `~/.zshrc` and `~/.bashrc`
+- `--force-commands` / `--force-extensions`: remove a slash command or extension file even if its content no longer matches what Hypomnema installed
+- `--hooks-dir=<path>`: only redirects the `~/.claude/hooks/*.mjs` cleanup, so a run scoped to a sandbox hooks directory still touches the real shell rc files and wiki vault unless `--keep-shell` and/or `--keep-wiki-hook` are also passed. The script warns about this before it does anything if it detects the combination
+- `--keep-shell`: skip the shell rc `claude()` block removal entirely
+- `--keep-wiki-hook`: skip the wiki pre-commit hook removal entirely, including the step that resolves which vault it would have looked at
 
 ---
 
 ## Notes
 
-- Wiki content (`~/hypomnema/`) is never touched — only hook files and settings.json entries
+- Wiki content under `~/hypomnema/` (pages, journal, sources, etc.) is never touched
+- What IS removed by `--apply`: hook files, settings.json entries, the shell rc `claude()` block, and the wiki's own pre-commit hook
 - To reinstall, run `/hypo:init`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -233,7 +233,7 @@ Hooks inline this logic in `hypo-shared.mjs`. Scripts use `scripts/lib/hypo-root
 
 ### `/hypo:uninstall`
 
-Removes hypo-prefixed hooks from `~/.claude/hooks/` and matching entries from `~/.claude/settings.json`. **Non-hypo hooks are preserved**. The wiki vault itself is never touched.
+Removes hypo-prefixed hooks from `~/.claude/hooks/` and matching entries from `~/.claude/settings.json`. **Non-hypo hooks are preserved**. `--apply` also reaches past `~/.claude/`: it strips the marked `claude()` block from the shell rc file(s) init wrote to, and removes the marked pre-commit hook from the wiki's own git repo. Both removals are marker-gated the same way the hooks-dir cleanup is, so a hand-edited block or hook is left in place rather than guessed at.
 
 ---
 

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'url';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 import { readRenameMarker, renameMarkerPath, RENAME_MARKER_REL } from './lib/rename-marker.mjs';
-import { resolveGitHooksDir } from './lib/git-hooks-dir.mjs';
+import { resolveGitHooksDir, WIKI_PRE_COMMIT_MARKER_START } from './lib/git-hooks-dir.mjs';
 import { parseFrontmatter } from './lib/frontmatter.mjs';
 import {
   readSyncState,
@@ -506,7 +506,7 @@ function checkGit(hypoDir) {
         ? 'Not installed — run /hypo:init to install .hypoignore guard'
         : 'Not installed, and /hypo:init will not install into this path — point core.hooksPath back inside the repository, or install the guard yourself',
     );
-  } else if (content.includes('# hypo-managed:pre-commit:start')) {
+  } else if (content.includes(WIKI_PRE_COMMIT_MARKER_START)) {
     pass(label, 'Hypomnema .hypoignore guard installed');
   } else {
     warn(label, 'Exists but not managed by Hypomnema — manual git add can bypass .hypoignore');

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -38,7 +38,16 @@ import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { expandHome, resolveHypoRoot } from './lib/hypo-root.mjs';
-import { hooksDirForInstall, unsafeHookTargetReason } from './lib/git-hooks-dir.mjs';
+import {
+  hooksDirForInstall,
+  unsafeHookTargetReason,
+  findMarkerSpan,
+  WIKI_PRE_COMMIT_MARKER_START,
+  WIKI_PRE_COMMIT_MARKER_END,
+  SHELL_MARKER_START,
+  SHELL_MARKER_END,
+  SHELL_FUNCTION_BODY,
+} from './lib/git-hooks-dir.mjs';
 import { readCoreHooksConfig } from './lib/core-hooks.mjs';
 import {
   readPkgJson as readPkgJsonSafe,
@@ -748,9 +757,6 @@ function installPkgGitHook(dryRun) {
 
 // ── wiki pre-commit hook ─────────────────────────────────────────────────────
 
-const WIKI_PRE_COMMIT_MARKER_START = '# hypo-managed:pre-commit:start';
-const WIKI_PRE_COMMIT_MARKER_END = '# hypo-managed:pre-commit:end';
-
 // Single-quote escaping prevents shell expansion of special chars (e.g. $HOME, backticks) in path
 function shellSingleQuote(p) {
   return `'${p.replace(/'/g, "'\\''")}'`;
@@ -859,16 +865,13 @@ function installWikiPreCommitHook(hypoDir, dryRun, force, root, lintStrict) {
 
 // ── shell function setup ─────────────────────────────────────────────────────
 
-const SHELL_MARKER_START = '# hypo-managed:shell-setup:start';
-const SHELL_MARKER_END = '# hypo-managed:shell-setup:end';
-
+// Built FROM SHELL_FUNCTION_BODY (./lib/git-hooks-dir.mjs), not a second copy
+// of the same literal: uninstall's isOwnedShellFunctionBody() compares an
+// existing marker span's body against that same constant byte-for-byte, so
+// this and that check can never drift apart the way two independent string
+// literals could.
 function shellFunctionBlock() {
-  return `${SHELL_MARKER_START}
-function claude() {
-  echo "{\\"cwd\\":\\"$(pwd)\\"}" | node "$HOME/.claude/hooks/hypo-session-start.mjs" > /dev/null 2>&1
-  command claude "$@"
-}
-${SHELL_MARKER_END}`;
+  return `${SHELL_MARKER_START}${SHELL_FUNCTION_BODY}${SHELL_MARKER_END}`;
 }
 
 function detectShellConfig(customPath) {
@@ -891,19 +894,32 @@ function installShellFunction(shellConfigPath, dryRun) {
   }
 
   const content = readFileSync(shellConfigPath, 'utf-8');
-  const startIdx = content.indexOf(SHELL_MARKER_START);
-  const endIdx = content.indexOf(SHELL_MARKER_END);
 
-  if (startIdx !== -1 && endIdx !== -1) {
+  if (content.includes(SHELL_MARKER_START) || content.includes(SHELL_MARKER_END)) {
+    // A block-shaped span is claimed here: validate it the same way uninstall
+    // does before touching a single byte. Two bare indexOf() calls cannot tell
+    // "well-formed" apart from "duplicated" (only the FIRST end is found, so a
+    // second full copy's body gets stranded in the untouched tail) or "swapped"
+    // (end before start silently duplicates whatever sits between them into the
+    // "replaced" span instead of raising anything). Neither corruption is
+    // something this script can safely repair, so a malformed span is left
+    // completely alone, the same contract uninstall.mjs holds for removal.
+    const span = findMarkerSpan(content, SHELL_MARKER_START, SHELL_MARKER_END);
+    if (!span.ok) {
+      log('skipped', `${shellConfigPath} (${span.reason}, leaving the file untouched)`);
+      return;
+    }
     // Block exists — check if already up to date
-    const existing = content.slice(startIdx, endIdx + SHELL_MARKER_END.length);
+    const existing = content.slice(span.startIdx, span.endIdx + SHELL_MARKER_END.length);
     if (existing === block) {
       log('skipped', `${shellConfigPath} (shell function up to date)`);
       return;
     }
     // Replace stale block
     const updated =
-      content.slice(0, startIdx) + block + content.slice(endIdx + SHELL_MARKER_END.length);
+      content.slice(0, span.startIdx) +
+      block +
+      content.slice(span.endIdx + SHELL_MARKER_END.length);
     if (!dryRun) writeFileSync(shellConfigPath, updated);
     log('merged', `${shellConfigPath} (shell function updated)`);
     return;

--- a/scripts/lib/git-hooks-dir.mjs
+++ b/scripts/lib/git-hooks-dir.mjs
@@ -38,6 +38,143 @@ import { execFileSync } from 'child_process';
 import { existsSync, lstatSync, realpathSync, statSync } from 'fs';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'path';
 
+// ── shared install/uninstall markers ────────────────────────────────────────
+// init.mjs writes these when it installs the wiki's git pre-commit hook and
+// the shell rc block; uninstall.mjs reads them back to remove exactly what
+// init created. Defined once here, imported by both, so the two scripts can
+// never drift into recognizing different markers.
+export const WIKI_PRE_COMMIT_MARKER_START = '# hypo-managed:pre-commit:start';
+export const WIKI_PRE_COMMIT_MARKER_END = '# hypo-managed:pre-commit:end';
+export const SHELL_MARKER_START = '# hypo-managed:shell-setup:start';
+export const SHELL_MARKER_END = '# hypo-managed:shell-setup:end';
+
+// ── marker-span validation (shared by both the writer in init.mjs and both
+// removal paths in uninstall.mjs) ───────────────────────────────────────────
+//
+// Two independent indexOf() calls cannot tell "well-formed" apart from
+// "duplicated" or "swapped": if a file happens to hold two full copies of the
+// block, indexOf finds only the first END, so slicing [firstStart, firstEnd]
+// leaves the second copy's install behind with no report of it. If END
+// precedes START (a hand-edited or corrupted file), slicing [start, end) with
+// start > end does not error, it silently duplicates whatever sits between
+// them into the "removed" (or, on the writer's side, the "replaced") span.
+// Neither script has a way back from either outcome, so a span is only
+// trusted when both markers appear EXACTLY once and START comes before END.
+function countOccurrences(content, needle) {
+  let count = 0;
+  let idx = 0;
+  while ((idx = content.indexOf(needle, idx)) !== -1) {
+    count++;
+    idx += needle.length;
+  }
+  return count;
+}
+
+export function findMarkerSpan(content, startMarker, endMarker) {
+  const startCount = countOccurrences(content, startMarker);
+  const endCount = countOccurrences(content, endMarker);
+  if (startCount !== 1 || endCount !== 1) {
+    return {
+      ok: false,
+      reason: `expected exactly one start and one end marker, found ${startCount} start / ${endCount} end`,
+    };
+  }
+  const startIdx = content.indexOf(startMarker);
+  const endIdx = content.indexOf(endMarker);
+  if (!(startIdx < endIdx)) {
+    return { ok: false, reason: 'the end marker appears before the start marker' };
+  }
+  return { ok: true, startIdx, endIdx };
+}
+
+// ── body-shape validation (shared by both removal paths in uninstall.mjs) ──
+//
+// findMarkerSpan proves the span itself is well-formed. It says nothing about
+// what sits INSIDE that span. A well-formed marker pair is trivial to forge
+// around arbitrary content — a user's own shell function, a user's own
+// pre-commit check — and codex reproduced exactly that (2026-08-27): a marker
+// pair wrapped around `echo USER_OWNED_DEPLOY_CHECK` passed every prior check
+// (one start, one end, start before end, a leading shebang) and got deleted
+// along with the user's line, because nothing ever looked at the body text
+// itself. These two functions are that missing check.
+//
+// The shell block is fully static — init never bakes a path into it — so its
+// body can be matched byte-for-byte against SHELL_FUNCTION_BODY below. The
+// pre-commit body cannot: it embeds the absolute install root, which moves
+// across machines and package versions, so requiring an exact match would
+// refuse to remove a hook a real (older, or differently-installed) init.mjs
+// actually wrote. It is matched structurally instead — the "one or two `node
+// '<path>' ... || exit 1` steps, then `exit 0`" shape — checking only that
+// the referenced script is ours (ends in `/hooks/hypo-pre-commit.mjs` or
+// `/scripts/lint.mjs`), not which root it lives under.
+//
+// Both directions of a mismatch here are unequal: failing to recognize a
+// hook init actually wrote costs a re-run with --force-*; deleting a file
+// that was never ours has no recovery. So an unrecognized shape is always
+// treated as "not ours" and left standing, never as "close enough".
+
+const PRE_COMMIT_WORKER_LINE = /^node '(.+)' \|\| exit 1$/;
+const PRE_COMMIT_LINT_LINE = /^node '(.+)' --hypo-dir='(?:.+)' --strict \|\| exit 1$/;
+
+// Reverses shellSingleQuote()'s escaping (a literal `'` becomes `'\''`) so the
+// captured path can be compared against the suffix it must end in.
+function unescapeShellSingleQuoted(s) {
+  return s.split("'\\''").join("'");
+}
+
+/**
+ * @param {string} content full pre-commit hook file content
+ * @param {{startIdx: number, endIdx: number}} span a `findMarkerSpan` result
+ *   already confirmed `ok: true` for WIKI_PRE_COMMIT_MARKER_START/END
+ * @returns {boolean} true when the text between the markers is recognizable
+ *   as a body init.mjs's wikiPreCommitContent() writes
+ */
+export function isOwnedWikiPreCommitBody(content, span) {
+  const body = content.slice(span.startIdx + WIKI_PRE_COMMIT_MARKER_START.length, span.endIdx);
+  const lines = body.split('\n');
+  // wikiPreCommitContent() always places a bare "\n" right after START and
+  // right before END, so the first and last split segments must be empty.
+  if (lines[0] !== '' || lines[lines.length - 1] !== '') return false;
+  const middle = lines.slice(1, -1);
+  if (middle.length < 2 || middle.length > 3 || middle[middle.length - 1] !== 'exit 0') {
+    return false;
+  }
+  const steps = middle.slice(0, -1);
+  const worker = PRE_COMMIT_WORKER_LINE.exec(steps[0]);
+  if (!worker || !unescapeShellSingleQuoted(worker[1]).endsWith('/hooks/hypo-pre-commit.mjs')) {
+    return false;
+  }
+  if (steps.length === 2) {
+    const lint = PRE_COMMIT_LINT_LINE.exec(steps[1]);
+    if (!lint || !unescapeShellSingleQuoted(lint[1]).endsWith('/scripts/lint.mjs')) return false;
+  }
+  return true;
+}
+
+// The exact text init.mjs's shellFunctionBlock() writes between the shell
+// markers. Exported so init.mjs builds the block FROM this constant rather
+// than a second copy of the same literal — the two can then never drift the
+// way independent copies of the pre-commit worker line already could not
+// (see the module-level comment on the markers above).
+export const SHELL_FUNCTION_BODY = `
+function claude() {
+  echo "{\\"cwd\\":\\"$(pwd)\\"}" | node "$HOME/.claude/hooks/hypo-session-start.mjs" > /dev/null 2>&1
+  command claude "$@"
+}
+`;
+
+/**
+ * @param {string} content full rc file content
+ * @param {{startIdx: number, endIdx: number}} span a `findMarkerSpan` result
+ *   already confirmed `ok: true` for SHELL_MARKER_START/END
+ * @returns {boolean} true when the text between the markers is byte-identical
+ *   to what init.mjs writes
+ */
+export function isOwnedShellFunctionBody(content, span) {
+  const body = content.slice(span.startIdx + SHELL_MARKER_START.length, span.endIdx);
+  return body === SHELL_FUNCTION_BODY;
+}
+
 // Fallback scrub list for git versions without `rev-parse --local-env-vars`.
 // Mirrors scripts/install-git-hooks.mjs, which established this trust model.
 const STATIC_LOCAL_ENV_VARS = [
@@ -72,7 +209,7 @@ function buildScrubbedEnv(localEnvList) {
 // Canonicalize a path that may not exist yet: realpath the deepest existing
 // ancestor and re-append the rest. Without this, a hooks dir git will create
 // lazily could evade the containment check via an unresolved symlinked parent.
-function canonicalize(p) {
+export function canonicalize(p) {
   let cur = resolve(p);
   const tail = [];
   for (;;) {
@@ -91,7 +228,7 @@ function canonicalize(p) {
   }
 }
 
-function isInside(child, parent) {
+export function isInside(child, parent) {
   return child === parent || child.startsWith(parent + sep);
 }
 

--- a/scripts/uninstall.mjs
+++ b/scripts/uninstall.mjs
@@ -14,6 +14,24 @@
  *   --force-commands     Remove user-modified slash commands instead of preserving them
  *   --force-extensions   Remove user-modified extension files (hypo-ext-*) instead of preserving them
  *   --hooks-dir=<path>   Override Claude hooks directory (default: ~/.claude/hooks)
+ *   --hypo-dir=<path>    Wiki vault to remove the pre-commit hook from (default: auto-resolve,
+ *                        same rules as init/lint/query)
+ *   --shell-config=<path> Shell rc file to strip the shell block from (default: checks both
+ *                        ~/.zshrc and ~/.bashrc, since init may have run under either shell)
+ *   --keep-shell         Skip the shell rc `claude()` block removal entirely
+ *   --keep-wiki-hook     Skip the wiki pre-commit hook removal entirely
+ *
+ * The wiki's git pre-commit hook and the shell rc's `claude()` wrapper function are removed
+ * only when they still carry the marker init.mjs wrote (WIKI_PRE_COMMIT_MARKER_START /
+ * SHELL_MARKER_START, both from ./lib/git-hooks-dir.mjs). A user's own pre-commit hook, a
+ * symlinked hook target, and any rc content outside the marker block are never touched.
+ *
+ * --hooks-dir only redirects where the ~/.claude/hooks/*.mjs removal looks; it does NOT bound
+ * the rc-block and wiki-hook removals above, since those live outside ~/.claude entirely and a
+ * hypo-dir override already exists for the latter. A caller that wants an uninstall run scoped
+ * to a throwaway hooks dir (a sandboxed CI check, for instance) and NOT touching the real
+ * machine's shell rc files or scanning for a real vault must say so explicitly with
+ * --keep-shell --keep-wiki-hook.
  *
  * Extensions: hypo-ext-* hard-copies under
  * ~/.claude/{hooks,commands,skills,agents}/ and ~/.codex/{hooks,commands}/ (with
@@ -23,7 +41,16 @@
  * does not follow them). The wiki source (~/hypomnema/extensions/) is preserved.
  */
 
-import { existsSync, readFileSync, writeFileSync, rmSync, rmdirSync, readdirSync } from 'fs';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  rmdirSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
@@ -48,6 +75,20 @@ import {
   buildHookCommand,
 } from './lib/extensions.mjs';
 import { removeProvenanceSidecar } from './lib/pkg-provenance.mjs';
+import {
+  hooksDirForInstall,
+  unsafeHookTargetReason,
+  findMarkerSpan,
+  isOwnedWikiPreCommitBody,
+  isOwnedShellFunctionBody,
+  canonicalize,
+  isInside,
+  WIKI_PRE_COMMIT_MARKER_START,
+  WIKI_PRE_COMMIT_MARKER_END,
+  SHELL_MARKER_START,
+  SHELL_MARKER_END,
+} from './lib/git-hooks-dir.mjs';
+import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -428,6 +469,226 @@ function stripExtensionSettings(settingsPath, hooksDir, apply, ownedCommands = n
   return { stripped };
 }
 
+// ── wiki pre-commit hook removal ────────────────────────────────────────────
+
+// Mirrors init.mjs's own resolution (hooksDirForInstall) as the PRIMARY
+// candidate, so this finds the hook wherever init would put it today,
+// including under a core.hooksPath override. A second, best-effort candidate
+// (the vault's plain .git/hooks/pre-commit) is checked too, but it only
+// recovers ONE specific drift: an install that went to the default .git/hooks
+// and had core.hooksPath pointed elsewhere afterward. It does not recover the
+// general case (an install that went to a non-default core.hooksPath which was
+// then repointed somewhere else again), since the only fallback candidate is
+// the plain .git/hooks path, never the original custom one. Both candidates go
+// through the same marker/ownership gate below, so widening the search costs
+// nothing in safety, only in how many places we bother to look.
+// A hook that still carries our marker is removed; a user's own pre-commit (no
+// marker), a symlinked/non-regular target, and a hook whose marker is
+// duplicated, swapped, or missing its shebang are all left standing.
+// `pre-commit.bak` (init's --force-commands backup of the user's original
+// hook) is never removed here, only reported so the user knows it exists.
+function removeWikiPreCommitHook(hypoDir, apply) {
+  const result = { removed: [], skipped: [], bakPresent: [] };
+
+  if (!hypoDir || !existsSync(join(hypoDir, 'hypo-config.md'))) {
+    result.skipped.push(
+      `no Hypomnema vault found${hypoDir ? ` at ${hypoDir}` : ''} — nothing to remove`,
+    );
+    return result;
+  }
+
+  const candidateDirs = [];
+  const { dir: hooksDir, skip } = hooksDirForInstall(hypoDir);
+  if (hooksDir) candidateDirs.push(hooksDir);
+  else if (skip) result.skipped.push(skip);
+
+  // Best-effort fallback: only when `.git` is a real directory here (a plain
+  // checkout, not a linked worktree's gitdir-pointer FILE, which this join
+  // would misread entirely — resolveGitHooksDir already handles that layout
+  // correctly via the primary candidate above).
+  const legacyGitDir = join(hypoDir, '.git');
+  if (existsSync(legacyGitDir) && statSync(legacyGitDir).isDirectory()) {
+    const legacyHooksDir = join(legacyGitDir, 'hooks');
+    // Canonicalize before trusting this candidate. The primary path above
+    // already refuses to write through a `.git/hooks` that resolves outside
+    // the repo (resolveGitHooksDir's `owned` check), but that refusal does
+    // nothing for THIS fallback, which built its candidate by string join,
+    // not by resolving anything. If `.git/hooks` (or any ancestor of it) is
+    // itself a symlink to an external directory, the join above still points
+    // there, and the leaf-only unsafeHookTargetReason() below cannot see it:
+    // lstat on the FINAL path component says nothing about a symlink the OS
+    // already followed to reach that component. Codex reproduced exactly
+    // this (2026-08-27): a symlinked `.git/hooks` pointing at an external
+    // directory let this fallback delete a file the primary path had
+    // already, correctly, refused to touch.
+    const resolvedCandidate = canonicalize(legacyHooksDir);
+    if (isInside(resolvedCandidate, canonicalize(legacyGitDir))) {
+      candidateDirs.push(legacyHooksDir);
+    }
+  }
+
+  const seen = new Set();
+  for (const dir of candidateDirs) {
+    const hookPath = join(dir, 'pre-commit');
+    // Dedupe by the resolved real path, not the string: the primary candidate
+    // is realpath'd internally (resolveGitHooksDir's canonicalize) while the
+    // legacy join above is not, so the same physical file can arrive under two
+    // different-looking paths. Falling back to the raw path when the file does
+    // not exist is fine — two distinct absent candidates never collide.
+    let key = hookPath;
+    try {
+      key = realpathSync(hookPath);
+    } catch {
+      // leave key as hookPath
+    }
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const unsafe = unsafeHookTargetReason(hookPath);
+    if (unsafe) {
+      result.skipped.push(`${hookPath} (${unsafe})`);
+      continue;
+    }
+    if (!existsSync(hookPath)) continue; // already absent, nothing to report
+
+    let content;
+    try {
+      content = readFileSync(hookPath, 'utf-8');
+    } catch (e) {
+      result.skipped.push(`${hookPath} (cannot read: ${e.code || e.message})`);
+      continue;
+    }
+    if (
+      !content.includes(WIKI_PRE_COMMIT_MARKER_START) ||
+      !content.includes(WIKI_PRE_COMMIT_MARKER_END)
+    ) {
+      result.skipped.push(`${hookPath} (not managed by Hypomnema — preserving)`);
+      continue;
+    }
+
+    // Report the backup only past the ownership gate above: a vault with no
+    // Hypomnema hook at all (or a symlinked/unreadable one) can still happen
+    // to have a stray pre-commit.bak lying around, and attributing that to
+    // "from --force-commands" before confirming this IS a Hypomnema-managed
+    // hook would misdescribe someone else's file.
+    const bakPath = `${hookPath}.bak`;
+    if (existsSync(bakPath)) result.bakPresent.push(bakPath);
+
+    const span = findMarkerSpan(content, WIKI_PRE_COMMIT_MARKER_START, WIKI_PRE_COMMIT_MARKER_END);
+    if (!span.ok) {
+      result.skipped.push(`${hookPath} (${span.reason} — preserving)`);
+      continue;
+    }
+
+    // init writes the marker as the ENTIRE hook body: a bare "#!/bin/sh\n"
+    // right before WIKI_PRE_COMMIT_MARKER_START, nothing after
+    // WIKI_PRE_COMMIT_MARKER_END. A file with no shebang there was never
+    // written by init even if it happens to carry a well-formed marker span
+    // (hand-authored or copy-pasted) — deleting it on marker presence alone
+    // would remove code we do not own. A user who appended their own check
+    // after the block turned this into a file we only partly own. init's own
+    // --force-commands path handles the analogous case by OVERWRITING with
+    // equivalent content (a safe merge); uninstall has no such repair, only
+    // rmSync, so treating "extra content" the same as "fully ours" would
+    // silently delete the user's check with no way back.
+    const before = content.slice(0, span.startIdx);
+    const after = content.slice(span.endIdx + WIKI_PRE_COMMIT_MARKER_END.length);
+    if (!/^#![^\n]*\n$/.test(before)) {
+      result.skipped.push(
+        `${hookPath} (hook carries content before the Hypomnema block — preserving)`,
+      );
+      continue;
+    }
+    if (after.trim() !== '') {
+      result.skipped.push(
+        `${hookPath} (hook carries content after the Hypomnema block — preserving)`,
+      );
+      continue;
+    }
+
+    // A well-formed span (one start, one end, in order) with a bare shebang
+    // before it and nothing after proves only the SHAPE around the block is
+    // ours. It says nothing about what is INSIDE the block — a marker pair
+    // can be hand-copied around arbitrary content, including a user's own
+    // check (codex BLOCKER, 2026-08-27). Refuse unless the body itself is
+    // recognizable as what wikiPreCommitContent() writes.
+    if (!isOwnedWikiPreCommitBody(content, span)) {
+      result.skipped.push(
+        `${hookPath} (marker span present but its body does not match the hook Hypomnema writes — preserving)`,
+      );
+      continue;
+    }
+
+    if (apply) rmSync(hookPath);
+    result.removed.push(hookPath);
+  }
+
+  // Every candidate came back plain-absent (existsSync(hookPath) was false for
+  // all of them): nothing was removed, and nothing was skipped-with-a-reason
+  // either, so silence here would read as "there was nothing to say" when it
+  // actually means "the fallback above did not find a marked hook anywhere it
+  // looked". Report that explicitly instead of just going quiet — and name the
+  // one drift this cannot recover from: if core.hooksPath pointed somewhere
+  // else at install time and has since been repointed AGAIN (custom to
+  // custom, not the default-to-custom case the fallback above does cover),
+  // the hook Hypomnema wrote is still sitting at that first custom path,
+  // still executable, and can fail a future commit there with no cleanup
+  // path from this run.
+  if (candidateDirs.length > 0 && result.removed.length === 0 && result.skipped.length === 0) {
+    result.skipped.push(
+      `no Hypomnema-marked pre-commit hook found in ${candidateDirs.join(' or ')} — if core.hooksPath ` +
+        `pointed somewhere else at install time and has since changed again, the hook Hypomnema wrote ` +
+        `may still be sitting at that earlier path; it will keep running on every commit there and can ` +
+        `fail commits until it is removed by hand`,
+    );
+  }
+
+  return result;
+}
+
+// ── shell function block removal ────────────────────────────────────────────
+
+// init picks ONE rc file at install time from $SHELL (or --shell-config), but
+// $SHELL by uninstall time may point somewhere else, or init may have run in
+// a different shell session altogether — so both common rc files are checked
+// by default rather than guessing one. Only the marker span itself is
+// stripped; every other byte in the file, including surrounding blank lines,
+// is left exactly as it was. A malformed span (duplicated or swapped markers,
+// see findMarkerSpan above) leaves the file completely untouched: an rc file
+// is the user's own, and this script has no backup to restore it from.
+function removeShellFunctionBlock(shellConfigPath, apply) {
+  if (!existsSync(shellConfigPath)) return null;
+  const content = readFileSync(shellConfigPath, 'utf-8');
+  if (!content.includes(SHELL_MARKER_START) && !content.includes(SHELL_MARKER_END)) {
+    return null; // block not present here at all
+  }
+
+  const span = findMarkerSpan(content, SHELL_MARKER_START, SHELL_MARKER_END);
+  if (!span.ok) {
+    return { path: shellConfigPath, removed: false, skipped: span.reason };
+  }
+
+  // A well-formed span proves only that a start and an end marker exist in
+  // order — nothing about what sits between them. A marker pair copy-pasted
+  // around a user's own function (or appended to, inside the same span) would
+  // pass every check above and get removed along with that user's code
+  // (codex BLOCKER, 2026-08-27). Refuse unless the body between the markers
+  // is byte-identical to what init.mjs installs.
+  if (!isOwnedShellFunctionBody(content, span)) {
+    return {
+      path: shellConfigPath,
+      removed: false,
+      skipped:
+        'marker span present but its body does not match the shell function Hypomnema installs',
+    };
+  }
+
+  const updated =
+    content.slice(0, span.startIdx) + content.slice(span.endIdx + SHELL_MARKER_END.length);
+  if (apply) writeFileSync(shellConfigPath, updated);
+  return { path: shellConfigPath, removed: true, skipped: null };
+}
+
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
@@ -437,13 +698,29 @@ function parseArgs(argv) {
     hooksDir: null,
     forceCommands: false,
     forceExtensions: false,
+    hypoDir: null,
+    shellConfig: null,
+    keepShell: false,
+    keepWikiHook: false,
   };
   for (const arg of argv.slice(2)) {
     if (arg === '--apply') args.apply = true;
     else if (arg === '--codex') args.codex = true;
     else if (arg === '--force-commands') args.forceCommands = true;
     else if (arg === '--force-extensions') args.forceExtensions = true;
+    else if (arg === '--keep-shell') args.keepShell = true;
+    else if (arg === '--keep-wiki-hook') args.keepWikiHook = true;
     else if (arg.startsWith('--hooks-dir=')) args.hooksDir = arg.slice(12);
+    // expandHome mirrors init.mjs's own --hypo-dir/--shell-config parsing
+    // (init.mjs's parseArgs) exactly, reusing the same function from
+    // ./lib/hypo-root.mjs rather than re-deriving it. Uninstall must undo
+    // whatever path init actually wrote to disk, and init resolves a leading
+    // "~/" itself (the shell never does, since the value arrives already
+    // quoted inside "--flag=value"); skipping that step here would silently
+    // fail to find the vault or rc file a user installed with "~/..." to
+    // begin with.
+    else if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
+    else if (arg.startsWith('--shell-config=')) args.shellConfig = expandHome(arg.slice(15));
   }
   return args;
 }
@@ -580,6 +857,22 @@ function stripSettingsJson(settingsPath, hooksDir, hookMap, apply) {
 const args = parseArgs(process.argv);
 const dryRun = !args.apply;
 
+// --hooks-dir only redirects the ~/.claude/hooks/*.mjs cleanup below (see the
+// module doc comment). A caller who passes it alone, expecting the run to
+// stay confined to that throwaway directory, is surprised when the real
+// machine's shell rc files and auto-resolved wiki vault get touched too
+// (codex CONCERN, 2026-08-27). Warn before any of the removal functions run,
+// not just in the final report, since by the time that report prints under
+// --apply the files are already gone.
+if (args.hooksDir && !args.keepShell && !args.keepWikiHook) {
+  console.error(
+    `⚠ --hooks-dir only redirects the ~/.claude/hooks/*.mjs cleanup. This run will still ` +
+      `${dryRun ? 'inspect' : 'modify'} the real shell rc files (~/.zshrc, ~/.bashrc, or --shell-config) ` +
+      `and the auto-resolved wiki vault's pre-commit hook. Pass --keep-shell and/or --keep-wiki-hook to ` +
+      `scope this run to --hooks-dir only.`,
+  );
+}
+
 const { hookMap, hookFiles } = loadHookFiles();
 
 const claudeHooksDir = args.hooksDir ?? join(HOME, '.claude', 'hooks');
@@ -588,6 +881,39 @@ const claudeSettings = join(HOME, '.claude', 'settings.json');
 const hookResult = removeHookFiles(claudeHooksDir, hookFiles, args.apply);
 const settingsResult = stripSettingsJson(claudeSettings, claudeHooksDir, hookMap, args.apply);
 const commandResult = removeCommands(args.apply, args.forceCommands);
+
+// Wiki-side cleanup: the git pre-commit hook and the shell rc block init.mjs
+// installs outside ~/.claude entirely. Both are independent of --codex/--hooks-dir:
+// --hooks-dir only redirects the ~/.claude/hooks/*.mjs removal above, it does not
+// bound these two, since they live outside ~/.claude and already have their own
+// scoping flags (--hypo-dir, --shell-config). A caller that wants an uninstall run
+// confined to a throwaway --hooks-dir and NOT touching the real machine's shell rc
+// files or scanning for a real vault (a sandboxed CI check, for instance) says so
+// explicitly with --keep-shell / --keep-wiki-hook rather than relying on
+// --hooks-dir to imply it.
+// resolveHypoRoot() scans a fixed list of candidate directories under HOME
+// (see ./lib/hypo-root.mjs). --keep-wiki-hook says the caller does not want
+// this run touching a vault at all, so the scan itself is skipped rather than
+// run and then discarded — matching the module doc comment above ("--keep-
+// wiki-hook" is described as skipping the cleanup outright, not as skipping
+// only the removal after still resolving a root).
+const hypoDir = args.keepWikiHook ? null : (args.hypoDir ?? resolveHypoRoot());
+const preCommitResult = args.keepWikiHook
+  ? {
+      removed: [],
+      skipped: ['--keep-wiki-hook passed: wiki pre-commit hook cleanup skipped'],
+      bakPresent: [],
+    }
+  : removeWikiPreCommitHook(hypoDir, args.apply);
+
+const shellConfigCandidates = args.shellConfig
+  ? [args.shellConfig]
+  : [join(HOME, '.zshrc'), join(HOME, '.bashrc')];
+const shellBlockOutcomes = args.keepShell
+  ? []
+  : shellConfigCandidates.map((p) => removeShellFunctionBlock(p, args.apply)).filter(Boolean);
+const shellBlockResults = shellBlockOutcomes.filter((r) => r.removed).map((r) => r.path);
+const shellBlockSkipped = shellBlockOutcomes.filter((r) => !r.removed);
 
 // Extensions. Order matters: remove files first, then strip
 // settings, then surgically clear the per-target SHA map. The SHA strip uses
@@ -736,6 +1062,27 @@ if (hookResult.missing.length)
   lines.push(
     `⊘ Already absent (${hookResult.missing.length}):\n${hookResult.missing.map((p) => `  ${p}`).join('\n')}`,
   );
+if (preCommitResult.removed.length)
+  lines.push(
+    `✓ Wiki pre-commit hook ${dryRun ? 'to remove' : 'removed'} (${preCommitResult.removed.length}):\n${preCommitResult.removed.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (preCommitResult.skipped.length)
+  lines.push(
+    `⊘ Wiki pre-commit hook preserved:\n${preCommitResult.skipped.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (preCommitResult.bakPresent.length)
+  lines.push(
+    `ⓘ Pre-commit backup left in place (from --force-commands, never touched by uninstall):\n${preCommitResult.bakPresent.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (shellBlockResults.length)
+  lines.push(
+    `✓ Shell function block ${dryRun ? 'to remove' : 'removed'} (${shellBlockResults.length}):\n${shellBlockResults.map((p) => `  ${p}`).join('\n')}`,
+  );
+if (shellBlockSkipped.length)
+  lines.push(
+    `⊘ Shell function block preserved:\n${shellBlockSkipped.map((r) => `  ${r.path} (${r.skipped})`).join('\n')}`,
+  );
+
 if (settingsResult.error) lines.push(`⚠ ${settingsResult.error}`);
 if (claudeExtSettings.error) lines.push(`⚠ ${claudeExtSettings.error}`);
 if (codexExtSettings.error) lines.push(`⚠ ${codexExtSettings.error}`);
@@ -750,7 +1097,9 @@ if (
   !pkgJsonRemoved &&
   !commandResult.skippedUserModified.length &&
   !extSkippedUserModified.length &&
-  !extSkippedNonRegular.length
+  !extSkippedNonRegular.length &&
+  !preCommitResult.removed.length &&
+  !shellBlockResults.length
 ) {
   lines.push('Nothing to uninstall — Hypomnema does not appear to be installed.');
 }

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -14,6 +14,8 @@ import {
   readFileSync,
   existsSync,
   statSync,
+  lstatSync,
+  symlinkSync,
   cpSync,
   realpathSync,
 } from 'node:fs';
@@ -22,12 +24,19 @@ import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
 import { PROVENANCE_FILENAME } from '../scripts/lib/pkg-provenance.mjs';
 import {
+  hooksDirForInstall,
+  SHELL_MARKER_START,
+  SHELL_MARKER_END,
+  SHELL_FUNCTION_BODY,
+} from '../scripts/lib/git-hooks-dir.mjs';
+import {
   HOME,
   HOOKS,
   REPO,
   SCRIPTS,
   SESSION_TMP_HOME,
   deriveCoreHookBasenames,
+  gitRepo,
   readCoreHooksConfig,
   run,
   runWithHome,
@@ -1453,3 +1462,669 @@ test('--dry-run does not write the provenance sidecar', () => {
     });
   });
 });
+
+// ── uninstall.mjs: wiki pre-commit hook + shell setup block ──────────────────
+//
+// uninstall.mjs must remove exactly the two vault-adjacent artifacts init.mjs
+// creates outside ~/.claude: the git pre-commit hook and the shell rc block.
+// Neither is a Claude-hooks-dir concern, so these are separate from the
+// --hooks-dir suites above.
+
+suite('uninstall.mjs: wiki pre-commit hook + shell setup');
+
+test('dry-run leaves the wiki pre-commit hook in place; --apply removes it', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      // init's own gitSetup/firstCommit only run --no-git-init-free in every other
+      // test in this file because they need a global git identity this process
+      // does not have. Pre-creating the repo with one sidesteps that and still
+      // exercises the real installWikiPreCommitHook path against a real repo.
+      mkdirSync(hypoDir, { recursive: true });
+      gitRepo(hypoDir);
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+      const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+      const hookPath = join(hooksDir, 'pre-commit');
+      assert.ok(existsSync(hookPath), 'fixture: init must install the pre-commit hook');
+
+      const dryR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`], home);
+      assert.equal(dryR.status, 0, `stderr: ${dryR.stderr}`);
+      assert.ok(existsSync(hookPath), 'dry-run must not delete the hook');
+      assert.ok(
+        dryR.stdout.includes(hookPath),
+        'dry-run report must name the hook it would remove',
+      );
+
+      // uninstall --apply also touches HOME/.claude (hypo-pkg.json, commands),
+      // so it must run against a per-test HOME, not the process-shared one:
+      // otherwise it deletes hypo-pkg.json out from under every other shard.
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(!existsSync(hookPath), '--apply must remove the Hypomnema-managed hook');
+    });
+  });
+});
+
+test('preserves a user pre-commit hook that carries no Hypomnema marker', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      writeFileSync(join(hypoDir, 'hypo-config.md'), '# config');
+      gitRepo(hypoDir);
+      const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+      mkdirSync(hooksDir, { recursive: true });
+      const hookPath = join(hooksDir, 'pre-commit');
+      const userContent = '#!/bin/sh\necho user hook\n';
+      writeFileSync(hookPath, userContent, { mode: 0o755 });
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(existsSync(hookPath), 'a user pre-commit hook must survive uninstall');
+      assert.equal(readFileSync(hookPath, 'utf-8'), userContent, 'its content must be untouched');
+    });
+  });
+});
+
+test('refuses to remove a symlinked pre-commit target', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      writeFileSync(join(hypoDir, 'hypo-config.md'), '# config');
+      gitRepo(hypoDir);
+      const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+      mkdirSync(hooksDir, { recursive: true });
+      const outside = join(dir, 'outside-target');
+      writeFileSync(
+        outside,
+        '#!/bin/sh\n# hypo-managed:pre-commit:start\nexit 0\n# hypo-managed:pre-commit:end\n',
+      );
+      const hookPath = join(hooksDir, 'pre-commit');
+      symlinkSync(outside, hookPath);
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(existsSync(outside), 'the symlink target file must survive');
+      assert.ok(
+        lstatSync(hookPath).isSymbolicLink(),
+        'the symlink itself must survive, never followed',
+      );
+    });
+  });
+});
+
+test('reports a pre-commit.bak without touching it', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      gitRepo(hypoDir);
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+      const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+      const bakPath = join(hooksDir, 'pre-commit.bak');
+      const bakContent = '#!/bin/sh\necho original user hook\n';
+      writeFileSync(bakPath, bakContent);
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.equal(
+        readFileSync(bakPath, 'utf-8'),
+        bakContent,
+        'pre-commit.bak must survive untouched',
+      );
+      assert.ok(applyR.stdout.includes('pre-commit.bak'), 'report must mention the backup');
+    });
+  });
+});
+
+test('preserves the whole hook when the user appended a line after the Hypomnema block', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      gitRepo(hypoDir);
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+      const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+      const hookPath = join(hooksDir, 'pre-commit');
+      const userLine = '\necho "my own check" && exit 1\n';
+      const withUserLine = readFileSync(hookPath, 'utf-8') + userLine;
+      writeFileSync(hookPath, withUserLine);
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(existsSync(hookPath), 'the hook must survive since it is no longer fully ours');
+      assert.equal(
+        readFileSync(hookPath, 'utf-8'),
+        withUserLine,
+        'the user line appended after the block must be untouched',
+      );
+    });
+  });
+});
+
+test('preserves a shebang-less hook even when it carries a well-formed marker span', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      gitRepo(hypoDir);
+      const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+      mkdirSync(hooksDir, { recursive: true });
+      const hookPath = join(hooksDir, 'pre-commit');
+      // A well-formed marker span with no leading shebang is NOT what init ever
+      // writes (wikiPreCommitContent always emits "#!/bin/sh\n" first), so this
+      // must never be treated as "fully ours" on marker presence alone.
+      const content =
+        '# hypo-managed:pre-commit:start\nsome_users_own_command || exit 1\nexit 0\n# hypo-managed:pre-commit:end\n';
+      writeFileSync(hookPath, content, { mode: 0o755 });
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(existsSync(hookPath), 'a marker span with no shebang must never be deleted');
+      assert.equal(readFileSync(hookPath, 'utf-8'), content, 'its content must be untouched');
+    });
+  });
+});
+
+test('still finds and removes the original hook after core.hooksPath moves elsewhere', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      gitRepo(hypoDir);
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+      const originalHookPath = join(hypoDir, '.git', 'hooks', 'pre-commit');
+      assert.ok(
+        existsSync(originalHookPath),
+        'fixture: init must install into the plain .git/hooks',
+      );
+
+      // Redirect core.hooksPath so the CURRENT resolution no longer points at
+      // the file init actually wrote — the exact drift this fallback exists for.
+      const elsewhere = join(dir, 'elsewhere-hooks');
+      mkdirSync(elsewhere, { recursive: true });
+      const cfg = spawnSync('git', ['config', 'core.hooksPath', elsewhere], {
+        cwd: hypoDir,
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: home, HYPO_DIR: '' },
+      });
+      assert.equal(cfg.status, 0, `git config stderr: ${cfg.stderr}`);
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(
+        !existsSync(originalHookPath),
+        'the original .git/hooks/pre-commit must still be found and removed via the fallback candidate',
+      );
+    });
+  });
+});
+
+test('reports a leftover hook instead of going silent when core.hooksPath moved custom-to-custom', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      gitRepo(hypoDir);
+      // Relative paths INSIDE the working tree, git's own `.githooks`
+      // convention — both count as "owned" (resolveGitHooksDir's `owned`
+      // check), unlike a shared directory outside the repo.
+      const cfg1 = spawnSync('git', ['config', 'core.hooksPath', '.hooks-before'], {
+        cwd: hypoDir,
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: home, HYPO_DIR: '' },
+      });
+      assert.equal(cfg1.status, 0, `git config stderr: ${cfg1.stderr}`);
+
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell'],
+        home,
+      );
+      assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+      const firstHookPath = join(hypoDir, '.hooks-before', 'pre-commit');
+      assert.ok(existsSync(firstHookPath), 'fixture: init must install into the first custom path');
+
+      // Move core.hooksPath a SECOND time, to a different custom path. Neither
+      // the primary candidate (resolves the CURRENT config) nor the legacy
+      // `.git/hooks` fallback (recovers only the default-to-custom drift, not
+      // custom-to-custom) can reach `.hooks-before` any more.
+      const cfg2 = spawnSync('git', ['config', 'core.hooksPath', '.hooks-after'], {
+        cwd: hypoDir,
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: home, HYPO_DIR: '' },
+      });
+      assert.equal(cfg2.status, 0, `git config stderr: ${cfg2.stderr}`);
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(
+        existsSync(firstHookPath),
+        'the hook at the abandoned custom path is unreachable and must be left in place',
+      );
+      assert.ok(
+        applyR.stdout.includes('earlier path') && applyR.stdout.includes('fail commits'),
+        `report must warn the leftover hook can fail future commits: ${applyR.stdout}`,
+      );
+    });
+  });
+});
+
+test('fallback candidate never crosses a symlinked .git/hooks into an external directory', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      writeFileSync(join(hypoDir, 'hypo-config.md'), '# config');
+      gitRepo(hypoDir);
+
+      const gitHooksDir = join(hypoDir, '.git', 'hooks');
+      rmSync(gitHooksDir, { recursive: true, force: true });
+      const external = join(dir, 'user-owned-hooks');
+      mkdirSync(external, { recursive: true });
+      const externalHook = join(external, 'pre-commit');
+      // A REGULAR file at the external location, wearing a well-formed marker
+      // pair — the codex reproduction (2026-08-27): the primary path already
+      // refuses to write through a `.git/hooks` that resolves outside the
+      // repo, but a leaf-only safety check on the fallback candidate cannot
+      // see that `.git/hooks` ITSELF is the symlink that got it there.
+      writeFileSync(
+        externalHook,
+        '#!/bin/sh\n# hypo-managed:pre-commit:start\necho user data\nexit 0\n# hypo-managed:pre-commit:end\n',
+        { mode: 0o755 },
+      );
+      symlinkSync(external, gitHooksDir);
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(
+        existsSync(externalHook),
+        'the external hook reached through the symlinked hooks dir must survive',
+      );
+      assert.ok(
+        lstatSync(gitHooksDir).isSymbolicLink(),
+        'the symlinked .git/hooks entry itself must survive',
+      );
+    });
+  });
+});
+
+test('preserves a pre-commit hook whose marker span wraps user content, not what init writes', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const hypoDir = join(dir, 'wiki');
+      mkdirSync(hypoDir, { recursive: true });
+      writeFileSync(join(hypoDir, 'hypo-config.md'), '# config');
+      gitRepo(hypoDir);
+      const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+      mkdirSync(hooksDir, { recursive: true });
+      const hookPath = join(hooksDir, 'pre-commit');
+      // Every OLD check passes: exactly one start and one end marker, in
+      // order, a leading shebang, nothing after. Only the body between the
+      // markers gives it away — it is the user's own command, not the
+      // `node '<...>/hooks/hypo-pre-commit.mjs' || exit 1` step init writes
+      // (codex reproduction, 2026-08-27).
+      const content =
+        '#!/bin/sh\n# hypo-managed:pre-commit:start\necho USER_OWNED_DEPLOY_CHECK\n# hypo-managed:pre-commit:end\n';
+      writeFileSync(hookPath, content, { mode: 0o755 });
+
+      const applyR = runWithHome('uninstall.mjs', [`--hypo-dir=${hypoDir}`, '--apply'], home);
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(existsSync(hookPath), 'a marker span wrapping user content must never be deleted');
+      assert.equal(readFileSync(hookPath, 'utf-8'), content, 'its content must be untouched');
+    });
+  });
+});
+
+test('warns before acting when --hooks-dir is passed without --keep-shell/--keep-wiki-hook', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const rcPath = join(home, '.zshrc');
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init', `--shell-config=${rcPath}`],
+        home,
+      );
+      assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+      assert.ok(
+        existsSync(rcPath),
+        'fixture: init must install the shell block at the default path',
+      );
+
+      const applyR = runWithHome(
+        'uninstall.mjs',
+        [`--hooks-dir=${join(dir, 'throwaway-hooks')}`, `--hypo-dir=${hypoDir}`, '--apply'],
+        home,
+      );
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.ok(
+        applyR.stderr.includes('--hooks-dir') && applyR.stderr.includes('--keep-shell'),
+        `must warn before acting that --hooks-dir alone still touches shell/wiki cleanup: ${applyR.stderr}`,
+      );
+      assert.ok(
+        !existsSync(rcPath) || !readFileSync(rcPath, 'utf-8').includes('hypo-managed:shell-setup'),
+        'the warning does not change behavior: the real rc block is still removed since --keep-shell was not passed',
+      );
+    });
+  });
+});
+
+test('dry-run leaves the shell marker block; --apply strips only that block', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const rcPath = join(dir, 'zshrc');
+      const before = 'export PATH=$PATH:/opt/tool\n\nalias ll="ls -la"\n';
+      writeFileSync(rcPath, before);
+
+      const hypoDir = join(dir, 'wiki');
+      const initR = runWithHome(
+        'init.mjs',
+        [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init', `--shell-config=${rcPath}`],
+        home,
+      );
+      assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+      const withBlock = readFileSync(rcPath, 'utf-8');
+      assert.ok(
+        withBlock.includes('# hypo-managed:shell-setup:start'),
+        'fixture: init must install the shell block',
+      );
+
+      const dryR = runWithHome(
+        'uninstall.mjs',
+        [`--hypo-dir=${hypoDir}`, `--shell-config=${rcPath}`],
+        home,
+      );
+      assert.equal(dryR.status, 0, `stderr: ${dryR.stderr}`);
+      assert.equal(readFileSync(rcPath, 'utf-8'), withBlock, 'dry-run must not modify the rc file');
+
+      const applyR = runWithHome(
+        'uninstall.mjs',
+        [`--hypo-dir=${hypoDir}`, `--shell-config=${rcPath}`, '--apply'],
+        home,
+      );
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      const after = readFileSync(rcPath, 'utf-8');
+      assert.ok(
+        !after.includes('hypo-managed:shell-setup'),
+        '--apply must remove the marker block',
+      );
+      assert.ok(
+        after.includes('export PATH=$PATH:/opt/tool'),
+        'the line before the block must survive',
+      );
+      assert.ok(after.includes('alias ll="ls -la"'), 'the line after the block must survive');
+    });
+  });
+});
+
+test('a swapped marker (END before START) leaves the rc file byte-for-byte untouched', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const rcPath = join(dir, 'zshrc');
+      // END literally precedes START — a hand-edited or corrupted file, not
+      // anything init would ever produce. Two bare indexOf() calls would slice
+      // [startIdx, endIdx) with startIdx > endIdx and DUPLICATE this content
+      // instead of raising anything.
+      const swapped =
+        'before\n# hypo-managed:shell-setup:end\nfunction claude() { true; }\n# hypo-managed:shell-setup:start\nafter\n';
+      writeFileSync(rcPath, swapped);
+
+      const applyR = runWithHome(
+        'uninstall.mjs',
+        [`--hypo-dir=${join(dir, 'wiki')}`, `--shell-config=${rcPath}`, '--apply'],
+        home,
+      );
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.equal(
+        readFileSync(rcPath, 'utf-8'),
+        swapped,
+        '--apply must not write a single byte to a swapped-marker rc',
+      );
+    });
+  });
+});
+
+test('preserves an rc marker block whose body carries a user function alongside the markers', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const rcPath = join(dir, 'zshrc');
+      // A well-formed span (one start, one end, in order) is not enough: the
+      // body between them is the user's own function, not the `claude()`
+      // wrapper init.mjs installs (codex reproduction, 2026-08-27 — the same
+      // shape as the pre-commit-body attack, applied to the rc block).
+      const content =
+        'before\n# hypo-managed:shell-setup:start\nfunction my_deploy() { echo USER_OWNED; }\n# hypo-managed:shell-setup:end\nafter\n';
+      writeFileSync(rcPath, content);
+
+      const applyR = runWithHome(
+        'uninstall.mjs',
+        [`--hypo-dir=${join(dir, 'wiki')}`, `--shell-config=${rcPath}`, '--apply'],
+        home,
+      );
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.equal(
+        readFileSync(rcPath, 'utf-8'),
+        content,
+        'a marker block whose body is not the exact function Hypomnema installs must survive untouched',
+      );
+    });
+  });
+});
+
+test('a duplicated block (two full START/END pairs) is preserved, not partially stripped', () => {
+  withTmpHome((home) => {
+    withTmpDir((dir) => {
+      const rcPath = join(dir, 'zshrc');
+      const oneBlock =
+        '# hypo-managed:shell-setup:start\nfunction claude() { true; }\n# hypo-managed:shell-setup:end\n';
+      const duplicated = `${oneBlock}\n${oneBlock}`;
+      writeFileSync(rcPath, duplicated);
+
+      const applyR = runWithHome(
+        'uninstall.mjs',
+        [`--hypo-dir=${join(dir, 'wiki')}`, `--shell-config=${rcPath}`, '--apply'],
+        home,
+      );
+      assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+      assert.equal(
+        readFileSync(rcPath, 'utf-8'),
+        duplicated,
+        'a duplicated block must be preserved whole, not have only the first copy stripped',
+      );
+      assert.ok(applyR.stdout.includes('preserved'), 'report must explain the block was preserved');
+    });
+  });
+});
+
+test('checks both ~/.zshrc and ~/.bashrc by default, not just $SHELL', () => {
+  withTmpHome((home) => {
+    // Must be the REAL block, not a stand-in: isOwnedShellFunctionBody()
+    // compares the marker span's body byte-for-byte against what init.mjs
+    // actually installs, so a fixture that only fakes the marker shape (as
+    // this one used to) is now, correctly, left untouched rather than
+    // stripped — this test is about the "both files checked" behavior, not
+    // about body validation, so the fixture has to be the genuine article.
+    const fakeBlock = `${SHELL_MARKER_START}${SHELL_FUNCTION_BODY}${SHELL_MARKER_END}\n`;
+    const zshrc = join(home, '.zshrc');
+    const bashrc = join(home, '.bashrc');
+    writeFileSync(zshrc, `# zsh stuff\n\n${fakeBlock}`);
+    writeFileSync(bashrc, `# bash stuff\n\n${fakeBlock}`);
+
+    const applyR = runWithHome('uninstall.mjs', ['--apply'], home);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(
+      !readFileSync(zshrc, 'utf-8').includes('hypo-managed:shell-setup'),
+      '.zshrc block must be stripped even without --shell-config',
+    );
+    assert.ok(
+      !readFileSync(bashrc, 'utf-8').includes('hypo-managed:shell-setup'),
+      '.bashrc block must be stripped even without --shell-config',
+    );
+    assert.ok(
+      readFileSync(zshrc, 'utf-8').includes('# zsh stuff'),
+      '.zshrc other content must survive',
+    );
+    assert.ok(
+      readFileSync(bashrc, 'utf-8').includes('# bash stuff'),
+      '.bashrc other content must survive',
+    );
+  });
+});
+
+test('--hypo-dir expands a leading ~ the same way init.mjs expands it', () => {
+  withTmpHome((home) => {
+    const hypoDir = join(home, 'vault');
+    mkdirSync(hypoDir, { recursive: true });
+    gitRepo(hypoDir);
+    const initR = runWithHome(
+      'init.mjs',
+      [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-shell'],
+      home,
+    );
+    assert.equal(initR.status, 0, `init stderr: ${initR.stderr}`);
+    const { dir: hooksDir } = hooksDirForInstall(hypoDir);
+    const hookPath = join(hooksDir, 'pre-commit');
+    assert.ok(existsSync(hookPath), 'fixture: init must install the pre-commit hook');
+
+    // The shell never expands "~" inside "--flag=value"; only the receiving
+    // script's own expandHome() call does. init.mjs's parseArgs already calls
+    // it (scripts/init.mjs), so uninstall must call the same function or this
+    // literally never resolves to anything on disk.
+    const applyR = runWithHome('uninstall.mjs', ['--hypo-dir=~/vault', '--apply'], home);
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(
+      !existsSync(hookPath),
+      '--hypo-dir=~/vault must resolve to the real vault path and remove its hook',
+    );
+  });
+});
+
+test('a missing vault is skipped with a reason, not a crash', () => {
+  withTmpHome((home) => {
+    const applyR = runWithHome(
+      'uninstall.mjs',
+      [`--hypo-dir=${join(home, 'no-such-wiki')}`, '--apply'],
+      home,
+    );
+    assert.equal(applyR.status, 0, `stderr: ${applyR.stderr}`);
+    assert.ok(
+      /vault/i.test(applyR.stdout),
+      'report must explain why the pre-commit hook was skipped',
+    );
+  });
+});
+
+// ── init.mjs: shell function block marker-span validation ───────────────────
+//
+// installShellFunction() used to slice the rc file with two bare indexOf()
+// calls, the exact damage shape cross-review flagged: a swapped marker
+// duplicates whatever sits between END and START into the "replaced" span,
+// and a duplicated block only ever finds the FIRST end, so a second full copy
+// survives untouched while its sibling gets silently rewritten. Both cases
+// must now be refused via the same findMarkerSpan() uninstall.mjs already
+// uses (scripts/lib/git-hooks-dir.mjs), leaving the rc file byte-for-byte as
+// it was.
+
+test('init refuses a swapped marker rc block instead of duplicating the content between END and START', () => {
+  withTmpDir((dir) => {
+    const rcPath = join(dir, 'zshrc');
+    // END literally precedes START, mirroring the uninstall-side regression
+    // fixture. Two bare indexOf() calls would slice [firstStart, firstEnd)
+    // with firstStart AFTER firstEnd here (since only START's own indexOf is
+    // used for both), duplicating MY_OWN_SECRET_LINE into the merged output.
+    const swapped =
+      'before\n# hypo-managed:shell-setup:end\nMY_OWN_SECRET_LINE\n# hypo-managed:shell-setup:start\nafter\n';
+    writeFileSync(rcPath, swapped);
+
+    const r = run('init.mjs', [
+      `--hypo-dir=${join(dir, 'wiki')}`,
+      '--no-hooks',
+      '--no-commands',
+      '--no-git-init',
+      `--shell-config=${rcPath}`,
+    ]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const after = readFileSync(rcPath, 'utf-8');
+    assert.equal(
+      after,
+      swapped,
+      'a swapped-marker rc must be left byte-for-byte untouched, not merged',
+    );
+    assert.equal(
+      countOccurrences(after, 'MY_OWN_SECRET_LINE'),
+      1,
+      'the line between END and START must never be duplicated',
+    );
+    assert.match(
+      r.stdout,
+      /skipped/i,
+      'report must say the block was skipped, not silently merged',
+    );
+  });
+});
+
+test('init refuses a duplicated marker rc block instead of overwriting only the first copy', () => {
+  withTmpDir((dir) => {
+    const rcPath = join(dir, 'zshrc');
+    const oneBlock =
+      '# hypo-managed:shell-setup:start\nfunction claude() { echo old; }\n# hypo-managed:shell-setup:end\n';
+    const duplicated = `${oneBlock}\n${oneBlock}`;
+    writeFileSync(rcPath, duplicated);
+
+    const r = run('init.mjs', [
+      `--hypo-dir=${join(dir, 'wiki')}`,
+      '--no-hooks',
+      '--no-commands',
+      '--no-git-init',
+      `--shell-config=${rcPath}`,
+    ]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const after = readFileSync(rcPath, 'utf-8');
+    assert.equal(
+      after,
+      duplicated,
+      'a duplicated block must be left whole; installing must not overwrite only the first copy',
+    );
+    assert.match(
+      r.stdout,
+      /skipped/i,
+      'report must say the block was skipped, not partially replaced',
+    );
+  });
+});
+
+// A tiny local mirror of countOccurrences() (scripts/lib/git-hooks-dir.mjs is
+// not exported for import here, this file only spawns the scripts as child
+// processes) so the swapped-marker test above can assert the duplication
+// count directly rather than eyeballing the string.
+function countOccurrences(content, needle) {
+  let count = 0;
+  let idx = 0;
+  while ((idx = content.indexOf(needle, idx)) !== -1) {
+    count++;
+    idx += needle.length;
+  }
+  return count;
+}


### PR DESCRIPTION
# English

## What changed

`uninstall` now removes the two things `init` creates and used to leave behind: the marked `claude()` block in the shell rc file, and the marked pre-commit hook in the wiki vault. `--hypo-dir` and `--shell-config` expand a leading `~` through the same helper `init` uses.

Removal is gated on ownership. A marker pair alone is not proof, so the body inside the span must also match what `init` writes before anything is deleted. Marker spans are parsed once by a shared helper that both `init` and `uninstall` call.

`--keep-shell` and `--keep-wiki-hook` opt out of the rc and vault cleanup.

## Why

The pair was advertised as an inverse and was not one. A user who ran `uninstall` kept a shell function pointing at a package they had removed, and a git hook in their vault that kept firing on every commit.

The ownership gate exists because both targets are files a user may have edited. Deleting someone's own script is a far more expensive failure than declining to clean up one of ours, so an unrecognized body is left standing with a reason.

## How

The shared span parser replaced two bare `indexOf` calls on each side. That pair cannot tell a well-formed block from a duplicated or a swapped one: on a swapped rc it duplicated whatever sat between the markers into the "replaced" span, and on a doubled block it rewrote only the first copy and stranded the second. The write side in `init` had the same flaw as the removal side, so both now refuse a malformed span rather than rewriting it.

Body matching is structural for the hook, whose baked-in install path varies, and byte-exact for the rc block, which has no variable part and is built from a single shared constant that `init` and `uninstall` both read. Two copies of the same literal would drift.

The legacy `.git/hooks` fallback is canonicalized against the repository's own git dir before it is trusted. Without that, a vault whose hooks directory is a symlink let the fallback reach a file outside the repository, even while the primary path was correctly refusing the same directory as shared.

When no marked hook is found anywhere, the report now says one may still sit at an earlier `core.hooksPath` and keep failing commits there. That drift is not recoverable, so the least it can do is name itself.

`--hooks-dir` never scoped the rc and vault cleanup. CI's uninstall smoke job relied on that by accident: it points `--hooks-dir` at a throwaway directory but never sandboxes `HOME`, so the run read the runner's real `~/.bashrc` and scanned its real `$HOME` for a vault. It passes because the runner has neither, not because the code prevents it. The job now passes both opt-outs, and a run that redirects the hooks dir without them warns before acting.

## Manual verification

No live-session QA run; `uninstall` is a CLI path and was exercised in isolated `HOME` fixtures, with the "before" side produced by running the pre-change code from a `git archive HEAD` snapshot rather than by reasoning about it.

```
# vault .git/hooks symlinked to an external directory holding a marked hook
before  -> external file DELETED
after   -> external file and symlink both intact

# marked span wrapping user content (hook body, and an rc function)
before  -> both DELETED
after   -> both preserved, each with a reason

# core.hooksPath moved custom-to-custom before uninstall
before  -> leftover hook, report silent about it
after   -> leftover hook, report names the earlier path and the failing-commit risk

# what must still work: a real init run, then uninstall --apply
        -> hook removed, rc block removed, both confirmed gone
```

Suites: init 80 passed, git-hooks-dir 14 passed. Disabling the ownership checks makes exactly the two preservation assertions fail; restoring them returns the suite to green.

## Migration notes

A user who edited the body inside the markers will now see the file preserved with a reason instead of removed. That is the intended behavior, not a failure to uninstall; the reason names what to delete by hand.

Anyone scripting `uninstall --hooks-dir` should add `--keep-shell --keep-wiki-hook` if they meant to scope the run to the hooks directory alone.

---

# 한국어

## 변경 내용

`uninstall` 이 `init` 이 만들고도 남겨 두던 둘을 제거한다. 셸 rc 파일의 마커 `claude()` 블록과 위키 볼트의 마커 pre-commit 훅이다. `--hypo-dir` 과 `--shell-config` 는 `init` 이 쓰는 것과 같은 헬퍼로 앞의 `~` 를 확장한다.

제거는 소유권으로 막는다. 마커 쌍만으로는 증명이 안 되므로, 지우기 전에 스팬 안의 본문이 `init` 이 쓰는 것과 일치해야 한다. 마커 스팬은 `init` 과 `uninstall` 이 함께 부르는 공유 헬퍼가 한 번만 파싱한다.

`--keep-shell` 과 `--keep-wiki-hook` 으로 rc·볼트 정리를 뺄 수 있다.

## 이유

역연산이라고 말해 놓고 아니었다. `uninstall` 을 돌린 사용자에게 이미 지운 패키지를 가리키는 셸 함수와, 커밋마다 계속 발화하는 볼트의 git 훅이 남았다.

소유권 게이트를 둔 이유는 두 대상 다 사용자가 편집했을 수 있는 파일이기 때문이다. 남의 스크립트를 지우는 실패가 우리 것을 못 지우는 실패보다 훨씬 비싸므로, 못 알아본 본문은 이유를 붙여 그대로 둔다.

## 방법

공유 스팬 파서가 양쪽의 맨 `indexOf` 두 개를 대체했다. 그 방식은 정상 블록과 중복된 블록, 뒤집힌 블록을 구별하지 못한다. 뒤집힌 rc 에서는 마커 사이에 있던 것을 "교체" 스팬에 중복해 넣었고, 두 벌인 블록에서는 첫 벌만 다시 쓰고 둘째를 남겼다. `init` 의 쓰는 쪽이 지우는 쪽과 같은 결함을 갖고 있었으므로 이제 양쪽 다 잘못된 스팬을 다시 쓰지 않고 거부한다.

본문 대조는 훅에 대해서는 구조 검사다. 박혀 있는 설치 경로가 가변이기 때문이다. rc 블록은 가변 부분이 없으므로 바이트 비교이고, `init` 과 `uninstall` 이 함께 읽는 공유 상수 하나에서 만든다. 같은 리터럴을 두 벌 두면 갈라진다.

legacy `.git/hooks` fallback 은 신뢰하기 전에 레포 자신의 git dir 에 대고 정규화한다. 그것이 없으면 훅 디렉터리가 심링크인 볼트에서 fallback 이 레포 밖 파일에 닿았다. primary 경로는 같은 디렉터리를 공유 디렉터리라고 정확히 거부하고 있는데도 그랬다.

마커 훅을 어디서도 못 찾으면, 이전 `core.hooksPath` 에 훅이 남아 거기서 커밋을 계속 실패시킬 수 있다고 보고한다. 그 어긋남은 복구가 안 되므로 최소한 자기 존재는 알려야 한다.

`--hooks-dir` 은 rc·볼트 정리를 가둔 적이 없다. CI 의 uninstall 스모크 잡이 그것에 우연히 기대고 있었다. `--hooks-dir` 을 버리는 디렉터리로 주지만 `HOME` 은 격리하지 않으므로, 그 실행이 러너의 진짜 `~/.bashrc` 를 읽고 진짜 `$HOME` 을 볼트로 스캔했다. 통과한 이유는 러너에 둘 다 없어서이지 코드가 막아서가 아니다. 이제 그 잡이 opt-out 둘을 넘기고, 그것 없이 훅 디렉터리만 돌리는 실행은 행동 전에 경고한다.

## 수동 검증

실제 세션 QA 는 안 돌렸다. `uninstall` 은 CLI 경로이고 격리된 `HOME` 픽스처에서 확인했다. "before" 쪽은 추론이 아니라 `git archive HEAD` 스냅샷의 옛 코드를 실제로 돌려 만들었다.

```
# 볼트 .git/hooks 가 마커 훅을 담은 외부 디렉터리로 심링크
before  -> 외부 파일 DELETED
after   -> 외부 파일과 심링크 둘 다 온전

# 마커 스팬이 사용자 코드를 감싼 경우 (훅 본문, 그리고 rc 함수)
before  -> 둘 다 DELETED
after   -> 둘 다 보존, 각각 이유와 함께

# uninstall 전에 core.hooksPath 를 custom 에서 custom 으로 변경
before  -> 훅이 남고 보고는 침묵
after   -> 훅이 남고 보고가 이전 경로와 커밋 실패 위험을 짚음

# 여전히 되어야 하는 것: 실제 init 실행 후 uninstall --apply
        -> 훅 제거, rc 블록 제거, 둘 다 사라진 것 확인
```

스위트는 init 80 passed, git-hooks-dir 14 passed. 소유권 검사를 우회하면 정확히 그 두 보존 단언만 실패하고, 복구하면 다시 green 이다.

## 마이그레이션 노트

마커 안 본문을 편집한 사용자는 이제 파일이 제거되는 대신 이유와 함께 보존되는 것을 본다. 그것이 의도한 동작이고 uninstall 실패가 아니다. 이유가 손으로 지울 대상을 짚어 준다.

`uninstall --hooks-dir` 을 스크립트로 돌리는 쪽은, 훅 디렉터리만 겨냥한 것이었다면 `--keep-shell --keep-wiki-hook` 을 같이 넘겨야 한다.

---

## Changelog

- EN: `uninstall` now removes the shell rc block and the vault pre-commit hook that `init` installs, and refuses to delete either when its contents no longer match what `init` wrote.
- KO: `uninstall` 이 `init` 이 설치한 셸 rc 블록과 볼트 pre-commit 훅을 제거한다. 내용이 `init` 이 쓴 것과 다르면 지우지 않는다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
