### PR TITLE
fix(close): let a multi-day session overwrite what a later SessionStart showed it

### DIFF
--- a/hooks/base-store.mjs
+++ b/hooks/base-store.mjs
@@ -250,6 +250,190 @@ export function advanceBaseForWrite(hypoDir, sessionId, relPath, absPath, knownH
   }
 }
 
+// ── observed set ───────────────────────────────────────────────────────────
+//
+// `targets` never moves except through the two invariants above, so a session
+// that outlives its first snapshot by days sees every intervening legitimate
+// write from OTHER sessions as drift and parks all four overwrite targets.
+// The observed set is a second, additive record: what this session was
+// actually SHOWN by a later SessionStart (resume/compact), kept separate from
+// `targets` so it can only ever widen what a close may write, never narrow or
+// replace the original base. `readBaseEntry`'s shape and `targets`' meaning
+// are unchanged; a consumer that never calls the functions below sees
+// identical behavior to before this section existed.
+//
+// Two guards keep the widening bounded to "what this session was just shown":
+//
+//   - Generation. `observedGeneration` is a per-session counter, bumped once
+//     per SessionStart by `beginObservedGeneration` (BEFORE the first read of
+//     that SessionStart, so it covers everything that SessionStart injects).
+//     `recordObserved` stamps each entry with the CURRENT generation but never
+//     advances it — advancing on every record would put the two files a HIT
+//     SessionStart injects (hot.md, session-state.md) into different
+//     generations, since they are recorded one call apart, and the second call
+//     would expire the first. `readObservedHash` only returns a hash whose
+//     `generation` equals the CURRENT `observedGeneration`; a SessionStart
+//     that bumps the generation and then injects nothing (ignored, scoped out,
+//     absent, no session_id) leaves every existing entry one generation stale,
+//     so it reads back as null everywhere. This is what makes "only the most
+//     recent SessionStart's injection licenses a write" true without an
+//     explicit expiry pass: staleness falls out of the generation compare.
+//   - Tracked-key scoping. Exactly like `advanceBaseForWrite`, `recordObserved`
+//     is a no-op for a key that is not already in `targets` — it cannot mint a
+//     new guarded target, only add provenance to one that was already
+//     snapshotted for this session.
+//
+// One entry per path, not an array: a later observation of the SAME path
+// simply overwrites the old `{generation, hash}` pair, so there is no
+// unbounded growth to cap or dedup.
+
+/**
+ * Bump this session's observed generation. Call once per SessionStart
+ * invocation, before the first `recordObserved` of that invocation — this is
+ * what makes an injection-free SessionStart (resume that hit no target, a
+ * scoped-out file, .hypoignore) expire every prior observation instead of
+ * leaving it licensed forever.
+ *
+ * No-op when the session has no snapshot yet: there is nothing to bump.
+ *
+ * @returns {boolean} true when base.json was updated
+ */
+export function beginObservedGeneration(hypoDir, sessionId) {
+  if (!sessionId) return false;
+  const parsed = readBaseFile(hypoDir, sessionId);
+  if (!parsed) return false;
+  const current = typeof parsed.observedGeneration === 'number' ? parsed.observedGeneration : 0;
+  parsed.observedGeneration = current + 1;
+  try {
+    atomicWrite(basePath(hypoDir, sessionId), JSON.stringify(parsed, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record that this session was just SHOWN `hash` for `relPath` (the exact
+ * bytes a SessionStart injection read, not a fresh disk re-read — the caller
+ * must pass the hash of the bytes it actually displayed).
+ *
+ * `truncated`: true when the injection sliced the file (2000-char HOT_CHARS /
+ * STATE_CHARS) before showing it, i.e. the caller only passed `hash` of a
+ * prefix's worth of trust even though `hash` itself is the FULL file's hash.
+ * A truncated observation is stored, not dropped, so a parked close can name
+ * the reason (`base-mismatch-truncated-observation`) instead of the plain
+ * `base-mismatch` a bare no-op would produce — but `readObservedHash` below
+ * refuses to hand it out as a licence: seeing 5% of a file is not seeing it.
+ *
+ * No-op, in order: no snapshot for this session; `relPath` is not one of the
+ * four tracked overwrite targets (mirrors `advanceBaseForWrite`'s scoping —
+ * this must not be able to mint a new guarded key). Stamped with the CURRENT
+ * `observedGeneration`, never advancing it: the caller advances once via
+ * `beginObservedGeneration`, not once per recorded target.
+ *
+ * @returns {boolean} true when base.json was updated
+ */
+/**
+ * A safe integer, or null. base.json is on disk and another writer (an older
+ * release, a half-finished write, a hand edit) can leave any shape in it, so a
+ * generation counter is only trusted when it is exactly that: `NaN`, `Infinity`,
+ * `1.5` and `"1"` all read as absent rather than as a value to compare against.
+ */
+function safeGeneration(v) {
+  return Number.isSafeInteger(v) ? v : null;
+}
+
+export function recordObserved(hypoDir, sessionId, relPath, hash, truncated = false) {
+  if (!sessionId) return false;
+  const parsed = readBaseFile(hypoDir, sessionId);
+  if (!parsed) return false;
+  if (!Object.prototype.hasOwnProperty.call(parsed.targets, relPath)) return false;
+  if (typeof hash !== 'string') return false;
+  const generation = typeof parsed.observedGeneration === 'number' ? parsed.observedGeneration : 0;
+  if (!parsed.observed || typeof parsed.observed !== 'object' || Array.isArray(parsed.observed)) {
+    parsed.observed = {};
+  }
+  parsed.observed[relPath] = { generation, hash, truncated: !!truncated };
+  try {
+    atomicWrite(basePath(hypoDir, sessionId), JSON.stringify(parsed, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The hash this session was shown for `relPath`, but ONLY when it was shown
+ * IN FULL during the CURRENT observed generation — the actual enforcement
+ * point of "only the most recent SessionStart's injection licenses a write".
+ * Returns null for: no snapshot, a session whose observed-generation counter
+ * was never created (see below), no observed entry, a malformed entry, a
+ * generation that does not match (stale — superseded by a later SessionStart,
+ * or never refreshed by one that injected nothing), or an entry the injection
+ * itself marked `truncated`.
+ *
+ * The `observedGeneration` check is deliberately ASYMMETRIC with how
+ * `recordObserved` reads the same field: that function normalizes a missing
+ * counter to `0` only to pick a generation to STAMP an entry with. Doing the
+ * same here — treating "no counter" as "generation 0" — would make a session
+ * whose `beginObservedGeneration` call never ran (never bumped past 0) match
+ * an entry `recordObserved` also stamped at 0, and the observed set would
+ * license writes despite the expiry mechanism that is supposed to gate it
+ * never having run at all. So here, "no counter" reads as "no current
+ * generation for anything to match" — null, not 0.
+ *
+ * @returns {string|null}
+ */
+export function readObservedHash(hypoDir, sessionId, relPath) {
+  if (!sessionId) return null;
+  const parsed = readBaseFile(hypoDir, sessionId);
+  if (!parsed) return null;
+  const current = safeGeneration(parsed.observedGeneration);
+  if (current === null) return null;
+  const observed = parsed.observed;
+  if (!observed || typeof observed !== 'object' || Array.isArray(observed)) return null;
+  const entry = observed[relPath];
+  if (!entry || typeof entry !== 'object' || typeof entry.hash !== 'string' || !entry.hash) {
+    return null;
+  }
+  if (safeGeneration(entry.generation) !== current) return null;
+  // `truncated` is checked for a STRICT boolean, and any other shape refuses the
+  // licence rather than falling through to `=== true` being false. A corrupt
+  // `"true"` string used to pass that comparison and hand out a licence for a
+  // sliced observation — the one thing this field exists to deny. Corruption
+  // parks; it never widens.
+  if (entry.truncated !== false) return null;
+  return entry.hash;
+}
+
+/**
+ * Whether this session has a CURRENT-generation observed entry for `relPath`
+ * that exists but was marked `truncated` by `recordObserved` — the one bit
+ * `readObservedHash`'s null collapses away. Consulted only to pick a park
+ * reason (`base-mismatch-truncated-observation` vs plain `base-mismatch`),
+ * never to license a write; a caller must keep treating `readObservedHash`'s
+ * null as "no licence" regardless of what this returns.
+ *
+ * @returns {boolean}
+ */
+export function wasObservedTruncated(hypoDir, sessionId, relPath) {
+  if (!sessionId) return false;
+  const parsed = readBaseFile(hypoDir, sessionId);
+  if (!parsed) return false;
+  const current = safeGeneration(parsed.observedGeneration);
+  if (current === null) return false;
+  const observed = parsed.observed;
+  if (!observed || typeof observed !== 'object' || Array.isArray(observed)) return false;
+  const entry = observed[relPath];
+  if (!entry || typeof entry !== 'object') return false;
+  if (safeGeneration(entry.generation) !== current) return false;
+  // Mirrors readObservedHash's strict check: anything that is not exactly `false`
+  // counts as truncated here. This only picks the park REASON (readObservedHash
+  // has already refused the licence), so erring toward "truncated" names a
+  // narrower cause than the generic mismatch and never unblocks a write.
+  return entry.truncated !== false;
+}
+
 // The four whole-file overwrite targets are prose-and-table markdown documents, and
 // a base-mismatch on one of them always parks. Five predicates lived here that tried
 // to skip the park when a payload "provably" lost nothing, and four rounds of review

--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -110,6 +110,14 @@ process.stdin.on('end', () => {
 
     const ignorePatterns = loadHypoIgnore(HYPO_DIR);
 
+    // This injection is not a licensing surface for the observed-set gate
+    // (see base-store.mjs's recordObserved): a session's tracked
+    // `targets` are fixed at whichever project the OWNING SessionStart hit,
+    // and a cwd move can land here in a different project entirely, so
+    // recording an observation against this read could credit a path outside
+    // that fixed target set. Nothing here calls recordObserved; the guard
+    // stays exactly as conservative for a cwd-change injection as it was
+    // before the observed set existed.
     if (newHit) {
       const fromFile = readIfNotIgnored(newHit.hotPath, ignorePatterns);
       const content =

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -60,7 +60,13 @@ import {
   clearPkgRootNullNotified,
   UPGRADE_APPLY_EITHER,
 } from './version-check.mjs';
-import { snapshotBase, overwriteTargets } from './base-store.mjs';
+import {
+  snapshotBase,
+  overwriteTargets,
+  beginObservedGeneration,
+  recordObserved,
+  hashContent,
+} from './base-store.mjs';
 import { listProposals } from './proposal-store.mjs';
 
 // Privacy guard: refuse to read+inject .hypoignore-matched
@@ -77,12 +83,18 @@ import { listProposals } from './proposal-store.mjs';
 // slicing first could cut the frontmatter off and silently fail open.
 // The root hot.md is a frontmatter-less pointer table, so it reads as '' and
 // passes (shared) unchanged.
+// Returns `{raw, shown}` rather than just the sliced string: the observed-set
+// record must hash the FULL bytes this call just read, not a fresh re-read at
+// record time, or a write that lands in the window between this read and the
+// record call would be credited to this session's observation without ever
+// having been shown to it. `shown` stays the maxChars-sliced display string
+// every existing caller already expects.
 function readIfNotIgnored(path, maxChars, patterns) {
   if (!path) return null;
   if (patterns.length > 0 && isIgnored(path, HYPO_DIR, patterns)) return null;
   const raw = readFileSync(path, 'utf-8');
   if (!scopeVisible(readVisibilityScope(raw), currentDevice())) return null;
-  return raw.slice(0, maxChars);
+  return { raw, shown: raw.slice(0, maxChars) };
 }
 
 // Scoped-out is not the same as absent. Both make readIfNotIgnored return null,
@@ -600,6 +612,12 @@ process.stdin.on('end', () => {
     // direct-write path.
     if (data.session_id) {
       snapshotBase(HYPO_DIR, data.session_id, overwriteTargets(hit ? hit.proj : null));
+      // Bumps the observed generation on EVERY SessionStart (first run and
+      // resume/compact alike), before the injections below record into it. A
+      // resume that ends up injecting nothing (ignored, scoped out, absent)
+      // still bumps, which is what lets a stale observation from an earlier
+      // resume expire instead of staying licensed for the rest of the session.
+      beginObservedGeneration(HYPO_DIR, data.session_id);
     }
 
     const ignorePatterns = loadHypoIgnore(HYPO_DIR);
@@ -617,8 +635,10 @@ process.stdin.on('end', () => {
       // marker is computed on raw content (staleMarkerForPath), then prepended
       // onto the sliced display content; a no-op when there is no verify_by_date.
       const TODAY = new Date().toISOString().slice(0, 10);
-      let hotContent = readIfNotIgnored(hit.hotPath, HOT_CHARS, ignorePatterns);
-      let stateContent = readIfNotIgnored(hit.statePath, STATE_CHARS, ignorePatterns);
+      const hotRead = readIfNotIgnored(hit.hotPath, HOT_CHARS, ignorePatterns);
+      const stateRead = readIfNotIgnored(hit.statePath, STATE_CHARS, ignorePatterns);
+      let hotContent = hotRead ? hotRead.shown : null;
+      let stateContent = stateRead ? stateRead.shown : null;
       const hotMarker = staleMarkerForPath(hit.hotPath, ignorePatterns, TODAY);
       const stateMarker = staleMarkerForPath(hit.statePath, ignorePatterns, TODAY);
       if (hotContent && hotMarker) hotContent = `${hotMarker}\n${hotContent}`;
@@ -647,6 +667,41 @@ process.stdin.on('end', () => {
             ),
           ),
         );
+        // Observed-set record: this is the actual injection point, so this is
+        // where "this session was SHOWN these bytes" becomes true. Recorded
+        // AFTER the marker write and the console.log above (fail-open
+        // ordering): if this throws, the model has already been shown the
+        // bytes above but no observed-entry lands, so the guard just fails
+        // safe into a park later, rather than the reverse — an entry on disk
+        // claiming an observation the injection never actually emitted.
+        // Gated on `hotContent`/`stateContent` (the same predicate that put
+        // each into `parts` above), not on `hotRead`/`stateRead` alone: an
+        // empty-but-not-ignored file makes `hotRead` a truthy `{raw:'',
+        // shown:''}`, and recording against that would create an observed
+        // entry for bytes the model was never actually shown a line of.
+        // Hash `.raw` (the full file this call just read), never a fresh
+        // `readFileSync` here — that would credit a write landing between the
+        // read above and this line to an observation that never happened.
+        if (data.session_id) {
+          if (hotContent) {
+            recordObserved(
+              HYPO_DIR,
+              data.session_id,
+              join('projects', hit.proj, 'hot.md'),
+              hashContent(hotRead.raw),
+              hotRead.raw.length > HOT_CHARS,
+            );
+          }
+          if (stateContent) {
+            recordObserved(
+              HYPO_DIR,
+              data.session_id,
+              join('projects', hit.proj, 'session-state.md'),
+              hashContent(stateRead.raw),
+              stateRead.raw.length > STATE_CHARS,
+            );
+          }
+        }
       } else {
         // A snapshot that exists but is scoped to another machine must not be
         // reported as "no snapshot yet": the model would treat a resumed project
@@ -701,7 +756,8 @@ process.stdin.on('end', () => {
       return;
     }
 
-    const globalContent = readIfNotIgnored(GLOBAL_HOT, HOT_CHARS, ignorePatterns);
+    const globalRead = readIfNotIgnored(GLOBAL_HOT, HOT_CHARS, ignorePatterns);
+    const globalContent = globalRead ? globalRead.shown : null;
     if (!globalContent) {
       // GLOBAL_HOT exists but is empty or .hypoignore'd — still surface any
       // pending notices (sync state, growth, AND the auto-project offer), which
@@ -722,6 +778,20 @@ process.stdin.on('end', () => {
         ),
       ),
     );
+    // Observed-set record: the MISS branch's root hot.md injection is the one
+    // place a project-less session observes anything at all. Recorded AFTER
+    // the console.log above — see the HIT branch's comment for why (fail-open
+    // ordering). Hashes `.raw`, not a fresh disk read, for the same reason
+    // given there.
+    if (data.session_id) {
+      recordObserved(
+        HYPO_DIR,
+        data.session_id,
+        'hot.md',
+        hashContent(globalRead.raw),
+        globalRead.raw.length > HOT_CHARS,
+      );
+    }
   } catch (err) {
     process.stderr.write(`[hypo-session-start] error: ${err?.message ?? String(err)}\n`);
     console.log(JSON.stringify(outExtra));

--- a/scripts/lib/crystallize-close-apply.mjs
+++ b/scripts/lib/crystallize-close-apply.mjs
@@ -36,7 +36,13 @@ import {
   withFileLock,
   resolveGateProjectOverride,
 } from '../../hooks/hypo-shared.mjs';
-import { hashContent, readBaseEntry, advanceBase } from '../../hooks/base-store.mjs';
+import {
+  hashContent,
+  readBaseEntry,
+  advanceBase,
+  readObservedHash,
+  wasObservedTruncated,
+} from '../../hooks/base-store.mjs';
 import { writeProposal } from '../../hooks/proposal-store.mjs';
 import {
   recordGateClosed,
@@ -157,13 +163,28 @@ function readTarget(path) {
  * `hash`: 'absent' and 'unknown' both carry `hash: null`, and collapsing them
  * would read never-observed as safe-to-write, defeating the guard entirely.
  *
+ * `observed` is this session's observed set for THIS target: the
+ * hash(es) a later SessionStart actually showed it, on top of the original
+ * base. It only ever widens what may be written, never narrows or replaces
+ * `entry` — a disk hash matching `entry.hash` still passes with `observed`
+ * empty, exactly as before this parameter existed. `case 'unknown'` does not
+ * consult it: with no snapshot at all there is no base for an observation to
+ * extend.
+ *
  * @param {{state: 'hash'|'absent'|'unknown', hash: string|null}} entry
  * @param {string|null|undefined} disk current bytes / absent / unreadable
+ * @param {{hash: string|null, truncated: boolean}} observed what this session
+ *   was shown for THIS target after its first snapshot: the exact hash (or
+ *   `null` when it was never shown anything current), plus whether the one
+ *   shown-but-not-licensing case (a truncated injection) applies — used only
+ *   to pick which park reason to report, never to license a write on its own.
  * @returns {string|null} a conflict reason, or null when this session may write
  */
-function overwriteConflictReason(entry, disk) {
+export function overwriteConflictReason(entry, disk, observed = { hash: null, truncated: false }) {
   // Cannot read what we are about to replace: fail safe, never assume unchanged.
   if (disk === undefined) return 'target-unreadable';
+  const observedHash = observed && observed.hash;
+  const observedTruncated = !!(observed && observed.truncated);
   switch (entry.state) {
     case 'unknown':
       // No snapshot for this (session, target). Someone else's edits could be
@@ -171,11 +192,23 @@ function overwriteConflictReason(entry, disk) {
       return 'base-unknown';
     case 'absent':
       // We observed no file. Creating it is safe; finding one now means another
-      // writer got there first.
-      return disk === null ? null : 'base-absent-target-exists';
+      // writer got there first, UNLESS this session was later shown exactly
+      // those bytes by a resume/compact SessionStart.
+      if (disk === null) return null;
+      if (observedHash && observedHash === hashContent(disk)) return null;
+      return observedTruncated
+        ? 'base-mismatch-truncated-observation'
+        : 'base-absent-target-exists';
     case 'hash':
       if (disk === null) return 'base-hash-target-missing';
-      return hashContent(disk) === entry.hash ? null : 'base-mismatch';
+      if (hashContent(disk) === entry.hash) return null;
+      // Drifted from the original base — still allowed when this session was
+      // shown these exact drifted bytes by a later SessionStart. A truncated
+      // injection never reaches `observedHash` (readObservedHash refuses it),
+      // so it falls through here and gets its own reason instead of the plain
+      // `base-mismatch` a no-observation-at-all case reports.
+      if (observedHash && observedHash === hashContent(disk)) return null;
+      return observedTruncated ? 'base-mismatch-truncated-observation' : 'base-mismatch';
     default:
       return 'base-unknown';
   }
@@ -1081,7 +1114,17 @@ export function applySessionClose(args) {
       // built for should stop being a shared whole-file overwrite target at all and
       // become a locally generated projection of the project files that already own
       // those facts; then two machines never contend over it.
-      const reason = overwriteConflictReason(entry, disk);
+      const observedHash = readObservedHash(args.hypoDir, args.sessionId, relPath);
+      // A truncated observation never comes back as `observedHash` (readObservedHash
+      // refuses it), so this second read is what lets the park reason below tell
+      // "never shown anything current" apart from "shown, but only a slice of it" —
+      // see base-store.mjs's recordObserved/readObservedHash docs.
+      const observedTruncated =
+        !observedHash && wasObservedTruncated(args.hypoDir, args.sessionId, relPath);
+      const reason = overwriteConflictReason(entry, disk, {
+        hash: observedHash,
+        truncated: observedTruncated,
+      });
       if (reason) {
         conflicts.push({
           key,

--- a/tests/proposal-base.test.mjs
+++ b/tests/proposal-base.test.mjs
@@ -29,7 +29,12 @@ import {
   advanceBase,
   advanceBaseForWrite,
   overwriteTargets,
+  beginObservedGeneration,
+  recordObserved,
+  readObservedHash,
+  wasObservedTruncated,
 } from '../hooks/base-store.mjs';
+import { overwriteConflictReason } from '../scripts/lib/crystallize-close-apply.mjs';
 import {
   writeProposal as psWriteProposal,
   listProposals as psListProposals,
@@ -1036,6 +1041,22 @@ await testAsync('FEAT-11 T7: a successful apply leaves the session base untouche
     // Breaking the apply-then-reclose loop is crystallize's idempotent-skip
     // (disk === payload), not a base advance here.
     assert.deepEqual(readBaseEntry(dir, sessionId, rel), before);
+
+    // ISSUE-116 AC4: base staying put is necessary but not sufficient — the close
+    // guard must actually RE-CHECK at close time, not treat "an apply happened"
+    // as a licence to skip re-verification. Apply is an out-of-band human
+    // override, not a SessionStart injection, so this session's observed set is
+    // still empty for `rel` and a close right after this apply must still park.
+    assert.equal(
+      readObservedHash(dir, sessionId, rel),
+      null,
+      'an apply must not have populated the observed set',
+    );
+    assert.equal(
+      overwriteConflictReason(before, readFileSync(target, 'utf-8')),
+      'base-mismatch',
+      'a close right after an out-of-band apply must still park',
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -2254,6 +2275,196 @@ test('advanceBaseForWrite with a knownHash advances to it, ignoring on-disk byte
   });
 });
 
+// ── base-store.mjs — observed set (ISSUE-116) ────────────────────────────────
+
+suite('base-store.mjs — observed set (ISSUE-116)');
+
+test('recordObserved is a no-op when the session has no snapshot yet', () => {
+  withBaseWiki((dir) => {
+    assert.equal(recordObserved(dir, 's1', 'hot.md', bsHashContent('x')), false);
+    assert.equal(existsSync(bsBasePath(dir, 's1')), false, 'must not create base.json');
+    assert.equal(readObservedHash(dir, 's1', 'hot.md'), null);
+  });
+});
+
+test('recordObserved is a no-op for a key outside targets (cannot widen the guard)', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    assert.equal(recordObserved(dir, 's1', 'not-a-target.md', bsHashContent('x')), false);
+    const parsed = JSON.parse(readFileSync(bsBasePath(dir, 's1'), 'utf-8'));
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(parsed.observed || {}, 'not-a-target.md'),
+      false,
+      'an untracked key must not be minted into the observed map',
+    );
+    assert.equal(readObservedHash(dir, 's1', 'not-a-target.md'), null);
+  });
+});
+
+test('recordObserved twice in one generation (hot + session-state) keeps both readable', () => {
+  // HIT SessionStart calls recordObserved twice, one call apart, for the same
+  // generation. Neither call may bump the generation itself — if it did, the
+  // second file would land in a different generation and immediately expire.
+  // Both keys mirror what the real HIT branch actually injects: the
+  // PROJECT-scoped hot.md, not the root one (the root only appears in the
+  // MISS branch — see hypo-session-start.mjs:765).
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    beginObservedGeneration(dir, 's1');
+    recordObserved(dir, 's1', join('projects', 'p1', 'hot.md'), bsHashContent('h'));
+    recordObserved(dir, 's1', join('projects', 'p1', 'session-state.md'), bsHashContent('s'));
+    assert.equal(readObservedHash(dir, 's1', join('projects', 'p1', 'hot.md')), bsHashContent('h'));
+    assert.equal(
+      readObservedHash(dir, 's1', join('projects', 'p1', 'session-state.md')),
+      bsHashContent('s'),
+    );
+  });
+});
+
+test('beginObservedGeneration expires an observation no later SessionStart refreshed', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    beginObservedGeneration(dir, 's1'); // generation 1
+    recordObserved(dir, 's1', 'hot.md', bsHashContent('gen1'));
+    assert.equal(readObservedHash(dir, 's1', 'hot.md'), bsHashContent('gen1'));
+
+    beginObservedGeneration(dir, 's1'); // generation 2 — nothing recorded this time
+    assert.equal(
+      readObservedHash(dir, 's1', 'hot.md'),
+      null,
+      'a SessionStart that injects nothing this generation must not keep the prior observation licensed',
+    );
+  });
+});
+
+test('recordObserved(..., truncated=true) is stored but never licenses a write', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    beginObservedGeneration(dir, 's1');
+    recordObserved(dir, 's1', 'hot.md', bsHashContent('sliced'), true);
+    assert.equal(
+      readObservedHash(dir, 's1', 'hot.md'),
+      null,
+      'a truncated observation must never be handed out as a licence',
+    );
+    assert.equal(wasObservedTruncated(dir, 's1', 'hot.md'), true);
+  });
+});
+
+// base.json sits on disk where an older release, a half-finished write, or a
+// hand edit can leave any shape in it. The licence checks must READ that as
+// corruption and park, never fall through a strict-equality comparison into
+// handing out a licence. `truncated: "true"` is the sharp case: it is obviously
+// meant to say "sliced", but `=== true` is false for it, so a check written that
+// way licenses exactly the observation the field exists to deny.
+test('a corrupt observed entry parks instead of licensing (truncated is not a strict boolean)', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    beginObservedGeneration(dir, 's1');
+    const disk = 'bytes on disk';
+    recordObserved(dir, 's1', 'hot.md', bsHashContent(disk), false);
+    assert.equal(
+      readObservedHash(dir, 's1', 'hot.md'),
+      bsHashContent(disk),
+      'fixture: a clean entry must license, or the corruptions below prove nothing',
+    );
+
+    const path = bsBasePath(dir, 's1');
+    const corruptions = [
+      ['truncated as the STRING "true"', (j) => (j.observed['hot.md'].truncated = 'true')],
+      ['truncated missing entirely', (j) => delete j.observed['hot.md'].truncated],
+      ['truncated as 1', (j) => (j.observed['hot.md'].truncated = 1)],
+      ['entry generation as NaN', (j) => (j.observed['hot.md'].generation = NaN)],
+      ['counter as a non-integer', (j) => (j.observedGeneration = 1.5)],
+      ['counter as the STRING "1"', (j) => (j.observedGeneration = '1')],
+      ['hash as an empty string', (j) => (j.observed['hot.md'].hash = '')],
+    ];
+    for (const [label, corrupt] of corruptions) {
+      const j = JSON.parse(readFileSync(path, 'utf-8'));
+      corrupt(j);
+      // NaN is not representable in JSON and serializes to null; that is fine —
+      // null is just as much "not a safe integer", which is what is under test.
+      writeFileSync(path, JSON.stringify(j));
+      assert.equal(
+        readObservedHash(dir, 's1', 'hot.md'),
+        null,
+        `${label} must refuse the licence, not fall through to it`,
+      );
+    }
+  });
+});
+
+test('recordObserved defaults truncated to false when the caller omits it', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    beginObservedGeneration(dir, 's1');
+    recordObserved(dir, 's1', 'hot.md', bsHashContent('full'));
+    assert.equal(readObservedHash(dir, 's1', 'hot.md'), bsHashContent('full'));
+    assert.equal(wasObservedTruncated(dir, 's1', 'hot.md'), false);
+  });
+});
+
+test('wasObservedTruncated goes false, not true, once a later generation expires the entry', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    beginObservedGeneration(dir, 's1');
+    recordObserved(dir, 's1', 'hot.md', bsHashContent('sliced'), true);
+    beginObservedGeneration(dir, 's1'); // a later SessionStart, injecting nothing this time
+    assert.equal(readObservedHash(dir, 's1', 'hot.md'), null);
+    assert.equal(
+      wasObservedTruncated(dir, 's1', 'hot.md'),
+      false,
+      'a stale generation must not report as truncated either — it is simply expired',
+    );
+  });
+});
+
+test('readObservedHash refuses when observedGeneration was never created, regardless of entry.generation', () => {
+  // Simulates beginObservedGeneration never having run for this session (the
+  // bug the ISSUE-116 review found: deleting that call left every base.json
+  // test green). recordObserved's own internal default stamps a MISSING
+  // observedGeneration as 0, but readObservedHash must not mirror that
+  // default when reading it back — if it did, this entry (generation 0)
+  // would match a "current generation" of 0 and license a write despite the
+  // counter that is supposed to gate it never having been created at all.
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1'));
+    recordObserved(dir, 's1', 'hot.md', bsHashContent('h')); // no beginObservedGeneration call
+    const parsed = JSON.parse(readFileSync(bsBasePath(dir, 's1'), 'utf-8'));
+    assert.equal(parsed.observedGeneration, undefined, 'no beginObservedGeneration call ran');
+    assert.equal(
+      parsed.observed['hot.md'].generation,
+      0,
+      'recordObserved stamped its own local default',
+    );
+    assert.equal(
+      readObservedHash(dir, 's1', 'hot.md'),
+      null,
+      'a missing observedGeneration counter must never license a write',
+    );
+  });
+});
+
+test('a legacy base.json (no observed/observedGeneration) reads exactly as before ISSUE-116', () => {
+  withBaseWiki((dir) => {
+    snapshotBase(dir, 's1', overwriteTargets('p1')); // writes the pre-ISSUE-116 shape
+    assert.equal(
+      readObservedHash(dir, 's1', 'hot.md'),
+      null,
+      'a legacy base.json has no observed hash for anything',
+    );
+    assert.equal(
+      readBaseEntry(dir, 's1', 'hot.md').state,
+      'hash',
+      'targets/readBaseEntry unaffected',
+    );
+
+    beginObservedGeneration(dir, 's1'); // missing observedGeneration normalizes to 0, then bumps to 1
+    const parsed = JSON.parse(readFileSync(bsBasePath(dir, 's1'), 'utf-8'));
+    assert.equal(parsed.observedGeneration, 1);
+  });
+});
+
 // ── FEAT-11 SessionStart base snapshot (T3) ──────────────────────────────────
 
 suite('hypo-session-start.mjs — observed-base snapshot once per session (FEAT-11 T3)');
@@ -2789,6 +3000,364 @@ test('a Write advances the base to the bytes it wrote, not a racy disk re-read',
       'the concurrent bytes must not become our base',
     );
   });
+});
+
+// ── observed set, end-to-end: real hypo-session-start.mjs + real close (ISSUE-116) ──
+//
+// A multi-day session: SessionStart (fresh) → another session writes AND commits
+// (the real vault's hypo-auto-commit does this within seconds, unlike the
+// uncommitted writeFileSync the T4 conflict tests above use on purpose) →
+// SessionStart again with the SAME session_id (resume) → close. Uses the real
+// hypo-session-start.mjs subprocess, not a unit-level base-store call, because
+// the injection point this depends on (recordObserved's call sites) lives there.
+
+suite('observed set — real SessionStart + real close (ISSUE-116)');
+
+function withObservedProject(fn) {
+  const work = mkdtempSync(join(tmpdir(), 'hypo-observed-work-'));
+  try {
+    withWiki(
+      (dir, today) => {
+        writeFileSync(
+          join(dir, 'projects', T4_PROJECT, 'index.md'),
+          `---\ntitle: ${T4_PROJECT}\ntype: project-index\nupdated: ${today}\nworking_dir: "${work}"\n---\n# ${T4_PROJECT}\n`,
+        );
+      },
+      (dir, today) => fn(dir, today, work),
+    );
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+test('AC1: resume that injected the drifted content unparks the target at close', () => {
+  withObservedProject((dir, today, work) => {
+    let r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'ac1-sess' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `first SessionStart stderr: ${r.stderr}`);
+    const baseBefore = readBaseEntry(dir, 'ac1-sess', t4Rel).hash;
+
+    // Another session writes AND commits while this one is away — the normal
+    // multi-day shape (hypo-auto-commit commits every session's writes within
+    // seconds), not the deliberately-uncommitted fixture the T4 conflict tests use.
+    const drifted = `${readFileSync(t4ProjectHot(dir), 'utf-8')}\nanother session wrote and committed this.\n`;
+    writeFileSync(t4ProjectHot(dir), drifted);
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-m', 'other session'], { cwd: dir });
+
+    // Resume: SAME session_id, so the base must not move (existence-check), but
+    // the injection this run performs records the drifted bytes as observed.
+    r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'ac1-sess', source: 'resume' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `resume SessionStart stderr: ${r.stderr}`);
+    assert.equal(
+      readBaseEntry(dir, 'ac1-sess', t4Rel).hash,
+      baseBefore,
+      'resume must not move the base itself — only the observed set grows',
+    );
+
+    const mine = `${drifted}\nthis session's own addition after resume.\n`;
+    const { r: closeR, out } = t4Apply(dir, t4Payload(dir, today, mine, 'ac1 resume'), 'ac1-sess');
+    assert.equal(
+      closeR.status,
+      0,
+      `close must succeed once resume observed the drift: ${JSON.stringify(out.conflicts)}`,
+    );
+    assert.deepEqual(out.conflicts, []);
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), mine, 'the close payload must land');
+  });
+});
+
+test('AC5: a committed external write, with no resume in between, still parks (a commit is not a licence)', () => {
+  // The axis the spec explicitly rejects as a licence (커밋 결합): pins that a
+  // commit by itself never substitutes for an actual SessionStart observation.
+  withWiki(null, (dir, today) => {
+    snapshotBase(dir, 's-committed', overwriteTargets(T4_PROJECT));
+    const observed = readFileSync(t4ProjectHot(dir), 'utf-8');
+    const otherSession = `${observed}\nthe OTHER session wrote AND committed this.\n`;
+    writeFileSync(t4ProjectHot(dir), otherSession);
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-m', 'other session commit'], { cwd: dir });
+
+    const mine = `${observed}\nmy stale payload.\n`;
+    const { r, out } = t4Apply(dir, t4Payload(dir, today, mine, 'ac5 committed'), 's-committed');
+
+    assert.notEqual(
+      r.status,
+      0,
+      'a committed external write is not, by itself, a licence to overwrite',
+    );
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(c, `the committed drift must still park: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(c.reason, 'base-mismatch');
+    assert.equal(
+      readFileSync(t4ProjectHot(dir), 'utf-8'),
+      otherSession,
+      "the other session's commit survives",
+    );
+  });
+});
+
+test('AC8: readBaseEntry reads an observed-bearing base.json the same as before ISSUE-116', () => {
+  withObservedProject((dir, _today, work) => {
+    const r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'ac8-sess' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const parsed = JSON.parse(readFileSync(bsBasePath(dir, 'ac8-sess'), 'utf-8'));
+    assert.ok(
+      parsed.observed && typeof parsed.observed === 'object',
+      'observed map must be present',
+    );
+    const entry = readBaseEntry(dir, 'ac8-sess', t4Rel);
+    assert.equal(entry.state, 'hash');
+    assert.equal(
+      entry.hash,
+      parsed.targets[t4Rel],
+      'readBaseEntry must still read straight off targets',
+    );
+  });
+});
+
+test('a resumed drift that arrived AFTER the observing SessionStart still parks (residual 2)', () => {
+  // The exact-hash comparison, end-to-end. `observed` holding SOME hash for a
+  // target is not a licence by itself — it must be the SAME hash disk carries
+  // right now. A loosened check ("any observation at all → allow") stays green
+  // on every other ISSUE-116 test here because they all drift BEFORE the
+  // observing resume; this one drifts AFTER, so only the exact comparison
+  // still parks it.
+  withObservedProject((dir, today, work) => {
+    let r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'resid2-sess' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `first SessionStart stderr: ${r.stderr}`);
+
+    r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'resid2-sess', source: 'resume' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `resume stderr: ${r.stderr}`);
+    assert.ok(
+      readObservedHash(dir, 'resid2-sess', t4Rel),
+      'the resume must have recorded an observation to begin with',
+    );
+
+    // Only AFTER this session was shown the file does another session write
+    // and commit — the one difference from AC1, where the drift lands BEFORE
+    // the observing resume.
+    const drifted = `${readFileSync(t4ProjectHot(dir), 'utf-8')}\nanother session wrote and committed this AFTER the resume observed it.\n`;
+    writeFileSync(t4ProjectHot(dir), drifted);
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-m', 'other session, post-observation'], { cwd: dir });
+
+    const mine = `${drifted}\nSHOULD NOT LAND.\n`;
+    const { r: closeR, out } = t4Apply(
+      dir,
+      t4Payload(dir, today, mine, 'resid2 close'),
+      'resid2-sess',
+    );
+    assert.notEqual(closeR.status, 0, 'drift that arrived after the observation must still park');
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(c, `post-observation drift must park: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(c.reason, 'base-mismatch');
+    assert.equal(
+      readFileSync(t4ProjectHot(dir), 'utf-8'),
+      drifted,
+      "the other session's post-observation write survives",
+    );
+  });
+});
+
+test('a SessionStart that injects nothing this generation expires a prior observation (end-to-end)', () => {
+  // Same shape as base-store.mjs's unit-level expiry test, but crossing the
+  // real hook process boundary: `beginObservedGeneration`'s call site in
+  // hypo-session-start.mjs, not a direct base-store call, is what must bump
+  // the generation on every SessionStart — deleting that call site left this
+  // green (readObservedHash's generation compare then always matches).
+  withObservedProject((dir, today, work) => {
+    let r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'expire-sess' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `first SessionStart stderr: ${r.stderr}`);
+
+    const drifted = `${readFileSync(t4ProjectHot(dir), 'utf-8')}\nanother session wrote and committed this.\n`;
+    writeFileSync(t4ProjectHot(dir), drifted);
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-m', 'other session'], { cwd: dir });
+
+    r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'expire-sess', source: 'resume' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `resume stderr: ${r.stderr}`);
+    assert.equal(
+      readObservedHash(dir, 'expire-sess', t4Rel),
+      bsHashContent(drifted),
+      'resume must have observed the drift',
+    );
+
+    // Hide the target from injection so the NEXT SessionStart shows this
+    // session nothing for it — the injection-free resume the expiry
+    // mechanism must expire the prior observation over.
+    writeFileSync(join(dir, '.hypoignore'), `${t4Rel}\n`);
+
+    r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'expire-sess', source: 'resume' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `second resume stderr: ${r.stderr}`);
+    assert.equal(
+      readObservedHash(dir, 'expire-sess', t4Rel),
+      null,
+      'a SessionStart that injected nothing this generation must expire the prior observation',
+    );
+
+    const mine = `${drifted}\nthis session's own addition after the injection-free resume.\n`;
+    const { r: closeR, out } = t4Apply(
+      dir,
+      t4Payload(dir, today, mine, 'expire close'),
+      'expire-sess',
+    );
+    assert.notEqual(closeR.status, 0, 'an expired observation must not license the write');
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(
+      c,
+      `the target must park once its observation expired: ${JSON.stringify(out.conflicts)}`,
+    );
+    assert.equal(c.reason, 'base-mismatch');
+    assert.equal(
+      readFileSync(t4ProjectHot(dir), 'utf-8'),
+      drifted,
+      "the other session's write survives",
+    );
+  });
+});
+
+test('two real SessionStarts (fresh + resume) advance observedGeneration to 2', () => {
+  // Cheap reinforcement of AC8: the generation counter itself must actually
+  // move across two real SessionStart invocations for the same session_id,
+  // not just once at the first snapshot.
+  withObservedProject((dir, _today, work) => {
+    let r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'gen2-sess' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `first SessionStart stderr: ${r.stderr}`);
+    r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'gen2-sess', source: 'resume' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `resume stderr: ${r.stderr}`);
+    const parsed = JSON.parse(readFileSync(bsBasePath(dir, 'gen2-sess'), 'utf-8'));
+    assert.equal(parsed.observedGeneration, 2, 'two SessionStarts must land two generations');
+  });
+});
+
+test('a truncated injection is stored but never licenses a close-time write (end-to-end)', () => {
+  // Real vault shape the spec measured (2026-09-03): 13 of 34 overwrite
+  // targets exceed HOT_CHARS/STATE_CHARS (2000). A file that grows past that
+  // slice gets recorded as observed-but-truncated, and truncated must never
+  // read back as a licence, regardless of how the drift arrived.
+  withObservedProject((dir, today, work) => {
+    let r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'trunc-sess' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `first SessionStart stderr: ${r.stderr}`);
+
+    const big = `${readFileSync(t4ProjectHot(dir), 'utf-8')}${'x'.repeat(2100)}\n`;
+    writeFileSync(t4ProjectHot(dir), big);
+    spawnSync('git', ['-C', dir, 'add', '-A']);
+    spawnSync('git', ['-C', dir, 'commit', '-m', 'grow past the injection slice'], { cwd: dir });
+
+    r = runHook(
+      'hypo-session-start.mjs',
+      { cwd: work, session_id: 'trunc-sess', source: 'resume' },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `resume stderr: ${r.stderr}`);
+    assert.equal(
+      readObservedHash(dir, 'trunc-sess', t4Rel),
+      null,
+      'a truncated injection must not read back as a licence',
+    );
+    assert.equal(wasObservedTruncated(dir, 'trunc-sess', t4Rel), true);
+
+    const mine = `${big}\nthis session's addition after the sliced resume.\n`;
+    const { r: closeR, out } = t4Apply(
+      dir,
+      t4Payload(dir, today, mine, 'truncated close'),
+      'trunc-sess',
+    );
+    assert.notEqual(closeR.status, 0, 'a truncated observation must not license the write');
+    const c = out.conflicts.find((x) => x.target === t4Rel);
+    assert.ok(c, `the target must park: ${JSON.stringify(out.conflicts)}`);
+    assert.equal(c.reason, 'base-mismatch-truncated-observation');
+    assert.equal(readFileSync(t4ProjectHot(dir), 'utf-8'), big, 'the target must stay untouched');
+  });
+});
+
+// The gate is only as good as the promise that nothing automated reaches it. Scan
+// EXECUTABLE code, not prose: a doc comment naming the command is documentation, a
+// call is a bypass.
+test('recordObserved is only ever handed injected bytes, never a fresh disk read', () => {
+  // The observed set licenses a close to overwrite bytes this session was SHOWN.
+  // That guarantee lives entirely in WHICH bytes get hashed at the call site:
+  // `hashContent(read.raw)`, where `read` is the same object the injection
+  // printed. Swapping it for `hashContent(readFileSync(path))` re-reads disk
+  // and would credit a write that landed between the read and this line as an
+  // observation that never happened — silently widening the license to bytes
+  // nobody saw.
+  //
+  // Behavioural tests cannot reach that window: it is inside a single hook
+  // process, between two adjacent statements, with no seam a fixture can drive.
+  // A mutation that made the swap left all 141 proposal-base tests green
+  // (measured 2026-09-03), which is exactly the gap this scan closes. Read
+  // the source, strip comments so a doc example cannot trip it, and pin the
+  // ARGUMENT SHAPE.
+  const src = readFileSync(join(REPO, 'hooks', 'hypo-session-start.mjs'), 'utf-8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+
+  // Every recordObserved(...) call, with its full argument list (the calls are
+  // multi-line, so `[\s\S]` and a lazy quantifier up to the closing paren).
+  const calls = [...src.matchAll(/recordObserved\(([\s\S]*?)\);/g)].map((m) => m[1]);
+  assert.equal(
+    calls.length,
+    3,
+    `expected the 3 known recordObserved call sites (HIT hot, HIT session-state, MISS root hot); found ${calls.length} — a new one must be checked by hand and added here`,
+  );
+
+  for (const args of calls) {
+    assert.match(
+      args,
+      /hashContent\(\s*\w+\.raw\s*\)/,
+      `recordObserved must hash the injected bytes (\`hashContent(<read>.raw)\`); got: ${args.replace(/\s+/g, ' ').trim()}`,
+    );
+    assert.equal(
+      /readFileSync|readIfNotIgnored|hashFile/.test(args),
+      false,
+      `recordObserved must not re-read the file at the call site; got: ${args.replace(/\s+/g, ' ').trim()}`,
+    );
+  }
 });
 
 // ── hypo-shared.mjs — withFileLock (FEAT-11 T5) ──────────────────────────────
@@ -3709,10 +4278,6 @@ test('ISSUE-49: hasTypedUserApproval pins the nonce shape (no wildcard match)', 
   });
 });
 
-// The gate is only as good as the promise that nothing automated reaches it. Scan
-// EXECUTABLE code, not prose: a doc comment naming the command is documentation, a
-// call is a bypass. (hypo-shared legitimately DEFINES the approval matcher; what it
-// must never do is drive an apply.)
 test('ISSUE-49: no hook invokes an apply path — approval is a human’s, never a hook’s', () => {
   const hooksDir = join(REPO, 'hooks');
   for (const name of readdirSync(hooksDir)) {


### PR DESCRIPTION
# English

## What changed

A session that spans days can now overwrite the close targets a later SessionStart showed it, instead of parking every one of them.

## Why

The base snapshot is taken once per session id by design: resume and compact reuse the same id, and re-taking it would adopt whatever another session had just written. Over a multi-day session other sessions commit to those same files legitimately, so by close time the base is days old and every compare reports drift. Nothing is lost, but a close that parks all four targets does not work.

## How

SessionStart records the hash of the bytes it injected, and close may write over a hash in that set. The snapshot itself never moves and the set only ever adds, so the original base is not lost.

This widens a contract, so the widening is bounded twice. Only the most recent SessionStart's injections count: a generation counter advances once per SessionStart and the reader requires an exact match, so a resume that injects nothing leaves every prior entry a generation behind and the licence expires without an explicit sweep. And a truncated injection is recorded but never licenses a write, because injection slices at 2000 characters while the hash covers the whole file. On the maintainer's vault 13 of 34 overwrite targets exceed that cap, the largest at 37,533 characters, so without this a file the model saw 5 percent of could be replaced wholesale. Those targets keep parking, under a reason that names truncation rather than reading as a generic mismatch.

Reader and writer normalize a missing generation counter differently, on purpose. Symmetric normalization had both sides read absent as zero, which compare equal, so deleting the single call that advances the counter would have disabled expiry with the whole suite still green.

Three guarantees are unchanged and still asserted: bytes written by another session with no SessionStart in between, a target this session only read, and one it wrote through an approved proposal all still park.

## Manual verification

Hooks changed, so beyond the suite:

- In an isolated vault, fed `hypo-session-start.mjs` directly and inspected the resulting base file: the generation counter, the per-target hashes, and the truncation flag. Grew one target past the cap and confirmed it records as truncated while a smaller one does not.
- Ran a third SessionStart with the targets excluded from injection and confirmed the counter advanced while every prior entry stayed behind it, so the licence expired on its own.
- Swapped the built hooks into the installed plugin cache, started a real headless Claude Code session, and confirmed via instrumentation that the plugin loader fires the hook. Restored the cache and verified it byte-identical to the pre-swap backup.
- Not verified: the same hook writing into a non-default vault under a real session. A session does not inherit `HYPO_DIR` from the invoking shell, so that path resolves to the operator's own vault and cannot be isolated without installing the plugin into a separate home.

## Migration notes

A base file written before this change has no observed set and no generation counter. The reader refuses a licence when the counter is absent, so those sessions behave exactly as they do today. A base file written by this change is ignored by an older reader, which requires only the targets map.

---

# 한국어

## 변경 내용

여러 날에 걸친 세션이 close 대상을 전부 파킹하지 않고, 나중 SessionStart가 보여준 바이트는 덮어쓸 수 있게 됐습니다.

## 이유

base 스냅샷은 세션 id마다 한 번만 찍도록 설계돼 있습니다. resume과 compact가 같은 id를 쓰므로 다시 찍으면 남이 방금 쓴 바이트를 base로 채택하게 됩니다. 그런데 여러 날 이어지는 세션에서는 그 사이 다른 세션들이 같은 파일을 정당하게 커밋하고, close 시점에 base가 며칠 묵어 모든 비교가 드리프트로 나옵니다. 데이터를 잃지는 않지만 대상 넷이 전부 파킹되면 close가 동작하지 않습니다.

## 방법

SessionStart가 주입한 바이트의 해시를 기록하고, close는 그 집합에 있는 해시를 덮어쓸 수 있습니다. 스냅샷 자체는 안 옮기고 집합은 덧붙이기만 하므로 원래 base를 잃지 않습니다.

계약을 넓히는 변경이라 두 겹으로 좁혔습니다. 가장 최근 SessionStart의 주입만 인정합니다. 세대 카운터가 SessionStart마다 한 번 오르고 reader가 정확한 일치를 요구하므로, 아무것도 주입하지 않은 resume은 이전 항목들을 한 세대 뒤에 남겨 면허가 저절로 만료됩니다. 그리고 잘린 주입은 기록은 되지만 면허가 되지 않습니다. 주입은 2000자에서 잘리는데 해시는 파일 전체를 덮기 때문입니다. 유지보수자 볼트 실측으로 overwrite 대상 34개 중 13개가 그 상한을 넘고 최대가 37,533자라, 이 방어가 없으면 모델이 5퍼센트만 본 파일이 통째로 교체될 수 있습니다. 그 대상들은 계속 파킹되고, 사유가 일반 불일치가 아니라 잘림을 지목합니다.

reader와 writer가 세대 카운터 부재를 일부러 다르게 정규화합니다. 대칭 정규화에서는 양쪽이 부재를 0으로 읽어 항상 일치하므로, 카운터를 올리는 그 한 호출을 지워도 만료가 죽은 채 스위트가 전부 green이었습니다.

바뀌지 않은 보증 셋도 그대로 단언됩니다. 사이에 SessionStart 없이 다른 세션이 쓴 바이트, 이 세션이 읽기만 한 대상, 승인된 proposal로 쓴 대상은 전부 계속 파킹됩니다.

## 수동 검증

훅을 바꿨으므로 테스트 외에:

- 격리된 볼트에서 `hypo-session-start.mjs`를 직접 먹이고 생성된 base 파일을 열어 세대 카운터, 대상별 해시, 잘림 표시를 확인했습니다. 한 대상을 상한 너머로 키워 잘림으로 기록되는 것과, 작은 대상은 아닌 것을 확인했습니다.
- 대상을 주입에서 제외한 채 세 번째 SessionStart를 돌려, 카운터는 올랐는데 이전 항목이 전부 뒤에 남아 면허가 스스로 만료되는 것을 확인했습니다.
- 빌드한 훅을 설치 플러그인 캐시에 갈아 끼우고 실제 헤드리스 세션을 띄워, 계측으로 플러그인 로더가 훅을 발화시키는 것을 확인했습니다. 캐시를 복원하고 교체 전 백업과 바이트 동일함을 확인했습니다.
- 확인하지 못한 것: 실제 세션에서 같은 훅이 기본값 아닌 볼트에 쓰는 경로. 세션은 호출 셸의 `HYPO_DIR`를 물려받지 않아 운영자 자신의 볼트로 해석되고, 별도 홈에 플러그인을 설치하지 않는 한 격리할 수 없습니다.

## 마이그레이션 노트

이 변경 이전에 쓰인 base 파일에는 관측 집합도 세대 카운터도 없습니다. reader가 카운터 부재에서 면허를 거부하므로 그 세션들은 지금과 똑같이 동작합니다. 이 변경이 쓴 base 파일은 구버전 reader가 무시합니다. 그쪽은 targets 맵만 요구하기 때문입니다.

---

## Changelog

- EN: A session that spans several days can close again: targets a later session start re-read are no longer parked as stale, while anything it was not shown in full still parks (#276).
- KO: 여러 날 이어진 세션도 close가 됩니다. 나중 세션 시작이 다시 읽어 보여준 대상은 묵었다고 파킹되지 않고, 전부를 보여주지 못한 것은 그대로 파킹됩니다 (#276).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
