### PR TITLE
refactor(plugin): centralize plugin-channel detection behind one resolver

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -64,11 +64,11 @@ import {
 } from './lib/pkg-provenance.mjs';
 import { resolveCliOnPath, classifyInstall, upgradeApplyHint } from '../hooks/version-check.mjs';
 import {
-  isHypomnemaPluginEnabled,
   enabledHypomnemaPluginKey,
   usablePkgRoot,
   leafVersionDrift,
-  resolveEnabledPluginRoot,
+  resolvePluginChannel,
+  resolveEnabledPluginEntry,
 } from './lib/plugin-detect.mjs';
 
 const HOME = homedir();
@@ -90,11 +90,15 @@ const HOOKS_SRC = join(PKG_ROOT, 'hooks');
 // dual-install variant — a manual/npm doctor.mjs run while the plugin is ALSO
 // enabled in settings.json (see lib/plugin-detect.mjs; fails open on any
 // uncertainty). Either signal means Claude's core hook surface is
-// plugin-managed, not missing.
-const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
-const hypomnemaPluginEnabled =
-  !pluginMode && isHypomnemaPluginEnabled(join(HOME, '.claude', 'settings.json'));
-const coreManagedByPlugin = pluginMode || hypomnemaPluginEnabled;
+// plugin-managed, not missing. resolvePluginChannel is the single place this
+// judgment is made — init.mjs and upgrade.mjs call the same function with their
+// own PKG_ROOT so all three tools agree.
+const pluginChannel = resolvePluginChannel({
+  pkgRoot: PKG_ROOT,
+  settingsPath: join(HOME, '.claude', 'settings.json'),
+  registryPath: join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
+});
+const { pluginMode, hypomnemaPluginEnabled, coreManagedByPlugin } = pluginChannel;
 
 // The durable root the vault's pre-commit hook SHOULD embed, mirroring the same
 // rule upgrade.mjs's self-heal uses: in normal operation (plain plugin mode or
@@ -106,10 +110,7 @@ const coreManagedByPlugin = pluginMode || hypomnemaPluginEnabled;
 // comparison rather than report a false pass or a false drift.
 function resolveDurableHookRoot() {
   if (!hypomnemaPluginEnabled) return PKG_ROOT;
-  return resolveEnabledPluginRoot(
-    join(HOME, '.claude', 'settings.json'),
-    join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
-  );
+  return pluginChannel.root;
 }
 
 // Shown after every fatal package-integrity error. These conditions mean the
@@ -2007,80 +2008,50 @@ function checkPluginLeafVersion() {
 //
 // `installed_plugins.json` records the exact commit each cache entry was
 // populated from (`gitCommitSha`); the marketplace clone's own `git rev-parse
-// HEAD` is the other half. Compared against the SAME install root
-// `resolveEnabledPluginRoot` resolves (user scope preferred, matching what
+// HEAD` is the other half. Compared against the SAME row
+// `resolveEnabledPluginEntry` picks (user scope preferred, matching what
 // actually runs), this is the only place the two can be told apart. Never a
 // hard failure: a developer's checkout running ahead of an install is the
 // normal state while iterating, so this only makes the gap visible (warn),
 // with what the user can actually do about it (wait for the next version
 // bump, or replace the cache directory by hand knowing the next real update
 // overwrites it anyway); there is no way to force the copy to happen sooner.
+//
+// Reads the row through resolveEnabledPluginEntry rather than resolving a path
+// and then re-filtering the registry for the row that produced it (an earlier
+// revision of this function did exactly that, in the opposite order — filter
+// for a sha first, prefer user scope second — which silently swaps rows
+// whenever the user row has no gitCommitSha; see resolveEnabledPluginEntry's
+// own comment in lib/plugin-detect.mjs). One resolver call means one selection
+// rule and one registry read; there is no second row to disagree with.
 function checkPluginInstallDrift() {
   const settingsPath = join(HOME, '.claude', 'settings.json');
-  const key = enabledHypomnemaPluginKey(settingsPath);
-  if (!key) return; // plugin not enabled, nothing to verify
-
   const registryPath = join(HOME, '.claude', 'plugins', 'installed_plugins.json');
-  const installRoot = resolveEnabledPluginRoot(settingsPath, registryPath);
-  if (!installRoot) {
-    warn(
-      'Installed cache vs marketplace HEAD',
-      `${key} is enabled but no usable install root could be positively resolved from ` +
-        `${registryPath}, so the installed cache's commit cannot be verified`,
-    );
-    return;
-  }
+  const resolved = resolveEnabledPluginEntry(settingsPath, registryPath);
+  if (resolved.reason === 'not-enabled') return; // plugin not enabled, nothing to verify
 
-  let reg;
-  try {
-    reg = JSON.parse(readFileSync(registryPath, 'utf-8'));
-  } catch {
+  if (resolved.reason === 'registry-unreadable') {
     warn(
       'Installed cache vs marketplace HEAD',
       `Cannot read ${registryPath}, so the installed cache's commit cannot be verified`,
     );
     return;
   }
-  const entries =
-    reg &&
-    typeof reg.plugins === 'object' &&
-    !Array.isArray(reg.plugins) &&
-    Array.isArray(reg.plugins[key])
-      ? reg.plugins[key]
-      : null;
-  // Same row this exact install root came from, not just any row for `key`,
-  // since a stale duplicate row (e.g. a leftover project-scope entry) can
-  // carry a different, and misleading, gitCommitSha.
-  //
-  // And among rows on that path, the same one resolveEnabledPluginRoot picked:
-  // user scope first. Measured, user and project rows share an installPath, so
-  // taking whichever comes first in the array means a project row's older sha
-  // can be read as the state of a user install that is actually at HEAD, and
-  // the answer would be "behind, replace it by hand" for a cache that is fine.
-  // Pick the row the resolver picked, THEN ask whether it carries a sha. Doing
-  // it the other way round (filter for a sha first, then prefer user scope)
-  // silently swaps rows when the user row has no gitCommitSha: the project
-  // row's older sha gets read as the provenance of the install that actually
-  // runs. Measured, user and project rows share an installPath, so the swap is
-  // reachable, and its output is "behind, replace it by hand" for a cache that
-  // may be fine. A chosen row without a sha is unverifiable, not a reason to
-  // ask a different row.
-  const onPath = (entries ?? []).filter((e) => e && e.installPath === installRoot);
-  const entry = onPath.find((e) => e.scope === 'user') ?? onPath[0];
-  if (entry && !(typeof entry.gitCommitSha === 'string' && entry.gitCommitSha)) {
+  if (resolved.reason === 'unresolved') {
+    warn(
+      'Installed cache vs marketplace HEAD',
+      `${resolved.key} is enabled but no usable install root could be positively resolved from ` +
+        `${registryPath}, so the installed cache's commit cannot be verified`,
+    );
+    return;
+  }
+  const { key, entry, root: installRoot } = resolved;
+  if (!(typeof entry.gitCommitSha === 'string' && entry.gitCommitSha)) {
     warn(
       'Installed cache vs marketplace HEAD',
       `The registry row for ${installRoot} carries no gitCommitSha, so the installed cache's ` +
         `commit cannot be verified. Another row on the same path may have one, but it describes ` +
         `a different install`,
-    );
-    return;
-  }
-  if (!entry) {
-    warn(
-      'Installed cache vs marketplace HEAD',
-      `No registry row for ${installRoot} carries a gitCommitSha, so the installed cache's ` +
-        `commit cannot be verified`,
     );
     return;
   }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -61,11 +61,7 @@ import { syncExtensions } from './lib/extensions.mjs';
 import { writeProvenanceSidecar } from './lib/pkg-provenance.mjs';
 import { templateSchemaVersion } from './lib/template-schema-version.mjs';
 import { classifyInstall, downgradeGuardMessage } from '../hooks/version-check.mjs';
-import {
-  isHypomnemaPluginEnabled,
-  resolveEnabledPluginRoot as resolveEnabledPluginRootShared,
-  usablePkgRoot,
-} from './lib/plugin-detect.mjs';
+import { resolvePluginChannel, usablePkgRoot } from './lib/plugin-detect.mjs';
 
 const HOME = homedir();
 const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
@@ -998,22 +994,15 @@ const args = parseArgs(process.argv);
 // `.claude/plugins/…` root); `hypomnemaPluginEnabled` catches the dual-install
 // variant (a manual/npm init.mjs run while the plugin is ALSO enabled — see
 // lib/plugin-detect.mjs, fail-open on any uncertainty). Either signal means
-// Claude's core hook/command surface is plugin-managed already.
-const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
-const hypomnemaPluginEnabled =
-  !pluginMode && isHypomnemaPluginEnabled(join(HOME, '.claude', 'settings.json'));
-const coreManagedByPlugin = pluginMode || hypomnemaPluginEnabled;
-
-// resolveEnabledPluginRoot lives in ./lib/plugin-detect.mjs (shared with
-// upgrade.mjs's dualSkip provenance correction, imported above as
-// resolveEnabledPluginRootShared). This wrapper binds it to init's own HOME-derived
-// settings/registry paths so callers below read the same as before the move.
-function resolveEnabledPluginRoot(settingsPath) {
-  return resolveEnabledPluginRootShared(
-    settingsPath,
-    join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
-  );
-}
+// Claude's core hook/command surface is plugin-managed already. resolvePluginChannel
+// is the single place this judgment is made — doctor.mjs and upgrade.mjs call the
+// same function with their own PKG_ROOT so all three tools agree.
+const pluginChannel = resolvePluginChannel({
+  pkgRoot: PKG_ROOT,
+  settingsPath: join(HOME, '.claude', 'settings.json'),
+  registryPath: join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
+});
+const { pluginMode, hypomnemaPluginEnabled, coreManagedByPlugin } = pluginChannel;
 
 // Non-mutating read of the recorded pkgRoot. resolveDurableRoot runs before init's
 // package validation and its "no writes before validation" guarantee, so it must
@@ -1039,8 +1028,7 @@ function recordedPkgRoot() {
 // only install.
 function resolveDurableRoot() {
   if (!hypomnemaPluginEnabled) return PKG_ROOT;
-  const pluginRoot = resolveEnabledPluginRoot(join(HOME, '.claude', 'settings.json'));
-  if (pluginRoot) return pluginRoot;
+  if (pluginChannel.root) return pluginChannel.root;
   const recorded = recordedPkgRoot();
   if (usablePkgRoot(recorded)) return recorded;
   return PKG_ROOT;

--- a/scripts/lib/plugin-detect.mjs
+++ b/scripts/lib/plugin-detect.mjs
@@ -175,47 +175,131 @@ export function leafVersionDrift(pkgRoot) {
   return { checked: true, drift: manifestVersion !== leaf, leaf, manifestVersion };
 }
 
-// Resolve the enabled Hypomnema plugin's REAL install root from the plugin
-// registry (~/.claude/plugins/installed_plugins.json). POSITIVE attribution: it
-// looks up the EXACT key that settingsPath marks enabled (via
-// enabledHypomnemaPluginKey), not just any hypo-named entry — a disabled legacy or
-// other-marketplace entry must never be selected. Among that key's registry
-// entries it prefers the user-scope install (the one a plugin-enabled user runs),
-// falling back to any usable entry. Returns a usable absolute install root, or
-// null when the registry is absent/unreadable, names no entry for the enabled key,
-// or that entry is not a usable package dir. Fails open (null) on every
-// uncertainty; callers must treat null as "cannot positively resolve", never as
-// "resolved to nothing usable exists".
+// Among a key's registry entries, the exact row resolveEnabledPluginEntry (and
+// therefore resolveEnabledPluginRoot) picks: the user-scope install first (the
+// one a plugin-enabled user runs), falling back to any usable entry. A caller
+// that needs a FIELD off that row (not just its path — e.g. checkPluginInstallDrift
+// wants gitCommitSha) must get the same row this returns, or it re-derives the
+// selection rule itself and the two can disagree the moment a project-scope row
+// sits ahead of the user row on the same installPath (measured 2026-09-02: PR
+// #269 reimplemented this exact filter-then-prefer-scope rule at its call site,
+// in the opposite order, which silently swaps rows whenever the user row has no
+// gitCommitSha).
+function selectEntry(entries, scope) {
+  return (
+    entries.find(
+      (e) => e && (scope === undefined || e.scope === scope) && usablePkgRoot(e.installPath),
+    ) ?? null
+  );
+}
+
+// Resolve the enabled Hypomnema plugin's registry row and its REAL install root
+// in one lookup, from the plugin registry (~/.claude/plugins/installed_plugins.json).
+// POSITIVE attribution: it looks up the EXACT key that settingsPath marks enabled
+// (via enabledHypomnemaPluginKey), not just any hypo-named entry — a disabled
+// legacy or other-marketplace entry must never be selected.
+//
+// Returns `{ key, reason, entry, root }`. `reason` distinguishes WHY `entry`/`root`
+// came back null, which is the distinction resolveEnabledPluginRoot's plain
+// null could not make and callers used to re-derive by hand:
+//   - 'not-enabled':         no enabledPlugins key is enabled — there is no
+//                            plugin-channel question to answer here at all.
+//   - 'registry-unreadable': the key IS enabled, but the registry file could not
+//                            be read or parsed — a judgment FAILURE, not "no
+//                            plugin installed".
+//   - 'unresolved':          the key is enabled and the registry parsed, but no
+//                            entry for that key is a usable package dir — also a
+//                            judgment failure, never "confirmed absent".
+//   - 'resolved':            a usable entry was found; `entry` and `root` are set.
+//
+// Every non-'resolved' reason means "cannot positively resolve" — never read it
+// as "resolved to nothing usable exists".
 //
 // Leaf-version drift does NOT exclude a candidate here, deliberately. An earlier
 // pass filtered on `!leafVersionDrift(p).drift`, and that turns a reporting
-// problem into a breaking one: when this returns null, resolveDurableRoot (init.mjs)
-// falls through to the recorded pkgRoot in hypo-pkg.json and, if that is not usable
-// either, to PKG_ROOT. In a dual install PKG_ROOT is the
-// manual/npm checkout the dual-install notice tells the user to remove. That path
-// gets written into the vault's pre-commit hook, so removing the npm copy leaves
-// the hook dangling and breaks every wiki commit (the failure init.mjs's own
-// `durableRoot` comment exists to prevent). It also silences upgrade's
-// dualSkipWouldCorrect trigger, disabling the very self-heal that fixes a stale
-// pointer. Drift is surfaced by doctor's checkPluginLeafVersion instead.
-export function resolveEnabledPluginRoot(settingsPath, registryPath) {
+// problem into a breaking one: when this returns no usable entry, resolveDurableRoot
+// (init.mjs) falls through to the recorded pkgRoot in hypo-pkg.json and, if that is
+// not usable either, to PKG_ROOT. In a dual install PKG_ROOT is the manual/npm
+// checkout the dual-install notice tells the user to remove. That path gets written
+// into the vault's pre-commit hook, so removing the npm copy leaves the hook
+// dangling and breaks every wiki commit (the failure init.mjs's own `durableRoot`
+// comment exists to prevent). It also silences upgrade's dualSkipWouldCorrect
+// trigger, disabling the very self-heal that fixes a stale pointer. Drift is
+// surfaced by doctor's checkPluginLeafVersion instead.
+export function resolveEnabledPluginEntry(settingsPath, registryPath) {
   const key = enabledHypomnemaPluginKey(settingsPath);
-  if (!key) return null;
+  if (!key) return { key: null, reason: 'not-enabled', entry: null, root: null };
   let reg;
   try {
     reg = JSON.parse(readFileSync(registryPath, 'utf-8'));
   } catch {
-    return null;
+    return { key, reason: 'registry-unreadable', entry: null, root: null };
   }
   const plugins =
     reg && typeof reg.plugins === 'object' && !Array.isArray(reg.plugins) ? reg.plugins : null;
   const entries = plugins && Array.isArray(plugins[key]) ? plugins[key] : null;
-  if (!entries) return null;
-  const paths = (scope) =>
-    entries
-      .filter((e) => e && (scope === undefined || e.scope === scope))
-      .map((e) => (typeof e.installPath === 'string' ? e.installPath : null))
-      .filter((p) => usablePkgRoot(p));
   // Prefer the user-scope install, then any usable entry for this exact key.
-  return paths('user')[0] ?? paths(undefined)[0] ?? null;
+  const entry = entries ? (selectEntry(entries, 'user') ?? selectEntry(entries)) : null;
+  if (!entry) return { key, reason: 'unresolved', entry: null, root: null };
+  return { key, reason: 'resolved', entry, root: entry.installPath };
+}
+
+// Thin projection of resolveEnabledPluginEntry for callers that only need the
+// path. Kept as its own export (rather than inlining `.root` everywhere) because
+// it is the one most callers actually want, and because it is the name this
+// repo's existing callers already know.
+export function resolveEnabledPluginRoot(settingsPath, registryPath) {
+  return resolveEnabledPluginEntry(settingsPath, registryPath).root;
+}
+
+// Single-computation answer to "is Claude's core hook/command surface
+// plugin-managed for THIS process, and if that requires a registry lookup, what
+// did it find?" doctor.mjs, init.mjs and upgrade.mjs each used to compute
+// `pluginMode` / `hypomnemaPluginEnabled` / `coreManagedByPlugin` independently
+// (three copies of the same three lines), and upgrade.mjs additionally called
+// resolveEnabledPluginRoot on its own without ever computing coreManagedByPlugin
+// at all. Same inputs everywhere:
+//   pkgRoot       — the caller's own PKG_ROOT (this script's own install root)
+//   settingsPath  — ~/.claude/settings.json
+//   registryPath  — ~/.claude/plugins/installed_plugins.json
+//
+// Returns `{ pluginMode, hypomnemaPluginEnabled, coreManagedByPlugin, enabledKey,
+// root, rootReason }`. `rootReason` is resolveEnabledPluginEntry's `reason`
+// field for the dual-install case, or 'self' when pluginMode is true (root is
+// pkgRoot itself — no registry lookup is needed or even meaningful there).
+// Why detectChannel (hooks/version-check.mjs) is NOT reused here: its bare
+// `/plugins/` substring is deliberately broader because that judgment is
+// display-only for the notifier, while pluginMode below gates install behavior
+// and needs the narrower `.claude/plugins/` match. The full rationale is at
+// scripts/upgrade.mjs (the "generic /plugins/ substring" comment above its own
+// channel block). The direction is not the obstacle: scripts/ importing hooks/
+// is the legal one and doctor.mjs already does it.
+//
+// NOTE for a future consolidator: `enabledKey` is null whenever pluginMode is
+// true (the short-circuit below). doctor.mjs's checkPluginLeafVersion therefore
+// asks the settings file directly instead of reading it from here, and it walks
+// EVERY registry row while resolveEnabledPluginEntry returns one. Two assertions
+// in tests/doctor.test.mjs pin both facts.
+export function resolvePluginChannel({ pkgRoot, settingsPath, registryPath }) {
+  const pluginMode = pkgRoot.replace(/\\/g, '/').includes('/.claude/plugins/');
+  if (pluginMode) {
+    return {
+      pluginMode: true,
+      hypomnemaPluginEnabled: false,
+      coreManagedByPlugin: true,
+      enabledKey: null,
+      root: pkgRoot,
+      rootReason: 'self',
+    };
+  }
+  const resolved = resolveEnabledPluginEntry(settingsPath, registryPath);
+  const hypomnemaPluginEnabled = resolved.reason !== 'not-enabled';
+  return {
+    pluginMode: false,
+    hypomnemaPluginEnabled,
+    coreManagedByPlugin: hypomnemaPluginEnabled,
+    enabledKey: resolved.key,
+    root: resolved.root,
+    rootReason: resolved.reason,
+  };
 }

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -55,7 +55,7 @@ import {
 } from './lib/pkg-json.mjs';
 import { syncExtensions } from './lib/extensions.mjs';
 import { writeProvenanceSidecar } from './lib/pkg-provenance.mjs';
-import { isHypomnemaPluginEnabled, resolveEnabledPluginRoot } from './lib/plugin-detect.mjs';
+import { resolvePluginChannel } from './lib/plugin-detect.mjs';
 import {
   resolveGitHooksDir,
   unsafeHookTargetReason,
@@ -990,7 +990,6 @@ const codexSettingsPath = join(HOME, '.codex', 'settings.json');
 // legitimate npm/dev checkout under some unrelated `…/plugins/…` path must not be
 // misclassified and silently stop managing its hooks. (detectChannel's broad
 // `/plugins/` test is fine for the notifier's display-only use, but too loose here.)
-const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
 // Dual install: the OTHER way the same double-registration can happen.
 // Here the MANUAL/npm upgrade.mjs is running (pluginMode=false), but the Hypomnema
 // plugin is ALSO enabled in ~/.claude/settings.json — so the plugin loader already
@@ -999,7 +998,17 @@ const pluginMode = PKG_ROOT.replace(/\\/g, '/').includes('/.claude/plugins/');
 // (see lib/plugin-detect.mjs): a false positive would wrongly alter a legitimate
 // npm-only user's upgrade, so it only fires on an exact `hypo@<mp>: true` (or the
 // legacy `hypomnema@<mp>: true`, matched across the plugin-rename migration window).
-const hypomnemaPluginEnabled = !pluginMode && isHypomnemaPluginEnabled(claudeSettingsPath);
+// resolvePluginChannel is the single place pluginMode/hypomnemaPluginEnabled/the
+// registry root are judged — doctor.mjs and init.mjs call the same function with
+// their own PKG_ROOT so all three tools agree. managesClaudeCore/dualSkip below
+// layer upgrade's own `--allow-dual-install` override on top of that judgment;
+// they are upgrade-specific and stay local to this script.
+const pluginChannel = resolvePluginChannel({
+  pkgRoot: PKG_ROOT,
+  settingsPath: claudeSettingsPath,
+  registryPath: join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
+});
+const { pluginMode, hypomnemaPluginEnabled } = pluginChannel;
 const dualInstallCoreConflict = hypomnemaPluginEnabled;
 // Surface policy: the Claude core surface (hooks/settings/commands/hook-name
 // migration) is skipped when EITHER the plugin runs this script (pluginMode) OR a
@@ -1032,12 +1041,7 @@ const pkgJson = checkPkgJson();
 // declined to repoint a hook doctor was still calling stale. Which install a
 // vault's git hook resolves through does not depend on whether the user allowed
 // writing the core surface twice.
-const pluginRegistryRoot = hypomnemaPluginEnabled
-  ? resolveEnabledPluginRoot(
-      claudeSettingsPath,
-      join(HOME, '.claude', 'plugins', 'installed_plugins.json'),
-    )
-  : null;
+const pluginRegistryRoot = hypomnemaPluginEnabled ? pluginChannel.root : null;
 const dualSkipRegistryRoot = dualSkip ? pluginRegistryRoot : null;
 // The recorded pkgRoot currently on disk, read non-mutatingly (readPkgJsonSafe
 // would rename aside a corrupt file — a write — before this script has decided

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -33,7 +33,12 @@ import {
   withTmpHome,
 } from './helpers.mjs';
 import { PROVENANCE_FILENAME, EXPECTED_PKG_NAME } from '../scripts/lib/pkg-provenance.mjs';
-import { resolveEnabledPluginRoot, leafVersionDrift } from '../scripts/lib/plugin-detect.mjs';
+import {
+  resolveEnabledPluginRoot,
+  resolveEnabledPluginEntry,
+  resolvePluginChannel,
+  leafVersionDrift,
+} from '../scripts/lib/plugin-detect.mjs';
 
 // ── doctor.mjs smoke tests ───────────────────────────────────────────────────
 
@@ -2455,6 +2460,199 @@ test('leafVersionDrift: unreadable manifest is checked:false, not a clean compar
   });
 });
 
+// ── Why checkPluginLeafVersion does NOT consume resolvePluginChannel ────────
+//
+// IMPR-45 pulled the channel judgment into one function, so the next reader
+// meets a leaf-version check that still calls enabledHypomnemaPluginKey and
+// reads the registry itself, and reasonably asks "is this the duplication we
+// just removed?". It is not, for two reasons a comment cannot enforce, so both
+// are pinned here. Consolidating would silently delete a diagnostic for exactly
+// the users it exists to serve, and a silent deletion is what ADR 0097 already
+// caught once by reading past a comment.
+
+test('checkPluginLeafVersion needs EVERY registry row, not the one the resolver picks', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    // Two DISTINCT cache directories, both drifted. resolveEnabledPluginEntry
+    // returns a single chosen row, so a caller built on it can only ever report
+    // one of these. This assertion fails the moment someone rewrites the check
+    // to consume that single entry.
+    const mk = (leaf, manifest) => {
+      const root = join(home, '.claude', 'plugins', 'cache', 'hypomnema', 'hypo', leaf);
+      mkdirSync(root, { recursive: true });
+      writeFileSync(
+        join(root, 'package.json'),
+        JSON.stringify({ name: 'hypomnema', version: manifest }),
+      );
+      return root;
+    };
+    const a = mk('1.7.4', '1.7.9');
+    const b = mk('1.8.0', '1.8.5');
+    mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+    writeFileSync(
+      join(home, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        plugins: {
+          [PLUGIN_KEY]: [
+            { installPath: a, scope: 'user' },
+            { installPath: b, scope: 'project' },
+          ],
+        },
+      }),
+    );
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const check = JSON.parse(r.stdout).find((c) => c.label === 'Plugin cache leaf version');
+    assert.ok(check, 'the leaf-version check must be reported at all');
+    assert.ok(check.detail.includes(a), `both drifted paths must be named, missing ${a}`);
+    assert.ok(check.detail.includes(b), `both drifted paths must be named, missing ${b}`);
+  });
+});
+
+test('resolvePluginChannel short-circuits enabledKey to null in pluginMode', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    const root = registerPluginCache(home, '1.7.4', '1.7.4');
+    const settingsPath = join(home, '.claude', 'settings.json');
+    const registryPath = join(home, '.claude', 'plugins', 'installed_plugins.json');
+
+    // Not in pluginMode: the key is there, so a consolidation would look safe.
+    const outside = resolvePluginChannel({
+      pkgRoot: join(home, 'checkout'),
+      settingsPath,
+      registryPath,
+    });
+    assert.ok(outside.enabledKey, 'outside pluginMode the key resolves, which is the trap');
+
+    // In pluginMode (PKG_ROOT under ~/.claude/plugins/), the channel short-circuits
+    // and enabledKey is null. checkPluginLeafVersion asks the settings file directly
+    // BECAUSE of this: routing it through the channel would skip the diagnostic on
+    // exactly the plugin-channel installs it is for.
+    const inside = resolvePluginChannel({ pkgRoot: root, settingsPath, registryPath });
+    assert.equal(inside.pluginMode, true);
+    assert.equal(inside.enabledKey, null, 'pluginMode must not carry an enabledKey');
+  });
+});
+
+// ── lib/plugin-detect.mjs: resolveEnabledPluginEntry reason discrimination ──
+//
+// A judge's null return must read as "cannot positively resolve", never as
+// "resolved to nothing usable exists". resolveEnabledPluginEntry's `reason`
+// field is what makes that distinction machine-checkable instead of a comment
+// a caller can read past. Pinned here as a pure-function contract, independent
+// of any one caller's response (doctor's own checkPluginInstallDrift/leaf-version
+// suites, plus init's and upgrade's dual-install suites, cover how each caller
+// reacts to it).
+
+suite('lib/plugin-detect.mjs — resolveEnabledPluginEntry (reason discrimination)');
+
+test('plugin not enabled: reason is not-enabled, not unresolved', () => {
+  withTmpHome((home) => {
+    const settingsPath = join(home, '.claude', 'settings.json');
+    const registryPath = join(home, '.claude', 'plugins', 'installed_plugins.json');
+    const r = resolveEnabledPluginEntry(settingsPath, registryPath);
+    assert.equal(r.reason, 'not-enabled');
+    assert.equal(r.key, null);
+    assert.equal(r.entry, null);
+    assert.equal(r.root, null);
+  });
+});
+
+test('enabled but registry file missing: reason is registry-unreadable, not unresolved', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    const settingsPath = join(home, '.claude', 'settings.json');
+    const registryPath = join(home, '.claude', 'plugins', 'installed_plugins.json'); // never written
+    const r = resolveEnabledPluginEntry(settingsPath, registryPath);
+    assert.equal(r.reason, 'registry-unreadable');
+    assert.equal(r.key, PLUGIN_KEY, 'the key is still known even when the registry cannot be read');
+    assert.equal(r.entry, null);
+    assert.equal(r.root, null);
+  });
+});
+
+test('enabled, registry present, no usable entry for the key: reason is unresolved', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    const registryDir = join(home, '.claude', 'plugins');
+    mkdirSync(registryDir, { recursive: true });
+    // installPath does not exist on disk, so no candidate is usable.
+    writeFileSync(
+      join(registryDir, 'installed_plugins.json'),
+      JSON.stringify({
+        plugins: { [PLUGIN_KEY]: [{ installPath: join(home, 'nowhere'), scope: 'user' }] },
+      }),
+    );
+    const settingsPath = join(home, '.claude', 'settings.json');
+    const registryPath = join(registryDir, 'installed_plugins.json');
+    const r = resolveEnabledPluginEntry(settingsPath, registryPath);
+    assert.equal(r.reason, 'unresolved');
+    assert.equal(r.key, PLUGIN_KEY);
+    assert.equal(r.entry, null);
+    assert.equal(r.root, null);
+  });
+});
+
+test('enabled, usable entry found: reason is resolved, and entry is the SAME row root came from', () => {
+  withTmpHome((home) => {
+    enablePlugin(home);
+    const root = registerPluginCache(home, '1.7.4', '1.7.4');
+    const settingsPath = join(home, '.claude', 'settings.json');
+    const registryPath = join(home, '.claude', 'plugins', 'installed_plugins.json');
+    const r = resolveEnabledPluginEntry(settingsPath, registryPath);
+    assert.equal(r.reason, 'resolved');
+    assert.equal(r.root, root);
+    assert.equal(r.entry.installPath, root, 'entry is the actual registry row, not just its path');
+  });
+});
+
+// resolveEnabledPluginRoot must stay a pure projection of `.root`, never a
+// second, independently-derived answer that could drift from resolveEnabledPluginEntry.
+// Compares the two functions AGAINST EACH OTHER, not against literals: the thin
+// projection can only be proven equivalent by calling both. Comparing
+// resolveEnabledPluginRoot to a hardcoded null/root would still pass if someone
+// re-implemented it independently and it drifted, which is the exact failure
+// IMPR-45 exists to stop. All four reasons are walked.
+test('resolveEnabledPluginRoot(...) === resolveEnabledPluginEntry(...).root, for every reason', () => {
+  withTmpHome((home) => {
+    const settingsPath = join(home, '.claude', 'settings.json');
+    const registryPath = join(home, '.claude', 'plugins', 'installed_plugins.json');
+    const bothAgree = (expectedReason) => {
+      const entry = resolveEnabledPluginEntry(settingsPath, registryPath);
+      assert.equal(entry.reason, expectedReason, `reason should be ${expectedReason}`);
+      assert.equal(
+        resolveEnabledPluginRoot(settingsPath, registryPath),
+        entry.root,
+        `projection diverged from the entry it projects (${expectedReason})`,
+      );
+      return entry;
+    };
+
+    bothAgree('not-enabled');
+
+    enablePlugin(home);
+    bothAgree('registry-unreadable');
+
+    // unresolved: the key IS enabled and the registry parses, but no row points at
+    // a usable package directory. Without this step the projection is never
+    // compared on the one reason where a naive re-implementation is most likely
+    // to return a path instead of null.
+    mkdirSync(join(home, '.claude', 'plugins'), { recursive: true });
+    writeFileSync(
+      registryPath,
+      JSON.stringify({
+        plugins: {
+          [PLUGIN_KEY]: [{ installPath: join(home, 'no', 'such', 'dir'), scope: 'user' }],
+        },
+      }),
+    );
+    bothAgree('unresolved');
+
+    const root = registerPluginCache(home, '1.7.4', '1.7.4');
+    const resolved = bothAgree('resolved');
+    assert.equal(resolved.root, root);
+  });
+});
+
 // ── doctor.mjs: installed cache vs marketplace HEAD ─────────────────────────
 //
 // `/plugin marketplace update <marketplace>` pulls the marketplace clone
@@ -2550,6 +2748,26 @@ test('plugin not enabled: check is silent (not reported at all)', () => {
     const out = JSON.parse(r.stdout);
     const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
     assert.equal(check, undefined, 'no enabled plugin means nothing to verify');
+  });
+});
+
+// "not enabled" (above, silent) and "enabled but the registry cannot be read"
+// (here, warns) must read differently to the actual production caller, not
+// just to the resolver's own reason field: this is checkPluginInstallDrift
+// itself, not a unit test of resolveEnabledPluginEntry in isolation.
+test('plugin enabled, registry file missing: warns, and does not read as "not enabled"', () => {
+  withTmpHome((home) => {
+    ipdEnablePlugin(home); // enabledPlugins set, installed_plugins.json never written
+    const r = runWithHome('doctor.mjs', [`--hypo-dir=${NONEXISTENT_WIKI}`, '--json'], home);
+    const out = JSON.parse(r.stdout);
+    const check = out.find((c) => c.label === 'Installed cache vs marketplace HEAD');
+    assert.ok(check, 'an enabled plugin must produce a check, not silence');
+    assert.equal(
+      check.status,
+      'warn',
+      `an unreadable registry must not read as verified: ${check.detail}`,
+    );
+    assert.match(check.detail, /Cannot read/, check.detail);
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`doctor`, `init`, and `upgrade` now share one function for "which install
channel is this, and where does the plugin actually live?". The channel
judgment (`pluginMode || enabled`) had been copied into two of them and was
absent from the third, and the newest caller re-implemented the resolver's own
registry-row selection rule in the reverse order to reach a field off the
chosen row.

The resolver also reports a reason: `not-enabled`, `registry-unreadable`,
`unresolved`, or `resolved`. Only the last carries an entry and a root.

## Why

A bare `null` return could not distinguish "no plugin is installed" from "the
plugin is enabled but its registry could not be read". Reading the second as
the first is a defect that recurred through several rounds of review on an
earlier change, and the source comment warning against it was not enough to
stop it. Making the distinction part of the return value takes the question
away from each caller.

## How

`resolveEnabledPluginEntry` returns the selected registry row rather than just
its path, so a caller needing another field off that row no longer re-derives
the selection rule. `resolvePluginChannel` wraps that plus the plugin-mode
self-check into the single judgment the three scripts used to compute apart.

Returning the row removed the second registry read, which closed the window
between the two reads. A defensive branch that only that window could reach is
removed rather than left as unreachable code.

`doctor`'s leaf-version check deliberately keeps asking the settings file
directly. It walks every registry row where the resolver returns one, and the
channel short-circuits its enabled key to null in plugin mode, so routing it
through the shared channel would skip the diagnostic on exactly the installs it
serves. Two assertions pin both facts so a future consolidation fails loudly.

## Manual verification

No hook files changed, so no live-session run was required.

```
node tests/runner.mjs --file=doctor    116 passed, 0 failed
node tests/runner.mjs --file=init       84 passed, 0 failed
node tests/runner.mjs --file=upgrade    69 passed, 0 failed
npm test                              2076 passed, 0 failed
npm run lint                          rc=0
npm run check:pack-surface            rc=0 (142 files, 0 closure violations)
npm run smoke-pack                    rc=0
```

Mutation check, run alone: collapsing `registry-unreadable` back into
`not-enabled` in the resolver's catch block makes two assertions fail (rc=1),
one at the unit level and one at the caller level ("an enabled plugin must
produce a check, not silence"). Reverted and re-ran green.

Second mutation: making the leaf-version check stop after the first registry
row makes its new assertion fail on the second drifted path. Reverted.

## Migration notes

None. No new files, no schema change, and the durable-root fallback is
unchanged.

---

# 한국어

## 변경 내용

`doctor` · `init` · `upgrade` 가 "이 실행은 어느 설치 채널이고 플러그인은
실제로 어디 있나" 를 한 함수로 묻습니다. 채널 판정(`pluginMode || enabled`)이
둘에 복제돼 있었고 나머지 하나는 아예 안 했으며, 가장 최근에 붙은 호출자는
resolver 의 registry 행 선택 규칙을 반대 순서로 다시 구현하고 있었습니다.

resolver 는 사유도 같이 냅니다. `not-enabled` · `registry-unreadable` ·
`unresolved` · `resolved` 이고, 마지막만 entry 와 root 를 들고 옵니다.

## 이유

`null` 하나로는 "플러그인이 없다" 와 "켜져 있는데 registry 를 못 읽었다" 를
구별할 수 없었습니다. 뒤를 앞으로 읽는 것이 앞선 변경의 검토 여러 라운드에서
반복된 결함이고, 그것을 경고하는 소스 주석이 있었는데도 막지 못했습니다. 구별을
반환값에 넣으면 호출자마다 다시 판단할 자리가 없어집니다.

## 방법

`resolveEnabledPluginEntry` 가 경로가 아니라 선택된 registry 행 자체를 돌려주므로,
그 행의 다른 필드가 필요한 호출자가 선택 규칙을 다시 만들지 않습니다.
`resolvePluginChannel` 이 거기에 plugin-mode 자체 판정을 더해, 세 스크립트가 각자
계산하던 판정을 하나로 냅니다.

행을 돌려주면서 registry 두 번째 읽기가 사라졌고 두 읽기 사이의 창도 닫혔습니다.
그 창으로만 도달하던 방어 분기는 도달 불가 코드로 남기지 않고 지웠습니다.

`doctor` 의 leaf 버전 검사는 일부러 settings 파일을 직접 봅니다. 그 검사는 registry
행을 전부 순회하는데 resolver 는 한 행만 돌려주고, 채널은 plugin mode 에서 enabled
key 를 null 로 단락합니다. 공유 채널로 돌리면 이 진단이 필요한 바로 그 설치에서
조용히 건너뛰어집니다. 두 사실을 각각 단언으로 고정해, 나중에 통합을 시도하면
시끄럽게 실패합니다.

## 수동 검증

훅 파일을 안 바꿔서 실세션 실행은 필요 없었습니다.

```
node tests/runner.mjs --file=doctor    116 passed, 0 failed
node tests/runner.mjs --file=init       84 passed, 0 failed
node tests/runner.mjs --file=upgrade    69 passed, 0 failed
npm test                              2076 passed, 0 failed
npm run lint                          rc=0
npm run check:pack-surface            rc=0 (142 files, 0 closure violations)
npm run smoke-pack                    rc=0
```

무력화 검증(단독 실행): resolver 의 catch 블록에서 `registry-unreadable` 을
`not-enabled` 로 되돌리면 단언 둘이 실패합니다(rc=1). 하나는 단위, 하나는 호출자
수준("an enabled plugin must produce a check, not silence")입니다. 복구 후 green.

두 번째 무력화: leaf 버전 검사가 첫 registry 행에서 멈추게 하면 새 단언이 두 번째
드리프트 경로에서 실패합니다. 복구했습니다.

## 마이그레이션 노트

없습니다. 새 파일도 스키마 변경도 없고 durable-root 폴백 동작도 그대로입니다.

---

## Changelog

- EN: `/hypo:doctor` now tells an unreadable plugin registry apart from no plugin at all, so an install it cannot verify is reported instead of being treated as absent (decisions/0097).
- KO: `/hypo:doctor` 가 읽을 수 없는 플러그인 registry 와 플러그인이 아예 없는 경우를 구별하여, 확인할 수 없는 설치를 부재로 취급하지 않고 보고합니다 (decisions/0097).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
