### PR TITLE
fix(close): keep a session's own edits blocking, and give each notice its own line

### DIFF
--- a/hooks/hypo-personal-check.mjs
+++ b/hooks/hypo-personal-check.mjs
@@ -170,45 +170,100 @@ process.stdin.on('end', () => {
     }
   }
 
-  // Non-blocking heads-up about pre-existing lint / out-of-scope design-history
-  // debt in untouched files. Surfaced so it is visible but never blocks compact.
-  // Scoped to the close-target (today-active) projects: debt under one of their
-  // dirs stays listed by filename; debt elsewhere (other projects, shared pages,
-  // root files) folds into a count so the same untouched-file debt does not
-  // re-list its filenames on every compact. Non-file diagnostics (a fail-open
-  // "lint skipped" notice carries no path) are preserved verbatim, never folded.
-  const debtNotices = gate.notices.filter((n) => n.type === 'lint' || n.type === 'design-history');
-  const activeSlugs = (gate.close?.projects || []).map((p) => p.project).filter(Boolean);
-  const nonFileNotices = debtNotices.filter((n) => !n.file);
-  const fileNotices = debtNotices.filter((n) => n.file);
-  const inScopeNotices = fileNotices.filter((n) => isUnderProjectDirs(n.file, activeSlugs));
-  const otherDebtCount = fileNotices.length - inScopeNotices.length;
-  const listed = [
-    ...nonFileNotices.map((n) => n.reason),
-    ...new Set(inScopeNotices.map((n) => n.reason.replace(/ \([^)]*\)$/, ''))),
-  ];
-  let noticeText = '';
-  if (listed.length > 0) {
-    noticeText = `[WIKI CHECK] ${listed.length} pre-existing lint issue(s) in files this session did not touch (not blocking): ${listed
-      .slice(0, 5)
-      .join(', ')}${listed.length > 5 ? ', …' : ''} — clean up when convenient.`;
+  // Non-blocking heads-up, one line per notice TYPE (session-close-scope-boundary
+  // spec §4). gate.notices can carry any of seven types: git, git-sync,
+  // close-debt, close-cwd-unresolved, lint, design-history, feedback. Folding
+  // them all into one "pre-existing lint issue(s)" sentence (the old
+  // renderer) mislabeled git/git-sync/close-cwd-unresolved as lint debt and
+  // dropped close-cwd-unresolved plus most feedback notices outright: visible
+  // but lying about what kind of issue it was and what fixes it. A count that
+  // can grow unbounded (foreign git paths, close-debt projects) is capped and
+  // the rest folds into "+N more", mirroring the existing lint/design-history
+  // fold (a vault-wide lint sweep once produced 125 lines here).
+  const NOTICE_LIST_CAP = 5;
+  const foldNames = (items) =>
+    items.length > NOTICE_LIST_CAP
+      ? `${items.slice(0, NOTICE_LIST_CAP).join(', ')}, +${items.length - NOTICE_LIST_CAP} more`
+      : items.join(', ');
+  const byType = (t) => gate.notices.filter((n) => n.type === t);
+  const noticeLines = [];
+
+  // git: a dirty file outside this session's scope (§2b's structural demotion,
+  // or the trusted-transcript foreign-file demotion above it).
+  const foreignGit = byType('git');
+  if (foreignGit.length > 0) {
+    noticeLines.push(
+      `[WIKI CHECK] ${foreignGit.length} uncommitted file(s) outside this session's scope (not blocking): ${foldNames(foreignGit.map((n) => n.file || n.reason))}.`,
+    );
   }
-  if (otherDebtCount > 0) {
-    const fold = `+${otherDebtCount} pre-existing lint issue(s) elsewhere in the vault (other projects / shared pages, not blocking) — run \`/hypo:lint\` for the full list.`;
-    noticeText = noticeText ? `${noticeText}\n${fold}` : `[WIKI CHECK] ${fold}`;
+  // git-sync / close-cwd-unresolved: single-fact notices, their own `reason`
+  // is already the full sentence.
+  for (const n of byType('git-sync')) noticeLines.push(`[WIKI CHECK] ${n.reason}.`);
+  // close-cwd-unresolved's own `reason` (hypo-shared.mjs) names --project /
+  // --log-only, crystallize CLI flags with no PreCompact-hook equivalent, so
+  // it is not echoed here. This session's own sentence names the one thing a
+  // /compact-time reader can actually do about it: nothing, this is
+  // best-effort and non-blocking.
+  for (const n of byType('close-cwd-unresolved')) {
+    noticeLines.push(
+      `[WIKI CHECK] session cwd did not resolve to a unique project (not blocking): close attribution for this session is best-effort here.`,
+    );
   }
-  // A demoted close: some OTHER session left a project's close incomplete. It no
-  // longer blocks this compact, but it must still be SEEN — a notice list that the
-  // gate silently swallows (suppressOutput when nothing else surfaced) would turn the
-  // demotion into a disappearance, and nobody would ever fix the dangling close
-  // (codex design BLOCKER).
-  const closeDebt = gate.notices.filter((n) => n.type === 'close-debt');
+
+  // close-debt: some OTHER session left a project's close incomplete. It no
+  // longer blocks this compact, but it must still be SEEN: a notice list that
+  // the gate silently swallows (suppressOutput when nothing else surfaced)
+  // would turn the demotion into a disappearance, and nobody would ever fix
+  // the dangling close (codex design BLOCKER).
+  const closeDebt = byType('close-debt');
   if (closeDebt.length > 0) {
-    const line = `[WIKI CHECK] ${closeDebt.length} project(s) with an incomplete session close from another session (not blocking this compact): ${closeDebt
-      .map((n) => n.project)
-      .join(', ')} — each is fixed by that project's next close.`;
-    noticeText = noticeText ? `${noticeText}\n${line}` : line;
+    noticeLines.push(
+      `[WIKI CHECK] ${closeDebt.length} project(s) with an incomplete session close from another session (not blocking this compact): ${foldNames(closeDebt.map((n) => n.project))}, each fixed by that project's next close.`,
+    );
   }
+
+  // lint / design-history: pre-existing debt in files this session did not
+  // touch. Scoped to the close-target (today-active) projects: debt under one
+  // of their dirs stays listed by filename; debt elsewhere (other projects,
+  // shared pages, root files) folds into a count so the same untouched-file
+  // debt does not re-list its filenames on every compact. Non-file
+  // diagnostics (a fail-open "lint skipped" notice carries no path) are
+  // preserved verbatim, never folded. lint and design-history each get their
+  // own line now instead of sharing one "lint issue(s)" sentence.
+  const activeSlugs = (gate.close?.projects || []).map((p) => p.project).filter(Boolean);
+  for (const type of ['lint', 'design-history']) {
+    const debtNotices = byType(type);
+    const nonFileNotices = debtNotices.filter((n) => !n.file);
+    const fileNotices = debtNotices.filter((n) => n.file);
+    const inScopeNotices = fileNotices.filter((n) => isUnderProjectDirs(n.file, activeSlugs));
+    const otherDebtCount = fileNotices.length - inScopeNotices.length;
+    const listed = [
+      ...nonFileNotices.map((n) => n.reason),
+      ...new Set(inScopeNotices.map((n) => n.reason.replace(/ \([^)]*\)$/, ''))),
+    ];
+    if (listed.length > 0) {
+      noticeLines.push(
+        `[WIKI CHECK] ${listed.length} pre-existing ${type} issue(s) in files this session did not touch (not blocking): ${foldNames(listed)}. Clean up when convenient.`,
+      );
+    }
+    if (otherDebtCount > 0) {
+      noticeLines.push(
+        `[WIKI CHECK] +${otherDebtCount} pre-existing ${type} issue(s) elsewhere in the vault (other projects / shared pages, not blocking); run \`/hypo:lint\` for the full list.`,
+      );
+    }
+  }
+
+  // feedback: side-file I/O warnings (a projection target's per-slug sidecar is
+  // unreadable). A drift notice is skipped ONLY when this run actually healed
+  // it (feedbackHealed non-empty, reported once below): when gate.ok is
+  // false (another blocker fired), the self-heal above never runs at all, so
+  // the drift itself was never reported anywhere and must not be dropped here.
+  for (const n of byType('feedback')) {
+    if (feedbackHealed && /^feedback projection drift/.test(n.reason)) continue;
+    noticeLines.push(`[WIKI CHECK] ${n.reason}.`);
+  }
+
+  let noticeText = noticeLines.join('\n');
   // Surface the self-heal so a re-synced projection is not a silent mutation of
   // the user's MEMORY.md / CLAUDE.md (transparency).
   if (feedbackHealed) noticeText = noticeText ? `${noticeText}\n${feedbackHealed}` : feedbackHealed;

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -3589,6 +3589,12 @@ export function partitionLintScope(findings, scope) {
  * every close. Same path policy as the lint-scope matcher above: separators
  * normalized to POSIX, exact prefix at a segment boundary.
  */
+// This function keeps the posixPath() normalization deliberately, unlike
+// isForeign (§2b), which reads the raw porcelain path so a literal-backslash
+// filename cannot be misread as a nested projects/<slug>/ path. Every caller
+// of isUnderProjectDirs would need to be checked before applying the same
+// raw-path treatment here, and that audit has not been done, so the existing
+// behavior stays until it has.
 export function isUnderProjectDirs(file, slugs) {
   const f = posixPath(file);
   return (slugs || []).some((s) => s && (f === `projects/${s}` || f.startsWith(`projects/${s}/`)));
@@ -3707,8 +3713,13 @@ export function resolveCloseScope(hypoDir, opts = {}, marker = null) {
  * compact-ready", codex design review) is replaced by that partition, not
  * restored by it — a marker's own `verified_scope`, attesting exactly what it
  * checked, is still missing (session-close-scope-boundary spec §3, next wave).
- * When a log-only marker governs the session, log-only mode wins and
- * projectOverride is ignored.
+ * Either key ALSO feeds the git-dirty partition (spec §2b): with an untrusted
+ * transcript (missing/corrupt), a dirty file structurally under a DIFFERENT
+ * eligible project's own directory is demoted to a notice, because the path
+ * alone proves it is not this session's; everything else keeps blocking.
+ * When a log-only marker governs the session, log-only mode wins for the
+ * close-status and lint scope (scope selection above); the git-dirty
+ * partition in spec §2b still applies regardless of projectOverride.
  *
  * @param {string} hypoDir
  * opts.sessionCwd (session-cwd close check): the authoritative cwd of the session being
@@ -3769,10 +3780,25 @@ export function precompactGateStatus(hypoDir, opts = {}) {
   // would make almost every real transcript untrusted and defeat the scoping
   // this fix exists to add.
   let sessionTouchTrusted = false;
+  // Transcript-derived files ONLY (not closeAccountableScope's mandatory-files
+  // base, which comes from closeFileTargetsGlobal and would fold every close
+  // file of every eligible project into "this session touched it"). §2b's
+  // isForeign below needs exactly this narrower set: a file this session's own
+  // Edit/Write proves it touched, even on a PARTIALLY-parsed transcript (the
+  // trailing line of an append-in-progress JSONL truncates in the ordinary
+  // course of a live session, not as an exceptional failure), must never be
+  // classified foreign by path prefix alone. Widening this to
+  // closeAccountableScope would re-open the exact foreign-close-file leak
+  // (b) fixed above (a genuinely different project's close file would count
+  // as "touched" just because it shares the mandatory-files base).
+  let transcriptTouched = new Set();
   if (opts.transcriptPath) {
     const widened = extractTouchedWikiFilesWithTrust(opts.transcriptPath, hypoDir);
     sessionTouchTrusted = widened.trusted;
-    for (const f of widened.files) closeAccountableScope.add(f);
+    for (const f of widened.files) {
+      closeAccountableScope.add(f);
+      transcriptTouched.add(f);
+    }
   }
 
   // 1. wiki git state. Uncommitted changes (real unsaved work) BLOCK, but only
@@ -3799,7 +3825,72 @@ export function precompactGateStatus(hypoDir, opts = {}) {
   const git = hypoIsClean(hypoDir);
   if (git.uncommitted) {
     const dirty = gitDirtyFiles(hypoDir);
-    if (dirty.length === 0 || !sessionTouchTrusted) {
+    if (dirty.length === 0) {
+      // Enumeration itself failed (or nothing is actually dirty despite the
+      // porcelain status): "cannot attribute" is not "clean", block exactly
+      // as before, override or not.
+      blockers.push({ type: 'git', reason: git.reason });
+    } else if (!sessionTouchTrusted && (opts.projectOverride || opts.attributionScope)) {
+      // session-close-scope-boundary spec §2b: a broken/missing transcript
+      // normally means "cannot attribute, fail closed" (the branch below).
+      // But when the CALLER told us which project is ours (an explicit
+      // --project, or the cwd-derived attributionScope), a dirty file that
+      // lives structurally under a DIFFERENT eligible project's own directory
+      // needs no attribution inference at all: the path alone proves it is
+      // not this session's file. Everything else (this session's own
+      // project, pages/, an unregistered or _template project dir) keeps the
+      // pre-existing fail-closed behavior; only a provably-foreign path is
+      // demoted.
+      const effectiveOverride = opts.projectOverride || opts.attributionScope;
+      // Computed once per gate call, never per file (collectProjectWorkingDirs
+      // walks the projects/ dir and reads every index.md). A throw here (a
+      // readdirSync failure it does not catch itself) must not escape as an
+      // exception, the PreCompact hook's outermost catch would turn that
+      // into a silent, fully-suppressed gate result, the opposite of "fail
+      // closed". Treat any failure as "no eligible projects known", which
+      // makes isForeign() below always false and every dirty file falls
+      // through to the unconditional blocker.
+      let eligibleSlugs = null;
+      try {
+        eligibleSlugs = new Set(collectProjectWorkingDirs(hypoDir).map((p) => p.slug));
+      } catch {
+        eligibleSlugs = null;
+      }
+      // Lexical, on the RAW git-porcelain path, BEFORE posixPath()'s
+      // unconditional `\` -> `/` conversion. A file whose actual NAME
+      // contains a literal backslash (`projects\other\x.md`, one path
+      // segment, no real subdirectory) must not be reinterpreted as living
+      // under `projects/other/` just because posixPath() would rewrite it
+      // that way; testing the raw string here means it never matches this
+      // regex and falls through to fail-closed instead.
+      const isForeign = (f) => {
+        // The transcript already PROVES this session edited f, whatever its
+        // path prefix says: transcript evidence outranks the path-prefix
+        // heuristic below, which only exists to cover files the (untrusted)
+        // transcript could not vouch for either way.
+        if (transcriptTouched.has(posixPath(f))) return false;
+        if (!eligibleSlugs) return false;
+        const m = /^projects\/([^/]+)\/.+$/.exec(f);
+        if (!m) return false;
+        const slug = m[1];
+        return slug !== effectiveOverride && eligibleSlugs.has(slug);
+      };
+      const foreign = dirty.filter(isForeign);
+      const rest = dirty.filter((f) => !isForeign(f));
+      if (rest.length > 0) {
+        blockers.push({
+          type: 'git',
+          reason: `uncommitted changes in ${hypoDir}: ${rest.join(', ')}`,
+        });
+      }
+      for (const f of foreign) {
+        notices.push({
+          type: 'git',
+          file: f,
+          reason: `uncommitted changes outside this session's scope: ${f}`,
+        });
+      }
+    } else if (!sessionTouchTrusted) {
       blockers.push({ type: 'git', reason: git.reason });
     } else {
       const mine = dirty.filter((f) => closeAccountableScope.has(posixPath(f)));
@@ -4004,6 +4095,11 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       // monorepo tie pickProjectByCwd declined): we cannot attribute a close
       // responsibility, so we do NOT hard-block (nothing proves there is anything
       // to close). Surface a best-effort notice so the coverage gap is visible.
+      // This reason names --project / --log-only, the crystallize CLI flags:
+      // correct for a --check-session-close caller, but not a lever a
+      // PreCompact hook reader has. The hook renderer (hypo-personal-check.mjs)
+      // builds its own sentence for this notice type instead of echoing this
+      // one verbatim; keep both in sync if the underlying condition changes.
       notices.push({
         type: 'close-cwd-unresolved',
         reason:

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -29,6 +29,7 @@ import {
   recordSyncSuccess,
   readSyncLastSuccess,
   classifySyncOp,
+  freshDates,
 } from '../hooks/hypo-shared.mjs';
 import {
   snapshotBase,
@@ -61,12 +62,34 @@ import {
   syncRemote,
   touchedPathsPath,
   vaultCommitLockTarget,
+  runHook,
+  withCleanWiki,
   withGrowthWiki,
   withSyncedWiki,
   withTmpDir,
   withWiki,
   writeMarker,
 } from './helpers.mjs';
+
+// mkdtempSync leaves its directory behind, and five transcript fixtures in this
+// file were each creating one per run with no cleanup — /tmp grew by five every
+// `npm test`. These fixtures hand a PATH to a spawned hook, so withTmpDir's
+// callback scoping does not fit without restructuring each test; registering for
+// deletion at process exit keeps the fixtures as they are and still bounds the
+// growth to one run's worth.
+const TRANSCRIPT_TMP_DIRS = [];
+function transcriptTmpDir() {
+  const d = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+  TRANSCRIPT_TMP_DIRS.push(d);
+  return d;
+}
+process.on('exit', () => {
+  for (const d of TRANSCRIPT_TMP_DIRS) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {}
+  }
+});
 
 suite('formatGrowthMetrics()');
 
@@ -2803,7 +2826,7 @@ test("precompactGateStatus: uncommitted change OUTSIDE this session's scope → 
     // earns the demotion below. Without a transcript the gate must fall back
     // to the unscoped blocker instead (see the two attribution-unknown tests
     // further down).
-    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const tdir = transcriptTmpDir();
     const transcript = join(tdir, 't.jsonl');
     writeFileSync(
       transcript,
@@ -2855,7 +2878,7 @@ test('precompactGateStatus: transcript with a corrupt line → a transcript-only
   withSyncedWiki((dir) => {
     mkdirSync(join(dir, 'pages'), { recursive: true });
     writeFileSync(join(dir, 'pages', 'mine.md'), '# wip\n');
-    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const tdir = transcriptTmpDir();
     const transcript = join(tdir, 't.jsonl');
     // One well-formed line plus one truncated (mid-write) line: the walk
     // still returns SOME files, but must not be trusted as complete.
@@ -2912,7 +2935,7 @@ test('precompactGateStatus: vault nested under a bigger git repo, my hot.md dirt
     spawnSync('git', ['add', '-A'], { cwd: base });
     spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: base });
     appendFileSync(join(vault, 'hot.md'), '\ndirty\n');
-    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const tdir = transcriptTmpDir();
     const transcript = join(tdir, 't.jsonl');
     writeFileSync(
       transcript,
@@ -2949,7 +2972,7 @@ test('precompactGateStatus: a renamed file landing in scope → still a git bloc
     spawnSync('git', ['-C', dir, 'add', '-A']);
     spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'seed draft']);
     spawnSync('git', ['-C', dir, 'mv', 'projects/demo/draft.md', 'projects/demo/session-state.md']);
-    const tdir = mkdtempSync(join(tmpdir(), 'hypo-transcript-'));
+    const tdir = transcriptTmpDir();
     const transcript = join(tdir, 't.jsonl');
     writeFileSync(
       transcript,
@@ -3130,6 +3153,329 @@ test('commitWikiChanges: a top-level (non-projects/) path counts as its own proj
     assert.ok(
       /\(1 paths across 1 projects\)/.test(subject),
       `a lone top-level path is its own 1-path/1-project commit: ${subject}`,
+    );
+  });
+});
+
+// ── session-close-scope-boundary spec §2b: structural git demotion under
+//    projectOverride / attributionScope ──────────────────────────────────
+//
+// All six fixtures below require `sessionTouchTrusted === false` (no
+// transcript is passed): with a trusted transcript the EXISTING partition a
+// few tests up already demotes a foreign dirty file, so a fixture that keeps
+// transcript trust would pass before this change too and pin nothing. The
+// gate here is called directly (not through a hook), same style as every
+// other precompactGateStatus test in this suite.
+
+// `slug` becomes an ELIGIBLE project for collectProjectWorkingDirs: index.md
+// present, not `_template`. Committed so it does not itself count as dirty.
+function registerEligibleProject(dir, slug) {
+  mkdirSync(join(dir, 'projects', slug), { recursive: true });
+  writeFileSync(
+    join(dir, 'projects', slug, 'index.md'),
+    `---\ntitle: ${slug}\ntype: project-index\nupdated: 2026-01-01\n---\n# ${slug}\n`,
+  );
+  spawnSync('git', ['-C', dir, 'add', '-A']);
+  spawnSync('git', ['-C', dir, 'commit', '-q', '-m', `register ${slug}`]);
+}
+
+suite('session-close-scope-boundary spec §2b: structural git demotion');
+
+test('precompactGateStatus: projectOverride + no transcript + foreign ELIGIBLE project dirty -> notice, not a git blocker', () => {
+  withSyncedWiki((dir) => {
+    registerEligibleProject(dir, 'other');
+    writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other session work\n');
+    // 'mine' needs no registered project dir here: the gate never validates
+    // projectOverride against an actual project, that validation belongs to
+    // resolveGateProjectOverride, upstream of this call.
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      projectOverride: 'mine',
+    });
+    assert.ok(
+      !(gate.blockers || []).some((b) => b.type === 'git'),
+      `a dirty file structurally under a DIFFERENT eligible project must be demoted even without a transcript: ${JSON.stringify(gate.blockers)}`,
+    );
+    assert.ok(
+      (gate.notices || []).some((n) => n.type === 'git' && n.file === 'projects/other/scratch.md'),
+      `the foreign file must still be listed by name in notices: ${JSON.stringify(gate.notices)}`,
+    );
+  });
+});
+
+// The four marker-writing paths never pass projectOverride; they pass
+// attributionScope instead (hypo-personal-check.mjs's resolveGateProjectOverride
+// result). §2b's six fixtures above all key off `opts.projectOverride`, which
+// only the check-only `--project` diagnostic ever sets in production. Every
+// caller that actually WRITES a marker routes through attributionScope, so a
+// suite that never tries that key is pinning behavior no production path can
+// reach. Duplicate the first fixture with attributionScope in place of
+// projectOverride, and assert on the ABSENCE of a git blocker (not just the
+// notice string), since a passing notice assertion alone would not catch a
+// regression that also left the blocker in place.
+test('precompactGateStatus: attributionScope + no transcript + foreign ELIGIBLE project dirty -> notice, not a git blocker', () => {
+  withSyncedWiki((dir) => {
+    registerEligibleProject(dir, 'other');
+    writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other session work\n');
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      attributionScope: 'mine',
+    });
+    assert.ok(
+      !(gate.blockers || []).some((b) => b.type === 'git'),
+      `attributionScope must demote a structurally-foreign dirty file exactly like projectOverride: ${JSON.stringify(gate.blockers)}`,
+    );
+    assert.ok(
+      (gate.notices || []).some((n) => n.type === 'git' && n.file === 'projects/other/scratch.md'),
+      `the foreign file must still be listed by name in notices: ${JSON.stringify(gate.notices)}`,
+    );
+  });
+});
+
+// Regression pin for the "which set does isForeign consult" question. This
+// file must land in closeAccountableScope for the fixture to mean anything:
+// registering 'other' as TODAY-active (a log.md entry dated today) puts
+// 'projects/other/hot.md' into closeFileTargetsGlobal (hypo-shared.mjs
+// ~3520-3552), which is closeAccountableScope's base whenever attributionScope
+// (not projectOverride) is the operative key (hypo-shared.mjs ~3757-3761). So
+// this file sits in BOTH candidate sets: closeAccountableScope (via the global
+// base) and, if isForeign wrongly checked that set instead of the narrower
+// transcriptTouched, it would read as "mine" purely because another project
+// closed today, not because THIS session's transcript proved it. The correct
+// guard (transcriptTouched, empty here: no transcript was ever passed) still
+// classifies the file as foreign by path, so it must demote to a notice.
+test('precompactGateStatus: attributionScope + no transcript + a foreign project active TODAY -> its close file still demotes to a notice, not a git blocker', () => {
+  withSyncedWiki((dir) => {
+    registerEligibleProject(dir, 'other');
+    const today = freshDates()[0];
+    writeFileSync(join(dir, 'log.md'), `## [${today}] session | other\n`);
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'other closed today']);
+    // The ONLY uncommitted file from here on.
+    writeFileSync(join(dir, 'projects', 'other', 'hot.md'), '# other session work\n');
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      attributionScope: 'mine',
+    });
+    assert.ok(
+      !(gate.blockers || []).some((b) => b.type === 'git'),
+      `a file that is in closeAccountableScope ONLY because a different project closed today must still demote by path, not become a git blocker: ${JSON.stringify(gate.blockers)}`,
+    );
+    assert.ok(
+      (gate.notices || []).some((n) => n.type === 'git' && n.file === 'projects/other/hot.md'),
+      `the foreign close file must still be listed by name in notices: ${JSON.stringify(gate.notices)}`,
+    );
+  });
+});
+
+test('precompactGateStatus: projectOverride + no transcript + own session-state.md dirty -> still a git blocker', () => {
+  withSyncedWiki((dir) => {
+    registerEligibleProject(dir, 'mine');
+    writeFileSync(join(dir, 'projects', 'mine', 'session-state.md'), '# wip\n');
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      projectOverride: 'mine',
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `a dirty file under the OVERRIDE'S OWN project must never be demoted: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+test('precompactGateStatus: projectOverride + no transcript + pages/mine.md dirty -> still a git blocker', () => {
+  withSyncedWiki((dir) => {
+    mkdirSync(join(dir, 'pages'), { recursive: true });
+    writeFileSync(join(dir, 'pages', 'mine.md'), '# wip\n');
+    // Again, 'mine' needs no registered project dir: see the comment on the
+    // first fixture above.
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      projectOverride: 'mine',
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `a path outside projects/ has no structural "not mine" proof and must stay fail-closed: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+test('precompactGateStatus: projectOverride + no transcript + projects/_template/x.md dirty -> still a git blocker', () => {
+  withSyncedWiki((dir) => {
+    mkdirSync(join(dir, 'projects', '_template'), { recursive: true });
+    writeFileSync(join(dir, 'projects', '_template', 'x.md'), '# template scratch\n');
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      projectOverride: 'mine',
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `_template is excluded from collectProjectWorkingDirs, so it cannot be structurally confirmed as someone else's project: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+test('precompactGateStatus: projectOverride + no transcript + an unregistered projects/new/x.md dirty -> still a git blocker', () => {
+  withSyncedWiki((dir) => {
+    // No index.md under `new`: it is not yet a real project, so it cannot be
+    // structurally confirmed as someone else's either.
+    mkdirSync(join(dir, 'projects', 'new'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'new', 'x.md'), '# not a registered project yet\n');
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      projectOverride: 'mine',
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `an unregistered project dir must stay fail-closed: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+test('precompactGateStatus: projectOverride + no transcript + a literal-backslash filename dirty -> still a git blocker (regression)', () => {
+  withSyncedWiki((dir) => {
+    registerEligibleProject(dir, 'other');
+    // ONE file whose NAME contains literal backslashes, not a real nested
+    // projects/other/x.md path. posixPath()'s unconditional `\` -> `/`
+    // conversion would misread this as living under projects/other/ and
+    // wrongly demote it; the classifier must run on the RAW porcelain path
+    // instead, where this string never matches the projects/<slug>/ prefix.
+    writeFileSync(join(dir, 'projects\\other\\x.md'), '# literal backslash name\n');
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      projectOverride: 'mine',
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `a literal-backslash filename must not be reinterpreted as a projects/other/ path: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+// A PARTIALLY-parsed transcript (a well-formed line proving this session
+// edited a file structurally under a DIFFERENT project's dir, followed by a
+// truncated trailing line, the ordinary state of an append-in-progress
+// JSONL, not corruption) must still count that file as THIS session's, not
+// foreign-by-path. sessionTouchTrusted is false here (the trailing line fails
+// to parse), so before the fix this fell straight into the path-prefix
+// heuristic and demoted the very file the transcript proves this session
+// touched.
+test('precompactGateStatus: projectOverride + a partially-parsed transcript proving THIS session edited a foreign-path file -> still a git blocker', () => {
+  withSyncedWiki((dir) => {
+    registerEligibleProject(dir, 'other');
+    writeFileSync(join(dir, 'projects', 'other', 'hot.md'), '# edited by this session\n');
+    const tdir = transcriptTmpDir();
+    const transcript = join(tdir, 't.jsonl');
+    writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: join(dir, 'projects', 'other', 'hot.md') },
+              },
+            ],
+          },
+        }),
+        '{"type": "assistant", "message": {"content": [{"trunc',
+      ].join('\n') + '\n',
+    );
+    const gate = precompactGateStatus(dir, {
+      claudeHome: join(dir, '.claude-none'),
+      projectOverride: 'mine',
+      transcriptPath: transcript,
+    });
+    assert.ok(
+      (gate.blockers || []).some((b) => b.type === 'git'),
+      `transcript evidence of THIS session's own edit must outrank the foreign-path heuristic: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+// ── session-close-scope-boundary spec §4: notice rendered by its own TYPE ──
+//
+// Through the real PreCompact hook (not a direct precompactGateStatus call):
+// this is what actually renders gate.notices into the user-facing
+// systemMessage, and §4 changes that rendering, not the gate itself.
+
+suite('session-close-scope-boundary spec §4: notice rendered by its own TYPE');
+
+test('hypo-personal-check.mjs: a foreign uncommitted file renders its own "outside this session\'s scope" line, not a folded lint line', () => {
+  const CWD = join(tmpdir(), 'hypo-spec4-workdir-test-project');
+  withWiki(
+    (dir) => {
+      writeFileSync(
+        join(dir, 'projects', 'test-project', 'index.md'),
+        `---\ntitle: test-project\ntype: project-index\nupdated: 2026-01-01\nworking_dir: "${CWD}"\n---\n# test-project\n`,
+      );
+      mkdirSync(join(dir, 'projects', 'other'), { recursive: true });
+      writeFileSync(
+        join(dir, 'projects', 'other', 'index.md'),
+        '---\ntitle: other\ntype: project-index\nupdated: 2026-01-01\n---\n# other\n',
+      );
+    },
+    (dir) => {
+      // Dirty AFTER withWiki's init commit, with no transcript in the hook
+      // input below: this exercises §2b's cwd-derived attributionScope path
+      // exactly as PreCompact really calls it.
+      writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other session work\n');
+      const r = runHook('hypo-personal-check.mjs', { cwd: CWD }, { HYPO_DIR: dir });
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.continue, true, `PreCompact never blocks (spec §1): ${r.stdout}`);
+      assert.ok(
+        out.systemMessage &&
+          /\[WIKI CHECK\] \d+ uncommitted file\(s\) outside this session's scope \(not blocking\): projects\/other\/scratch\.md/.test(
+            out.systemMessage,
+          ),
+        `the foreign git file must render its own typed line, not fold into a lint sentence: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('hypo-personal-check.mjs: unpushed commits render their own git-sync line, not a folded lint line', () => {
+  withSyncedWiki((dir) => {
+    writeFileSync(join(dir, 'ahead.md'), '# ahead\n');
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'ahead']);
+    const r = runHook('hypo-personal-check.mjs', {}, { HYPO_DIR: dir });
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, `PreCompact never blocks (spec §1): ${r.stdout}`);
+    assert.ok(
+      out.systemMessage && /unpushed commits in /.test(out.systemMessage),
+      `an unpushed commit must render its own git-sync line: ${r.stdout}`,
+    );
+    assert.ok(
+      !/pre-existing lint issue/.test(out.systemMessage || ''),
+      `a git-sync notice must not be folded into the lint sentence: ${r.stdout}`,
+    );
+  });
+});
+
+test('hypo-personal-check.mjs: an unresolved session cwd renders its own close-cwd-unresolved line, not a folded lint line', () => {
+  withCleanWiki((dir) => {
+    // No project in this fixture carries an index.md (buildCleanWikiTree never
+    // writes one), so collectProjectWorkingDirs sees zero projects and any cwd
+    // is, by construction, unresolved.
+    const r = runHook(
+      'hypo-personal-check.mjs',
+      { cwd: join(tmpdir(), 'hypo-spec4-unresolved-cwd') },
+      { HYPO_DIR: dir },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.continue, true, `PreCompact never blocks (spec §1): ${r.stdout}`);
+    assert.ok(
+      out.systemMessage &&
+        /session cwd did not resolve to a unique project/.test(out.systemMessage),
+      `an unresolved cwd must render its own close-cwd-unresolved line: ${r.stdout}`,
+    );
+    assert.ok(
+      !/pre-existing lint issue/.test(out.systemMessage || ''),
+      `a close-cwd-unresolved notice must not be folded into the lint sentence: ${r.stdout}`,
     );
   });
 });


### PR DESCRIPTION
# English

## What changed

The PreCompact gate stops demoting a file this session actually edited, and each notice type renders on its own line instead of being folded into one lint sentence.

## Why

A dirty file under `projects/<other>/` was demoted to a notice on path shape alone whenever the session declared a scope. That is right for someone else's file and wrong for one this session edited, and the gate had the evidence to tell them apart: the transcript walk returns the files it did parse even when it reports itself untrusted. A hook reading a JSONL file that is still being appended to hits that case routinely, so the common state was a real edit demoted and the marker written anyway.

Separately, seven notice types reached the renderer and three were folded into a single "pre-existing lint issue(s)" sentence. That labelled `git-sync` and `close-cwd-unresolved` as lint debt and collapsed foreign git paths into a lint count: visible, but with the wrong type and the wrong remedy.

## How

The demotion yields to the transcript-derived set only, not to the whole accountable scope. That scope is seeded from every project's close targets, so consulting it would fold back in the foreign close files the demotion exists to release. Both directions are pinned by assertions, because removing the guard and widening it are different regressions and a test that catches one can miss the other.

Foreign git paths and close-debt projects cap at five with the remainder shown as a count. The `close-cwd-unresolved` line is composed for the hook's reader rather than echoing the CLI reason, which tells the reader to pass `--project` or `--log-only`; those are crystallize flags and not levers anyone has at `/compact`. The CLI keeps its own wording.

Feedback drift no longer disappears when another blocker is present: the self-heal that would have reported it only runs on a green gate, so the unconditional skip hid the drift exactly when the gate was red.

## Manual verification

Hooks changed, so beyond the suite:

- Fed `hypo-personal-check.mjs` directly in an isolated vault and confirmed each notice type renders on its own line, and that a foreign path is not counted as lint.
- Swapped the built hooks into the installed plugin cache and started a real headless Claude Code session; instrumented the cached hook and confirmed the plugin loader fires it. Restored the cache and verified it byte-identical to the pre-swap backup.
- **Not verified in a live session: the PreCompact path itself.** That hook only fires on `/compact`, which cannot be triggered from outside the session. The gate's input/output contract is covered by the suite and by the direct-feed run above, but how Claude Code surfaces these notices during an actual compact has not been observed.

## Migration notes

None.

---

# 한국어

## 변경 내용

PreCompact 게이트가 이 세션이 실제로 편집한 파일을 강등하지 않게 됐고, notice가 유형별로 각자 줄에 나옵니다. 전에는 셋이 lint 한 문장에 접혀 있었습니다.

## 이유

세션이 스코프를 선언하면 `projects/<other>/` 아래 미커밋 파일이 경로 모양만으로 notice로 강등됐습니다. 남의 파일이면 맞지만 이 세션이 편집한 파일이면 틀립니다. 그리고 그 둘을 가를 증거가 이미 있었습니다. transcript 훑기는 자신이 신뢰할 수 없다고 보고할 때도 파싱에 성공한 파일 목록은 그대로 돌려줍니다. 훅은 append 중인 JSONL을 읽으므로 그 상태가 예외가 아니라 일상입니다. 그래서 실제 편집이 강등되고 마커가 써지는 일이 흔했습니다.

별개로, 렌더러에 닿는 notice 유형이 일곱인데 셋이 "pre-existing lint issue(s)" 한 문장에 접혔습니다. `git-sync`와 `close-cwd-unresolved`가 lint 부채로 표시되고 남의 git 경로가 lint 개수로 접혔습니다. 보이기는 하는데 유형과 조치가 거짓입니다.

## 방법

강등은 transcript에서 나온 집합에만 양보하고 accountable scope 전체는 안 봅니다. 그 스코프는 모든 프로젝트의 close 대상에서 시작하므로, 그걸 참조하면 강등이 풀어 주려던 남의 close 파일이 도로 들어옵니다. 양방향을 단언으로 고정했습니다. 가드를 지우는 것과 넓히는 것은 다른 회귀이고, 하나를 잡는 시험이 다른 하나를 놓칠 수 있습니다.

남의 git 경로와 close-debt 프로젝트는 다섯에서 자르고 나머지는 개수로 접습니다. `close-cwd-unresolved` 줄은 CLI reason을 그대로 echo하지 않고 훅 문맥에 맞게 조립합니다. 그 reason은 `--project`나 `--log-only`를 넘기라고 하는데 둘 다 crystallize 플래그이고 `/compact` 시점 독자에게는 누를 레버가 아닙니다. CLI는 자기 문구를 그대로 씁니다.

feedback drift는 다른 blocker가 있을 때 사라지지 않습니다. 그것을 보고했을 self-heal이 green 게이트에서만 돌기 때문에, 무조건 건너뛰기는 게이트가 빨간 바로 그때 drift를 감췄습니다.

## 수동 검증

훅을 바꿨으므로 테스트 외에:

- 격리된 볼트에서 `hypo-personal-check.mjs`를 직접 먹여 유형별로 각자 줄에 나오는지, 남의 경로가 lint로 세어지지 않는지 확인했습니다.
- 빌드한 훅을 설치 플러그인 캐시에 갈아 끼우고 실제 헤드리스 Claude Code 세션을 띄웠습니다. 캐시 훅에 흔적을 심어 플러그인 로더가 그것을 발화시키는 것을 확인했습니다. 캐시는 복원했고 교체 전 백업과 바이트 동일함을 확인했습니다.
- **실세션에서 확인하지 못한 것: PreCompact 경로 자체.** 그 훅은 `/compact`에서만 발화하는데 세션 밖에서 일으킬 수 없습니다. 게이트의 입출력 계약은 테스트와 위 직접 실행으로 덮이지만, 실제 compact 중에 Claude Code가 이 notice들을 어떻게 표시하는지는 관측하지 못했습니다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: The session-close gate no longer demotes a file the session itself edited when the transcript is only partially readable, and each pending-work notice now names its own type instead of being reported as a lint issue (#275).
- KO: transcript가 일부만 읽히는 상황에서 세션이 직접 편집한 파일이 강등되지 않고, 남은 작업 notice가 lint로 뭉뚱그려지지 않고 각자 유형으로 표시됩니다 (#275).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
