### PR TITLE
fix(skills): point five skills at the flag their script actually parses, and derive that from the source

### DIFF
--- a/skills/crystallize/SKILL.md
+++ b/skills/crystallize/SKILL.md
@@ -20,7 +20,7 @@ When invoked to close a session — via an explicit close signal ("세션 종료
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` or reinstall instead of guessing the cache layout.
 
-If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag and the script resolves the Hypomnema root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
 
 ---
 
@@ -28,7 +28,7 @@ If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherw
 
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs \
-  [--wiki-dir="<path>"] \
+  [--hypo-dir="<path>"] \
   [--min-group=<n>] \
   [--json]
 ```

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -16,7 +16,7 @@ You are running `/hypo:graph`. Build a wikilink dependency graph from all pages 
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` or reinstall instead of guessing the cache layout.
 
-If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag and the script resolves the Hypomnema root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
 
 ---
 
@@ -38,7 +38,7 @@ Optionally ask:
 
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/graph.mjs \
-  [--wiki-dir="<path>"] \
+  [--hypo-dir="<path>"] \
   [--format=json|mermaid|dot] \
   [--min-edges=<n>]
 ```

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -16,7 +16,7 @@ You are running `/hypo:ingest`. Add a new source document to `sources/` and crea
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` or reinstall instead of guessing the cache layout.
 
-If the user specified a wiki directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag and the script resolves the Hypomnema root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
 
 ---
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -18,14 +18,14 @@ You are running `/hypo:lint`. Validate all wiki pages for frontmatter correctnes
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` or reinstall instead of guessing the cache layout.
 
-If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag and the script resolves the Hypomnema root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
 
 ---
 
 ## Step 2 — Run lint
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.mjs [--wiki-dir="<path>"] [--json] [--fix]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.mjs [--hypo-dir="<path>"] [--json] [--fix]
 ```
 
 Options:

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -16,7 +16,7 @@ You are running `/hypo:query`. Full-text search across all wiki pages and projec
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` or reinstall instead of guessing the cache layout.
 
-If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag and the script resolves the Hypomnema root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
 
 ---
 
@@ -33,7 +33,7 @@ Use the search terms from the user's message. If no query was provided, ask:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/query.mjs \
   --q="<search terms>" \
-  [--wiki-dir="<path>"] \
+  [--hypo-dir="<path>"] \
   [--limit=<n>] \
   [--json]
 ```

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -16,7 +16,7 @@ You are running `/hypo:verify`. Check all wiki pages for `verify_by` and `verify
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` or reinstall instead of guessing the cache layout.
 
-If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherwise omit the flag and the script resolves the wiki root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise omit the flag and the script resolves the Hypomnema root automatically via `HYPO_DIR` → `hypo-config.md` scan → `~/hypomnema`.
 
 ---
 
@@ -24,7 +24,7 @@ If the user specified a wiki directory, pass it as `--wiki-dir="<path>"`. Otherw
 
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/verify.mjs \
-  [--wiki-dir="<path>"] \
+  [--hypo-dir="<path>"] \
   [--file="<path>"] \
   [--json]
 ```

--- a/tests/collect-changelog.test.mjs
+++ b/tests/collect-changelog.test.mjs
@@ -719,22 +719,52 @@ test('prompt surfaces: bundled-script references resolve via CLAUDE_PLUGIN_ROOT/
   surfaceFiles.push(join(REPO, 'templates', 'hypo-guide.md')); // the operational guide
 
   // Collect code-context text: fenced-block lines + inline `code` spans on prose lines.
-  const codeText = (md) => {
+  const codeLines = (md) => {
     const out = [];
     let inFence = false;
-    for (const line of md.split('\n')) {
+    md.split('\n').forEach((line, i) => {
       if (line.trim().startsWith('```')) {
         inFence = !inFence;
-        continue;
+        return;
       }
       if (inFence) {
-        out.push(line);
-        continue;
+        out.push({ text: line, lineNo: i + 1 });
+        return;
       }
       const spans = line.match(/`[^`]+`/g);
-      if (spans) out.push(spans.join(' '));
-    }
-    return out.join('\n');
+      if (spans) out.push({ text: spans.join(' '), lineNo: i + 1 });
+    });
+    return out;
+  };
+  // Keeps the ORIGINAL 1-based file line on every entry: a diagnostic pointing
+  // at an index into the stripped text sends the reader to the wrong place,
+  // which is worse than giving no line at all.
+  const codeText = (md) =>
+    codeLines(md)
+      .map((e) => e.text)
+      .join('\n');
+
+  // A logical shell command: physical lines glued on a trailing backslash.
+  const joinContinuations = (entries) => {
+    const out = [];
+    let buf = null;
+    let start = 0;
+    entries.forEach(({ text: raw, lineNo }) => {
+      const cont = /\\\s*$/.test(raw);
+      const body = raw.replace(/\\\s*$/, '');
+      if (buf === null) {
+        buf = body;
+        start = lineNo;
+      } else {
+        buf = `${buf} ${body.trim()}`;
+      }
+      if (!cont) {
+        out.push({ line: buf, startLine: start });
+        buf = null;
+      }
+    });
+    if (buf !== null) out.push({ line: buf, startLine: start });
+    return out;
   };
 
   // Known bundled-script basenames, derived from scripts/ so the gate stays current.
@@ -783,4 +813,101 @@ test('prompt surfaces: bundled-script references resolve via CLAUDE_PLUGIN_ROOT/
     0,
     `surfaces invoking a bundled script but missing the hypo-pkg.json resolution fallback: ${missingFallback.join(', ')}`,
   );
+
+  // Same surfaces, second question: does every flag a surface tells the model to
+  // pass actually get PARSED by the script it names? Most shipped scripts do not
+  // reject an unknown flag (init.mjs:210-220 is the exception, exiting 2), so a
+  // wrong one is usually dropped and the run falls through to default vault
+  // resolution while reporting success. That is how `--wiki-dir` sat
+  // in five SKILL.md files against scripts that only ever read `--hypo-dir`, with
+  // `crystallize` among them, so a close could have been written into a vault the
+  // user did not name. The same-named commands/*.md had it right the whole time,
+  // which is why this sweeps BOTH surfaces from the one `surfaceFiles` list above.
+  //
+  // Derive the parsed set, never `src.includes(flag)`: a substring test passes for
+  // `--apply`, `--check` and `--mark` against crystallize.mjs, because each is a
+  // prefix of a real flag AND appears in that file's own usage header. Those are
+  // the most likely next drift, and a substring guard waves them through.
+  //
+  // The path class includes `/` on purpose: templates/hypo-guide.md invokes
+  // scripts/lib/project-create.mjs, and a `[a-z0-9-]+` class silently skipped that
+  // surface entirely — neither swept nor reported as unswept, which is the exact
+  // hole the completeness check below exists to catch.
+  //
+  // ponytail: recognises the two arg-parsing shapes this repo uses (`arg === '--x'`
+  // and `arg.startsWith('--x=')`). A script that switches to a table-driven or
+  // third-party parser yields an empty set and fails loudly here rather than
+  // silently passing; retune this regex then.
+  const parsedFlags = (src) =>
+    new Set(
+      [...src.matchAll(/(?:===?\s*|startsWith\(\s*)['"`](--[a-z][a-z0-9-]*)=?['"`]/g)].map(
+        (m) => m[1],
+      ),
+    );
+  const flagCache = new Map();
+  const badFlags = [];
+  const sweptSurfaces = new Set();
+  for (const p of surfaceFiles) {
+    const rel = p.slice(REPO.length + 1);
+    const code = codeText(readFileSync(p, 'utf8'));
+    // Join backslash continuations into one logical shell command before
+    // scanning. The usage blocks that matter are written multi-line:
+    //   node ${CLAUDE_PLUGIN_ROOT}/scripts/verify.mjs \
+    //     [--hypo-dir="<path>"] \
+    //     [--json]
+    // A per-physical-line sweep sees the script name on one line and the flags
+    // on the next, matches neither against the other, and reports nothing. That
+    // is not hypothetical: graph, query, verify and crystallize all use this
+    // shape, so four of the five files this guard was written for were not
+    // actually covered by it, and a revert of their `--hypo-dir` passed green.
+    // The line number is the logical command's first physical line, which is
+    // where the reader has to look even when the flag sits on a continuation.
+    let lineNo = 0;
+    for (const { line, startLine } of joinContinuations(codeLines(readFileSync(p, 'utf8')))) {
+      lineNo = startLine;
+      const named = line.match(/scripts\/([a-z0-9/-]+\.mjs)/);
+      if (!named) continue;
+      const scriptPath = join(REPO, 'scripts', named[1]);
+      if (!existsSync(scriptPath)) {
+        // Not a silent skip: a surface naming a script that is not there is itself
+        // a finding, and the unresolved sweep above would not see a well-formed path.
+        badFlags.push(`${rel}:${lineNo} names scripts/${named[1]}, which does not exist`);
+        continue;
+      }
+      if (!flagCache.has(named[1]))
+        flagCache.set(named[1], parsedFlags(readFileSync(scriptPath, 'utf8')));
+      const parsed = flagCache.get(named[1]);
+      assert.ok(parsed.size > 0, `parsed-flag sweep found no flags in scripts/${named[1]}`);
+      sweptSurfaces.add(rel);
+      for (const flag of new Set(line.match(/--[a-z][a-z0-9-]*/g) || [])) {
+        if (!parsed.has(flag)) {
+          badFlags.push(
+            `${rel}:${lineNo} passes ${flag} to scripts/${named[1]}, which never parses it`,
+          );
+        }
+      }
+    }
+  }
+  assert.equal(
+    badFlags.length,
+    0,
+    `A prompt surface tells the model to pass a flag its script does not parse. ` +
+      `FIX THE DOCUMENT, not the script: the flag the script really takes is the ` +
+      `correct one, and adding a parser to match the doc would ship a second spelling. ` +
+      `Most scripts ignore an unknown flag rather than rejecting it (init.mjs is the ` +
+      `exception), so the value is usually dropped and the run falls through to default ` +
+      `vault resolution while reporting success.\n  ${badFlags.join('\n  ')}`,
+  );
+  // Guard the guard, per surface rather than by a global count: a threshold like
+  // ">= 5" against the real 24 stays green with five of six skills missing.
+  for (const p of surfaceFiles) {
+    const rel = p.slice(REPO.length + 1);
+    const code = codeText(readFileSync(p, 'utf8'));
+    if (/scripts\/[a-z0-9/-]+\.mjs/.test(code)) {
+      assert.ok(
+        sweptSurfaces.has(rel),
+        `${rel} names a bundled script but was not swept for flags`,
+      );
+    }
+  }
 });


### PR DESCRIPTION
# English

## What changed

Five `SKILL.md` files told the model to pass `--wiki-dir="<path>"` when the user
named a vault directory. They now name `--hypo-dir`, the flag the scripts
actually parse, and a test derives that expectation from each script's own arg
parsing so the two cannot drift apart again.

## Why

No script has ever parsed `--wiki-dir`. `lint.mjs` reads `--hypo-dir`; so do
`verify.mjs`, `graph.mjs`, `query.mjs` and `crystallize.mjs`. None of them
rejects an unknown flag either, so the value was dropped and the run fell
through to default vault resolution (`HYPO_DIR`, then a `hypo-config.md` scan,
then `~/hypomnema`) while reporting success.

`crystallize` is one of the five. A session close could have been written into
a vault the user did not name, and reported that it succeeded.

The same-named `commands/*.md` carried the correct flag the whole time. Only one
side of a near-duplicate document drifted, which is what made it survive.

## How

The guard went into the prompt-surfaces test that already collects
`commands/*.md`, every `skills/*/SKILL.md` and `templates/hypo-guide.md`, and
already knows how to pull code out of prose. Writing a second, weaker copy of
that collection was the first attempt and it covered fewer surfaces.

It derives the accepted flags from each script's own arg parsing rather than
testing for a substring. `src.includes()` passes `--apply`, `--check` and
`--mark` against `crystallize.mjs`: each is a prefix of a real flag AND appears
in that file's own usage header, which makes them the most likely next drift.

Two shapes had to be handled before the guard covered what it claimed to.

- The usage blocks are written multi-line with backslash continuations, so a
  per-physical-line sweep saw the script name on one line and the flags on the
  next and matched neither against the other. Four of the five files were not
  actually covered, and reverting their flag passed green. Logical shell
  commands are now joined before scanning.
- A `[a-z0-9-]+` path class skipped `scripts/lib/project-create.mjs` entirely,
  so `templates/hypo-guide.md` was neither swept nor reported as unswept: the
  completeness check had the exact hole it exists to catch.

That completeness check is per surface rather than a global count. A threshold
of five against a real twenty-four stays green with five of six skills missing.

Failure output names the file and the first line of the logical command, and
says to fix the document rather than add a second spelling to the parser.

## Manual verification

Each direction was proven red before being accepted:

```
revert --wiki-dir in skills/lint (single-line)          exit 1
revert --wiki-dir in verify, graph, query, crystallize  exit 1 each (all four were silent before)
add --apply to a crystallize block (prefix case)        exit 1 (a substring guard passed this)
add --nope to templates/hypo-guide.md                   exit 1 (this surface was invisible before)

node tests/parallel.mjs --shards=4    2044 passed, 0 failed
npm run lint                          0 errors
npm run check:tracker-ids             clean
npm run check:pack-surface            137 files, 0 closure violations
```

## Migration notes

**This does not reach an existing install until the version string moves.** The
plugin installer names its cache directory after `plugin.json`'s version, so it
skips the copy when that string has not changed, and npm installs resolve the
published version. Until the next release, an installed copy keeps telling the
model to pass `--wiki-dir`.

Nothing has to be migrated by hand: the corrected prompts arrive with the next
release like any other shipped file. The note is here because "it is on `main`,
so people have it" is false on both channels, and this is a correctness fix
whose user-visible effect starts at the release, not at the merge.

---

# 한국어

## 변경 내용

다섯 `SKILL.md` 가 사용자가 볼트 디렉터리를 지정했을 때 `--wiki-dir="<path>"` 를
넘기라고 모델에게 지시했다. 이제 스크립트가 실제로 파싱하는 `--hypo-dir` 를 말하고,
테스트가 그 기대값을 각 스크립트의 인자 파싱에서 파생해 둘이 다시 어긋나지 못하게 한다.

## 이유

`--wiki-dir` 를 파싱한 스크립트는 한 번도 없었다. `lint.mjs` 는 `--hypo-dir` 를 읽고
`verify.mjs`·`graph.mjs`·`query.mjs`·`crystallize.mjs` 도 같다. 게다가 다섯 다 미지정
플래그를 거부하지 않아서, 값이 버려진 채 기본 볼트 해석(`HYPO_DIR`, 그다음
`hypo-config.md` 스캔, 그다음 `~/hypomnema`)으로 가면서 성공을 보고했다.

`crystallize` 가 그 다섯에 있다. 세션 close 가 사용자가 지정하지 않은 볼트에 쓰이고도
성공했다고 보고할 수 있었다.

같은 이름의 `commands/*.md` 는 처음부터 맞는 플래그를 갖고 있었다. 거의 같은 문서의
한쪽만 드리프트했고, 그래서 이것이 살아남았다.

## 방법

가드는 이미 `commands/*.md` 와 모든 `skills/*/SKILL.md` 와 `templates/hypo-guide.md` 를
모으고 산문에서 코드를 뽑을 줄 아는 prompt-surfaces 테스트 안으로 들어갔다. 처음에는 그
수집의 두 번째 약한 사본을 새로 썼는데, 그쪽이 덮는 표면이 더 적었다.

문자열 포함 검사 대신 각 스크립트의 인자 파싱에서 허용 플래그를 파생한다.
`src.includes()` 는 `crystallize.mjs` 에 대해 `--apply`·`--check`·`--mark` 를 통과시킨다.
셋 다 진짜 플래그의 접두사이면서 그 파일 자기 usage 헤더가 쓰는 표기라, 다음 드리프트가
될 가능성이 가장 높은 것들이다.

가드가 자기가 주장하는 범위를 실제로 덮으려면 두 모양을 먼저 다뤄야 했다.

- usage 블록은 백슬래시 continuation 으로 여러 줄에 걸쳐 있어서, 물리 줄 단위 스윕은
  스크립트 이름을 한 줄에서 보고 플래그를 다음 줄에서 보며 둘을 서로 대조하지 못했다.
  다섯 중 넷이 실제로는 안 덮여 있었고, 그 파일들의 플래그를 되돌려도 green 이었다.
  이제 논리적 셸 명령으로 이어 붙인 뒤 스캔한다.
- `[a-z0-9-]+` 경로 문자 클래스가 `scripts/lib/project-create.mjs` 를 통째로 건너뛰어
  `templates/hypo-guide.md` 가 스윕 대상으로도, "스윕 안 됨" 으로도 안 잡혔다. 완결성
  검사가 자기가 잡으려는 바로 그 구멍을 갖고 있었다.

그 완결성 검사는 전역 개수가 아니라 표면별이다. 실제 24 에 대해 임계값 5 는 여섯 스킬 중
다섯이 빠져도 green 이다.

실패 출력은 파일과 논리 명령의 첫 줄을 짚고, 파서에 두 번째 표기를 더하지 말고 문서를
고치라고 말한다.

## 수동 검증

각 방향을 red 로 확인한 뒤에 받았다.

```
skills/lint 의 --wiki-dir 되돌리기 (한 줄짜리)              exit 1
verify·graph·query·crystallize 되돌리기                    각각 exit 1 (넷 다 전에는 조용했다)
crystallize 블록에 --apply 넣기 (접두사)                    exit 1 (문자열 포함 가드는 통과시켰다)
templates/hypo-guide.md 에 --nope 넣기                      exit 1 (이 표면은 전에 안 보였다)

node tests/parallel.mjs --shards=4    2044 passed, 0 failed
npm run lint                          0 errors
npm run check:tracker-ids             clean
npm run check:pack-surface            137 files, 0 closure violations
```

## 마이그레이션 노트

**버전 문자열이 움직이기 전까지 기존 설치본에 닿지 않는다.** 플러그인 설치기는 캐시
디렉터리 이름을 `plugin.json` 의 버전으로 짓기 때문에 그 문자열이 안 바뀌면 복사를
건너뛰고, npm 설치는 공개된 버전을 해석한다. 다음 릴리스 전까지 설치된 사본은 계속
모델에게 `--wiki-dir` 를 넘기라고 말한다.

손으로 옮길 것은 없다. 고쳐진 프롬프트는 다른 출하 파일과 마찬가지로 다음 릴리스와 함께
도착한다. 이 노트를 적는 이유는 "`main` 에 있으니 사용자에게 있다" 가 두 채널 모두에서
거짓이고, 이것이 사용자에게 보이는 효과가 머지가 아니라 릴리스에서 시작하는 정확성
수정이기 때문이다.

---

## Changelog

- EN: Five skills told Claude to pass `--wiki-dir` to scripts that only ever parsed `--hypo-dir`, and none of those scripts rejects an unknown flag, so the value was dropped and the command silently used the default vault instead of the one you named (#266). `crystallize` was among them, so a session close could land in the wrong vault and still report success. A test now derives each surface's accepted flags from the script's own arg parsing.
- KO: 다섯 스킬이 `--hypo-dir` 만 파싱하는 스크립트에 `--wiki-dir` 를 넘기라고 지시했고, 그 스크립트들이 미지정 플래그를 거부하지 않아 값이 버려진 채 지정한 볼트가 아니라 기본 볼트가 쓰였습니다 (#266). `crystallize` 가 그중 하나라 세션 마무리가 엉뚱한 볼트에 쓰이고도 성공을 보고할 수 있었습니다. 이제 테스트가 각 표면의 허용 플래그를 스크립트의 인자 파싱에서 파생합니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
