### PR TITLE
docs(automation): state the network calls the hooks actually make, and derive the hook table from hooks.json

### DIFF
--- a/templates/hypo-automation.md
+++ b/templates/hypo-automation.md
@@ -14,17 +14,48 @@ session continuity, and git sync.
 
 ## Hook Overview
 
+All 15 hooks registered in `hooks/hooks.json` are listed below, in registration order.
+
 | Hook | Event | Purpose |
 |------|-------|---------|
-| `hypo-session-start.mjs` | Session start | Injects `hot.md` and `session-state.md` into context |
-| `hypo-first-prompt.mjs` | First user prompt | Injects active project context on first message |
-| `hypo-auto-stage.mjs` | File save | Auto-stages changed wiki files |
-| `hypo-auto-commit.mjs` | Session stop | Commits and pushes staged wiki changes |
-| `hypo-compact-guard.mjs` | Pre-compact | Blocks `/compact` if session-log entry is missing |
-| `hypo-hot-rebuild.mjs` | Post-tool | Rebuilds `hot.md` from project hot caches |
-| `hypo-personal-check.mjs` | Pre-tool | Validates config and blocks on lint errors |
+| `hypo-close-guard.mjs` | `PreToolUse` | Blocks a direct Write/Edit/MultiEdit bypass of the session-close approval flow |
+| `hypo-session-start.mjs` | `SessionStart` | Injects `hot.md` and `session-state.md` into context on session start |
+| `hypo-session-end.mjs` | `SessionEnd` | Records the dying session's identity so a `/clear` can be detected and recovered from on the next start |
+| `hypo-first-prompt.mjs` | `UserPromptSubmit` | Injects a one-line resume summary on the first prompt after a session start or cwd change |
+| `hypo-lookup.mjs` | `UserPromptSubmit` | Searches the wiki index for each prompt and injects matched pages as context |
+| `hypo-compact-guard.mjs` | `UserPromptSubmit` | Prompts session close in chat when `/compact` or `/clear` is typed and close is incomplete |
+| `hypo-personal-check.mjs` | `PreCompact` | Hard-gates `/compact`, blocking on missing session-close files, uncommitted wiki changes, or lint blockers |
+| `hypo-auto-stage.mjs` | `PostToolUse` | Auto-stages a wiki file after it is written |
+| `hypo-web-fetch-ingest.mjs` | `PostToolUse` | Nudges Claude to ingest WebFetch/WebSearch results into `sources/` |
+| `hypo-hot-rebuild.mjs` | `Stop` | Rebuilds root `hot.md`'s pointer table and frontmatter at session end |
+| `hypo-session-record.mjs` | `Stop` | Appends the completed session to the session index |
+| `hypo-auto-commit.mjs` | `Stop` | Stages, commits, and pushes this session's touched wiki paths |
+| `hypo-auto-minimal-crystallize.mjs` | `Stop` | Blocks `Stop` when the session did substantial work, the user signalled wrap-up, and no close was recorded. A substantial session with no close signal is let through |
+| `hypo-cwd-change.mjs` | `CwdChanged` | Re-injects the matching project's `hot.md` when the working directory changes mid-session |
+| `hypo-file-watch.mjs` | `FileChanged` | Re-injects any vault file changed on disk outside the session, once it passes the ignore and visibility filters |
 
-All hooks run **locally** — no network requests.
+Two hooks reach the network; the rest compute locally. There are two separate kinds of
+network traffic here, and only one of them can be turned off.
+
+**Your vault's own git remote.** Whenever the vault is a git repo with a remote, the wiki
+syncs through it and its contents go wherever that remote lives. No flag disables this;
+remove the remote if you do not want it.
+
+- `hypo-session-start.mjs` (`SessionStart`) runs `git pull --ff-only` before it reads any
+  vault file. It waits for that pull, up to a 10 second timeout.
+- `hypo-auto-commit.mjs` (`Stop`) runs `git pull` and `git push` after committing this
+  session's touched paths.
+
+**The update check.** `hypo-session-start.mjs` also spawns a background check that fetches
+two URLs:
+
+- `https://registry.npmjs.org/hypomnema/latest`
+- `https://raw.githubusercontent.com/sk-lim19f/Hypomnema/main/.claude-plugin/marketplace.json`
+
+That one is non-blocking, and it is skipped entirely when `HYPO_NO_UPDATE_CHECK`,
+`NO_UPDATE_NOTIFIER`, or `CI` holds a non-empty value (an empty string does not count).
+The same variables also silence the stale-sibling and package-root warnings. None of them
+affect the git sync above.
 
 ---
 
@@ -35,20 +66,28 @@ Session start
   └─ hypo-session-start.mjs → reads hot.md + session-state.md → injects context
 
 During session
-  └─ hypo-auto-stage.mjs → auto-stages .md edits in wiki dir
-  └─ hypo-hot-rebuild.mjs → refreshes hot.md after project hot.md changes
+  └─ hypo-auto-stage.mjs → git-adds any wiki path a tool touched (not only .md edits)
+  └─ hypo-web-fetch-ingest.mjs → after WebFetch/WebSearch, nudges an ingest
+  └─ hypo-lookup.mjs → BM25-matches each prompt against the wiki index
 
-Session end
-  └─ /session-compact → writes session-log, session-state, ADRs
+Session end (Stop chain, in order)
+  └─ hypo-hot-rebuild.mjs → refreshes root hot.md
+  └─ hypo-session-record.mjs → appends to the session index
   └─ hypo-auto-commit.mjs → git commit + push
+  └─ hypo-auto-minimal-crystallize.mjs → blocks Stop if session close never ran
 ```
 
 ---
 
 ## `.hypoignore`
 
-Files matching patterns in `.hypoignore` are excluded from hook reads and index lookups.
-They remain on disk but are invisible to all Hypomnema tooling.
+Files matching patterns in `.hypoignore` are kept out of the context hooks inject and out
+of index lookups. They stay on disk.
+
+This is not a blanket read barrier. Some hooks touch a file before the ignore list is
+consulted: the `SessionStart` base snapshot hashes the four session-close overwrite
+targets whether or not they are ignored. Treat `.hypoignore` as "do not surface this",
+not as "nothing in Hypomnema opens this".
 
 ```
 # Example .hypoignore

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -642,6 +642,152 @@ test('defensive: odd cfg does not throw, yields a (possibly partial) Set', () =>
   assert.ok(names.has('ok.mjs') && !names.has('no-ext'), 'only .mjs names admitted');
 });
 
+// ── templates/hypo-automation.md hook table vs hooks.json (drift guard, ISSUE-92) ──
+// The doc's `| hook | event | purpose |` table is a hand-maintained mirror of
+// hooks.json. Nothing regenerates it, so a hook added to hooks.json (or an event
+// typo'd in the doc) drifts silently. Reuses readCoreHooksConfig/deriveCoreHookBasenames
+// (already proven above against the real hooks.json) instead of re-parsing it here.
+
+suite('templates/hypo-automation.md hook table');
+
+function actualEventByBasename() {
+  const res = readCoreHooksConfig(REPO);
+  assert.equal(res.ok, true, `real hooks.json should load: ${res.error}`);
+  const eventOf = new Map();
+  for (const [event, groups] of Object.entries(res.cfg.hooks)) {
+    // Scope the derive call to one event at a time (shared:[] so no shared
+    // basenames leak in) so the union helper still does the extraction/
+    // lowercasing, but per-event instead of flattened.
+    for (const name of deriveCoreHookBasenames({ hooks: { [event]: groups }, shared: [] })) {
+      eventOf.set(name, event);
+    }
+  }
+  return eventOf;
+}
+
+function readAutomationDoc() {
+  return readFileSync(join(REPO, 'templates', 'hypo-automation.md'), 'utf-8');
+}
+
+test('doc table lists exactly the hooks.json hooks, with matching events', () => {
+  const eventOf = actualEventByBasename();
+  const doc = readAutomationDoc();
+
+  const rowRe = /^\|\s*`([\w.-]+\.mjs)`\s*\|\s*`([A-Za-z]+)`\s*\|/gm;
+  const docEventOf = new Map();
+  let m;
+  while ((m = rowRe.exec(doc)) !== null) {
+    docEventOf.set(m[1].toLowerCase(), m[2]);
+  }
+  assert.ok(docEventOf.size > 0, 'expected to parse at least one hook row from the doc table');
+
+  const actualNames = new Set(eventOf.keys());
+  const docNames = new Set(docEventOf.keys());
+
+  const missingFromDoc = [...actualNames].filter((n) => !docNames.has(n));
+  const extraInDoc = [...docNames].filter((n) => !actualNames.has(n));
+  assert.deepEqual(
+    missingFromDoc,
+    [],
+    `hooks.json hooks missing from the doc table: ${missingFromDoc}`,
+  );
+  assert.deepEqual(
+    extraInDoc,
+    [],
+    `doc table lists hooks that hooks.json does not register: ${extraInDoc}`,
+  );
+
+  for (const [name, event] of docEventOf) {
+    assert.equal(
+      event,
+      eventOf.get(name),
+      `doc lists ${name} under ${event}, hooks.json says ${eventOf.get(name)}`,
+    );
+  }
+});
+
+test('doc states the current hook count, matching hooks.json', () => {
+  const eventOf = actualEventByBasename();
+  const doc = readAutomationDoc();
+  const m = /All (\d+) hooks registered in `hooks\/hooks\.json`/.exec(doc);
+  assert.ok(m, 'expected a stated hook count sentence in the doc');
+  assert.equal(Number(m[1]), eventOf.size, 'stated hook count must match hooks.json');
+});
+
+// The two hooks known to reach the network as of this commit, plus the fact that the
+// vault's own git remote is one of the two destinations. Deriving "reaches the network"
+// from source is not something a test can do, so this pins the shape that kept getting
+// written wrong rather than the property in general.
+//
+// Two rewrites of this paragraph shipped false claims before this assertion took its
+// current form. First "no network requests" while the hook table four lines above said
+// hypo-auto-commit "pushes". Then "one exception: SessionStart's update check", which
+// missed that SessionStart ALSO runs a blocking `git pull --ff-only`
+// (hypo-session-start.mjs:537, unconditional; isOptedOut only guards the notice
+// builders). So the git-sync verbs are asserted too: dropping them is how both misses
+// happened.
+test('doc names every hook that reaches the network', () => {
+  const doc = readAutomationDoc();
+  // Bound the slice to the network paragraph itself. Slicing to end of file instead
+  // let the Session Flow block below it satisfy the check: that block names the same
+  // hooks for an unrelated reason, so the assertion passed with the network paragraph
+  // stripped of every hook name.
+  const start = doc.search(/^.*reach the network.*$/m);
+  assert.ok(start >= 0, 'expected a network paragraph in the doc');
+  const rest = doc.slice(start);
+  const end = rest.search(/\n---\n|\n## /);
+  const section = end >= 0 ? rest.slice(0, end) : rest;
+  for (const hook of ['hypo-auto-commit.mjs', 'hypo-session-start.mjs']) {
+    assert.ok(
+      section.includes(hook),
+      `network section must name ${hook}: it makes network calls (auto-commit runs ` +
+        `git pull/push via syncRemote; session-start spawns the update check)`,
+    );
+  }
+  for (const verb of ['git pull', 'git push']) {
+    assert.ok(
+      section.includes(verb),
+      `network section must name \`${verb}\`: the vault's own remote is one of the two ` +
+        `network destinations, and it has no opt-out flag`,
+    );
+  }
+  assert.ok(
+    !/no network requests/i.test(doc),
+    'doc must not blanket-claim no network requests',
+  );
+});
+
+// The facts inside the network section, not just which hooks it names. Version 3 shortened
+// the marketplace URL to its host and wrote "set to any value" for the opt-out; both were
+// wrong and both passed the name-and-verb check above. So read the URLs out of
+// version-check-fetch.mjs and require the document to carry them verbatim, and require the
+// opt-out sentence to name all three variables the implementation actually reads.
+test('doc carries the update-check URLs verbatim and names every opt-out variable', () => {
+  const doc = readAutomationDoc();
+  const fetchSrc = readFileSync(join(REPO, 'hooks', 'version-check-fetch.mjs'), 'utf-8');
+  const urls = [...fetchSrc.matchAll(/'(https:\/\/[^']+)'/g)].map((m) => m[1]);
+  assert.ok(urls.length >= 2, `expected the fetch URLs in version-check-fetch.mjs, got ${urls.length}`);
+  for (const u of urls) {
+    assert.ok(doc.includes(u), `doc must carry the fetched URL verbatim: ${u}`);
+  }
+
+  const checkSrc = readFileSync(join(REPO, 'hooks', 'version-check.mjs'), 'utf-8');
+  const optOut = /Boolean\(([^)]*)\)/.exec(checkSrc.slice(checkSrc.indexOf('isOptedOut')));
+  assert.ok(optOut, 'expected the isOptedOut expression in version-check.mjs');
+  const vars = [...optOut[1].matchAll(/env\.([A-Z_]+)/g)].map((m) => m[1]);
+  assert.ok(vars.length >= 3, `expected the opt-out variables, got ${vars}`);
+  for (const v of vars) {
+    assert.ok(doc.includes(v), `doc must name the opt-out variable ${v}`);
+  }
+  // `Boolean(a || b || c)` means an empty string is NOT an opt-out. The document said
+  // "set to any value" until this was caught; keep the distinction stated.
+  assert.match(
+    doc,
+    /non-empty value/,
+    'doc must say the opt-out needs a non-empty value, not merely being set',
+  );
+});
+
 // ── init.mjs still exits 1 on a malformed hooks.json (loader routed via helper) ─
 // loadHookMap now reads+parses through readCoreHooksConfig but keeps init's own
 // validation + process.exit(1). Copy the package, corrupt hooks.json, and run


### PR DESCRIPTION
# English

## What changed

`templates/hypo-automation.md`, the automation reference that init and upgrade
install into every vault, now describes the hooks that actually exist and the
network calls they actually make. The hook table is derived from
`hooks/hooks.json` instead of being maintained by hand, and five assertions in
`tests/init.test.mjs` derive the hook list, the events, the stated count, the
fetched URLs, and the opt-out variable names from the source.

## Why

The document told users the opposite of the truth on the page they read to
decide what leaves their machine. It claimed "All hooks run locally, no network
requests" while its own hook table, four lines above, already said
`hypo-auto-commit` pushes. The vault also syncs through the user's git remote at
session start and at session end, and no flag turns that off.

It listed 7 hooks against the 15 registered in `hooks/hooks.json`, and placed
three of them under the wrong event: hot-rebuild as a post-tool hook,
personal-check as a pre-tool hook.

Four more claims in the same file were wrong:

- auto-stage git-adds any wiki path a tool touched, not only `.md` edits
- the Stop chain does not block on substantial work alone
- FileChanged re-injects any changed vault file, not only `hot.md`
- `.hypoignore` is a "do not surface this" list, not a read barrier: the
  SessionStart base snapshot hashes the four overwrite targets before the ignore
  list is consulted

## How

The hook table is generated from `hooks/hooks.json`, which is already the source
of truth for the event-to-hook map. Asserting the absence of one wrong sentence
was not enough. That check passes for an empty file and for the next wrong
sentence, and this paragraph shipped false twice before it landed, so the tests
now assert the positive: each derived value must match what the source says.

`docs/ARCHITECTURE.md` carries the same drift and is deliberately left alone
here. Its sentences each assume a single install channel, so every correction
surfaced a different false one. It is tracked separately.

## Manual verification

```
node tests/runner.mjs --file=init      # 5 new assertions green
node tests/parallel.mjs --shards=4     # 2044 passed
```

A fresh `init` into a temp vault writes the corrected file; the derived hook
table matches `hooks/hooks.json` line for line.

## Migration notes

**Existing vaults keep the stale copy.** `templates/hypo-automation.md` has no
update channel: `hypomnema upgrade --apply` does not overwrite it, and nothing
compares the installed copy against the shipped one. So this correction reaches
newly created vaults only, and an existing vault keeps telling its owner that no
hook makes a network request.

Until that channel exists, an existing vault can pick up the fix by replacing
`hypo-automation.md` by hand from this repo's `templates/` directory. Adding the
version stamp and the comparison (the mechanism `checkTemplateVersion` already
performs for `SCHEMA.md` and `hypo-guide.md`) is tracked separately.

---

# 한국어

## 변경 내용

init 과 upgrade 가 모든 볼트에 설치하는 자동화 참조 문서
`templates/hypo-automation.md` 가 실제로 존재하는 훅과 실제로 나가는 네트워크
호출을 기술하도록 고쳤다. 훅 표는 손으로 관리하는 대신 `hooks/hooks.json` 에서
파생되고, `tests/init.test.mjs` 의 단언 다섯이 훅 목록, 이벤트, 문서가 말하는
개수, 요청 URL, opt-out 환경변수 이름을 소스에서 파생한다.

## 이유

사용자가 "내 기계에서 무엇이 나가는가" 를 판단하려고 읽는 바로 그 페이지가
사실의 반대를 말하고 있었다. "All hooks run locally, no network requests" 라고
적혀 있는데, 네 줄 위의 훅 표는 이미 `hypo-auto-commit` 이 push 한다고 말한다.
볼트는 세션 시작과 세션 종료에 사용자의 git 리모트로 동기화되고, 그것을 끄는
플래그는 없다.

`hooks/hooks.json` 에 15개가 등록돼 있는데 문서는 7개만 나열했고, 그중 셋은
이벤트가 틀렸다(hot-rebuild 를 post-tool, personal-check 를 pre-tool 로 적었다).

같은 파일의 다른 주장 넷도 틀렸다.

- auto-stage 는 `.md` 편집만이 아니라 도구가 건드린 모든 볼트 경로를 git add 한다
- Stop 체인은 작업량이 많다는 것만으로는 막지 않는다
- FileChanged 는 `hot.md` 만이 아니라 변경된 모든 볼트 파일을 다시 주입한다
- `.hypoignore` 는 읽기 차단이 아니라 "이건 노출하지 마라" 목록이다. SessionStart
  의 base 스냅샷은 무시 목록을 보기 전에 덮어쓰기 대상 넷을 해시한다

## 방법

훅 표는 이미 이벤트 대 훅 매핑의 정본인 `hooks/hooks.json` 에서 생성한다.
틀린 문장 하나가 없다는 것을 단언하는 것으로는 부족했다. 그 검사는 빈 파일에도
통과하고 그다음 틀린 문장에도 통과하며, 실제로 이 문단은 확정되기 전에 거짓인
채로 두 번 나갔다. 그래서 테스트는 긍정을 단언한다. 파생한 값 각각이 소스가
말하는 것과 일치해야 한다.

`docs/ARCHITECTURE.md` 도 같은 드리프트를 안고 있으나 여기서는 일부러 건드리지
않았다. 그 문서는 문장마다 설치 채널 하나만 상정해서, 고칠 때마다 다른 거짓이
드러났다. 별건으로 추적한다.

## 수동 검증

```
node tests/runner.mjs --file=init      # 새 단언 5개 green
node tests/parallel.mjs --shards=4     # 2044 passed
```

임시 볼트에 fresh `init` 을 돌리면 고쳐진 파일이 쓰이고, 파생된 훅 표가
`hooks/hooks.json` 과 줄 단위로 일치한다.

## 마이그레이션 노트

**기존 볼트는 낡은 사본을 그대로 유지한다.** `templates/hypo-automation.md` 에는
갱신 채널이 없다. `hypomnema upgrade --apply` 가 이 파일을 덮지 않고, 설치된
사본을 배포본과 대조하는 것도 없다. 그래서 이 수정은 새로 만든 볼트에만 도달하고,
기존 볼트는 계속 "어떤 훅도 네트워크 요청을 하지 않는다" 고 주인에게 말한다.

그 채널이 생기기 전까지 기존 볼트는 이 레포의 `templates/` 에서
`hypo-automation.md` 를 손으로 복사해 고칠 수 있다. 버전 스탬프와 대조
(`checkTemplateVersion` 이 `SCHEMA.md` 와 `hypo-guide.md` 에 대해 이미 하는 일)를
더하는 것은 별건으로 추적한다.

---

## Changelog

- EN: The automation reference installed into a vault no longer claims that no hook makes a network request, lists all 15 registered hooks under their correct events, and corrects five further claims about auto-stage, the Stop chain, FileChanged, and `.hypoignore` (#263). Existing vaults keep their old copy: the file has no update channel yet.
- KO: 볼트에 설치되는 자동화 참조가 더 이상 "어떤 훅도 네트워크 요청을 하지 않는다" 고 말하지 않고, 등록된 훅 15개를 각자의 올바른 이벤트 아래 나열하며, auto-stage·Stop 체인·FileChanged·`.hypoignore` 에 대한 다섯 가지 서술을 함께 고친다 (#263). 기존 볼트는 낡은 사본을 유지한다. 이 파일에는 아직 갱신 채널이 없다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
