### PR TITLE
feat(doctor): report a plugin cache directory whose name disagrees with the release inside it

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -59,7 +59,12 @@ import {
   computeHooksDigest,
 } from './lib/pkg-provenance.mjs';
 import { resolveCliOnPath, classifyInstall } from '../hooks/version-check.mjs';
-import { isHypomnemaPluginEnabled } from './lib/plugin-detect.mjs';
+import {
+  isHypomnemaPluginEnabled,
+  enabledHypomnemaPluginKey,
+  usablePkgRoot,
+  leafVersionDrift,
+} from './lib/plugin-detect.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -1839,6 +1844,116 @@ function checkStaleSibling() {
   }
 }
 
+// ── plugin cache leaf version (plugin channel) ──────────────────────────────
+//
+// `/plugin marketplace update` names its cache directory after the release it
+// copies in (`cache/<marketplace>/hypo/<version>/`, per the plugin-channel
+// invariant in this repo's CLAUDE.md) and skips the copy whenever that version
+// string has not moved, so a leaf can end up naming an older release than the
+// package.json actually sitting inside it (2026-08-29 QA constructed that shape:
+// leaf "1.7.3", package.json "1.7.4"). This is the ONLY surface for that signal.
+// resolveEnabledPluginRoot (lib/plugin-detect.mjs) deliberately does NOT exclude a
+// drifted candidate: an earlier revision did, and excluding it makes that function
+// return null. init's resolveDurableRoot then tries the recorded pkgRoot and, when that
+// is unusable too, PKG_ROOT, which in a dual install is a removable npm checkout that
+// would get baked into the vault's git hook. So resolution stays permissive
+// and reporting lives here, named per-entry so a user can see exactly which registry
+// path disagrees with itself and what it actually contains.
+//
+// Only meaningful when the Hypomnema plugin is actually enabled: an entry in
+// installed_plugins.json for a disabled/other plugin proves nothing about this
+// install, so the check is silent (not even a pass) when the plugin key is not
+// enabled in settings.json.
+function checkPluginLeafVersion() {
+  const settingsPath = join(HOME, '.claude', 'settings.json');
+  const key = enabledHypomnemaPluginKey(settingsPath);
+  if (!key) return; // plugin not enabled, nothing to verify
+
+  const registryPath = join(HOME, '.claude', 'plugins', 'installed_plugins.json');
+  let reg;
+  try {
+    reg = JSON.parse(readFileSync(registryPath, 'utf-8'));
+  } catch {
+    warn(
+      'Plugin cache leaf version',
+      `Cannot read ${registryPath}, so the plugin cache directory's identity cannot be verified`,
+    );
+    return;
+  }
+  const entries =
+    reg &&
+    typeof reg.plugins === 'object' &&
+    !Array.isArray(reg.plugins) &&
+    Array.isArray(reg.plugins[key])
+      ? reg.plugins[key]
+      : null;
+  if (!entries || entries.length === 0) {
+    warn(
+      'Plugin cache leaf version',
+      `No registry entry for ${key} in ${registryPath}, so the plugin cache directory's identity cannot be verified`,
+    );
+    return;
+  }
+
+  // Deduped by installPath: one plugin key routinely carries several registry
+  // entries (a user-scope and a project-scope row) that name the SAME directory.
+  // Counting rows instead of paths reports "2 plugin cache path(s)" and lists the
+  // identical path twice — both the count and the list mislead about how many
+  // installs are actually drifted.
+  const driftedByPath = new Map();
+  const seen = new Set();
+  let compared = 0;
+  for (const e of entries) {
+    const installPath = e && typeof e.installPath === 'string' ? e.installPath : null;
+    if (!installPath || seen.has(installPath)) continue;
+    seen.add(installPath);
+    if (!usablePkgRoot(installPath)) continue;
+    const d = leafVersionDrift(installPath);
+    if (!d.checked) continue;
+    compared += 1;
+    if (d.drift) {
+      driftedByPath.set(
+        installPath,
+        `${installPath} (leaf says v${d.leaf}, package.json says v${d.manifestVersion})`,
+      );
+    }
+  }
+  const drifted = [...driftedByPath.values()];
+
+  // "Nothing drifted" and "nothing was comparable" are different answers, and this check
+  // used to give the same one for both. A path that is unreadable, or whose leaf is not
+  // version-named, was never compared — reporting "matches" there states a fact nobody
+  // established. The function already warns on its other two unverifiable states (an
+  // unreadable registry, a key with no entries), so passing here was the odd one out.
+  if (compared === 0) {
+    warn(
+      'Plugin cache leaf version',
+      `The plugin is enabled and the registry names ${key}, but no path it names could be ` +
+        `compared: none is a readable package dir with a version-named leaf. Common for a ` +
+        `local or dev marketplace checkout. The cache directory's identity is unverified; ` +
+        `this is not a statement that the installed version matches.`,
+    );
+  } else if (drifted.length === 0) {
+    pass(
+      'Plugin cache leaf version',
+      `Cache directory name matches the package installed inside it (${compared} path(s) compared)`,
+    );
+  } else {
+    // Scoped to the paths themselves. resolveEnabledPluginRoot picks ONE entry
+    // (user scope first, then any usable one), so a drifted project-scope row beside a
+    // healthy user-scope row is not the root Hypomnema actually runs from. Claiming
+    // "Hypomnema is silently running a different version" for every drifted row
+    // overstates what was measured.
+    warn(
+      'Plugin cache leaf version',
+      `${drifted.length} plugin cache path(s) whose directory name disagrees with the release ` +
+        `installed inside it: ${drifted.join(', ')}. Anything resolving through such a path ` +
+        `runs a different version than the name claims. Run ` +
+        `\`/plugin marketplace update hypomnema\` then \`/reload-plugins\`, or reinstall the plugin.`,
+    );
+  }
+}
+
 // ── provenance sidecar (manual/npm channel) ────────────────────────────────────
 //
 // `.hypo-provenance.json` lives next to a standalone-copied hooks/ dir
@@ -2106,6 +2221,7 @@ checkHooks(coreManagedByPlugin);
 checkSettingsJson(coreManagedByPlugin);
 checkPkgIntegrity(args.claudeHome);
 checkStaleSibling();
+checkPluginLeafVersion();
 if (args.codex) checkCodexPaths();
 if (rootOk) checkExtensions(args.hypoDir, args.claudeHome, 'claude');
 if (rootOk && args.codex) checkExtensions(args.hypoDir, args.claudeHome, 'codex');

--- a/scripts/lib/plugin-detect.mjs
+++ b/scripts/lib/plugin-detect.mjs
@@ -116,6 +116,64 @@ export function usablePkgRoot(pkgRoot) {
   );
 }
 
+// The version-shaped leaf of a plugin cache path (its last path component), or
+// null when that leaf does not look like a version. Claude Code names a plugin
+// cache directory after the release it copied in (`cache/<marketplace>/<name>/
+// <version>/`, per the plugin-channel invariant in this repo's CLAUDE.md), but
+// not every usable install root is shaped that way (a dev checkout or an npm
+// global root has no version-named leaf), so this returns null rather than
+// forcing a comparison that would misfire on those.
+function cacheLeafVersion(pkgRoot) {
+  if (typeof pkgRoot !== 'string' || !pkgRoot) return null;
+  const leaf = pkgRoot.replace(/\\/g, '/').replace(/\/+$/, '').split('/').pop();
+  // Anchored at BOTH ends. Unanchored at the end, a directory that merely starts
+  // with a version ("1.7.4-hypomnema-backup") reads as version-shaped, and its
+  // package.json version can never equal the whole leaf string, so a healthy root
+  // reports drift forever. Erring toward `checked: false` is the safe direction:
+  // a prerelease leaf goes unchecked rather than falsely flagged.
+  return leaf && /^\d+\.\d+\.\d+$/.test(leaf) ? leaf : null;
+}
+
+// Does a plugin cache root's leaf directory name (the version Claude Code named
+// it after) match what the package actually installed there declares in its own
+// package.json? A mismatch means every hook and script reading through that root
+// silently runs a different release than the directory name claims, with no
+// signal anywhere.
+//
+// Provenance, stated precisely because it bounds what this may do: the 2026-08-29
+// v1.7.4 pre-ship QA CONSTRUCTED this combination (a worker wrote a registry
+// entry whose leaf read "1.7.3" over a package.json reading "1.7.4"). This exact
+// shape, one registry-named path whose leaf disagrees with its own package.json,
+// has not been seen arising on its own, and check-versions.mjs forces
+// package.json, plugin.json and marketplace.json to agree at release time, so the
+// installer names the directory from the same gated commit it copies inside. That
+// is why this reports and never excludes: a constructed hazard does not justify
+// dropping a working install root (see resolveEnabledPluginRoot below).
+//
+// A DIFFERENT and real shape is out of scope here: several stale leaf directories
+// left behind beside the current one, each internally consistent, with something
+// outside the registry (a slash command's substituted plugin root) still pointing
+// at an old one. Measured 2026-08-31: five leaves 1.7.0 through 1.7.4 all matching
+// their own package.json, the registry naming only 1.7.4, and a command handing an
+// agent the 1.7.3 scripts path. This function compares registry-named paths, so it
+// reports pass there and is right to.
+//
+// `checked: false` means pkgRoot's leaf is not version-shaped, so there is
+// nothing to compare (not every usable root is a plugin cache path).
+export function leafVersionDrift(pkgRoot) {
+  const leaf = cacheLeafVersion(pkgRoot);
+  if (!leaf) return { checked: false, drift: false, leaf: null, manifestVersion: null };
+  const manifestVersion = readPkgVersionAt(pkgRoot);
+  // Unreadable package.json, or one with no version, is a judgment FAILURE, not a clean
+  // result. Returning `{checked: true, drift: false}` there would read as "compared and
+  // matched" and contradicts the sibling rule above (err toward `checked: false`).
+  // doctor happens to gate on usablePkgRoot first, which requires a readable version, so
+  // this is unreachable today; it is closed here because this is an exported API and the
+  // next caller will not know to add that gate.
+  if (manifestVersion === null) return { checked: false, drift: false, leaf, manifestVersion: null };
+  return { checked: true, drift: manifestVersion !== leaf, leaf, manifestVersion };
+}
+
 // Resolve the enabled Hypomnema plugin's REAL install root from the plugin
 // registry (~/.claude/plugins/installed_plugins.json). POSITIVE attribution: it
 // looks up the EXACT key that settingsPath marks enabled (via
@@ -125,8 +183,20 @@ export function usablePkgRoot(pkgRoot) {
 // falling back to any usable entry. Returns a usable absolute install root, or
 // null when the registry is absent/unreadable, names no entry for the enabled key,
 // or that entry is not a usable package dir. Fails open (null) on every
-// uncertainty — callers must treat null as "cannot positively resolve", never as
+// uncertainty; callers must treat null as "cannot positively resolve", never as
 // "resolved to nothing usable exists".
+//
+// Leaf-version drift does NOT exclude a candidate here, deliberately. An earlier
+// pass filtered on `!leafVersionDrift(p).drift`, and that turns a reporting
+// problem into a breaking one: when this returns null, resolveDurableRoot (init.mjs)
+// falls through to the recorded pkgRoot in hypo-pkg.json and, if that is not usable
+// either, to PKG_ROOT. In a dual install PKG_ROOT is the
+// manual/npm checkout the dual-install notice tells the user to remove. That path
+// gets written into the vault's pre-commit hook, so removing the npm copy leaves
+// the hook dangling and breaks every wiki commit (the failure init.mjs's own
+// `durableRoot` comment exists to prevent). It also silences upgrade's
+// dualSkipWouldCorrect trigger, disabling the very self-heal that fixes a stale
+// pointer. Drift is surfaced by doctor's checkPluginLeafVersion instead.
 export function resolveEnabledPluginRoot(settingsPath, registryPath) {
   const key = enabledHypomnemaPluginKey(settingsPath);
   if (!key) return null;

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -32,6 +32,7 @@ import {
   withTmpHome,
 } from './helpers.mjs';
 import { PROVENANCE_FILENAME, EXPECTED_PKG_NAME } from '../scripts/lib/pkg-provenance.mjs';
+import { resolveEnabledPluginRoot, leafVersionDrift } from '../scripts/lib/plugin-detect.mjs';
 
 // ── doctor.mjs smoke tests ───────────────────────────────────────────────────
 
@@ -2280,5 +2281,171 @@ test('hooks installed, self-location fails, no sidecar at all → doctor warns, 
       assert.equal(check.status, 'warn', `must not stay silent: ${check.detail}`);
       assert.match(check.detail, /PKG_ROOT resolves to null/);
     });
+  });
+});
+
+// ── plugin cache leaf version (plugin channel) ──────────────────────────────
+//
+// ISSUE-113: `/plugin marketplace update` names its cache directory after the
+// release it copies in and skips the copy once that version string stops
+// moving, so the leaf can end up naming an older release than the
+// package.json actually sitting inside it. Registry shape mirrors upgrade.mjs
+// dualSkip's own fixtures (tests/upgrade.test.mjs writeRegistry/withRegistryRoot):
+// `{ plugins: { "<key>": [{ installPath, scope }] } }`.
+
+suite('doctor.mjs: plugin cache leaf version (ISSUE-113)');
+
+const PLUGIN_KEY = 'hypo@hypomnema';
+
+function enablePlugin(home) {
+  mkdirSync(join(home, '.claude'), { recursive: true });
+  writeFileSync(
+    join(home, '.claude', 'settings.json'),
+    JSON.stringify({ enabledPlugins: { [PLUGIN_KEY]: true } }),
+  );
+}
+
+// Builds a plugin cache root shaped like Claude Code's own
+// `cache/<marketplace>/hypo/<leafVersion>/` and points installed_plugins.json
+// at it, with a package.json inside carrying `manifestVersion`. Passing
+// `leafVersion !== manifestVersion` reproduces the exact QA fixture (leaf
+// "1.7.3", package.json "1.7.4").
+// `scopes` mirrors the real registry shape: a live machine carries BOTH a
+// user-scope and a project-scope row for one key, and both name the SAME
+// installPath (verified on this machine 2026-08-31). The default stays single so
+// the existing tests read unchanged.
+function registerPluginCache(home, leafVersion, manifestVersion, scopes = ['user']) {
+  const root = join(home, '.claude', 'plugins', 'cache', 'hypomnema', 'hypo', leafVersion);
+  mkdirSync(root, { recursive: true });
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'hypomnema', version: manifestVersion }),
+  );
+  const registryDir = join(home, '.claude', 'plugins');
+  mkdirSync(registryDir, { recursive: true });
+  writeFileSync(
+    join(registryDir, 'installed_plugins.json'),
+    JSON.stringify({
+      plugins: { [PLUGIN_KEY]: scopes.map((scope) => ({ installPath: root, scope })) },
+    }),
+  );
+  return root;
+}
+
+test('plugin not enabled: check is silent (not reported at all)', () => {
+  withTmpHome((home) => {
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Plugin cache leaf version');
+    assert.equal(check, undefined, 'no enabled plugin means nothing to verify');
+  });
+});
+
+test('plugin enabled, leaf matches package.json version: passes', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    registerPluginCache(home, '1.7.4', '1.7.4');
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Plugin cache leaf version');
+    assert.ok(check, 'expected a Plugin cache leaf version check');
+    assert.equal(check.status, 'pass', `matching leaf must pass: ${check.detail}`);
+  });
+});
+
+test('plugin enabled, leaf drifted from package.json version: warns and names the exact drift', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    // The measured 2026-08-29 QA shape: cache leaf "1.7.3", package.json "1.7.4".
+    registerPluginCache(home, '1.7.3', '1.7.4');
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Plugin cache leaf version');
+    assert.ok(check, 'expected a Plugin cache leaf version check');
+    assert.equal(check.status, 'warn', `drifted leaf must warn, not pass: ${check.detail}`);
+    assert.match(check.detail, /leaf says v1\.7\.3/);
+    assert.match(check.detail, /package\.json says v1\.7\.4/);
+  });
+});
+
+// Two registry rows, one directory. The real shape on a live machine: `hypo@hypomnema`
+// carries a user-scope AND a project-scope entry pointing at the same installPath.
+// Iterating rows instead of paths reported "2 plugin cache path(s)" and printed the
+// identical path twice, so both the count and the list overstated the damage.
+test('duplicate registry rows naming one path are reported once', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    registerPluginCache(home, '1.7.3', '1.7.4', ['user', 'project']);
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Plugin cache leaf version');
+    assert.ok(check, 'expected a Plugin cache leaf version check');
+    assert.equal(check.status, 'warn');
+    assert.match(check.detail, /1 plugin cache path\(s\)/, `count must dedupe: ${check.detail}`);
+    const hits = check.detail.match(/leaf says v1\.7\.3/g) || [];
+    assert.equal(hits.length, 1, `path must be listed once, got ${hits.length}: ${check.detail}`);
+  });
+});
+
+// A leaf that merely STARTS with a version is not a version-named cache dir. An
+// unanchored test read it as one, and since package.json can never equal the whole
+// leaf string, a perfectly healthy root warned forever.
+test('a leaf that only starts with a version is not treated as version-named', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    registerPluginCache(home, '1.7.4-hypomnema-backup', '1.7.4');
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Plugin cache leaf version');
+    assert.ok(check, 'expected a Plugin cache leaf version check');
+    // Not `pass`: nothing was compared, and saying "matches" would state a fact nobody
+    // established. Not the drift wording either — that is what an unanchored regex
+    // produces here, so asserting on the detail is what makes this test distinguish the
+    // two failure directions rather than just the status word.
+    assert.equal(check.status, 'warn', `unverifiable must not read as verified: ${check.detail}`);
+    assert.match(check.detail, /could be compared/, `expected the unverified wording: ${check.detail}`);
+    assert.doesNotMatch(
+      check.detail,
+      /leaf says v/,
+      `a non-version leaf must not be reported as drifted: ${check.detail}`,
+    );
+  });
+});
+
+// The exclusion this feature deliberately does NOT do. Filtering drifted roots out
+// of resolveEnabledPluginRoot makes it return null, and init.mjs's resolveDurableRoot
+// then falls back to PKG_ROOT — in a dual install that is the npm checkout, which
+// gets baked into the vault's pre-commit hook and dangles the moment the user removes
+// it. Drift is a reporting concern; resolution must still hand back the working root.
+test('a drifted leaf is still resolved as the plugin root (report, never exclude)', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    const root = registerPluginCache(home, '1.7.3', '1.7.4');
+    const settingsPath = join(home, '.claude', 'settings.json');
+    const registryPath = join(home, '.claude', 'plugins', 'installed_plugins.json');
+    assert.equal(
+      resolveEnabledPluginRoot(settingsPath, registryPath),
+      root,
+      'drift must not remove a usable root from resolution',
+    );
+    assert.equal(leafVersionDrift(root).drift, true, 'fixture must actually be drifted');
+  });
+});
+
+// leafVersionDrift is exported, and doctor is not its only possible caller. doctor
+// happens to gate on usablePkgRoot first (which requires a readable version), so an
+// unreadable package.json cannot reach the comparison today. Pin the contract directly
+// anyway: a version-shaped leaf over a package.json with no version is a judgment
+// FAILURE, and reporting it as `checked: true, drift: false` would read as "compared
+// and matched" — the same fail-open shape doctor's own `compared === 0` branch closes.
+test('leafVersionDrift: unreadable manifest is checked:false, not a clean compare', () => {
+  withTmpHome((home) => {
+    const root = join(home, '.claude', 'plugins', 'cache', 'hypomnema', 'hypo', '1.7.4');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'hypomnema' })); // no version
+    const d = leafVersionDrift(root);
+    assert.equal(d.checked, false, 'a manifest with no version was never compared');
+    assert.equal(d.drift, false, 'and an uncompared root must not be reported as drifted');
+    assert.equal(d.manifestVersion, null);
   });
 });


### PR DESCRIPTION
# English

## What changed

`hypo:doctor` now reports a plugin cache directory whose name disagrees with the
release inside it. `leafVersionDrift()` compares the leaf directory name against
the `version` in the `package.json` sitting in that directory, and doctor prints
the mismatch for each registry path.

## Why

Claude Code names a plugin cache directory after the release it copied in
(`cache/hypomnema/hypo/1.7.4`). When that name and the `package.json` inside it
disagree, every hook and script resolving through that root runs a different
release than the name claims, and nothing anywhere says so: the hooks fire, the
slash commands appear, the version string reads correctly, and a bug fixed weeks
ago keeps reproducing.

#239 gave the npm and manual channels a defense against a stale package root.
The plugin channel had none.

## How

**It reports and never excludes.** Filtering drifted roots out of
`resolveEnabledPluginRoot` makes that function return null, and init's
`resolveDurableRoot` then falls back to the recorded `pkgRoot` and, when that is
unusable, to `PKG_ROOT`, which in a dual install is the npm checkout that the
dual-install notice tells the user to remove. That path would be written into
the vault's pre-commit hook, so removing the npm copy would break every wiki
commit afterwards. A test pins that a drifted root is still resolved.

The report is deduplicated by install path, because one plugin key routinely
carries a user-scope and a project-scope registry row naming the same directory.

"Nothing drifted" and "nothing was comparable" are now different answers. An
unreadable root, or a leaf that is not version-named, is reported as unverified
rather than silently counted as a match.

## Manual verification

```
node tests/runner.mjs --file=doctor    # new assertions green
node tests/parallel.mjs --shards=4
```

Reproduced against an isolated `HOME` with a manifest version of 1.7.4 and a
cache leaf named for a different release: doctor reports the drift and still
resolves the root, and the pre-commit hook path written by init is unchanged.

## Migration notes

None. This is a new report in `hypo:doctor` output; no existing install changes
behavior, and nothing is excluded or rewritten as a result of the report.

---

# 한국어

## 변경 내용

`hypo:doctor` 가 이름과 그 안의 릴리스가 어긋난 플러그인 캐시 디렉터리를
보고한다. `leafVersionDrift()` 가 leaf 디렉터리 이름을 그 디렉터리 안
`package.json` 의 `version` 과 대조하고, doctor 가 레지스트리 경로마다 그
어긋남을 출력한다.

## 이유

Claude Code 는 플러그인 캐시 디렉터리를 자기가 복사해 넣은 릴리스 이름으로
짓는다(`cache/hypomnema/hypo/1.7.4`). 그 이름과 안쪽 `package.json` 이 어긋나면,
그 루트로 해석되는 모든 훅과 스크립트가 이름이 주장하는 것과 다른 릴리스를
돌리는데 어디에도 신호가 없다. 훅은 발화하고, 슬래시 명령은 보이고, 버전
문자열은 맞게 읽히고, 몇 주 전에 고친 버그가 계속 재현된다.

#239 가 npm 채널과 수동 설치 채널에 낡은 패키지 루트에 대한 방어를 줬다.
플러그인 채널에는 그것이 없었다.

## 방법

**보고만 하고 배제하지 않는다.** 어긋난 루트를 `resolveEnabledPluginRoot` 에서
걸러 내면 그 함수가 null 을 돌려주고, init 의 `resolveDurableRoot` 는 기록된
`pkgRoot` 로, 그것도 못 쓰면 `PKG_ROOT` 로 떨어진다. 이중 설치에서 `PKG_ROOT` 는
이중 설치 안내가 사용자에게 지우라고 말하는 바로 그 npm 체크아웃이다. 그 경로가
볼트의 pre-commit 훅에 적히므로, npm 사본을 지우면 그 뒤 모든 위키 커밋이
깨진다. 어긋난 루트도 여전히 해석된다는 것을 테스트가 고정한다.

보고는 설치 경로로 중복 제거한다. 플러그인 키 하나가 같은 디렉터리를 가리키는
user 스코프 행과 project 스코프 행을 함께 갖는 일이 흔하기 때문이다.

"어긋난 것이 없다" 와 "대조할 수 있는 것이 없었다" 가 이제 서로 다른 답이다.
읽을 수 없는 루트나 버전 이름이 아닌 leaf 는 일치로 조용히 세지 않고 미확인으로
보고한다.

## 수동 검증

```
node tests/runner.mjs --file=doctor    # 새 단언 green
node tests/parallel.mjs --shards=4
```

격리된 `HOME` 에서 매니페스트 버전 1.7.4 와 다른 릴리스 이름의 캐시 leaf 로
재현했다. doctor 가 어긋남을 보고하면서 루트는 여전히 해석하고, init 이 쓰는
pre-commit 훅 경로는 그대로다.

## 마이그레이션 노트

없다. `hypo:doctor` 출력에 보고가 하나 늘어날 뿐이고, 기존 설치의 동작은 바뀌지
않으며, 이 보고를 근거로 무엇을 배제하거나 다시 쓰지도 않는다.

---

## Changelog

- EN: `hypo:doctor` now reports a plugin cache directory whose name disagrees with the release inside it, so an install that silently runs a different release than its version string claims becomes visible (#265). The drifted root is reported, never excluded from resolution.
- KO: `hypo:doctor` 가 이름과 그 안의 릴리스가 어긋난 플러그인 캐시 디렉터리를 보고한다. 버전 문자열이 주장하는 것과 다른 릴리스를 조용히 돌리던 설치가 이제 눈에 보인다 (#265). 어긋난 루트는 보고할 뿐 해석에서 배제하지 않는다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)

