### PR TITLE
chore: skip the reformat commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # style: apply Prettier formatting to scripts/, hooks/, tests/ (2026-05-16)
 4dac33c
+
+# style: reformat seven files that drifted past the pre-commit hook (2026-09-02)
+cc4ebdc


### PR DESCRIPTION
# English

## What changed

`.git-blame-ignore-revs` gains the reformat commit that just landed.

## Why

`cc4ebdc` rewrapped seven files to Prettier's output. `tests/rename-wikilink.test.mjs`
alone moved 161 lines. Without an entry, `git blame` attributes every one of
those lines to the reformat instead of to whoever wrote the code, and GitHub's
web blame does the same because it honors this file automatically.

The file already carries the 2026-05-16 reformat for exactly this reason, so
this follows a rule the repository set for itself.

## How

One line plus a dated comment, matching the existing entry's shape.

The sha could not go into the reformat commit itself: this repository
squash-merges, so the sha to skip only exists once the merge has happened.
That is why this is a follow-up rather than part of the change it points at.

## Manual verification

```
git blame --ignore-revs-file=.git-blame-ignore-revs tests/rename-wikilink.test.mjs
```
now attributes the rewrapped lines to their original commits rather than to
`cc4ebdc`.

## Migration notes

None.

---

# 한국어

## 변경 내용

`.git-blame-ignore-revs`에 방금 들어간 재포맷 커밋을 등재한다.

## 이유

`cc4ebdc`가 일곱 파일을 Prettier 출력으로 다시 접었다. `tests/rename-wikilink.test.mjs`
하나만 161줄이 움직였다. 등재가 없으면 `git blame`이 그 줄들을 원 저자 대신 재포맷
커밋에 귀속시키고, GitHub 웹 blame도 이 파일을 자동으로 존중하므로 같이 어긋난다.

이 파일은 2026-05-16 재포맷을 같은 이유로 이미 담고 있다. 레포가 스스로 세운 관행을
따르는 것이다.

## 방법

날짜가 붙은 주석 한 줄과 sha 한 줄이고, 기존 항목과 같은 모양이다.

그 sha를 재포맷 커밋 자신에 넣을 수는 없었다. 이 레포는 squash 머지라 건너뛸 sha가
머지된 뒤에야 생긴다. 그래서 가리키는 대상과 한 커밋이 못 되고 후속으로 온다.

## 수동 검증

```
git blame --ignore-revs-file=.git-blame-ignore-revs tests/rename-wikilink.test.mjs
```
이 이제 다시 접힌 줄들을 `cc4ebdc`가 아니라 원래 커밋에 귀속시킨다.

## 마이그레이션 노트

없음.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
