### PR TITLE
docs: say that a plugin-channel update lands only when the manifest version moves

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -404,7 +404,7 @@ E. 멈춘 프로젝트 재개.
 
 | 설치 경로 | 슬래시 커맨드 위치 |
 |---|---|
-| 플러그인 (Path A) | Claude Code 플러그인 캐시. `/plugin marketplace update hypomnema` 후 `/reload-plugins`로 갱신 |
+| 플러그인 (Path A) | Claude Code 플러그인 캐시. `/plugin marketplace update hypomnema` 후 `/reload-plugins`로 갱신. 캐시 디렉터리 이름이 매니페스트 버전이라, 그 버전이 바뀌어야 갱신이 반영된다. 버전을 그대로 둔 채 머지한 커밋은 이미 설치된 곳에 닿지 않는다. |
 | npm CLI (Path B) | `~/.claude/commands/hypo/`. `hypomnema upgrade --apply`로 갱신, 파일별 SHA 추적. 사용자 수정본까지 덮어쓰려면 `--force-commands`(원본은 `.bak`으로 보존) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Place a `hypo-config.md` at the wiki root to make it portable across machines wi
 
 | Install path | Slash commands served from |
 |---|---|
-| Plugin (Path A) | Claude Code's plugin cache; updated via `/plugin marketplace update hypomnema` then `/reload-plugins` |
+| Plugin (Path A) | Claude Code's plugin cache; updated via `/plugin marketplace update hypomnema` then `/reload-plugins`. The cache directory is named after the manifest version, so an update lands only when that version has changed. A commit merged under an unchanged version does not reach an existing install. |
 | npm CLI (Path B) | `~/.claude/commands/hypo/`; updated via `hypomnema upgrade --apply` with per-file SHA tracking. Pass `--force-commands` to overwrite hand-edits (creates `.bak`). |
 
 ---

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -326,6 +326,12 @@ in **both** the CHANGELOG section AND the git tag annotation. The release
 workflow enforces this with `scripts/check-bilingual.mjs`; a lightweight tag, or
 a gated CHANGELOG section missing its `#### 한국어` sub-block, will block `npm publish`.
 
+A release is what makes a fix reachable, on both channels. The plugin installer names its
+cache directory after the manifest version, so it skips the copy when that version has not
+moved: commits merged to `main` under an unchanged version never reach an existing install.
+"It is on main, so people have it" is false. Bump the version and cut the release, or the
+work sits where nobody can run it.
+
 The READMEs are not part of a release. They describe what Hypomnema does now, not
 what each version added, so cutting a release never edits them. Version history
 lives in `CHANGELOG.md` alone. (A gate used to require the release version to


### PR DESCRIPTION
# English

## What changed

The contributor notes said a merge to `main` reaches every plugin-channel user. Both READMEs described how to update without saying when the update lands. All three now state the actual condition: a plugin-channel install picks up new commits only when the manifest version changes.

## Why

The old claim was acted on. A fix was merged, the maintainer was told it had reached users without waiting for a tag, and it had not. The installer names its cache directory after the manifest version, so an unchanged version means the directory already exists, the copy is skipped, and the commits never arrive.

The measurement behind the old claim came from a case where that cache directory was created for the first time, which is the one shape where the newest HEAD does land. A rule was drawn from a boundary condition.

## How

Measured 2026-08-28: two install roots on one machine both sat three merges behind `main` with byte-identical hook files, and neither `autoUpdate` nor a fresh session moved them. The note keeps the old reading alongside the correction and explains why that case differed, so the same misreading does not get re-derived from the same evidence.

The release checklist now says plainly that skipping a release leaves the work where nobody can run it, on this channel as much as on npm.

## Manual verification

Documentation only; no behavior changed. The claim was checked against `gitCommitSha` and `lastUpdated` in `installed_plugins.json`, the cache directory listing, and a sha256 comparison of the deployed hook files.

## Migration notes

None.

---

# 한국어

## 변경 내용

기여 노트가 `main` 머지는 곧 모든 플러그인 채널 사용자에게 닿는다고 적고 있었다. 두 README 는 갱신 방법만 적고 언제 반영되는지를 말하지 않았다. 셋 다 실제 조건을 적는다. 플러그인 채널 설치는 매니페스트 버전이 바뀔 때만 새 커밋을 받는다.

## 이유

그 문장을 믿고 행동했다. 수정을 머지하고 태그를 안 기다려도 사용자에게 닿았다고 보고했는데 닿지 않았다. 설치기가 캐시 디렉터리 이름을 매니페스트 버전으로 짓기 때문에, 버전이 그대로면 디렉터리가 이미 있고 복사를 건너뛰어 커밋이 도착하지 않는다.

옛 문장의 근거가 된 측정은 그 캐시 디렉터리가 처음 만들어지는 경우였고, 그때가 최신 HEAD 가 실제로 들어가는 유일한 모양이다. 경계 조건에서 규칙을 뽑은 것이다.

## 방법

2026-08-28 실측: 한 기계의 설치 루트 둘이 `main` 보다 세 머지 뒤에 멈춰 있었고 훅 파일의 sha256 이 서로 같았다. `autoUpdate` 도 새 세션도 그 값을 움직이지 않았다. 노트는 정정과 함께 옛 읽기를 남기고 그 경우가 왜 달랐는지 적는다. 같은 근거에서 같은 오독이 다시 나오지 않게 하기 위해서다.

릴리스 체크리스트는 릴리스를 건너뛰면 그 작업이 아무도 돌릴 수 없는 자리에 남는다고 적는다. 이 채널에서도 npm 과 똑같이 그렇다.

## 수동 검증

문서만 바뀌었고 동작 변경은 없다. 주장은 `installed_plugins.json` 의 `gitCommitSha` 와 `lastUpdated`, 캐시 디렉터리 목록, 배포된 훅 파일의 sha256 비교로 확인했다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: The contributor notes and both READMEs now say that a plugin-channel install picks up new commits only when the manifest version changes, correcting the claim that any merge to `main` reaches users.
- KO: 기여 노트와 두 README 가 플러그인 채널 설치는 매니페스트 버전이 바뀔 때만 새 커밋을 받는다고 적는다. `main` 머지가 곧 사용자 도달이라던 서술을 정정한 것이다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
