### PR TITLE
fix(init,upgrade): stop recording a guessed npm path as the durable pointer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -218,7 +218,8 @@ Hooks inline this logic in `hypo-shared.mjs`. Scripts use `scripts/lib/hypo-root
 2. Creates the vault directory structure: `pages/`, `projects/`, `sources/`, `journal/{daily,weekly,monthly}/`.
 3. Copies `templates/` files: 6 root files (`hypo-config.md`, `index.md`, `hot.md`, `log.md`, `SCHEMA.md`, `hypo-guide.md`) + 4 helpers (`Home.md`, `Overview.md`, `hypo-automation.md`, `hypo-help.md`) + `pages/_index.md` + `projects/_template/`.
 4. Deploys 10 hooks to `~/.claude/hooks/` and merges entries into `~/.claude/settings.json` (idempotent; preserves non-hypo hooks).
-5. Writes `~/.claude/hypo-pkg.json` with `pkgRoot` for upgrade tracking.
+5. Writes `~/.claude/hypo-pkg.json` with `pkgRoot` for upgrade tracking (skipped when the
+   plugin channel judgment fails; see `init.mjs`'s `resolveDurableRoot`).
 6. `git init` + first commit `init: hypomnema wiki`. Pushes to remote when one is provided.
 
 `--dry-run` previews; `--no-hooks` and `--no-git-init` are also supported. Re-running `init` is idempotent — existing files are skipped, never overwritten.

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -270,13 +270,24 @@ function buildPkgRootDriftNotice() {
     const cache = readCache(cachePath);
     if (pkgRootDriftAlreadyNotified(cache, key)) return '';
     markPkgRootDriftNotified(cachePath, key);
+    // status.cached is null both for a genuinely fresh install (never ran
+    // /hypo:init) AND for the channel-judgment-failure guard (init/upgrade
+    // positively decided to leave pkgRoot unset; see scripts/init.mjs's
+    // resolveDurableRoot). "run /hypo:upgrade and confirm the apply step" is a
+    // dead end in the second case: apply skips the same write until the
+    // registry itself is fixed. Point at that fix directly rather than send the
+    // user in a loop.
+    const recoveryLine = status.cached
+      ? '  → run `/hypo:upgrade` and confirm the apply step to bring hypo-pkg.json back in sync.'
+      : '  → if `/hypo:upgrade` keeps leaving this unwritten, the plugin channel itself cannot be ' +
+        'resolved: repair `~/.claude/plugins/installed_plugins.json` first (reinstall the plugin, or ' +
+        'run `/plugin marketplace update hypomnema` then `/reload-plugins`), then re-run `/hypo:upgrade`.';
     return (
       `[Hypomnema] Package metadata drift: hypo-pkg.json still points at ` +
       `\`${status.cached || '(none)'}\`, but the code actually running resolves to ` +
       `\`${status.self}\`.\n` +
       `  Hooks already resolved the correct root for this session — this is a ` +
-      `heads-up, not a blocker.\n` +
-      `  → run \`/hypo:upgrade\` and confirm the apply step to bring hypo-pkg.json back in sync.`
+      `heads-up, not a blocker.\n${recoveryLine}`
     );
   } catch {
     return '';

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -2294,9 +2294,25 @@ function checkPkgIntegrity(claudeHome) {
   // no longer exists and this correctly falls into the silent fresh-install branch.
   if (!existsSync(pkgPath)) return;
   if (!meta || !meta.pkgRoot) {
+    // A missing pkgRoot has two distinct causes with different fixes. Re-running
+    // /hypo:init or /hypo:upgrade only helps the ordinary one (a corrupt or
+    // never-written file). When the enabled plugin's channel judgment itself
+    // failed ('registry-unreadable'/'unresolved'), init/upgrade skip the very
+    // same write on every re-run until the registry is fixed first (see
+    // resolveDurableRoot in init.mjs and the dualSkip branch in upgrade.mjs).
+    const channelJudgmentFailed =
+      hypomnemaPluginEnabled &&
+      (pluginChannel.rootReason === 'registry-unreadable' ||
+        pluginChannel.rootReason === 'unresolved');
     warn(
       'hypo-pkg.json pkgRoot',
-      `hypo-pkg.json has no pkgRoot field — metadata is incomplete; re-run /hypo:init or /hypo:upgrade`,
+      channelJudgmentFailed
+        ? `hypo-pkg.json has no pkgRoot field because the enabled plugin's channel judgment failed ` +
+            `(${pluginChannel.rootReason}): re-running /hypo:init or /hypo:upgrade will skip the same ` +
+            `write until this resolves. Fix: repair or refresh ~/.claude/plugins/installed_plugins.json ` +
+            '(reinstall the plugin, or run `/plugin marketplace update hypomnema` then `/reload-plugins`), ' +
+            'then re-run /hypo:init or /hypo:upgrade to record the confirmed root.'
+        : `hypo-pkg.json has no pkgRoot field — metadata is incomplete; re-run /hypo:init or /hypo:upgrade`,
     );
     return;
   }

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -954,11 +954,16 @@ function gitSetup(hypoDir, remote, dryRun) {
 
 // ── first commit + push ──────────────────────────────────────────────────────
 
+// Returns true only when THIS run actually created a commit. The
+// channel-unresolved notice keys its "the commit this run just made was
+// unguarded" sentence off that, so a repo that already had commits, a dry run,
+// and a failed commit must all read as false — none of them produced an
+// unguarded commit to warn about.
 function firstCommit(hypoDir, remote, dryRun) {
   const logR = git(hypoDir, ['log', '--oneline', '-1']);
   if (logR.status === 0 && logR.stdout.trim()) {
     log('skipped', 'first commit (repo already has commits)');
-    return;
+    return false;
   }
   const today = new Date().toISOString().slice(0, 10);
   if (!dryRun) {
@@ -966,7 +971,7 @@ function firstCommit(hypoDir, remote, dryRun) {
     const commitR = git(hypoDir, ['commit', '-m', `chore: init hypomnema (${today})`]);
     if (commitR.status !== 0) {
       log('errors', 'first commit failed');
-      return;
+      return false;
     }
     if (remote) {
       const actualOrigin = git(hypoDir, ['remote', 'get-url', 'origin']);
@@ -977,6 +982,7 @@ function firstCommit(hypoDir, remote, dryRun) {
     }
   }
   log('created', `first commit (${today})`);
+  return !dryRun;
 }
 
 // ── main ─────────────────────────────────────────────────────────────────────
@@ -1031,9 +1037,52 @@ function resolveDurableRoot() {
   if (pluginChannel.root) return pluginChannel.root;
   const recorded = recordedPkgRoot();
   if (usablePkgRoot(recorded)) return recorded;
-  return PKG_ROOT;
+  // pluginChannel.root is null here because the channel JUDGMENT FAILED (reason
+  // 'registry-unreadable' or 'unresolved'), not because no plugin is installed —
+  // hypomnemaPluginEnabled is already true, and that case already returned
+  // above. Falling back to PKG_ROOT would persist a GUESS as if it were the
+  // confirmed durable root; in a dual install PKG_ROOT is the manual/npm
+  // checkout the dual-install notice tells the user to remove, so that guess
+  // dangles the moment they do. A judge returning null here means "cannot
+  // positively resolve", never "resolved to nothing usable exists" — treating
+  // it as the latter is exactly the failure this fix closes.
+  // With no existing usable pointer to preserve either, leave the durable root
+  // UNRESOLVED (null) instead of guessing — the caller below skips writing the
+  // pointer and the pre-commit hook and prints recovery guidance rather than
+  // confirm a guess.
+  return null;
 }
 const durableRoot = resolveDurableRoot();
+// True only when the channel judgment itself failed and there was nothing usable
+// to fall back on (see resolveDurableRoot above) — never true for a genuinely
+// disabled/absent plugin, which resolves to PKG_ROOT and never reaches here.
+const channelUnresolved = durableRoot === null;
+let madeFirstCommit = false;
+
+function channelUnresolvedNotice(madeFirstCommit) {
+  // Step 9 (firstCommit) runs AFTER step 8b skipped the pre-commit hook install,
+  // so a commit this run created went out unguarded, not just future ones. Key
+  // this off what firstCommit actually did, never off the flags that merely make
+  // it eligible: --dry-run writes nothing, a repo with existing commits skips,
+  // and a failed commit produced none. Asserting "just made" in those cases
+  // sends the reader looking for a commit that does not exist.
+  const firstCommitCaveat = madeFirstCommit
+    ? ' The initial commit this run just made in the vault was not checked by that guard ' +
+      'either: it landed before any pre-commit hook existed to check it.'
+    : '';
+  return (
+    `⚠ Cannot positively resolve the enabled Hypomnema plugin's install root ` +
+    `(${pluginChannel.rootReason} — checked ~/.claude/plugins/installed_plugins.json). ` +
+    `Leaving the durable pointer UNSET rather than guessing the npm path at ${PKG_ROOT}: ` +
+    `that path is what a dual install's own notice tells you to remove, and baking it in ` +
+    `now would break every wiki commit the moment you do. hypo-pkg.json's pkgRoot and the ` +
+    `vault's git pre-commit hook are both skipped this run, so this wiki has no pre-commit ` +
+    `.hypoignore guard until this resolves.${firstCommitCaveat}\n` +
+    `  → Fix: repair or refresh ~/.claude/plugins/installed_plugins.json (reinstall the ` +
+    'plugin, or run `/plugin marketplace update hypomnema` then `/reload-plugins`), then ' +
+    're-run `hypomnema init` to record the confirmed root.'
+  );
+}
 
 // Validate hooks.json before any file writes so a bad package leaves no partial state
 const HOOK_MAP = args.hooks || args.codex ? loadHookMap() : null;
@@ -1157,7 +1206,20 @@ if (args.hooks) {
 // so this never clobbers a commands/extensions map written elsewhere.
 // Record hypo-pkg.json against the durable root (the plugin's real cache root in a
 // dual install, PKG_ROOT otherwise), the same root the wiki pre-commit hook uses.
-writePkgJson(args.dryRun, commandSHAs ? { commands: commandSHAs } : {}, durableRoot);
+// A null durableRoot means the channel judgment failed with nothing usable to
+// preserve (see resolveDurableRoot) — skip the write rather than stamp a guess;
+// channelUnresolvedNotice() above explains why and what closes it. The
+// extensions sync below (step 4b) still runs unconditionally and can leave a
+// pkgRoot-less hypo-pkg.json on disk in this case; that is doctor.mjs's own
+// distinct reported state ("no pkgRoot field"), never a confirmed PKG_ROOT.
+if (!channelUnresolved) {
+  writePkgJson(args.dryRun, commandSHAs ? { commands: commandSHAs } : {}, durableRoot);
+} else {
+  log(
+    'skipped',
+    'hypo-pkg.json pkgRoot (plugin channel judgment failed — see notice above; re-run after fixing the registry)',
+  );
+}
 
 // 4b. user extensions companion sync. Runs after
 // writePkgJson so the per-target SHA map is merged into the same hypo-pkg.json
@@ -1249,23 +1311,35 @@ if (args.hooks) {
 
 // 8b. wiki pre-commit hook (.hypoignore last-line-of-defence guard — §6.8).
 // Point it at the durable install root, not PKG_ROOT, so a dual install does not
-// embed a manual/npm path that dangles once the user uninstalls it.
-installWikiPreCommitHook(
-  args.hypoDir,
-  args.dryRun,
-  args.forceCommands,
-  durableRoot,
-  args.lintStrict,
-);
+// embed a manual/npm path that dangles once the user uninstalls it. A null
+// durableRoot means the channel judgment failed with nothing usable to fall
+// back on — skip installing the hook with a guessed root; an existing hook (if
+// any) is left exactly as-is, and channelUnresolvedNotice() above says what to
+// do next.
+if (!channelUnresolved) {
+  installWikiPreCommitHook(
+    args.hypoDir,
+    args.dryRun,
+    args.forceCommands,
+    durableRoot,
+    args.lintStrict,
+  );
+} else {
+  log(
+    'skipped',
+    `${args.hypoDir} pre-commit hook (plugin channel judgment failed — see notice above)`,
+  );
+}
 
 // 9. first commit + push (skip when cloned from remote — already has commits)
 if (args.gitInit && !args.fromRemote) {
-  firstCommit(args.hypoDir, args.gitRemote, args.dryRun);
+  madeFirstCommit = firstCommit(args.hypoDir, args.gitRemote, args.dryRun);
 }
 
 // ── report ───────────────────────────────────────────────────────────────────
 
 const lines = [];
+if (channelUnresolved) lines.push(channelUnresolvedNotice(madeFirstCommit), '');
 if (results.created.length)
   lines.push(
     `✓ Created (${results.created.length}):\n${results.created.map((p) => `  ${p}`).join('\n')}`,

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -1281,13 +1281,44 @@ if (args.apply) {
     //
     // If the metadata is MISSING or corrupt (status 'missing'; corrupt files are
     // renamed to *.corrupt-*.json by readPkgJson and then read as absent), there is
-    // no plugin identity to preserve. Write minimal fallback metadata pointing at
-    // this (same-version) npm copy so the plugin runtime can resolve a package root
-    // at all — strictly better than the pkgRoot-less file extension sync would
-    // otherwise create, or no file at all. The dual-install banner still tells the
-    // user to resolve the dual install.
+    // no plugin identity to preserve. Write minimal fallback metadata, but ONLY
+    // when the registry POSITIVELY resolves the plugin's root (pluginRegistryRoot
+    // below): a confirmed fact, not a guess. When the registry judgment instead
+    // fails ('registry-unreadable' or 'unresolved', pluginRegistryRoot null), this
+    // write is skipped; the unconditional extensions-SHA sync further down can
+    // still leave a pkgRoot-less hypo-pkg.json on disk in that case, and that is
+    // doctor.mjs's own distinct reported state ("no pkgRoot field"), never read as
+    // "resolved to PKG_ROOT". The dual-install banner still tells the user to
+    // resolve the dual install either way.
     if (pkgJson.status === 'missing') {
-      appliedPkgJson = writePluginModeMetadata();
+      if (pluginRegistryRoot) {
+        // Write the REGISTRY's root, not PKG_ROOT. writePluginModeMetadata()
+        // hardcodes PKG_ROOT — this npm/manual checkout, the very copy the
+        // dual-install banner above tells the user to uninstall — so calling it
+        // here made `upgrade --apply` bake a dangling pointer whenever the
+        // registry was fine and only hypo-pkg.json was missing. init writes the
+        // plugin root in that same state, so the two commands disagreed.
+        // writeDualSkipProvenance re-reads the registry root's package.json and
+        // returns false if it became unreadable since resolution (TOCTOU), so a
+        // false here means nothing was written, not that a guess was.
+        //
+        // It preserves `commands` where writePluginModeMetadata dropped it. That
+        // drop guarded against a manual install's stale SHA map falsely claiming
+        // ~/.claude/commands/hypo. This branch only runs when hypo-pkg.json is
+        // MISSING, so there is no prior map to carry over and the guard has
+        // nothing to do.
+        appliedPkgJson = writeDualSkipProvenance(pkgJsonPath(), pluginRegistryRoot);
+      } else {
+        // pluginRegistryRoot is null here because the registry JUDGMENT FAILED
+        // (reason 'registry-unreadable' or 'unresolved') — hypomnemaPluginEnabled
+        // is true throughout this branch, so this is never "no plugin installed".
+        // With no existing metadata to preserve either, writing PKG_ROOT (this
+        // npm/manual checkout) would persist a GUESS as durable truth — exactly
+        // the removable copy the dual-install banner above tells the user to
+        // uninstall. Leave hypo-pkg.json unwritten instead; the banner below
+        // names the fix.
+        appliedPkgJson = false;
+      }
     } else if (dualSkipWouldCorrect) {
       // npm-first correction: a usable pkgRoot IS already recorded (status
       // 'stale' or 'up-to-date'), but the registry positively resolves a
@@ -1496,6 +1527,33 @@ if (dualSkip) {
     '    risk), re-run with `--allow-dual-install`.',
     '',
   );
+  // The registry judgment failed (registry-unreadable / unresolved) and there
+  // was no existing hypo-pkg.json to preserve, so the guard above left it
+  // unwritten rather than guess PKG_ROOT. Tell the user what unblocks it —
+  // without this, "no metadata written" looks like a silent no-op with no path
+  // forward.
+  if (pkgJson.status === 'missing' && !pluginRegistryRoot) {
+    // hooks/hypo-shared.mjs's resolvePkgRoot() resolves lint/feedback scripts by
+    // self-location first, never through this cache, so those keep working with
+    // or without this file. What actually goes without a root to resolve through:
+    // commands/*.md's resolution chain, and hypo-session-start's update-notifier
+    // and stale-sibling notices (both read hypo-pkg.json directly).
+    const unwrittenClause = args.apply
+      ? 'Leaving hypo-pkg.json UNWRITTEN this run'
+      : 'hypo-pkg.json would be left UNWRITTEN on --apply';
+    lines.push(
+      `⚠ Cannot positively resolve the enabled plugin's install root (${pluginChannel.rootReason}` +
+        ' — checked ~/.claude/plugins/installed_plugins.json), and no existing hypo-pkg.json to' +
+        ` fall back on. ${unwrittenClause} instead of guessing the npm path above: ` +
+        "`commands/*.md`'s resolution chain and the session-start update/sibling notices have no" +
+        ' pkgRoot to read until this is fixed (hooks keep resolving their own root by' +
+        ' self-location regardless).',
+      '  → Fix: repair or refresh ~/.claude/plugins/installed_plugins.json (reinstall the plugin,',
+      '    or run `/plugin marketplace update hypomnema` then `/reload-plugins`),',
+      '    then re-run `hypomnema upgrade --apply` to record the confirmed root.',
+      '',
+    );
+  }
 } else if (dualInstallCoreConflict && args.allowDualInstall) {
   // Override path: the user forced core registration despite the enabled plugin.
   lines.push(

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -1302,11 +1302,18 @@ if (args.apply) {
         // returns false if it became unreadable since resolution (TOCTOU), so a
         // false here means nothing was written, not that a guess was.
         //
-        // It preserves `commands` where writePluginModeMetadata dropped it. That
-        // drop guarded against a manual install's stale SHA map falsely claiming
-        // ~/.claude/commands/hypo. This branch only runs when hypo-pkg.json is
-        // MISSING, so there is no prior map to carry over and the guard has
-        // nothing to do.
+        // Drop `commands` on the way through. writeDualSkipProvenance preserves
+        // it (correctly, for the npm-first correction path where a real prior
+        // pointer is being retargeted), but this branch is reached whenever
+        // checkPkgJson reports 'missing' — and that includes a file that EXISTS
+        // with no usable pkgRoot, not just an absent one. Such a file can still
+        // carry a manual install's command SHA map, and no commands were copied
+        // in this dual-install skip, so carrying it over would re-assert
+        // ownership of ~/.claude/commands/hypo that this run never took. That
+        // drop is exactly what writePluginModeMetadata was doing here before,
+        // and it is the one part of it worth keeping.
+        const { commands: _stale, ...keep } = readPkgJsonSafe(pkgJsonPath()) || {};
+        writePkgJsonAtomic(pkgJsonPath(), keep);
         appliedPkgJson = writeDualSkipProvenance(pkgJsonPath(), pluginRegistryRoot);
       } else {
         // pluginRegistryRoot is null here because the registry JUDGMENT FAILED

--- a/tests/init.test.mjs
+++ b/tests/init.test.mjs
@@ -19,7 +19,7 @@ import {
   cpSync,
   realpathSync,
 } from 'node:fs';
-import { join, isAbsolute } from 'node:path';
+import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
 import { PROVENANCE_FILENAME } from '../scripts/lib/pkg-provenance.mjs';
@@ -28,6 +28,7 @@ import {
   SHELL_MARKER_START,
   SHELL_MARKER_END,
   SHELL_FUNCTION_BODY,
+  wikiPreCommitContent,
 } from '../scripts/lib/git-hooks-dir.mjs';
 import {
   HOME,
@@ -1246,9 +1247,15 @@ test('dual install prefers the user-scope registry entry over a preceding local 
 
 // A relative installPath (e.g. ".") would resolve against the caller's cwd and
 // break the vault hook from any other directory, so it is not a usable durable
-// root; resolution falls back rather than recording a relative pointer.
-test('dual install rejects a relative registry installPath and falls back', () => {
-  withFakeInitInstall(false, ({ init, root, home }) => {
+// root — but the registry itself parsed fine (reason 'unresolved'), which is a
+// channel JUDGMENT FAILURE, never "no plugin installed". IMPR-51 / ADR 0097:
+// with no existing pointer to preserve either, resolution must leave the
+// durable root UNRESOLVED rather than fall back to a guessed PKG_ROOT — a
+// guessed npm path baked into hypo-pkg.json/the pre-commit hook would dangle
+// the moment the dual-install notice's recommended npm uninstall happens.
+// This replaces the prior expectation (fallback to PKG_ROOT was blessed).
+test('dual install + unresolved registry entry (relative installPath) + new vault: no pkgRoot is guessed', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
     const hypoDir = join(tmpdir(), `hypo-init-relpath-${process.pid}-${Date.now()}`);
     try {
       enablePlugin(home);
@@ -1262,17 +1269,20 @@ test('dual install rejects a relative registry installPath and falls back', () =
       );
       const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init'], home);
       assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
-      const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
-      assert.notEqual(
-        meta.pkgRoot,
-        '.',
-        'a relative installPath must never be recorded as pkgRoot',
-      );
-      assert.ok(isAbsolute(meta.pkgRoot), `recorded pkgRoot must be absolute: ${meta.pkgRoot}`);
       assert.equal(
-        realpathSync(meta.pkgRoot),
-        realpathSync(root),
-        'with no usable registry root, resolution falls back to PKG_ROOT',
+        existsSync(join(home, '.claude', 'hypo-pkg.json')),
+        false,
+        'with --no-hooks, nothing else writes hypo-pkg.json — an unresolved registry judgment must leave it absent, not stamp a guessed PKG_ROOT',
+      );
+      assert.match(
+        r.stdout,
+        /Cannot positively resolve the enabled Hypomnema plugin's install root/,
+        'must explain why the pointer was left unset and what unblocks it',
+      );
+      assert.match(
+        r.stdout,
+        /re-run `hypomnema init`/,
+        'recovery guidance must name the concrete next step',
       );
     } finally {
       rmSync(hypoDir, { recursive: true, force: true });
@@ -1317,10 +1327,18 @@ test('dual install refuses to run an older npm init against a newer registry plu
   });
 });
 
-test('dual install falls back when the recorded pkgRoot is not a usable package dir', () => {
+// IMPR-51 / ADR 0097: `enablePlugin` (no installed_plugins.json write) makes the
+// registry lookup fail with reason 'registry-unreadable' — a JUDGMENT FAILURE,
+// never "no plugin installed". The existing pointer here is already unusable
+// (no package.json), so there is nothing valid to preserve either. Confirming
+// it as PKG_ROOT (the old fallback) would bless a GUESS as durable truth; the
+// fix leaves the existing (already-invalid) pointer exactly as recorded,
+// touching nothing, rather than replace one guess with another.
+test('dual install + unusable existing pkgRoot + unreadable registry: pointer is left untouched, not replaced with a guess', () => {
   withFakeInitInstall(false, ({ init, root, home }) => {
     // An existing directory that is NOT a package (no package.json): the runtime
-    // cannot resolve scripts through it, so preservation must NOT bless it.
+    // cannot resolve scripts through it, so preservation must NOT bless it —
+    // but confirming a DIFFERENT guess in its place is exactly as wrong.
     const emptyRoot = mkdtempSync(join(tmpdir(), 'hypo-empty-root-'));
     const hypoDir = join(tmpdir(), `hypo-init-dual-unusable-${process.pid}-${Date.now()}`);
     try {
@@ -1333,9 +1351,19 @@ test('dual install falls back when the recorded pkgRoot is not a usable package 
       assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
       const meta = JSON.parse(readFileSync(join(home, '.claude', 'hypo-pkg.json'), 'utf-8'));
       assert.equal(
+        meta.pkgRoot,
+        emptyRoot,
+        'an unresolvable registry judgment must leave an already-invalid pointer untouched, not confirm PKG_ROOT in its place',
+      );
+      assert.notEqual(
         realpathSync(meta.pkgRoot),
         realpathSync(root),
-        'an existing-but-unusable pkgRoot (no package.json) must fall back to PKG_ROOT, not be preserved',
+        'PKG_ROOT must never be stamped as a substitute guess here',
+      );
+      assert.match(
+        r.stdout,
+        /Cannot positively resolve the enabled Hypomnema plugin's install root/,
+        'must explain why the invalid pointer was left as-is',
       );
     } finally {
       rmSync(emptyRoot, { recursive: true, force: true });
@@ -1344,27 +1372,155 @@ test('dual install falls back when the recorded pkgRoot is not a usable package 
   });
 });
 
-test('dual install writes fallback metadata when no prior pointer exists', () => {
-  withFakeInitInstall(false, ({ init, root, home }) => {
+// IMPR-51 / ADR 0097: same registry failure, but a genuinely NEW vault (no
+// hypo-pkg.json at all) — nothing to preserve. hypo-pkg.json may still end up
+// on disk (the unconditional extensions-SHA sync writes one even with zero
+// extensions), but it must carry no pkgRoot field: a pkgRoot-less file is
+// doctor's own distinct, reported state, never "resolved to PKG_ROOT".
+// The unguarded-first-commit sentence in the channel-unresolved notice must key
+// off what firstCommit ACTUALLY did, not off the flags that merely make it
+// eligible. These two are a pair: the same notice, once where this run created
+// the commit and once where it did not. Without the negative half, conditioning
+// the sentence on `args.gitInit && !args.fromRemote` — which is wrong for
+// --dry-run and for a vault that already has commits — reads as correct.
+test('channel unresolved + a vault that already has commits: the notice does NOT claim this run made one', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
+    const hypoDir = join(tmpdir(), `hypo-init-nocommit-${process.pid}-${Date.now()}`);
+    try {
+      // gitInit stays TRUE here on purpose. `--no-git-init` would make the old
+      // flag-based condition (`args.gitInit && !args.fromRemote`) false too, so
+      // the two halves of this pair would agree under both the old and the new
+      // code and distinguish nothing. The condition this pins is the one where
+      // the flags say "eligible" but firstCommit still produced nothing: a repo
+      // that already has a commit, which firstCommit skips outright.
+      mkdirSync(hypoDir, { recursive: true });
+      spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+      spawnSync('git', ['-C', hypoDir, 'config', 'user.email', 'test@test.com']);
+      spawnSync('git', ['-C', hypoDir, 'config', 'user.name', 'Test']);
+      writeFileSync(join(hypoDir, 'seed.md'), 'seed\n');
+      spawnSync('git', ['-C', hypoDir, 'add', '-A'], { stdio: 'ignore' });
+      spawnSync('git', ['-C', hypoDir, 'commit', '-m', 'seed'], { stdio: 'ignore' });
+      enablePlugin(home);
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`], home);
+      assert.equal(r.status, 0, `init should exit 0: ${r.stderr}`);
+      assert.match(
+        r.stdout,
+        /Cannot positively resolve the enabled Hypomnema plugin's install root/,
+        'fixture: the channel-unresolved notice must actually be printed here',
+      );
+      assert.doesNotMatch(
+        r.stdout,
+        /initial commit this run just made/,
+        'firstCommit skipped a repo that already had commits, so the notice must not send the reader looking for one',
+      );
+    } finally {
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('channel unresolved + a git-init run: the notice DOES name the unguarded first commit', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
+    const hypoDir = join(tmpdir(), `hypo-init-didcommit-${process.pid}-${Date.now()}`);
+    try {
+      enablePlugin(home);
+      // init runs `git init` itself here, so there is no repo to `git config`
+      // beforehand and HOME is a bare temp dir with no global identity. Without
+      // these, the commit fails and init exits 1 — the assertion below would
+      // then be measuring a failed run, not an unguarded commit.
+      const r = spawnSync(process.execPath, [init, `--hypo-dir=${hypoDir}`], {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          HYPO_DIR: '',
+          HOME: home,
+          GIT_AUTHOR_NAME: 'Test',
+          GIT_AUTHOR_EMAIL: 'test@test.com',
+          GIT_COMMITTER_NAME: 'Test',
+          GIT_COMMITTER_EMAIL: 'test@test.com',
+        },
+      });
+      assert.equal(r.status, 0, `init should exit 0: ${r.stdout}\n${r.stderr}`);
+      assert.match(
+        r.stdout,
+        /Cannot positively resolve the enabled Hypomnema plugin's install root/,
+        'fixture: the channel-unresolved notice must actually be printed here',
+      );
+      assert.match(
+        r.stdout,
+        /initial commit this run just made/,
+        'a run that DID create the first commit must say that commit went out unguarded',
+      );
+    } finally {
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('dual install + no prior pointer + unreadable registry: no pkgRoot is guessed', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
     const hypoDir = join(tmpdir(), `hypo-init-dual-fresh-${process.pid}-${Date.now()}`);
     try {
+      // A real git repo, not the `--no-git-init` absence of one: without this
+      // `.git`, hooksDirForInstall no-ops before the channelUnresolved guard on
+      // the pre-commit-hook write ever runs, so the assertion on it below would
+      // pass whether or not that guard exists at all.
+      spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
       enablePlugin(home); // plugin enabled, but no hypo-pkg.json on disk yet
       const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
       assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
       const pkgPath = join(home, '.claude', 'hypo-pkg.json');
-      assert.ok(
-        existsSync(pkgPath),
-        'runtime needs a resolvable pointer — fallback must be written',
-      );
-      const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-      // init derives PKG_ROOT from its own real script path; realpath both sides so
-      // the macOS /var → /private/var symlink does not make an equal path look unequal.
+      const meta = existsSync(pkgPath) ? JSON.parse(readFileSync(pkgPath, 'utf-8')) : {};
       assert.equal(
-        realpathSync(meta.pkgRoot),
-        realpathSync(root),
-        'with no prior pointer to preserve, dual install falls back to its own PKG_ROOT so resolution is not left empty',
+        meta.pkgRoot,
+        undefined,
+        'with no prior pointer to preserve, an unresolvable registry must leave pkgRoot unset rather than guess PKG_ROOT',
+      );
+      assert.equal(
+        existsSync(join(hypoDir, '.git', 'hooks', 'pre-commit')),
+        false,
+        'the channel-judgment-failure guard must also skip the vault pre-commit hook install, not just the pkgRoot write',
+      );
+      assert.match(
+        r.stdout,
+        /Cannot positively resolve the enabled Hypomnema plugin's install root/,
+        'must explain why no pointer was written and what unblocks it',
+      );
+      assert.match(
+        r.stdout,
+        /re-run `hypomnema init`/,
+        'recovery guidance must name the concrete next step',
       );
     } finally {
+      rmSync(hypoDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Sibling to the test above: it pins the "skip installing" half of the guard.
+// This pins the other half, "leave an ALREADY-installed hook exactly as-is" —
+// a run that hits channelUnresolved must not touch a hypo-managed pre-commit
+// hook that a prior, successful init already wrote.
+test('dual install + unreadable registry + an existing hypo-managed pre-commit hook: the hook is left byte-identical', () => {
+  withFakeInitInstall(false, ({ init, home }) => {
+    const hypoDir = join(tmpdir(), `hypo-init-dual-existing-hook-${process.pid}-${Date.now()}`);
+    const priorRoot = makePluginRoot(); // stand-in for whatever root the prior successful init used
+    try {
+      spawnSync('git', ['init', hypoDir], { stdio: 'ignore' });
+      const hookPath = join(hypoDir, '.git', 'hooks', 'pre-commit');
+      writeFileSync(hookPath, wikiPreCommitContent(priorRoot, hypoDir, false), { mode: 0o755 });
+      const beforeSHA = createHash('sha256').update(readFileSync(hookPath)).digest('hex');
+      enablePlugin(home); // plugin enabled, but the registry itself is unreadable
+      const r = runInitFrom(init, [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
+      assert.equal(r.status, 0, `dual-install init should exit 0: ${r.stderr}`);
+      const afterSHA = createHash('sha256').update(readFileSync(hookPath)).digest('hex');
+      assert.equal(
+        afterSHA,
+        beforeSHA,
+        'an existing hypo-managed pre-commit hook must be left byte-identical when the channel judgment fails',
+      );
+    } finally {
+      rmSync(priorRoot, { recursive: true, force: true });
       rmSync(hypoDir, { recursive: true, force: true });
     }
   });

--- a/tests/upgrade.test.mjs
+++ b/tests/upgrade.test.mjs
@@ -1033,24 +1033,46 @@ test('dual install: --apply does NOT copy hooks or register settings (no double-
   });
 });
 
-test('dual install + missing metadata: --apply writes fallback with a pkgRoot (no pkgRoot-less file)', () => {
+// IMPR-51 / ADR 0097: `withDualInstall` enables the plugin in settings.json but
+// never writes installed_plugins.json, so the registry lookup fails with reason
+// 'registry-unreadable' — a JUDGMENT FAILURE, not "no plugin installed". With no
+// existing hypo-pkg.json to preserve either, writing PKG_ROOT (this npm/manual
+// checkout) here would persist a GUESS as durable truth — the exact removable
+// copy the dual-install banner tells the user to uninstall. This replaces the
+// prior expectation (a fallback pkgRoot was always written); the fallback must
+// NOT fire when the channel judgment itself failed. hypo-pkg.json may still
+// exist afterward (the unconditional extensions-SHA sync writes one even with
+// zero extensions — see syncExtensions step (4)), so the assertion is on the
+// pkgRoot FIELD, not file existence: doctor already treats a pkgRoot-less file
+// as its own distinct, reported state (`hypo-pkg.json has no pkgRoot field`),
+// never as "resolved to PKG_ROOT".
+test('dual install + missing metadata + unresolvable registry: --apply does not stamp a guessed pkgRoot', () => {
   withDualInstall(true, ({ upgrade, home, wiki }) => {
     const pkgPath = join(home, '.claude', 'hypo-pkg.json');
     assert.equal(existsSync(pkgPath), false, 'precondition: no metadata yet');
     const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
     assert.equal(r.status, 0, `dual-install --apply (missing meta) should exit 0: ${r.stderr}`);
-    assert.ok(existsSync(pkgPath), 'a fallback hypo-pkg.json must be written when none existed');
-    const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    const meta = existsSync(pkgPath) ? JSON.parse(readFileSync(pkgPath, 'utf-8')) : {};
     assert.equal(
-      typeof meta.pkgRoot === 'string' && meta.pkgRoot.length > 0,
-      true,
-      'fallback metadata must carry a pkgRoot — never a pkgRoot-less file (codex CONCERN)',
+      meta.pkgRoot,
+      undefined,
+      'an unresolvable registry judgment must not confirm a guessed PKG_ROOT as the durable pointer',
     );
-    // still no core hooks copied (skip stands; only metadata was written)
+    assert.match(
+      r.stdout,
+      /Cannot positively resolve the enabled plugin's install root/,
+      'must explain why no pkgRoot was written and what unblocks it',
+    );
+    assert.match(
+      r.stdout,
+      /re-run `hypomnema upgrade --apply`/,
+      'recovery guidance must name the concrete next step',
+    );
+    // still no core hooks copied (skip stands; the pkgRoot write was skipped too)
     assert.equal(
       existsSync(join(home, '.claude', 'hooks')),
       false,
-      'fallback metadata write must not also copy core hooks',
+      'the skipped fallback write must not also copy core hooks',
     );
   });
 });
@@ -1170,6 +1192,55 @@ function writeRegistry(home, key, installPath) {
 }
 
 const DUAL_INSTALL_KEY = 'hypomnema@hypomnema'; // matches withDualInstall's settings.json fixture
+
+// Positive control for the missing-metadata guard: once the registry DOES
+// positively resolve a usable root, metadata is still written — the guard is
+// keyed to the judgment-FAILURE case, not to "missing metadata" in general.
+//
+// The recorded root is the REGISTRY's, not this run's PKG_ROOT. An earlier draft
+// of this test asserted PKG_ROOT and called correcting it "a separate concern".
+// It is not separate: PKG_ROOT here is the npm/manual copy the dual-install
+// banner tells the user to uninstall, so stamping it leaves a pointer that
+// dangles the moment they follow that advice — the exact failure this lane
+// exists to close. It also made `init` and `upgrade --apply` disagree in the
+// same state, since init writes the plugin root. Asserting PKG_ROOT here pinned
+// the defect as the contract.
+test("dual install + missing metadata + resolvable registry: --apply records the REGISTRY root, not this run's PKG_ROOT", () => {
+  withDualInstall(true, ({ upgrade, home, wiki, root }) => {
+    withRegistryRoot('9.9.9', (registryRoot) => {
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      writeRegistry(home, DUAL_INSTALL_KEY, registryRoot);
+      assert.equal(existsSync(pkgPath), false, 'precondition: no metadata yet');
+      const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+      assert.equal(
+        r.status,
+        0,
+        `dual-install --apply (resolvable registry) should exit 0: ${r.stderr}`,
+      );
+      assert.ok(
+        existsSync(pkgPath),
+        'a fallback hypo-pkg.json must still be written once the registry resolves',
+      );
+      const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      assert.equal(
+        realpathSync(meta.pkgRoot),
+        realpathSync(registryRoot),
+        'the durable pointer must name the registry root, never this npm run',
+      );
+      assert.notEqual(
+        realpathSync(meta.pkgRoot),
+        realpathSync(root),
+        'stamping PKG_ROOT here would dangle as soon as the user uninstalls the npm copy',
+      );
+      assert.equal(meta.pkgVersion, '9.9.9', 'and the version read at that same root');
+      assert.doesNotMatch(
+        r.stdout,
+        /Cannot positively resolve the enabled plugin's install root/,
+        'a resolvable registry must not print the judgment-failure recovery notice',
+      );
+    });
+  });
+});
 
 test('npm-first correction: stale npm pkgRoot + a real registry entry → dualSkip corrects to the registry root', () => {
   withDualInstall(true, ({ upgrade, home, wiki }) => {

--- a/tests/upgrade.test.mjs
+++ b/tests/upgrade.test.mjs
@@ -1242,6 +1242,48 @@ test("dual install + missing metadata + resolvable registry: --apply records the
   });
 });
 
+// checkPkgJson reports 'missing' for a file that EXISTS but has no usable
+// pkgRoot, so the dual-skip fallback branch is reached with a real file on disk
+// — not only with none. That file can carry a manual install's command SHA map,
+// and this run copied no commands, so carrying the map over would re-assert
+// ownership of ~/.claude/commands/hypo that the run never took. The writer used
+// here preserves unknown fields by design (the npm-first correction path needs
+// that), so the drop has to happen at this call site.
+test('dual install + a pkgRoot-less file that still carries a commands map: the map is dropped, not carried over', () => {
+  withDualInstall(true, ({ upgrade, home, wiki }) => {
+    withRegistryRoot('9.9.9', (registryRoot) => {
+      const pkgPath = join(home, '.claude', 'hypo-pkg.json');
+      writeRegistry(home, DUAL_INSTALL_KEY, registryRoot);
+      // No pkgRoot: checkPkgJson calls this 'missing' even though it exists.
+      writeFileSync(
+        pkgPath,
+        JSON.stringify({
+          commands: { 'hypo/query.md': 'deadbeef' },
+          extensions: { claude: { 'skills/x': 'cafe' } },
+        }),
+      );
+      const r = runUpgrade(upgrade, [`--hypo-dir=${wiki}`, '--apply'], home);
+      assert.equal(r.status, 0, `dual-install --apply should exit 0: ${r.stderr}`);
+      const meta = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      assert.equal(
+        realpathSync(meta.pkgRoot),
+        realpathSync(registryRoot),
+        'fixture: the registry root must still be recorded',
+      );
+      assert.equal(
+        'commands' in meta,
+        false,
+        'a stale command SHA map must not survive: this run copied no commands',
+      );
+      assert.equal(
+        typeof meta.extensions,
+        'object',
+        `every other prior field survives the drop (extensions=${JSON.stringify(meta.extensions)})`,
+      );
+    });
+  });
+});
+
 test('npm-first correction: stale npm pkgRoot + a real registry entry → dualSkip corrects to the registry root', () => {
   withDualInstall(true, ({ upgrade, home, wiki }) => {
     withRegistryRoot('9.9.9', (registryRoot) => {


### PR DESCRIPTION
# English

## What changed

`init` and `upgrade` no longer record a guessed npm path as the durable package pointer when the plugin channel cannot be resolved, and the recovery guidance in three places now names the step that actually unblocks it.

## Why

With the plugin enabled but its registry unreadable or unresolvable, both commands fell through to the currently running npm checkout and wrote that path into `hypo-pkg.json` and the vault's git pre-commit hook. That checkout is the copy the dual-install notice tells the user to remove, so following that advice left a dangling pointer and broke every wiki commit. A null from the resolver means the judgment failed; it does not mean no plugin is installed, and reading the second as the first is what produced the guess.

## How

Neither command persists a root it could not confirm. An existing pointer is left exactly as found, valid or not. The cost is real and stated rather than hidden: a new vault is left without the `.hypoignore` pre-commit guard until the registry is repaired, and a run that created the vault's first commit says that commit went out unchecked.

Three surfaces that report this state used to send the reader to `/hypo:upgrade`, which in this state skips again. The session-start drift banner and doctor's pkgRoot warning now split on the same judgment and ask for the registry first. A recovery step that cannot work is worse than none, because the reader spends the loop before doubting it.

The missing-metadata path with a working registry was writing the npm root too. That sat outside the judgment-failure guard and read as a separate concern, but it is the same invariant: `init` writes the plugin root in that state while `upgrade --apply` wrote the removable copy, so the two disagreed. It now writes the registry's own root, and the assertion that had pinned the old value as the contract asserts the registry root instead.

## Manual verification

A hook changed (`hypo-session-start.mjs`, for the drift banner), so beyond the suite:

- Built a judgment-failure state in an isolated vault (plugin enabled in settings, unreadable registry file) and ran the hook directly. Confirmed the banner names the registry repair and the plugin marketplace refresh, not a bare `/hypo:upgrade`.
- Ran the same probe against a worktree without this change as a control, and saw the old dead-end wording, so the check distinguishes the two.
- Swapped the built hooks into the installed plugin cache, started a real headless Claude Code session, and confirmed via instrumentation that the plugin loader fires the hook. Restored the cache and verified it byte-identical to the pre-swap backup.
- `npm run check:pack-surface` unchanged at 142 files: no new file was added to the ship surface.

## Migration notes

An install that already has a valid pointer is untouched. An install whose pointer is absent or invalid while the registry cannot be read now keeps that state instead of overwriting it with the npm path, and the notice explains what to repair. No data migration is required.

---

# 한국어

## 변경 내용

플러그인 채널을 해석하지 못할 때 `init`과 `upgrade`가 추측한 npm 경로를 durable 포인터로 기록하지 않습니다. 그리고 세 자리의 복구 안내가 실제로 상황을 푸는 단계를 지목합니다.

## 이유

플러그인이 enabled인데 registry를 못 읽거나 해석하지 못하면, 두 명령 모두 지금 도는 npm 체크아웃으로 폴백해 그 경로를 `hypo-pkg.json`과 볼트 git pre-commit 훅에 썼습니다. 그 체크아웃은 dual install 안내가 지우라고 권하는 사본입니다. 안내대로 지우면 포인터가 끊겨 모든 위키 커밋이 깨집니다. resolver의 null은 판정이 실패했다는 뜻이지 플러그인이 없다는 뜻이 아닌데, 후자로 읽은 것이 그 추측을 만들었습니다.

## 방법

두 명령 다 확인하지 못한 root를 영속하지 않습니다. 기존 포인터는 유효하든 아니든 있는 그대로 둡니다. 비용은 감추지 않고 명시합니다. 새 볼트는 registry가 복구될 때까지 `.hypoignore` pre-commit 보호 없이 남고, 볼트의 첫 커밋을 만든 실행은 그 커밋이 검사 없이 나갔다고 말합니다.

이 상태를 보고하던 세 표면이 `/hypo:upgrade`를 지목했는데 그 명령은 이 상태에서 다시 건너뜁니다. 세션 시작 drift 배너와 doctor의 pkgRoot 경고가 같은 판정으로 갈려 registry 수리를 먼저 요구합니다. 동작할 수 없는 복구 단계는 없느니만 못합니다. 독자가 의심하기 전에 그 왕복을 먼저 쓰기 때문입니다.

registry가 멀쩡한데 metadata만 없는 경로도 npm root를 쓰고 있었습니다. 판정 실패 가드 밖이라 별개 관심사로 읽혔지만 같은 불변식입니다. 그 상태에서 `init`은 플러그인 root를 쓰는데 `upgrade --apply`는 지우라고 권하는 사본을 써서 둘이 어긋났습니다. 이제 registry 자신의 root를 쓰고, 옛 값을 계약으로 고정하던 단언이 registry root를 단언합니다.

## 수동 검증

훅을 바꿨으므로(`hypo-session-start.mjs`의 drift 배너) 테스트 외에:

- 격리된 볼트에 판정 실패 상태를 만들고(settings에는 enabled, registry 파일은 못 읽음) 훅을 직접 실행했습니다. 배너가 맨 `/hypo:upgrade`가 아니라 registry 수리와 플러그인 마켓플레이스 갱신을 지목하는 것을 확인했습니다.
- 이 변경이 없는 워크트리에 같은 프로브를 돌려 대조군으로 옛 막다른 문구를 봤습니다. 이 확인이 둘을 실제로 구별합니다.
- 빌드한 훅을 설치 플러그인 캐시에 갈아 끼우고 실제 헤드리스 세션을 띄워, 계측으로 플러그인 로더가 훅을 발화시키는 것을 확인했습니다. 캐시를 복원하고 교체 전 백업과 바이트 동일함을 확인했습니다.
- `npm run check:pack-surface`가 142개 파일로 그대로입니다. 출하 표면에 새 파일이 안 붙었습니다.

## 마이그레이션 노트

이미 유효한 포인터가 있는 설치는 안 건드립니다. 포인터가 없거나 무효인데 registry를 못 읽는 설치는 이제 그 상태를 npm 경로로 덮어쓰지 않고 유지하며, 안내가 무엇을 고쳐야 하는지 설명합니다. 데이터 마이그레이션은 필요 없습니다.

---

## Changelog

- EN: When the plugin registry cannot be read, init and upgrade leave the package pointer and the vault's pre-commit hook alone instead of recording the npm copy the dual-install notice asks you to delete, and the drift banner and doctor now point at repairing the registry (#277).
- KO: 플러그인 registry를 못 읽을 때 init과 upgrade가 dual install 안내가 지우라고 하는 npm 사본을 기록하지 않고 포인터와 볼트 pre-commit 훅을 그대로 둡니다. drift 배너와 doctor도 registry 수리를 지목합니다 (#277).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
