### PR TITLE
chore: release v1.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "hypo",
       "source": "./",
       "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
-      "version": "1.7.4",
+      "version": "1.8.0",
       "homepage": "https://github.com/sk-lim19f/Hypomnema"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hypo",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "LLM-native personal wiki system — session-aware knowledge base for Claude Code",
   "author": {
     "name": "sk-lim19f",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to Hypomnema are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-09-03
+
+### New Features
+
+#### English
+
+- `hypomnema capture` handles hooks written in python or bash, not only node. A captured hook records its interpreter, and the command it registers on another machine uses that interpreter. Hooks captured before this keep working unchanged. ([#238](https://github.com/sk-lim19f/Hypomnema/pull/238))
+- `/hypo:doctor` reports a plugin cache directory whose name disagrees with the release inside it, so an install silently running a different release than its version string claims becomes visible. The drifted root is reported, never excluded from resolution. ([#265](https://github.com/sk-lim19f/Hypomnema/pull/265))
+- `/hypo:doctor` reports when the installed plugin cache is running a different commit than the marketplace clone, and tells "behind" apart from "ahead" and from "cannot tell". ([#269](https://github.com/sk-lim19f/Hypomnema/pull/269))
+
+#### 한국어
+
+- `hypomnema capture` 가 node 뿐 아니라 python·bash 로 작성된 훅도 다룹니다. 캡처된 훅이 자기 interpreter 를 기록하고, 다른 머신에 등록되는 커맨드가 그 interpreter 를 씁니다. 이전에 캡처한 훅은 그대로 동작합니다. ([#238](https://github.com/sk-lim19f/Hypomnema/pull/238))
+- `/hypo:doctor` 가 이름과 그 안의 릴리스가 어긋난 플러그인 캐시 디렉터리를 보고합니다. 버전 문자열이 주장하는 것과 다른 릴리스를 조용히 돌리던 설치가 이제 눈에 보입니다. 어긋난 루트는 보고할 뿐 해석에서 배제하지 않습니다. ([#265](https://github.com/sk-lim19f/Hypomnema/pull/265))
+- `/hypo:doctor` 가 설치된 플러그인 캐시와 마켓플레이스 클론의 커밋이 갈렸을 때 그것을 보고하고, "뒤졌다" 와 "앞섰다" 와 "판정 불가" 를 구별합니다. ([#269](https://github.com/sk-lim19f/Hypomnema/pull/269))
+
+### Bug Fixes
+
+#### English
+
+- A session close no longer writes over a page that changed since it read it, in any case: every drifted whole-file overwrite parks for review. `CHANGELOG.md` ships in the npm package, so the README links to it resolve. ([#262](https://github.com/sk-lim19f/Hypomnema/pull/262))
+- Five skills told Claude to pass `--wiki-dir` to scripts that only ever parsed `--hypo-dir`, and none of those scripts rejects an unknown flag, so the value was dropped and the command silently used the default vault instead of the one you named. `crystallize` was among them, so a session close could land in the wrong vault and still report success. ([#266](https://github.com/sk-lim19f/Hypomnema/pull/266))
+- `hypomnema upgrade --apply` repoints the git pre-commit hook in your wiki repo at the install you are actually running, and `/hypo:doctor` reports when that hook names an older one. The hook holds an absolute path baked in at init time, so until now a vault could keep checking every commit against a release from months earlier while the version string read correctly. Installing a release does not repoint it: run the apply step once after updating. ([#267](https://github.com/sk-lim19f/Hypomnema/pull/267))
+- `/compact` is no longer blocked by an unfinished session close. The PreCompact hook reports what it finds and lets the compact through, and a close gate scoped to the project this session is actually closing stops charging one session for another session's unfinished close (decisions/0095). ([#273](https://github.com/sk-lim19f/Hypomnema/pull/273))
+- The session-close gate no longer demotes a file the session itself edited when the transcript is only partially readable, and each pending-work notice names its own type instead of being reported as a lint issue. ([#275](https://github.com/sk-lim19f/Hypomnema/pull/275))
+- A session that spans several days can close again: targets a later session start re-read are no longer parked as stale, while anything it was not shown in full still parks. ([#276](https://github.com/sk-lim19f/Hypomnema/pull/276))
+- When the plugin registry cannot be read, init and upgrade leave the package pointer and the vault's pre-commit hook alone instead of recording the npm copy the dual-install notice asks you to delete, and the drift banner and doctor point at repairing the registry (decisions/0097). ([#277](https://github.com/sk-lim19f/Hypomnema/pull/277))
+
+#### 한국어
+
+- 세션 마무리가 자기가 읽은 뒤 바뀐 페이지를 덮어쓰는 경우가 이제 없습니다. 드리프트된 전체 덮어쓰기는 전부 보류되고 검토를 기다립니다. `CHANGELOG.md` 가 npm 패키지에 실려 README 의 링크가 살아납니다. ([#262](https://github.com/sk-lim19f/Hypomnema/pull/262))
+- 다섯 스킬이 `--hypo-dir` 만 파싱하는 스크립트에 `--wiki-dir` 를 넘기라고 지시했고, 그 스크립트들이 미지정 플래그를 거부하지 않아 값이 버려진 채 지정한 볼트가 아니라 기본 볼트가 쓰였습니다. `crystallize` 가 그중 하나라 세션 마무리가 엉뚱한 볼트에 쓰이고도 성공을 보고할 수 있었습니다. ([#266](https://github.com/sk-lim19f/Hypomnema/pull/266))
+- `hypomnema upgrade --apply` 가 위키 레포의 git pre-commit 훅을 실제로 돌고 있는 설치로 다시 겨눕니다. 그리고 `/hypo:doctor` 가 그 훅이 더 오래된 설치를 가리키면 보고합니다. 이 훅은 init 시점의 절대경로를 들고 있어서, 지금까지는 버전 문자열이 맞게 읽히는 동안에도 볼트가 몇 달 전 릴리스로 모든 커밋을 계속 검사할 수 있었습니다. 릴리스를 설치하는 것만으로는 다시 겨눠지지 않으니 업데이트 후 apply 단계를 한 번 돌리세요. ([#267](https://github.com/sk-lim19f/Hypomnema/pull/267))
+- 세션 마무리가 미완결이어도 `/compact` 가 막히지 않습니다. PreCompact 훅은 찾은 것을 보고만 하고 compact 를 통과시키며, 이 세션이 실제로 닫는 프로젝트로 좁혀진 close 게이트가 남의 세션이 남긴 미완결 close 를 이 세션에 물리지 않습니다 (decisions/0095). ([#273](https://github.com/sk-lim19f/Hypomnema/pull/273))
+- transcript 가 일부만 읽히는 상황에서 세션이 직접 편집한 파일이 강등되지 않고, 남은 작업 notice 가 lint 로 뭉뚱그려지지 않고 각자 유형으로 표시됩니다. ([#275](https://github.com/sk-lim19f/Hypomnema/pull/275))
+- 여러 날 이어진 세션도 close 가 됩니다. 나중 세션 시작이 다시 읽어 보여준 대상은 묵었다고 파킹되지 않고, 전부를 보여주지 못한 것은 그대로 파킹됩니다. ([#276](https://github.com/sk-lim19f/Hypomnema/pull/276))
+- 플러그인 registry 를 못 읽을 때 init 과 upgrade 가 dual install 안내가 지우라고 하는 npm 사본을 기록하지 않고 포인터와 볼트 pre-commit 훅을 그대로 둡니다. drift 배너와 doctor 도 registry 수리를 지목합니다 (decisions/0097). ([#277](https://github.com/sk-lim19f/Hypomnema/pull/277))
+
+### Chores
+
+#### English
+
+- The automation reference installed into a vault no longer claims that no hook makes a network request, lists all 15 registered hooks under their correct events, and corrects five further claims about auto-stage, the Stop chain, FileChanged, and `.hypoignore`. Existing vaults keep their old copy: the file has no update channel yet. ([#263](https://github.com/sk-lim19f/Hypomnema/pull/263))
+- `/hypo:doctor` tells an unreadable plugin registry apart from no plugin at all, so an install it cannot verify is reported instead of being treated as absent (decisions/0097). ([#272](https://github.com/sk-lim19f/Hypomnema/pull/272))
+
+#### 한국어
+
+- 볼트에 설치되는 자동화 참조가 더 이상 "어떤 훅도 네트워크 요청을 하지 않는다" 고 말하지 않고, 등록된 훅 15 개를 각자의 올바른 이벤트 아래 나열하며, auto-stage·Stop 체인·FileChanged·`.hypoignore` 에 대한 다섯 가지 서술을 함께 고칩니다. 기존 볼트는 낡은 사본을 유지합니다. 이 파일에는 아직 갱신 채널이 없습니다. ([#263](https://github.com/sk-lim19f/Hypomnema/pull/263))
+- `/hypo:doctor` 가 읽을 수 없는 플러그인 registry 와 플러그인이 아예 없는 경우를 구별하여, 확인할 수 없는 설치를 부재로 취급하지 않고 보고합니다 (decisions/0097). ([#272](https://github.com/sk-lim19f/Hypomnema/pull/272))
+
 ## [1.7.4] - 2026-08-29
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypomnema",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypomnema",
-      "version": "1.7.4",
+      "version": "1.8.0",
       "license": "MIT",
       "bin": {
         "hypomnema": "scripts/init.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypomnema",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "LLM-native personal wiki system for Claude Code",
   "type": "module",
   "license": "MIT",

--- a/templates/hypo-config.md
+++ b/templates/hypo-config.md
@@ -1,7 +1,7 @@
 ---
 title: Hypomnema Config
 type: config
-version: "1.7.4"
+version: "1.8.0"
 created: YYYY-MM-DD
 ---
 


### PR DESCRIPTION
# English

## What changed

Version bump to 1.8.0 across the four manifest files plus the lockfile, and the CHANGELOG section for this release.

## Why

`main` is 16 commits past `v1.7.4` with three `feat` commits, so the next release cannot be a patch. More to the point, none of those 16 commits reaches anyone until the version string moves: the plugin installer names its cache directory after the manifest version and skips the copy when that directory already exists. Work merged under an unchanged version sits where nobody can run it.

## How

`scripts/bump-version.mjs 1.8.0`, then `npm install --package-lock-only` for the lockfile (bump-version does not touch it, and the lock carries the version twice).

The CHANGELOG section is the collector's draft finalized by hand: the duplicated PR reference on each line was dropped in favour of the link alone, and the four `None` entries under Chores were removed since they name no user-visible change.

## Manual verification

The full local gate set from `docs/CONTRIBUTING.md` step 3:

```
npm test                   2121 passed, 0 failed
npm run lint               0 error(s)
npm run check:versions     all version-carrying files agree on 1.8.0
npm run check:bilingual    OK, 926 Hangul chars across the 한국어 sub-blocks
npm run smoke:plugin       OK
npm run smoke-pack         OK
npm run check:tracker-ids  OK
npm run format:check       OK
```

Re-ran `check:versions`, `check:bilingual` and `format:check` after the pre-commit formatter touched all six staged files.

**One gap this release ships with.** The PreCompact hook changed in #275 and has not been exercised in a live session: that hook only fires on `/compact`, and triggering it during the release would have discarded the working context. The gate's input/output contract is covered by the suite and by feeding the hook directly in an isolated vault, and #273 already removed PreCompact's ability to block, so the worst case is a mislabeled notice rather than a blocked compact. The other two hook changes in this release were exercised against a real plugin-loader session.

## Migration notes

None for the version bump itself. Two entries in the CHANGELOG carry their own upgrade note: #267 asks for one `hypomnema upgrade --apply` run to repoint a vault's git pre-commit hook, and #263 notes that existing vaults keep their old automation reference because that file has no update channel yet.

---

# 한국어

## 변경 내용

매니페스트 네 파일과 lockfile 의 버전을 1.8.0 으로 올리고, 이 릴리스의 CHANGELOG 섹션을 씁니다.

## 이유

`main` 이 `v1.7.4` 보다 16 커밋 앞서 있고 그중 `feat` 이 셋이라 다음 릴리스가 patch 일 수 없습니다. 더 중요한 것은 버전 문자열이 움직이기 전까지 그 16 커밋이 아무에게도 안 간다는 점입니다. 플러그인 설치기가 매니페스트 버전으로 캐시 디렉터리 이름을 짓고, 그 디렉터리가 이미 있으면 복사를 건너뜁니다. 버전이 그대로인 채 머지된 작업은 아무도 돌릴 수 없는 자리에 남습니다.

## 방법

`scripts/bump-version.mjs 1.8.0` 을 돌리고, lockfile 은 `npm install --package-lock-only` 로 맞췄습니다. bump-version 이 lockfile 을 안 건드리는데 lock 은 버전을 두 번 들고 있습니다.

CHANGELOG 섹션은 수집기 초안을 손으로 마무리한 것입니다. 줄마다 중복되던 PR 참조를 링크 하나로 줄였고, Chores 의 `None` 항목 넷은 사용자에게 보이는 변화가 없어 뺐습니다.

## 수동 검증

`docs/CONTRIBUTING.md` 3 단계의 전체 게이트를 로컬에서 돌렸습니다.

```
npm test                   2121 passed, 0 failed
npm run lint               0 error(s)
npm run check:versions     버전을 가진 파일 전부 1.8.0 일치
npm run check:bilingual    OK, 한국어 하위 블록에 한글 926 자
npm run smoke:plugin       OK
npm run smoke-pack         OK
npm run check:tracker-ids  OK
npm run format:check       OK
```

pre-commit 포매터가 스테이징된 여섯 파일을 손댔으므로 `check:versions` · `check:bilingual` · `format:check` 를 다시 돌렸습니다.

**이 릴리스가 안고 나가는 공백 하나.** #275 가 PreCompact 훅을 바꿨는데 실세션에서 확인하지 못했습니다. 그 훅은 `/compact` 에서만 발화하고, 릴리스 도중에 그것을 일으키면 작업 맥락을 잃습니다. 게이트의 입출력 계약은 테스트와 격리된 볼트에서의 직접 실행으로 덮었고, #273 이 이미 PreCompact 의 차단 능력을 없앴으므로 최악의 경우는 compact 가 막히는 것이 아니라 notice 표시가 틀리는 것입니다. 이 릴리스의 다른 훅 변경 둘은 실제 플러그인 로더 세션으로 확인했습니다.

## 마이그레이션 노트

버전 bump 자체에는 없습니다. CHANGELOG 항목 둘이 각자의 업그레이드 노트를 답니다. #267 은 볼트의 git pre-commit 훅을 다시 겨누기 위해 `hypomnema upgrade --apply` 를 한 번 돌리라고 하고, #263 은 기존 볼트가 낡은 자동화 참조를 유지한다고(그 파일에 아직 갱신 채널이 없어서) 적습니다.

---

## Changelog

- EN: None (this PR only carries the version bump and the CHANGELOG section that the release collector assembles).
- KO: None (이 PR 은 버전 bump 와 릴리스 수집기가 모으는 CHANGELOG 섹션만 담습니다).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
