### PR TITLE
chore(ci): format the seven files that drifted, and add the gate that would have caught them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,28 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  format:
+    name: Format
+    # The only place that catches drift, and it detects rather than prevents:
+    # no branch protection makes this a required check, so a red result has to
+    # be read before merging. The local pre-commit hook (scripts/pre-commit-
+    # format.mjs) warns on stderr but does not block when
+    # node_modules/.bin/prettier is missing in the worktree that made the
+    # commit, and prepublishOnly does not run format:check either, so a file
+    # can go un-formatted past both and reach `main`. `npm ci` here rather than
+    # `npx`: the devDependency is pinned exactly, so this job and the hook
+    # measure against the same prettier, while a bare `npx prettier` resolves
+    # whatever is newest and will disagree.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Every checked file matches Prettier's output
+        run: npm run format:check
+
   tracker-ids:
     name: Tracker-id gate
     runs-on: ubuntu-latest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -448,7 +448,11 @@ does not matter.
 
 ## CI / Release
 
-### `ci.yml` — 7 independent jobs
+### `ci.yml` — independent jobs
+
+The table below is not exhaustive and the count is deliberately left out: it went
+stale once already. `.github/workflows/ci.yml` is the source of truth for which
+jobs exist.
 
 | Job | Purpose |
 |---|---|

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -384,6 +384,7 @@ npm run check:bilingual    # each gated CHANGELOG section has #### English + ###
 npm run smoke:plugin       # plugin manifest + hooks/commands/skills load-valid
 npm run smoke-pack         # packed tarball installs and resolves
 npm run check:tracker-ids  # no private-tracker pointers leaked into shipped files
+npm run format:check       # every checked file matches Prettier's output
 
 # 4. Commit every file the bump touched, plus the lockfile.
 git add package.json package-lock.json .claude-plugin/ templates/hypo-config.md \

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "hypomnema": "scripts/init.mjs"
       },
       "devDependencies": {
-        "prettier": "^3.8.3"
+        "prettier": "3.8.3"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     "prepublishOnly": "npm test && npm run lint && npm run check:versions && npm run smoke:plugin && node scripts/check-pack-surface.mjs && npm run smoke-pack && npm run check:bilingual && npm run check:tracker-ids"
   },
   "devDependencies": {
-    "prettier": "^3.8.3"
+    "prettier": "3.8.3"
   }
 }

--- a/scripts/lib/plugin-detect.mjs
+++ b/scripts/lib/plugin-detect.mjs
@@ -170,7 +170,8 @@ export function leafVersionDrift(pkgRoot) {
   // doctor happens to gate on usablePkgRoot first, which requires a readable version, so
   // this is unreachable today; it is closed here because this is an exported API and the
   // next caller will not know to add that gate.
-  if (manifestVersion === null) return { checked: false, drift: false, leaf, manifestVersion: null };
+  if (manifestVersion === null)
+    return { checked: false, drift: false, leaf, manifestVersion: null };
   return { checked: true, drift: manifestVersion !== leaf, leaf, manifestVersion };
 }
 

--- a/tests/capture.test.mjs
+++ b/tests/capture.test.mjs
@@ -742,7 +742,10 @@ test('a hook whose extension disagrees with its interpreter is skipped with a vi
       );
       const settingsPath = join(home, '.claude', 'settings.json');
       const settingsText = existsSync(settingsPath) ? readFileSync(settingsPath, 'utf-8') : '';
-      assert.ok(!settingsText.includes('mismatch'), 'no settings.json entry for the mismatched hook');
+      assert.ok(
+        !settingsText.includes('mismatch'),
+        'no settings.json entry for the mismatched hook',
+      );
       assert.ok(
         out.applied.extensions.warnings.some(
           (w) => w.includes('interpreter-extension-mismatch') && w.includes('hypo-ext-mismatch'),

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -540,7 +540,11 @@ test('check with no --project and no evidence resolves nothing (matches the QA r
     seedUndiscoverableProject(dir, 'hook-qa');
     const r = run('crystallize.mjs', [`--hypo-dir=${dir}`, '--check-session-close', '--json']);
     const out = JSON.parse(r.stdout);
-    assert.equal(out.project, null, `discovery alone must not find a project this fresh: ${r.stdout}`);
+    assert.equal(
+      out.project,
+      null,
+      `discovery alone must not find a project this fresh: ${r.stdout}`,
+    );
     assert.ok(
       out.missing.includes('hot.md (no active project in pointer table)'),
       `must reproduce the exact QA message: ${JSON.stringify(out.missing)}`,
@@ -559,8 +563,16 @@ test('check with --transcript-path, single-project transcript: resolves via the 
       '--json',
     ]);
     const out = JSON.parse(r.stdout);
-    assert.equal(out.project, 'hook-qa', `check must resolve hook-qa via the transcript: ${r.stdout}`);
-    assert.equal(out.scope, 'project', 'an inferred project is a scoped diagnostic, like --project');
+    assert.equal(
+      out.project,
+      'hook-qa',
+      `check must resolve hook-qa via the transcript: ${r.stdout}`,
+    );
+    assert.equal(
+      out.scope,
+      'project',
+      'an inferred project is a scoped diagnostic, like --project',
+    );
     assert.equal(out.scoped_project, 'hook-qa');
     assert.equal(
       out.project_inferred_from_transcript,
@@ -574,7 +586,10 @@ test('check with a transcript touching two different projects still refuses to g
   withSyncedWiki((dir) => {
     seedUndiscoverableProject(dir, 'alpha');
     seedUndiscoverableProject(dir, 'beta');
-    const transcript = toolUseTranscript(dir, ['projects/alpha/index.md', 'projects/beta/index.md']);
+    const transcript = toolUseTranscript(dir, [
+      'projects/alpha/index.md',
+      'projects/beta/index.md',
+    ]);
     const r = run('crystallize.mjs', [
       `--hypo-dir=${dir}`,
       '--check-session-close',
@@ -625,7 +640,10 @@ test('check with a transcript that reads single-project but has a corrupt line s
       `an untrustworthy walk must not be read as a complete single-project scope: ${r.stdout}`,
     );
     assert.equal(out.scope, 'global');
-    assert.ok(!('scoped_project' in out), 'no scoped_project when the transcript walk cannot be trusted');
+    assert.ok(
+      !('scoped_project' in out),
+      'no scoped_project when the transcript walk cannot be trusted',
+    );
   });
 });
 
@@ -1318,7 +1336,14 @@ test('uncommitted wiki + conditional close phrase, no decline → reconfirm bloc
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } },
+          ],
+        },
+      },
       {
         type: 'user',
         message: { role: 'user', content: '구현 완료하면 세션 마무리하자' },
@@ -1360,7 +1385,14 @@ test('a correlated "아직, 계속" decline suppresses the reconfirm → continu
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } },
+          ],
+        },
+      },
       { type: 'user', message: { role: 'user', content: '구현 완료하면 세션 마무리하자' } },
       askCloseReconfirmToolUse('q1'),
       {
@@ -1435,7 +1467,14 @@ test('decline label variants ("나중에" / "later") also suppress (label-drift 
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } },
+          ],
+        },
+      },
       { type: 'user', message: { role: 'user', content: '구현 완료하면 세션 마무리하자' } },
       askCloseReconfirmToolUse('q1'),
       {
@@ -1473,7 +1512,14 @@ test('genuine close-now + uncommitted, no decline → still reconfirm block (no 
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } },
+          ],
+        },
+      },
       { type: 'user', message: { role: 'user', content: '다 끝났으면 세션 마무리하자' } },
     ]);
     const r = runAutoMinimal(dir, {
@@ -1640,7 +1686,14 @@ test('absent background_tasks + uncommitted → in-flight fails open, git alone 
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'x.md'), '# wip\n');
     const transcript = writeTranscript(dir, [
-      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } }] } },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'pages', 'x.md') } },
+          ],
+        },
+      },
       { type: 'user', message: { role: 'user', content: '오늘은 이만 마무리하자' } },
     ]);
     // No background_tasks key at all in the payload.
@@ -1974,7 +2027,10 @@ test('--apply-session-close --session-id with an unresolvable transcript → ref
     // longer sweeps the whole working tree, so a payload file left inside
     // `dir` would sit there as a real git blocker instead of being silently
     // absorbed by the apply's own commit.
-    const payloadPath = join(tmpdir(), `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`);
+    const payloadPath = join(
+      tmpdir(),
+      `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`,
+    );
     writeFileSync(payloadPath, JSON.stringify(payload));
     const sessionStateBefore = readFileSync(
       join(dir, 'projects', 'test-project', 'session-state.md'),
@@ -2030,7 +2086,10 @@ test('--apply-session-close --session-id WITH user-close signal → commits payl
     // longer sweeps the whole working tree, so a payload file left inside
     // `dir` would sit there as a real git blocker instead of being silently
     // absorbed by the apply's own commit.
-    const payloadPath = join(tmpdir(), `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`);
+    const payloadPath = join(
+      tmpdir(),
+      `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`,
+    );
     writeFileSync(payloadPath, JSON.stringify(payload));
     // Plant a transcript resolvable by session-id that carries a user-close signal.
     const cleanup = seedCloseTranscript('s-apply-land');

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -2403,7 +2403,11 @@ test('a leaf that only starts with a version is not treated as version-named', (
     // produces here, so asserting on the detail is what makes this test distinguish the
     // two failure directions rather than just the status word.
     assert.equal(check.status, 'warn', `unverifiable must not read as verified: ${check.detail}`);
-    assert.match(check.detail, /could be compared/, `expected the unverified wording: ${check.detail}`);
+    assert.match(
+      check.detail,
+      /could be compared/,
+      `expected the unverified wording: ${check.detail}`,
+    );
     assert.doesNotMatch(
       check.detail,
       /leaf says v/,

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -751,10 +751,7 @@ test('doc names every hook that reaches the network', () => {
         `network destinations, and it has no opt-out flag`,
     );
   }
-  assert.ok(
-    !/no network requests/i.test(doc),
-    'doc must not blanket-claim no network requests',
-  );
+  assert.ok(!/no network requests/i.test(doc), 'doc must not blanket-claim no network requests');
 });
 
 // The facts inside the network section, not just which hooks it names. Version 3 shortened
@@ -766,7 +763,10 @@ test('doc carries the update-check URLs verbatim and names every opt-out variabl
   const doc = readAutomationDoc();
   const fetchSrc = readFileSync(join(REPO, 'hooks', 'version-check-fetch.mjs'), 'utf-8');
   const urls = [...fetchSrc.matchAll(/'(https:\/\/[^']+)'/g)].map((m) => m[1]);
-  assert.ok(urls.length >= 2, `expected the fetch URLs in version-check-fetch.mjs, got ${urls.length}`);
+  assert.ok(
+    urls.length >= 2,
+    `expected the fetch URLs in version-check-fetch.mjs, got ${urls.length}`,
+  );
   for (const u of urls) {
     assert.ok(doc.includes(u), `doc must carry the fetched URL verbatim: ${u}`);
   }

--- a/tests/rename-wikilink.test.mjs
+++ b/tests/rename-wikilink.test.mjs
@@ -46,14 +46,16 @@ test('an inbound rewrite keeps the page mode it found (no widening via temp+rena
     writeFileSync(priv, '---\ntitle: private\n---\nsee [[foo]].\n');
     chmodSync(priv, 0o600);
 
-    const r = run('rename.mjs', [`--hypo-dir=${dir}`, '--from=foo', '--to=bar', '--apply', '--json']);
+    const r = run('rename.mjs', [
+      `--hypo-dir=${dir}`,
+      '--from=foo',
+      '--to=bar',
+      '--apply',
+      '--json',
+    ]);
     assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
     assert.ok(readFileSync(priv, 'utf-8').includes('[[bar]]'), 'the link was actually rewritten');
-    assert.equal(
-      statSync(priv).mode & 0o777,
-      0o600,
-      'a rewritten page keeps its original mode',
-    );
+    assert.equal(statSync(priv).mode & 0o777, 0o600, 'a rewritten page keeps its original mode');
   });
 });
 
@@ -377,10 +379,22 @@ cpSync(SCRIPTS, KILL_SCRIPTS, { recursive: true });
   // caring which mode or which file is currently being written.
   const atomicWriteDecl = 'function atomicWrite(path, content) {';
   const atomicWriteAnchor = 'renameSync(tmp, path);';
-  assert.ok(src.includes(pageAnchor), `page-mode renameSync anchor not found — did rename.mjs change?`);
-  assert.ok(src.includes(dirAnchor), `dir-mode renameSync anchor not found — did rename.mjs change?`);
-  assert.ok(src.includes(atomicWriteDecl), `atomicWrite declaration not found — did rename.mjs change?`);
-  assert.ok(src.includes(atomicWriteAnchor), `atomicWrite renameSync anchor not found — did rename.mjs change?`);
+  assert.ok(
+    src.includes(pageAnchor),
+    `page-mode renameSync anchor not found — did rename.mjs change?`,
+  );
+  assert.ok(
+    src.includes(dirAnchor),
+    `dir-mode renameSync anchor not found — did rename.mjs change?`,
+  );
+  assert.ok(
+    src.includes(atomicWriteDecl),
+    `atomicWrite declaration not found — did rename.mjs change?`,
+  );
+  assert.ok(
+    src.includes(atomicWriteAnchor),
+    `atomicWrite renameSync anchor not found — did rename.mjs change?`,
+  );
   src = src.replace(
     pageAnchor,
     `if (process.env.HYPO_TEST_KILL_PAGE_PRE) process.kill(process.pid, 'SIGKILL');\n        ${pageAnchor}\n        if (process.env.HYPO_TEST_KILL_PAGE_POST) process.kill(process.pid, 'SIGKILL');`,
@@ -411,12 +425,23 @@ test('crash bracketing the single-file renameSync converges, two paths never coe
       // write actually runs before the PRE kill point.
       writeFileSync(join(wiki, 'pages', 'foo.md'), '---\ntitle: foo\n---\nsee [[foo]] itself.\n');
 
-      const cmd = [KILL_RENAME, `--hypo-dir=${wiki}`, '--from=foo', '--to=bar', '--apply', '--json'];
+      const cmd = [
+        KILL_RENAME,
+        `--hypo-dir=${wiki}`,
+        '--from=foo',
+        '--to=bar',
+        '--apply',
+        '--json',
+      ];
       const killed = spawnSync(process.execPath, cmd, {
         encoding: 'utf-8',
         env: { ...process.env, HOME: home, [envVar]: '1' },
       });
-      assert.equal(killed.signal, 'SIGKILL', `[${label}] expected the kill hook to fire: ${killed.stderr}`);
+      assert.equal(
+        killed.signal,
+        'SIGKILL',
+        `[${label}] expected the kill hook to fire: ${killed.stderr}`,
+      );
 
       const fooPath = join(wiki, 'pages', 'foo.md');
       const barPath = join(wiki, 'pages', 'bar.md');
@@ -424,10 +449,16 @@ test('crash bracketing the single-file renameSync converges, two paths never coe
       const barExists = existsSync(barPath);
       // The property the fix pins: renameSync is one syscall, so no kill point
       // can observe both the old and the new path at once.
-      assert.ok(!(fooExists && barExists), `[${label}] old and new path must never coexist after a crash`);
+      assert.ok(
+        !(fooExists && barExists),
+        `[${label}] old and new path must never coexist after a crash`,
+      );
       assert.ok(fooExists || barExists, `[${label}] exactly one path must survive the crash`);
 
-      const rerun = spawnSync(process.execPath, cmd, { encoding: 'utf-8', env: { ...process.env, HOME: home } });
+      const rerun = spawnSync(process.execPath, cmd, {
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: home },
+      });
       if (fooExists) {
         // Killed before the rename: --from still resolves, re-run finishes the move.
         assert.equal(
@@ -438,7 +469,10 @@ test('crash bracketing the single-file renameSync converges, two paths never coe
         assert.ok(existsSync(barPath), `[${label}] bar.md exists after re-run`);
         assert.ok(!existsSync(fooPath), `[${label}] foo.md gone after re-run`);
         const bar = readFileSync(barPath, 'utf-8');
-        assert.ok(bar.includes('[[bar]]'), `[${label}] self-reference rewrite carried through: ${bar}`);
+        assert.ok(
+          bar.includes('[[bar]]'),
+          `[${label}] self-reference rewrite carried through: ${bar}`,
+        );
       } else {
         // Killed after the rename: the move already landed, --from correctly
         // no longer resolves — nothing left to converge.
@@ -488,23 +522,36 @@ test('crash bracketing the directory renameSync converges, two dirs never coexis
         encoding: 'utf-8',
         env: { ...process.env, HOME: home, [envVar]: '1' },
       });
-      assert.equal(killed.signal, 'SIGKILL', `[${label}] expected the kill hook to fire: ${killed.stderr}`);
+      assert.equal(
+        killed.signal,
+        'SIGKILL',
+        `[${label}] expected the kill hook to fire: ${killed.stderr}`,
+      );
 
       const oldDir = join(wiki, 'projects', 'old');
       const newDir = join(wiki, 'projects', 'new');
       const oldExists = existsSync(oldDir);
       const newExists = existsSync(newDir);
-      assert.ok(!(oldExists && newExists), `[${label}] old and new directory must never coexist after a crash`);
+      assert.ok(
+        !(oldExists && newExists),
+        `[${label}] old and new directory must never coexist after a crash`,
+      );
       assert.ok(oldExists || newExists, `[${label}] exactly one directory must survive the crash`);
 
-      const rerun = spawnSync(process.execPath, cmd, { encoding: 'utf-8', env: { ...process.env, HOME: home } });
+      const rerun = spawnSync(process.execPath, cmd, {
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: home },
+      });
       if (oldExists) {
         assert.equal(
           rerun.status,
           0,
           `[${label}] re-run from the pre-rename state must converge: ${rerun.stdout}${rerun.stderr}`,
         );
-        assert.ok(existsSync(join(newDir, 'a.md')), `[${label}] a.md exists at the new path after re-run`);
+        assert.ok(
+          existsSync(join(newDir, 'a.md')),
+          `[${label}] a.md exists at the new path after re-run`,
+        );
         assert.ok(!existsSync(oldDir), `[${label}] projects/old gone after re-run`);
         const a = readFileSync(join(newDir, 'a.md'), 'utf-8');
         assert.ok(
@@ -912,7 +959,13 @@ test('successful --apply clears the marker (page mode)', () => {
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'foo.md'), '---\ntitle: foo\n---\nfoo page\n');
     writeFileSync(join(dir, 'pages', 'a.md'), '---\ntitle: a\n---\nsee [[foo]].\n');
-    const r = run('rename.mjs', [`--hypo-dir=${dir}`, '--from=foo', '--to=bar', '--apply', '--json']);
+    const r = run('rename.mjs', [
+      `--hypo-dir=${dir}`,
+      '--from=foo',
+      '--to=bar',
+      '--apply',
+      '--json',
+    ]);
     assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
     assert.ok(
       !existsSync(join(dir, '.cache', 'rename-in-progress.json')),
@@ -966,8 +1019,18 @@ test('marker write failure is fail-closed: --apply aborts before any rewrite or 
     writeFileSync(join(dir, 'pages', 'a.md'), '---\ntitle: a\n---\nsee [[foo]].\n');
     chmodSync(join(dir, '.cache'), 0o500); // read+execute only — no write inside it
     try {
-      const r = run('rename.mjs', [`--hypo-dir=${dir}`, '--from=foo', '--to=bar', '--apply', '--json']);
-      assert.notEqual(r.status, 0, `--apply must fail when the marker cannot be written: ${r.stdout}${r.stderr}`);
+      const r = run('rename.mjs', [
+        `--hypo-dir=${dir}`,
+        '--from=foo',
+        '--to=bar',
+        '--apply',
+        '--json',
+      ]);
+      assert.notEqual(
+        r.status,
+        0,
+        `--apply must fail when the marker cannot be written: ${r.stdout}${r.stderr}`,
+      );
       assert.ok(existsSync(join(dir, 'pages', 'foo.md')), 'foo.md must not have moved');
       assert.ok(!existsSync(join(dir, 'pages', 'bar.md')), 'bar.md must not exist');
       const a = readFileSync(join(dir, 'pages', 'a.md'), 'utf-8');
@@ -1004,16 +1067,27 @@ test('existing marker for a DIFFERENT rename → --apply refused, zero rewrites,
       '--apply',
       '--json',
     ]);
-    assert.equal(r.status, 1, `a different in-progress marker must refuse --apply: ${r.stdout}${r.stderr}`);
+    assert.equal(
+      r.status,
+      1,
+      `a different in-progress marker must refuse --apply: ${r.stdout}${r.stderr}`,
+    );
     assert.ok(existsSync(join(dir, 'pages', 'foo.md')), 'foo.md not moved (0 moves)');
     assert.ok(!existsSync(join(dir, 'pages', 'bar.md')), 'bar.md not created');
     const a = readFileSync(join(dir, 'pages', 'a.md'), 'utf-8');
     assert.ok(a.includes('[[foo]]') && !a.includes('[[bar]]'), '0 inbound rewrites happened');
-    const marker = JSON.parse(readFileSync(join(dir, '.cache', 'rename-in-progress.json'), 'utf-8'));
+    const marker = JSON.parse(
+      readFileSync(join(dir, '.cache', 'rename-in-progress.json'), 'utf-8'),
+    );
     assert.deepEqual(
       marker,
-      { mode: 'page', from: 'pages/other.md', to: 'pages/moved.md', started_at: '2026-01-01T00:00:00.000Z' },
-      'the OTHER rename\'s marker must survive untouched, not be overwritten',
+      {
+        mode: 'page',
+        from: 'pages/other.md',
+        to: 'pages/moved.md',
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+      "the OTHER rename's marker must survive untouched, not be overwritten",
     );
   });
 });
@@ -1043,7 +1117,11 @@ test('existing marker for the SAME rename → --apply proceeds and converges (re
       '--apply',
       '--json',
     ]);
-    assert.equal(r.status, 0, `a same-command marker must not block the legitimate re-run: ${r.stdout}${r.stderr}`);
+    assert.equal(
+      r.status,
+      0,
+      `a same-command marker must not block the legitimate re-run: ${r.stdout}${r.stderr}`,
+    );
     assert.ok(existsSync(join(dir, 'pages', 'bar.md')), 'bar.md exists');
     assert.ok(!existsSync(join(dir, 'pages', 'foo.md')), 'foo.md gone');
     assert.ok(
@@ -1104,7 +1182,11 @@ test('doctor.mjs after a post-renameSync crash: marker present + move done → "
       encoding: 'utf-8',
       env: { ...process.env, HOME: home, HYPO_TEST_KILL_PAGE_POST: '1' },
     });
-    assert.equal(killed.signal, 'SIGKILL', `expected the kill hook to fire post-rename: ${killed.stderr}`);
+    assert.equal(
+      killed.signal,
+      'SIGKILL',
+      `expected the kill hook to fire post-rename: ${killed.stderr}`,
+    );
 
     const markerPath = join(wiki, '.cache', 'rename-in-progress.json');
     assert.ok(existsSync(markerPath), 'the marker must survive a post-move crash');
@@ -1115,7 +1197,11 @@ test('doctor.mjs after a post-renameSync crash: marker present + move done → "
     const checks = JSON.parse(doctorR.stdout);
     const check = checks.find((c) => c.label === 'Incomplete rename');
     assert.ok(check, 'Incomplete rename check not found');
-    assert.equal(check.status, 'warn', `stale-but-done marker must still warn (not pass): ${check.detail}`);
+    assert.equal(
+      check.status,
+      'warn',
+      `stale-but-done marker must still warn (not pass): ${check.detail}`,
+    );
     assert.ok(
       !/re-run/i.test(check.detail),
       `must NOT tell the user to re-run a command that would fail (--from no longer resolves): ${check.detail}`,
@@ -1130,7 +1216,11 @@ test('doctor.mjs after a post-renameSync crash: marker present + move done → "
     rmSync(markerPath, { force: true });
     const doctorR2 = run('doctor.mjs', [`--hypo-dir=${wiki}`, '--json']);
     const check2 = JSON.parse(doctorR2.stdout).find((c) => c.label === 'Incomplete rename');
-    assert.equal(check2.status, 'pass', `following the guidance must leave doctor clean: ${check2.detail}`);
+    assert.equal(
+      check2.status,
+      'pass',
+      `following the guidance must leave doctor clean: ${check2.detail}`,
+    );
   });
 });
 
@@ -1153,7 +1243,11 @@ test('crash mid-rewrite-loop: marker records mode/from/to, page not yet moved, r
       encoding: 'utf-8',
       env: { ...process.env, HOME: home, HYPO_TEST_KILL_AFTER_N: '3' },
     });
-    assert.equal(killed.signal, 'SIGKILL', `expected the kill hook to fire: ${killed.stdout}${killed.stderr}`);
+    assert.equal(
+      killed.signal,
+      'SIGKILL',
+      `expected the kill hook to fire: ${killed.stdout}${killed.stderr}`,
+    );
 
     const markerPath = join(wiki, '.cache', 'rename-in-progress.json');
     assert.ok(existsSync(markerPath), 'marker must survive the crash');
@@ -1174,7 +1268,10 @@ test('crash mid-rewrite-loop: marker records mode/from/to, page not yet moved, r
     );
 
     // Re-running the SAME command (no kill env) must converge and clear the marker.
-    const rerun = spawnSync(process.execPath, cmd, { encoding: 'utf-8', env: { ...process.env, HOME: home } });
+    const rerun = spawnSync(process.execPath, cmd, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: home },
+    });
     assert.equal(rerun.status, 0, `re-run must converge: ${rerun.stdout}${rerun.stderr}`);
     assert.ok(existsSync(join(wiki, 'pages', 'bar.md')), 'bar.md must exist after re-run');
     assert.ok(!existsSync(join(wiki, 'pages', 'foo.md')), 'foo.md must be gone after re-run');

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -252,7 +252,11 @@ test('hot-rebuild advances this session base to the bytes it just wrote, so a ma
         hashContent(disk),
         'hot-rebuild must advance this session base to the bytes it just wrote',
       );
-      assert.notEqual(baseAfter.hash, baseBefore.hash, 'the base must have MOVED off the stale snapshot');
+      assert.notEqual(
+        baseAfter.hash,
+        baseBefore.hash,
+        'the base must have MOVED off the stale snapshot',
+      );
 
       // Assertion 2: an apply carrying VALID BUT BYTE-DISTINCT content (one
       // trailing newline off disk, the exact shape that reproduced the false
@@ -2790,7 +2794,7 @@ test('precompactGateStatus: uncommitted change in the base scope (hot.md) → gi
 // DIFFERENT session sharing the same vault still has its own file dirty. That
 // file is human-fixable by whoever owns it, not by this session, so it must
 // not refuse THIS session's close.
-test('precompactGateStatus: uncommitted change OUTSIDE this session\'s scope → notice, not a git blocker', () => {
+test("precompactGateStatus: uncommitted change OUTSIDE this session's scope → notice, not a git blocker", () => {
   withSyncedWiki((dir) => {
     writeFileSync(join(dir, 'unrelated-session.md'), "# another session's own edit\n");
     // The partition only fires with a TRUSTED transcript (codex pre-commit
@@ -2805,7 +2809,9 @@ test('precompactGateStatus: uncommitted change OUTSIDE this session\'s scope →
       transcript,
       JSON.stringify({
         type: 'assistant',
-        message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'hot.md') } }] },
+        message: {
+          content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'hot.md') } }],
+        },
       }) + '\n',
     );
     const gate = precompactGateStatus(dir, {
@@ -2817,9 +2823,7 @@ test('precompactGateStatus: uncommitted change OUTSIDE this session\'s scope →
       `a foreign session's dirty file must NOT be a git blocker: ${JSON.stringify(gate.blockers)}`,
     );
     assert.ok(
-      (gate.notices || []).some(
-        (n) => n.type === 'git' && n.file === 'unrelated-session.md',
-      ),
+      (gate.notices || []).some((n) => n.type === 'git' && n.file === 'unrelated-session.md'),
       `the foreign dirty file must still be listed by name in notices: ${JSON.stringify(gate.notices)}`,
     );
   });
@@ -2860,7 +2864,11 @@ test('precompactGateStatus: transcript with a corrupt line → a transcript-only
       [
         JSON.stringify({
           type: 'assistant',
-          message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'log.md') } }] },
+          message: {
+            content: [
+              { type: 'tool_use', name: 'Edit', input: { file_path: join(dir, 'log.md') } },
+            ],
+          },
         }),
         '{"type": "assistant", "message": {"content": [{"trunc',
       ].join('\n') + '\n',
@@ -2897,7 +2905,10 @@ test('precompactGateStatus: vault nested under a bigger git repo, my hot.md dirt
       '---\ntitle: Hot\nupdated: today\n---\n## Active Projects\n\n| Project | Last Session | Hot Cache |\n|---|---|---|\n',
     );
     writeFileSync(join(vault, 'log.md'), '# Log\n');
-    writeFileSync(join(base, 'host-repo-file.md'), '# unrelated content living outside the vault\n');
+    writeFileSync(
+      join(base, 'host-repo-file.md'),
+      '# unrelated content living outside the vault\n',
+    );
     spawnSync('git', ['add', '-A'], { cwd: base });
     spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: base });
     appendFileSync(join(vault, 'hot.md'), '\ndirty\n');
@@ -2907,7 +2918,11 @@ test('precompactGateStatus: vault nested under a bigger git repo, my hot.md dirt
       transcript,
       JSON.stringify({
         type: 'assistant',
-        message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: join(vault, 'log.md') } }] },
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Edit', input: { file_path: join(vault, 'log.md') } },
+          ],
+        },
       }) + '\n',
     );
     const gate = precompactGateStatus(vault, {
@@ -2933,13 +2948,7 @@ test('precompactGateStatus: a renamed file landing in scope → still a git bloc
     writeFileSync(join(dir, 'projects', 'demo', 'draft.md'), '# draft session-state\n'.repeat(20));
     spawnSync('git', ['-C', dir, 'add', '-A']);
     spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed draft']);
-    spawnSync('git', [
-      '-C',
-      dir,
-      'mv',
-      'projects/demo/draft.md',
-      'projects/demo/session-state.md',
-    ]);
+    spawnSync('git', ['-C', dir, 'mv', 'projects/demo/draft.md', 'projects/demo/session-state.md']);
     const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
     const transcript = join(tdir, 't.jsonl');
     writeFileSync(


### PR DESCRIPTION
# English

## What changed

Seven files that did not match Prettier's output are formatted, a CI job now
runs `format:check`, and the `prettier` devDependency is pinned exactly instead
of by caret.

## Why

`npx prettier --check .` on main returned 1 and named seven files:
`scripts/lib/plugin-detect.mjs` and six test files. All seven were committed
while the pre-commit hook already existed, so the hook let them through.

It does that by design. `scripts/lib/pre-commit-format.mjs` looks for
`node_modules/.bin/prettier` in the repo root and returns no formatter when it
is absent, deliberately, because reaching for `npx` there could try a network
install on a cold machine. It says so on stderr, and git passes hook stderr
through. What it does not do is stop the commit, and a line of stderr during a
commit is easy to walk past. This repository runs more than ten worktrees at
once and a freshly added one has no `node_modules` until someone installs, so
that path is walked often; the worktree that formatted these files had to run
`npm install` first.

Nothing else was watching. No CI job ran prettier, and `format:check` is not in
the `prepublishOnly` chain either, so a commit that skipped the hook reached
main with nothing to catch it.

## How

The job runs `npm ci` rather than `npx` so it measures against the version the
lockfile pins. That only holds if the lockfile can pin one, which is why the
caret is gone: `^3.8.3` let a fresh `npm install` in any worktree pick a
different 3.x, and today the difference is real. `npx prettier@3.9.6 --check .`
returns 1 on `scripts/lib/pre-commit-format.mjs`, a file this branch does not
touch, because 3.9 changed how it prints a `for` loop with an empty update
clause. With the caret gone, the hook, the job and a local `npm run
format:check` all measure with the same prettier.

`docs/CONTRIBUTING.md`'s pre-tag gate list gains `format:check`, since that
list is what a maintainer actually runs. `docs/ARCHITECTURE.md` said
"7 independent jobs" while there were twelve; the count is removed and
`ci.yml` named as the source of truth rather than corrected to a number that
will go stale again.

## Manual verification

That the seven files changed by formatting only was settled mechanically, not
by reading: each file's `main` revision was run through prettier 3.8.3 and
compared to the committed revision. All seven are byte-identical, so the
committed content is prettier's own output with nothing inserted by hand.

The job's command was verified to fail: breaking one file's formatting makes
`npm run format:check` exit 1 and name that file.

The CI job itself is not exercised until this lands on GitHub. `npm ci` is
safe here because `scripts/install-git-hooks.mjs` exits 0 when `CI` is `true`.

## Migration notes

Contributors who run `npm install` will get exactly 3.8.3 rather than the
newest 3.x. Nothing else changes.

---

# 한국어

## 변경 내용

Prettier 출력과 어긋나 있던 일곱 파일을 포맷하고, CI 잡이 `format:check`를 돌게 하고,
`prettier` devDependency를 캐럿 대신 정확한 버전으로 고정했다.

## 이유

main에서 `npx prettier --check .`가 1을 내며 일곱 파일을 짚었다.
`scripts/lib/plugin-detect.mjs`와 테스트 여섯이다. 일곱 다 pre-commit 훅이 이미 있던
시기에 커밋됐으니 훅이 통과시킨 것이다.

의도된 설계다. `scripts/lib/pre-commit-format.mjs`는 레포 루트에서
`node_modules/.bin/prettier`를 찾고 없으면 포매터 없이 넘어간다. 거기서 `npx`를 쓰면
차가운 기계에서 네트워크 설치를 시도하기 때문이다. 그 사실을 stderr로 말하고 git이 훅
stderr를 통과시킨다. 다만 커밋을 막지는 않고, 커밋 중 stderr 한 줄은 지나치기 쉽다. 이
레포는 워크트리를 열 개 넘게 동시에 굴리고 새로 판 워크트리에는 `npm install` 전까지
`node_modules`가 없어서 그 경로를 자주 밟는다. 이 파일들을 포맷한 워크트리부터
`npm install`을 먼저 해야 했다.

받쳐 주는 자리가 없었다. 어떤 CI 잡도 prettier를 안 돌렸고 `prepublishOnly` 체인에도
`format:check`가 없어서, 훅을 건너뛴 커밋이 아무것에도 안 걸리고 main에 닿았다.

## 방법

잡이 `npx` 대신 `npm ci`를 도는 것은 lockfile이 고정한 버전으로 재기 위해서다. 그건
lockfile이 하나를 고정할 수 있을 때만 성립하고, 그래서 캐럿을 없앴다. `^3.8.3`은 어느
워크트리에서 `npm install`을 하든 다른 3.x가 앉을 수 있게 두고, 오늘 그 차이가 실재한다.
`npx prettier@3.9.6 --check .`는 이 브랜치가 안 건드린 `scripts/lib/pre-commit-format.mjs`에
대해 1을 낸다. 3.9가 update 절이 빈 `for` 문을 다르게 쓰기 때문이다. 캐럿이 사라지면 훅과
잡과 로컬 `npm run format:check`가 같은 prettier로 잰다.

`docs/CONTRIBUTING.md`의 태그 직전 게이트 목록에 `format:check`를 넣었다. 그 목록이
메인테이너가 실제로 돌리는 것이기 때문이다. `docs/ARCHITECTURE.md`는 잡이 열둘인데
"7 independent jobs"라고 적고 있었다. 숫자를 다시 낡을 숫자로 고치는 대신 빼고 `ci.yml`을
정본으로 가리키게 했다.

## 수동 검증

일곱 파일이 포맷만 바뀌었다는 것은 읽어서가 아니라 기계로 확정했다. 각 파일의 `main`
판본을 prettier 3.8.3으로 포맷한 결과와 커밋된 판본을 대조했더니 일곱 다 바이트가 같다.
즉 커밋된 내용은 prettier 자신의 출력이고 손으로 끼워 넣은 것이 없다.

잡의 명령이 실제로 실패하는 것도 확인했다. 파일 하나의 포맷을 깨면 `npm run format:check`가
1로 끝나며 그 파일을 짚는다.

CI 잡 자체는 GitHub에 올라가기 전까지 안 돈다. `npm ci`가 여기서 안전한 것은
`scripts/install-git-hooks.mjs`가 `CI`가 `true`면 0으로 빠지기 때문이다.

## 마이그레이션 노트

`npm install`을 돌리는 기여자는 최신 3.x 대신 정확히 3.8.3을 받는다. 그 외에는 바뀌는
것이 없다.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
