### PR TITLE
feat(doctor): tell the two directions of installed-cache drift apart

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -52,6 +52,15 @@ For any `✗` failures:
 - Missing Hypomnema root or required directories/files → run `/hypo:init`.
 - 0 hook files installed → run `/hypo:init`.
 - 0 hook registrations in settings.json → run `/hypo:init`.
+- `Hook execution smoke test` failed → show the stderr excerpt in the detail
+  verbatim; it names the cause. The repair depends on the channel, and
+  `/hypo:init` is only right on one of them. If `Hook files installed` says
+  "provided by the plugin loader", the install is plugin-managed and
+  `/hypo:init` deliberately leaves core hooks alone: tell the user to
+  re-install the plugin. Otherwise (npm or manual install) `/hypo:init`
+  repairs an incomplete copy. When the excerpt is not a missing module, have
+  the user run the hook directly in their shell
+  (`echo '{}' | node <the path in the detail>`) and read the error there.
 
 For `⚠` warnings:
 - Missing `hypo-config.md` → run `/hypo:init` — it creates the config marker.
@@ -59,6 +68,11 @@ For `⚠` warnings:
 - Partial hook files (some missing) → run `/hypo:init` to install missing hooks.
 - Partial settings.json registrations → run `/hypo:init` to merge missing entries.
 - Missing git remote → `git -C <hypo-dir> remote add origin <url>`.
+- `Installed cache vs marketplace HEAD` says the install is behind → the plugin
+  version string did not move, so the update left the old cache in place. Wait
+  for the next version bump, or swap the cache directory by hand knowing the
+  next real update overwrites it. If it says *ahead* instead, that is a local
+  checkout running in front of the marketplace and there is nothing to do.
 - Broken `[[links]]` → list the affected files and ask if the user wants to fix them now.
 - Overdue `verify_by_date` → offer to open the affected pages for review.
 - Missing `verify_by` question → suggest adding a `verify_by` field to the listed pages.

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -78,7 +78,7 @@ const HOOKS_SRC = join(PKG_ROOT, 'hooks');
 
 // ── install channel ───────────────────────────────────────────────────────────
 //
-// A plugin-channel install registers its 14 core hooks straight out of the
+// A plugin-channel install registers the core hooks named in hooks/hooks.json straight out of the
 // package's own hooks/hooks.json (CLAUDE_PLUGIN_ROOT) — Claude Code auto-wires
 // them, they are never copied into ~/.claude/hooks and never listed in
 // ~/.claude/settings.json. checkHooks/checkSettingsJson used to treat that
@@ -1992,6 +1992,184 @@ function checkPluginLeafVersion() {
   }
 }
 
+// ── installed cache vs marketplace clone (plugin channel) ──────────────────
+//
+// `/plugin marketplace update <marketplace>` pulls the marketplace repo to its
+// own clone at `~/.claude/plugins/marketplaces/<marketplace>/`, but only
+// re-copies that clone into the plugin CACHE (the directory hooks actually run
+// from) when plugin.json's version string has moved, the same skip-the-copy
+// behavior `checkPluginLeafVersion` above reports on. When the version string
+// has not moved, the marketplace clone can sit commits ahead of the cache with
+// no symptom anywhere: hooks run, slash commands resolve, the version string
+// still reads correctly, and a bug already fixed on `main` keeps reproducing.
+// Measured 2026-08-27: marketplace clone at one commit, install cache three
+// merges behind, same version string, no surface said so.
+//
+// `installed_plugins.json` records the exact commit each cache entry was
+// populated from (`gitCommitSha`); the marketplace clone's own `git rev-parse
+// HEAD` is the other half. Compared against the SAME install root
+// `resolveEnabledPluginRoot` resolves (user scope preferred, matching what
+// actually runs), this is the only place the two can be told apart. Never a
+// hard failure: a developer's checkout running ahead of an install is the
+// normal state while iterating, so this only makes the gap visible (warn),
+// with what the user can actually do about it (wait for the next version
+// bump, or replace the cache directory by hand knowing the next real update
+// overwrites it anyway); there is no way to force the copy to happen sooner.
+function checkPluginInstallDrift() {
+  const settingsPath = join(HOME, '.claude', 'settings.json');
+  const key = enabledHypomnemaPluginKey(settingsPath);
+  if (!key) return; // plugin not enabled, nothing to verify
+
+  const registryPath = join(HOME, '.claude', 'plugins', 'installed_plugins.json');
+  const installRoot = resolveEnabledPluginRoot(settingsPath, registryPath);
+  if (!installRoot) {
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `${key} is enabled but no usable install root could be positively resolved from ` +
+        `${registryPath}, so the installed cache's commit cannot be verified`,
+    );
+    return;
+  }
+
+  let reg;
+  try {
+    reg = JSON.parse(readFileSync(registryPath, 'utf-8'));
+  } catch {
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `Cannot read ${registryPath}, so the installed cache's commit cannot be verified`,
+    );
+    return;
+  }
+  const entries =
+    reg &&
+    typeof reg.plugins === 'object' &&
+    !Array.isArray(reg.plugins) &&
+    Array.isArray(reg.plugins[key])
+      ? reg.plugins[key]
+      : null;
+  // Same row this exact install root came from, not just any row for `key`,
+  // since a stale duplicate row (e.g. a leftover project-scope entry) can
+  // carry a different, and misleading, gitCommitSha.
+  //
+  // And among rows on that path, the same one resolveEnabledPluginRoot picked:
+  // user scope first. Measured, user and project rows share an installPath, so
+  // taking whichever comes first in the array means a project row's older sha
+  // can be read as the state of a user install that is actually at HEAD, and
+  // the answer would be "behind, replace it by hand" for a cache that is fine.
+  // Pick the row the resolver picked, THEN ask whether it carries a sha. Doing
+  // it the other way round (filter for a sha first, then prefer user scope)
+  // silently swaps rows when the user row has no gitCommitSha: the project
+  // row's older sha gets read as the provenance of the install that actually
+  // runs. Measured, user and project rows share an installPath, so the swap is
+  // reachable, and its output is "behind, replace it by hand" for a cache that
+  // may be fine. A chosen row without a sha is unverifiable, not a reason to
+  // ask a different row.
+  const onPath = (entries ?? []).filter((e) => e && e.installPath === installRoot);
+  const entry = onPath.find((e) => e.scope === 'user') ?? onPath[0];
+  if (entry && !(typeof entry.gitCommitSha === 'string' && entry.gitCommitSha)) {
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `The registry row for ${installRoot} carries no gitCommitSha, so the installed cache's ` +
+        `commit cannot be verified. Another row on the same path may have one, but it describes ` +
+        `a different install`,
+    );
+    return;
+  }
+  if (!entry) {
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `No registry row for ${installRoot} carries a gitCommitSha, so the installed cache's ` +
+        `commit cannot be verified`,
+    );
+    return;
+  }
+  const installedSha = entry.gitCommitSha;
+
+  // `hypo@<marketplace>` / legacy `hypomnema@<marketplace>` → the marketplace
+  // clone lives at `~/.claude/plugins/marketplaces/<marketplace>/`.
+  const marketplaceName = key.slice(key.indexOf('@') + 1);
+  const marketplaceDir = join(HOME, '.claude', 'plugins', 'marketplaces', marketplaceName);
+  const headResult = spawnSync('git', ['-C', marketplaceDir, 'rev-parse', 'HEAD'], {
+    encoding: 'utf-8',
+  });
+  if (headResult.status !== 0 || !headResult.stdout.trim()) {
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `Cannot read the marketplace clone's HEAD at ${marketplaceDir}, so the installed cache ` +
+        `cannot be compared to it`,
+    );
+    return;
+  }
+  const marketplaceHead = headResult.stdout.trim();
+
+  if (installedSha === marketplaceHead) {
+    pass(
+      'Installed cache vs marketplace HEAD',
+      `matches marketplace HEAD (${marketplaceHead.slice(0, 7)})`,
+    );
+    return;
+  }
+
+  // Which way the two shas sit is a question about ancestry, so ask git that
+  // directly instead of inferring it from a count. `A..B` returns 0 both when
+  // the install is ahead and when history is truncated so the walk cannot
+  // reach back, and those two want opposite advice: telling someone to
+  // overwrite a newer cache with an older clone is a downgrade. The
+  // marketplace clone on this machine is shallow (`.git/shallow` present), so
+  // the truncated case is the normal one here, not an edge.
+  const ancestor = (older, newer) =>
+    spawnSync('git', ['-C', marketplaceDir, 'merge-base', '--is-ancestor', older, newer], {
+      encoding: 'utf-8',
+    }).status === 0;
+
+  if (ancestor(marketplaceHead, installedSha)) {
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `The installed cache (${installRoot}) is running ${installedSha.slice(0, 7)}, which is ` +
+        `ahead of the marketplace clone's HEAD (${marketplaceHead.slice(0, 7)}). That is the ` +
+        `normal state while developing against a local checkout; nothing to do.`,
+    );
+    return;
+  }
+
+  if (!ancestor(installedSha, marketplaceHead)) {
+    // Neither reaches the other. Divergent histories, a force-pushed branch, a
+    // commit that predates a shallow clone's graft point. The shas differ and
+    // that is worth saying, but any "N commits behind" or "replace it by hand"
+    // would be a guess about a direction git just declined to give.
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `The installed cache (${installRoot}) is running ${installedSha.slice(0, 7)} and the ` +
+        `marketplace clone's HEAD is ${marketplaceHead.slice(0, 7)}. Neither commit reaches the ` +
+        `other in this clone, so which one is newer cannot be determined here (the clone may be ` +
+        `shallow, or the branch force-pushed). Compare them against the upstream repository ` +
+        `before changing anything.`,
+    );
+    return;
+  }
+
+  // Behind, established by ancestry. The count is a nice-to-have on top; a
+  // shallow clone can refuse to produce one and the sentence still holds.
+  const countResult = spawnSync(
+    'git',
+    ['-C', marketplaceDir, 'rev-list', '--count', `${installedSha}..${marketplaceHead}`],
+    { encoding: 'utf-8' },
+  );
+  const behindCount =
+    countResult.status === 0 && countResult.stdout.trim() !== '' ? countResult.stdout.trim() : null;
+  const behindText = behindCount !== null ? `${behindCount} commit(s) behind` : 'behind';
+  warn(
+    'Installed cache vs marketplace HEAD',
+    `The installed cache (${installRoot}) is running ${installedSha.slice(0, 7)}, ${behindText} ` +
+      `the marketplace clone's HEAD (${marketplaceHead.slice(0, 7)}). The version string did not ` +
+      `move, so \`/plugin marketplace update ${marketplaceName}\` pulled the marketplace clone ` +
+      `forward but skipped re-copying the cache hooks actually run from. Wait for the next ` +
+      `version bump, or replace ${installRoot} by hand with a copy of ${marketplaceDir} (a real ` +
+      `update will overwrite it anyway).`,
+  );
+}
+
 // ── provenance sidecar (manual/npm channel) ────────────────────────────────────
 //
 // `.hypo-provenance.json` lives next to a standalone-copied hooks/ dir
@@ -2260,6 +2438,7 @@ checkSettingsJson(coreManagedByPlugin);
 checkPkgIntegrity(args.claudeHome);
 checkStaleSibling();
 checkPluginLeafVersion();
+checkPluginInstallDrift();
 if (args.codex) checkCodexPaths();
 if (rootOk) checkExtensions(args.hypoDir, args.claudeHome, 'claude');
 if (rootOk && args.codex) checkExtensions(args.hypoDir, args.claudeHome, 'codex');

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -989,7 +989,7 @@ const args = parseArgs(process.argv);
 
 // ── install channel ───────────────────────────────────────────────────────────
 //
-// A plugin-channel install already provides the 14 core hooks + slash commands
+// A plugin-channel install already provides the core hooks in hooks/hooks.json plus the slash commands
 // through the package's own hooks/hooks.json + commands/ (Claude Code auto-wires
 // them). Copying the same hooks into ~/.claude/hooks and registering the same
 // events in settings.json on top makes every core hook fire TWICE, the same

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -25,6 +25,7 @@ import {
   REPO,
   SCRIPTS,
   SESSION_TMP_HOME,
+  gitHead,
   gitRepo,
   run,
   runWithHome,
@@ -2453,3 +2454,368 @@ test('leafVersionDrift: unreadable manifest is checked:false, not a clean compar
     assert.equal(d.manifestVersion, null);
   });
 });
+
+// ── doctor.mjs: installed cache vs marketplace HEAD ─────────────────────────
+//
+// `/plugin marketplace update <marketplace>` pulls the marketplace clone
+// forward but only re-copies the plugin CACHE when the version string moved,
+// so the cache can sit commits behind a marketplace clone under the same
+// version string. installed_plugins.json's `gitCommitSha` records the commit
+// each cache row was populated from; the marketplace clone's own `git
+// rev-parse HEAD` is the other half of the comparison.
+
+suite('doctor.mjs: installed cache vs marketplace HEAD');
+
+const IPD_KEY = 'hypo@hypomnema';
+
+function ipdEnablePlugin(home) {
+  mkdirSync(join(home, '.claude'), { recursive: true });
+  writeFileSync(
+    join(home, '.claude', 'settings.json'),
+    JSON.stringify({ enabledPlugins: { [IPD_KEY]: true } }),
+  );
+}
+
+// A real git clone with `commitCount` commits, standing in for
+// ~/.claude/plugins/marketplaces/hypomnema/. Returns every commit sha, oldest
+// first, so a test can pin the installed cache to any point in the history.
+// Every git child here gets HOME pinned to the fixture's own home and hooks
+// switched off. gitRepo() from helpers.mjs does neither, and a developer with a
+// global core.hooksPath would have this fixture's commits run their real hooks
+// against a temp repo. The suite already sets core.hooksPath=/dev/null in its
+// other git fixture; this brings the marketplace one in line.
+function ipdGit(home, args, opts = {}) {
+  return spawnSync('git', args, {
+    encoding: 'utf-8',
+    ...opts,
+    env: {
+      ...process.env,
+      HOME: home,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_SYSTEM: '/dev/null',
+    },
+  });
+}
+
+function ipdBuildMarketplace(home, commitCount) {
+  const marketplaceDir = join(home, '.claude', 'plugins', 'marketplaces', 'hypomnema');
+  mkdirSync(marketplaceDir, { recursive: true });
+  const cwd = { cwd: marketplaceDir };
+  ipdGit(home, ['init', '-q'], cwd);
+  ipdGit(home, ['config', 'user.email', 't@t.test'], cwd);
+  ipdGit(home, ['config', 'user.name', 'test'], cwd);
+  ipdGit(home, ['config', 'commit.gpgsign', 'false'], cwd);
+  ipdGit(home, ['config', 'core.hooksPath', '/dev/null'], cwd);
+  const shas = [];
+  for (let i = 0; i < commitCount; i++) {
+    writeFileSync(join(marketplaceDir, 'f.txt'), String(i));
+    ipdGit(home, ['add', '-A'], cwd);
+    const c = ipdGit(home, ['commit', '-q', '-m', `c${i}`], cwd);
+    assert.equal(c.status, 0, `fixture commit c${i} failed: ${c.stderr}`);
+    shas.push(ipdGit(home, ['rev-parse', 'HEAD'], cwd).stdout.trim());
+  }
+  return { marketplaceDir, shas };
+}
+
+// installed_plugins.json entry shape, `gitCommitSha` included: the field
+// this check reads and the older `registerPluginCache` fixture (leaf-version
+// suite above) does not carry.
+function ipdRegisterCache(home, installedSha, scopes = ['user']) {
+  const root = join(home, '.claude', 'plugins', 'cache', 'hypomnema', 'hypo', '1.7.4');
+  mkdirSync(root, { recursive: true });
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'hypomnema', version: '1.7.4' }),
+  );
+  const registryDir = join(home, '.claude', 'plugins');
+  mkdirSync(registryDir, { recursive: true });
+  writeFileSync(
+    join(registryDir, 'installed_plugins.json'),
+    JSON.stringify({
+      plugins: {
+        [IPD_KEY]: scopes.map((scope) => ({
+          installPath: root,
+          scope,
+          gitCommitSha: installedSha,
+        })),
+      },
+    }),
+  );
+  return root;
+}
+
+test('plugin not enabled: check is silent (not reported at all)', () => {
+  withTmpHome((home) => {
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.equal(check, undefined, 'no enabled plugin means nothing to verify');
+  });
+});
+
+test('installed sha matches marketplace HEAD: passes', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home);
+    const { shas } = ipdBuildMarketplace(home, 2);
+    ipdRegisterCache(home, shas[1]); // shas[1] is HEAD
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.equal(check.status, 'pass', `matching sha must pass: ${check.detail}`);
+  });
+});
+
+test('installed sha behind marketplace HEAD: warns and names the commit count', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home);
+    const { shas } = ipdBuildMarketplace(home, 3);
+    ipdRegisterCache(home, shas[0]); // two commits behind HEAD (shas[2])
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.equal(check.status, 'warn', `drifted sha must warn, not pass: ${check.detail}`);
+    assert.match(check.detail, /2 commit\(s\) behind/, check.detail);
+  });
+});
+
+test('installed sha ahead of marketplace HEAD: says ahead, never tells the user to overwrite it', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home);
+    const { marketplaceDir, shas } = ipdBuildMarketplace(home, 3);
+    // Roll the clone back so the install (shas[2]) is a descendant of its HEAD.
+    // `rev-list --count shas[2]..shas[0]` is 0 here, the same value a matching
+    // pair would give, which is why the shas are compared for equality first.
+    const reset = ipdGit(home, ['reset', '--hard', '-q', shas[0]], { cwd: marketplaceDir });
+    assert.equal(reset.status, 0, `fixture reset failed: ${reset.stderr}`);
+    ipdRegisterCache(home, shas[2]);
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.match(check.detail, /ahead of/, check.detail);
+    assert.doesNotMatch(
+      check.detail,
+      /behind/,
+      `an ahead install must not read as behind: ${check.detail}`,
+    );
+    assert.doesNotMatch(
+      check.detail,
+      /replace .* by hand/,
+      `overwriting a newer cache with an older clone is a downgrade: ${check.detail}`,
+    );
+  });
+});
+
+// The marketplace clone on a real machine is shallow: `/plugin marketplace
+// update` clones with a truncated history, so `.git/shallow` is present and a
+// walk that has to cross the graft point simply stops. A full-clone fixture
+// never exercises that, which is how a count-based direction check passed here
+// while being wrong on the only clone shape that actually ships.
+test('shallow marketplace clone: an undecidable direction is said, not guessed', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home);
+    const { marketplaceDir, shas } = ipdBuildMarketplace(home, 3);
+    // Re-clone at depth 1 over the same path, so HEAD is the tip and every
+    // earlier commit is beyond the graft point.
+    const upstream = join(home, 'upstream.git');
+    const mv = ipdGit(home, ['clone', '-q', '--bare', marketplaceDir, upstream]);
+    assert.equal(mv.status, 0, `fixture bare clone failed: ${mv.stderr}`);
+    rmSync(marketplaceDir, { recursive: true, force: true });
+    const cl = ipdGit(home, ['clone', '-q', '--depth', '1', `file://${upstream}`, marketplaceDir]);
+    assert.equal(cl.status, 0, `fixture shallow clone failed: ${cl.stderr}`);
+    assert.ok(
+      existsSync(join(marketplaceDir, '.git', 'shallow')),
+      'the fixture must actually be shallow, or it tests the same thing as the full-clone case',
+    );
+
+    // shas[0] is real upstream history but unreachable from this clone's graft
+    // point, so git can place it in neither direction.
+    ipdRegisterCache(home, shas[0]);
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.match(check.detail, /cannot be determined/, check.detail);
+    assert.doesNotMatch(
+      check.detail,
+      /commit\(s\) behind/,
+      `no count may be claimed when the direction is unknown: ${check.detail}`,
+    );
+    assert.doesNotMatch(
+      check.detail,
+      /replace .* by hand/,
+      `overwriting on an unknown direction can be a downgrade: ${check.detail}`,
+    );
+  });
+});
+
+// The exact combination the task names: BOTH the current key (`hypo@hypomnema`)
+// and the legacy key (`hypomnema@hypomnema`) present in one registry file, only
+// the current one enabled. The legacy row is deliberately stale (an unrelated
+// sha) — if the check ever picked the wrong key, this would read as drifted.
+test('registry carries both the current and legacy plugin key: only the enabled key is compared', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home); // enables hypo@hypomnema only
+    const { shas } = ipdBuildMarketplace(home, 2);
+    ipdRegisterCache(home, shas[1]); // current key matches HEAD
+    const registryPath = join(home, '.claude', 'plugins', 'installed_plugins.json');
+    const reg = JSON.parse(readFileSync(registryPath, 'utf-8'));
+    reg.plugins['hypomnema@hypomnema'] = [
+      {
+        installPath: join(home, '.claude', 'plugins', 'cache', 'hypomnema', 'hypo', '1.6.0'),
+        scope: 'user',
+        gitCommitSha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      },
+    ];
+    writeFileSync(registryPath, JSON.stringify(reg));
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.equal(
+      check.status,
+      'pass',
+      `must compare the enabled key's row, not the legacy one: ${check.detail}`,
+    );
+  });
+});
+
+// A registry from before gitCommitSha existed (or an entry missing it) — must
+// degrade to an unverifiable warn, never read as a clean compare.
+test('registry entry carries no gitCommitSha: warns, does not silently pass', () => {
+  withTmpHome((home) => {
+    enablePlugin(home); // shared fixture from the leaf-version suite, same key
+    registerPluginCache(home, '1.7.4', '1.7.4'); // no gitCommitSha field
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.equal(
+      check.status,
+      'warn',
+      `missing gitCommitSha must not read as verified: ${check.detail}`,
+    );
+    assert.match(check.detail, /gitCommitSha/, check.detail);
+  });
+});
+
+// ── doctor.mjs: hook execution smoke test ───────────────────────────────────
+//
+// checkHooks/checkSettingsJson only prove a hook file exists and is
+// registered. This proves it can actually run: spawn hypo-file-watch.mjs with
+// a stdin payload it cannot match against HYPO_DIR, and check it exits 0 with
+// parseable JSON. The broken-hook fixture below deletes the hook's own
+// hypo-shared.mjs dependency so `node hypo-file-watch.mjs` dies at ESM
+// resolution with `Cannot find module ... Require stack:` on stderr and exit
+// 1 — the same shape (any node invocation of this file dies before its own
+// code runs) as the measured incident's stale NODE_OPTIONS `--require`, without
+// literally exporting that env: NODE_OPTIONS is inherited by doctor.mjs's own
+// process too, so setting it globally kills doctor before it reaches this
+// check at all (confirmed empirically), not just the hook subprocess.
+
+suite('doctor.mjs: hook execution smoke test');
+// The registry can carry a user row and a project row on the SAME installPath.
+// resolveEnabledPluginRoot picks the user one; the drift check has to pick the
+// same one or it reports a stale project sha as the state of a user install
+// that is actually at HEAD, and answers a healthy cache with "replace it by
+// hand". Ordering the project row first is what makes the two rules diverge.
+// The order the two rules run in decides which row answers. Filtering for a sha
+// first and preferring user scope second silently swaps rows when the user row
+// has no gitCommitSha: the project row's older sha becomes the provenance of an
+// install it does not describe, and the reader is told to replace a cache by
+// hand. Choosing the row first and asking about its sha second cannot swap.
+test('user row on the path has no sha: says unverifiable, does not borrow the project row sha', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home);
+    const { shas } = ipdBuildMarketplace(home, 3);
+    const root = join(home, '.claude', 'plugins', 'cache', 'hypomnema', 'hypo', '1.7.4');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'hypomnema', version: '1.7.4' }),
+    );
+    writeFileSync(
+      join(home, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        plugins: {
+          [IPD_KEY]: [
+            {
+              scope: 'project',
+              projectPath: join(home, 'some-project'),
+              installPath: root,
+              version: '1.7.4',
+              gitCommitSha: shas[0],
+            },
+            // The row the resolver picks, and it carries no sha.
+            { scope: 'user', installPath: root, version: '1.7.4' },
+          ],
+        },
+      }),
+    );
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.match(check.detail, /carries no gitCommitSha/, check.detail);
+    assert.doesNotMatch(
+      check.detail,
+      /behind/,
+      `an unverifiable row must not be answered with a drift verdict: ${check.detail}`,
+    );
+    assert.doesNotMatch(check.detail, /replace .* by hand/, check.detail);
+  });
+});
+
+test('registry has user and project rows on one path: drift reads the user row, not whichever is first', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home);
+    const { shas } = ipdBuildMarketplace(home, 3);
+    const root = join(home, '.claude', 'plugins', 'cache', 'hypomnema', 'hypo', '1.7.4');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'hypomnema', version: '1.7.4' }),
+    );
+    writeFileSync(
+      join(home, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        plugins: {
+          [IPD_KEY]: [
+            // Project row FIRST, carrying an older sha.
+            {
+              scope: 'project',
+              projectPath: join(home, 'some-project'),
+              installPath: root,
+              version: '1.7.4',
+              gitCommitSha: shas[0],
+            },
+            { scope: 'user', installPath: root, version: '1.7.4', gitCommitSha: shas[2] },
+          ],
+        },
+      }),
+    );
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'expected an Installed cache vs marketplace HEAD check');
+    assert.equal(
+      check.status,
+      'pass',
+      `the user row is at HEAD, so this install is not behind: ${check.detail}`,
+    );
+    assert.doesNotMatch(check.detail, /behind/, check.detail);
+  });
+});
+// ── doctor.mjs: feedback projection attributes "no JSON report" to a broken
+// hook smoke test when one already fired ─────────────────────────────────────
+//
+// A copy of doctor's own scripts/hooks tree (mirrors ISSUE-52's
+// withFakeDoctorInstall above) with scripts/feedback-sync.mjs replaced by a
+// stub that prints nothing and exits 1 — reliably reproducing "no JSON
+// report" without depending on a real feedback-sync crash path (the script's
+// own defenses against filesystem errors are already hardened; see the
+// build-failed comment in evaluateTarget).
+
+suite('doctor.mjs: feedback projection attributes hook-broken');


### PR DESCRIPTION
# English

## What changed

`/hypo:doctor` gains one check: it compares the commit the installed plugin
cache is running against the marketplace clone's HEAD, and reports the gap.

## Why

The cache directory is named after the version string, so an update whose
version has not moved finds the directory already there and skips the copy. The
install then runs old code under a correct-looking version, and defects that
were fixed keep reproducing. Both halves of the comparison are already on disk,
in `installed_plugins.json` and the marketplace clone's git HEAD; nothing was
putting them side by side.

## How

Direction is a question about ancestry, so it asks git that instead of
inferring it from a commit count. `A..B` returns 0 both when the install is
ahead and when history is truncated so the walk cannot reach back, and those
two want opposite advice: telling someone to overwrite a newer cache with an
older clone is a downgrade. The marketplace clone is shallow in practice, so
the truncated case is the normal one rather than an edge. When neither commit
reaches the other, it says so instead of naming a count.

Registry rows are chosen the way `resolveEnabledPluginRoot` chooses them, user
scope first, and only then asked for a sha. Filtering for a sha first and
preferring user scope second swaps rows whenever the user row has no
`gitCommitSha`: the project row's older sha becomes the provenance of an
install it does not describe. User and project rows do share an `installPath`
in practice, so the swap is reachable, and its output is "behind, replace it by
hand" for a cache that may be fine.

It stays a warning throughout. A checkout running ahead of an install is the
normal state while iterating, and a diagnostic that fails on it is worth less.

## Manual verification

Each defence was verified by defeating it and watching the matching test go
red, then restoring:

```
merge-base direction check -> if (false)   ahead reported as "0 commit(s) behind" + replace by hand
row order (choose, then ask) -> sha filter first   user row at HEAD read as the project row's older sha
```

The fixtures build the shapes this meets in practice rather than convenient
ones: a shallow marketplace clone reached through a bare intermediate (which is
what `/plugin marketplace update` leaves on disk), a registry with user and
project rows on one path with the project row first and older, and one where
the user row carries no sha at all. Every git child in those fixtures runs with
`HOME` pinned and `core.hooksPath` off, so a developer's global git config
cannot reach into a temp repo.

## Migration notes

None. New check, no schema change, no new flag.

---

# 한국어

## 변경 내용

`/hypo:doctor`에 검사가 하나 늘었다. 설치된 플러그인 캐시가 도는 커밋과 마켓플레이스
클론의 HEAD를 대조해 그 간격을 보고한다.

## 이유

캐시 디렉터리 이름이 버전 문자열이라, 버전이 안 움직인 업데이트는 디렉터리가 이미
있어서 복사를 건너뛴다. 그러면 설치본이 옛 코드를 도는데 버전은 맞아 보이고, 고쳐진
결함이 계속 재현된다. 대조에 필요한 값 둘은 이미 디스크에 있다. `installed_plugins.json`과
마켓플레이스 클론의 git HEAD인데, 그 둘을 나란히 놓는 자리가 없었다.

## 방법

방향은 조상 관계에 대한 질문이므로 커밋 수로 추론하지 않고 git에 직접 묻는다.
`A..B`는 설치본이 앞설 때와 히스토리가 잘려 뒤로 못 갈 때 둘 다 0을 준다. 그 둘은
정반대의 처방을 원한다. 더 새 캐시를 더 낡은 클론으로 덮으라는 말은 다운그레이드다.
마켓플레이스 클론은 실제로 shallow라, 잘린 경우가 예외가 아니라 보통이다. 어느 쪽도
다른 쪽에 닿지 못하면 커밋 수를 말하는 대신 그 사실을 말한다.

registry 행은 `resolveEnabledPluginRoot`가 고르는 방식대로 user scope를 먼저 고르고,
그 뒤에 sha가 있는지를 묻는다. sha를 먼저 거르고 user를 나중에 우선하면 user 행에
`gitCommitSha`가 없을 때 행이 바뀐다. project 행의 낡은 sha가, 그것이 설명하지 않는
설치본의 provenance가 되어 버린다. 실제로 user 행과 project 행이 같은 `installPath`를
공유하므로 이 뒤바뀜은 닿을 수 있는 상태이고, 그 결과는 멀쩡할 수도 있는 캐시에 대고
"뒤졌으니 손으로 갈아라"다.

전 구간에서 warn으로 남는다. 체크아웃이 설치본보다 앞서는 것은 개발 중 정상이고,
거기서 실패를 내는 진단은 값이 줄어든다.

## 수동 검증

방어마다 무력화해서 해당 테스트가 red를 내는 것을 보고 복구했다.

```
merge-base 방향 판정 -> if (false)   앞선 설치가 "0 commit(s) behind" + 손복사 지시로 나옴
행 선택 순서(고르고 나서 묻기) -> sha 필터 먼저   HEAD인 user 행이 project 행의 낡은 sha로 읽힘
```

픽스처는 편한 모양이 아니라 실제로 만나는 모양을 만든다. bare 중간 단계를 거쳐 뜬
shallow 마켓플레이스 클론(`/plugin marketplace update`가 디스크에 남기는 그 모양),
user와 project 행이 한 경로에 있고 project 행이 먼저이며 더 낡은 registry, 그리고 user
행에 sha가 아예 없는 registry다. 그 픽스처의 모든 git 자식은 `HOME`을 고정하고
`core.hooksPath`를 끈 채로 돈다. 개발자의 전역 git 설정이 임시 저장소에 닿지 못하게 하려는
것이다.

## 마이그레이션 노트

없음. 새 검사이고 스키마 변경도 새 플래그도 없다.

---

## Changelog

- EN: `/hypo:doctor` now reports when the installed plugin cache is running a different commit than the marketplace clone, and tells "behind" apart from "ahead" and from "cannot tell" (#269)
- KO: `/hypo:doctor`가 설치된 플러그인 캐시와 마켓플레이스 클론의 커밋이 갈렸을 때 그것을 보고하고, "뒤졌다"와 "앞섰다"와 "판정 불가"를 구별한다 (#269)

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
