### PR TITLE
fix(resume,session-start): surface uncommitted work this session does not own

### DIFF
--- a/commands/resume.md
+++ b/commands/resume.md
@@ -29,6 +29,7 @@ When `--project` is omitted, the script prefers the project whose `working_dir` 
 ## Step 2 — Present session state
 
 Show the output from the script:
+- **`[WIKI: ...]` notice**, if present, first and verbatim. It names uncommitted changes elsewhere in the vault (another project, or unattributable to any project) that are not this session's scope. Do not fold this line into the project summary or fetch/edit the paths it names without the user's explicit instruction.
 - **Project** name
 - **Next tasks** from `session-state.md`
 - **Background** from `hot.md` (what was done last session, condensed)

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -484,6 +484,170 @@ function pendingProposalNotice() {
     return '';
   }
 }
+// ── foreign-project uncommitted notice ──────────────────────────────────────
+// Same signal precompactGateStatus already computes for its own gate
+// (closeAccountableScope / sessionTouchTrusted, hypo-shared.mjs), surfaced
+// here instead for the AGENT reading additionalContext: a project this
+// session isn't scoped to may still have uncommitted changes sitting in the
+// shared vault, and without this line the agent has no way to tell those
+// apart from its own unfinished work. Cannot import hypo-shared.mjs's
+// `projectOfPath` / `gitDirtyFiles` here, not a technical constraint (both
+// are simply not exported), but an ownership decision: hypo-shared.mjs
+// belongs to a different lane, so this hook keeps a local, self-contained
+// duplicate rather than adding an export for it. The cost is real: a future
+// fix to gitDirtyFiles (e.g. its rename re-attribution) does not propagate
+// here automatically.
+
+const FOREIGN_GIT_TIMEOUT_MS = 3000;
+// Cap on how many foreign project names the notice spells out. Past this the
+// rest collapse into a count, so one session cannot grow the prompt by however
+// many projects are dirty.
+const FOREIGN_NAME_CAP = 5;
+
+/** `projects/<slug>/...` → `<slug>`; everything else → null. `null` here does
+ * not mean "not one project's work": the caller below folds every non-null
+ * hit into a per-name foreign count and every null hit into a nameless
+ * "unattributed" count, and both feed the same notice. Not the same
+ * classification hypo-auto-commit.mjs's commit message uses for its own
+ * "(N paths across M projects)" count (hypo-shared.mjs's private
+ * `projectOfPath`): that one folds a non-`projects/` path to its first path
+ * segment (`extensions`, `hot.md`, ...) for a tally; this one folds it to
+ * `null` because attribution, not tallying, is the job here. A top-level
+ * segment is not a project name, and this notice must not present it as
+ * one.
+ */
+function projectOfPath(relPath) {
+  const parts = relPath.split('/');
+  return parts[0] === 'projects' && parts.length > 1 && parts[1] ? parts[1] : null;
+}
+
+/** Vault-relative dirty paths (tracked + untracked), normalized to be
+ * relative to `hypoDir` itself via `git rev-parse --show-prefix` (empty when
+ * `hypoDir` IS the repo top level), the same normalization
+ * hypo-shared.mjs's `gitDirtyFiles` applies for staging correctness: without
+ * it, a vault nested under a larger host repo reports paths relative to that
+ * repo's top level, and every one of them would fail to classify as this
+ * vault's own. NUL-separated porcelain so Korean project/page names survive
+ * intact. This also re-attributes a rename/copy's `from` path (codex
+ * 3rd-round review follow-up), the same as gitDirtyFiles does for
+ * staging correctness, so a rename OUT of a foreign project is not silently
+ * lost just because its destination happens to land under `ownProject`.
+ *
+ * Returns `null`, not `[]`, on any git failure (repo missing, `rev-parse` or
+ * `status` non-zero, or a timeout): folding "cannot enumerate" into the same
+ * empty array a truly clean repo returns would render the two identically,
+ * which is the silent failure this notice exists to catch (mirrors
+ * `gitDirtyFiles`'s own contract: "an empty return here just means 'cannot
+ * attribute', not 'clean'"). A clean repo returns `[]`.
+ */
+function listDirtyPaths(hypoDir) {
+  const prefixRes = spawnSync('git', ['-C', hypoDir, 'rev-parse', '--show-prefix'], {
+    encoding: 'utf-8',
+    timeout: FOREIGN_GIT_TIMEOUT_MS,
+  });
+  if (prefixRes.status !== 0) return null;
+  // trimEnd(), not trim(): the prefix is a real path segment, and a leading
+  // space or control char in a directory name is valid there. trim() would
+  // strip it off the front, so the stripped prefix no longer matches the
+  // (untouched) start of every path `git status` reports, and every path
+  // under that directory would wrongly read as "outside the vault" (the
+  // notice going silent for exactly the same reason a missing rename `from`
+  // does below). Only the trailing `\n` `--show-prefix` always appends needs
+  // stripping.
+  const prefix = (prefixRes.stdout || '').trimEnd();
+
+  const r = spawnSync('git', ['-C', hypoDir, 'status', '--porcelain', '-uall', '-z'], {
+    encoding: 'utf-8',
+    timeout: FOREIGN_GIT_TIMEOUT_MS,
+  });
+  if (r.status !== 0) return null;
+  const out = [];
+  const records = (r.stdout || '').split('\0');
+  const toVaultRelative = (f) => {
+    if (!f) return null;
+    if (!prefix) return f; // hypoDir IS the repo top level, nothing to strip
+    return f.startsWith(prefix) ? f.slice(prefix.length) : null; // outside the vault
+  };
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i];
+    if (!rec) continue;
+    const xy = rec.slice(0, 2);
+    const file = rec.slice(3); // destination path for a rename/copy
+    const isRenameOrCopy = xy[0] === 'R' || xy[1] === 'R' || xy[0] === 'C' || xy[1] === 'C';
+    // A rename/copy emits a paired `to\0from` record. Attribute BOTH: the
+    // origin project lost a file just as surely as the destination gained
+    // one, and dropping `from` (as this used to) silently loses that origin
+    // whenever it differs from the destination's project (a rename INTO
+    // ownProject from a foreign one would otherwise vanish entirely). One
+    // rename/copy is therefore counted as up to 2 dirty paths, inflating
+    // foreignCount/unattributedCount by one per cross-project rename; the
+    // name Set below still de-dupes, so the project NAME list does not grow.
+    let fromFile = null;
+    if (isRenameOrCopy) {
+      i++;
+      fromFile = records[i] || null;
+    }
+    const rel = toVaultRelative(file);
+    if (rel) out.push(rel);
+    const relFrom = toVaultRelative(fromFile);
+    if (relFrom) out.push(relFrom);
+  }
+  return out;
+}
+
+/** One-line notice covering two counts: uncommitted paths under a named
+ * project other than `ownProject` (`projects/<slug>/...`, or, when
+ * `ownProject` is null, no cwd-matched project this session, so ANY named
+ * project counts), and uncommitted paths this classifier cannot attribute to
+ * any project at all (everything else, root vault infra, `extensions/`,
+ * `_specs/`, ...). This is attribution, not narrowing, so the
+ * unattributed bucket is surfaced with a count rather than silently dropped
+ * just because it has no project name to show. '' only when enumeration
+ * succeeded and both counts are zero, so the quiet path stays quiet exactly
+ * there. A `null` from `listDirtyPaths` (enumeration failed) gets its own
+ * distinct line instead: the caller must not read "could not tell" as
+ * "nothing foreign".
+ */
+function foreignUncommittedNotice(hypoDir, ownProject) {
+  const dirty = listDirtyPaths(hypoDir);
+  if (dirty === null) {
+    return '[WIKI: 미커밋 변경의 귀속을 확인하지 못했습니다. git 상태를 근거로 작업 범위를 정하지 마십시오.]';
+  }
+  const foreignProjects = new Set();
+  let foreignCount = 0;
+  let unattributedCount = 0;
+  for (const f of dirty) {
+    const slug = projectOfPath(f);
+    if (slug === ownProject) continue;
+    if (slug) {
+      foreignProjects.add(slug);
+      foreignCount++;
+    } else {
+      unattributedCount++;
+    }
+  }
+  if (foreignCount === 0 && unattributedCount === 0) return '';
+  const clauses = [];
+  if (foreignCount > 0) {
+    // The slug comes from a directory name in `git status` output, so it is
+    // untrusted text on its way into a prompt. sanitizeProjForPrompt is the same
+    // guard the hot-cache notices in this file already use; skipping it here would
+    // let a newline or a control char in a project directory name break the
+    // one-line notice apart and inject into the surrounding context. The name list
+    // is also capped, because an unbounded one grows the context by however many
+    // projects happen to be dirty.
+    const all = [...foreignProjects].sort();
+    const shown = all.slice(0, FOREIGN_NAME_CAP).map((s) => `projects/${sanitizeProjForPrompt(s)}`);
+    const names =
+      all.length > FOREIGN_NAME_CAP
+        ? `${shown.join(', ')} 외 ${all.length - FOREIGN_NAME_CAP}개`
+        : shown.join(', ');
+    clauses.push(`현재 프로젝트 외 ${names} 변경 ${foreignCount}건`);
+  }
+  if (unattributedCount > 0) clauses.push(`귀속 불명 변경 ${unattributedCount}건`);
+  return `[WIKI: ${clauses.join(', ')}이 있습니다. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오.]`;
+}
+
 const GLOBAL_HOT = join(HYPO_DIR, 'hot.md');
 const HOT_CHARS = 2000;
 const STATE_CHARS = 2000;
@@ -612,6 +776,17 @@ process.stdin.on('end', () => {
     const sessionId = data.session_id || 'default';
     const MARKER_FILE = sessionMarkerPath(sessionId);
     const hit = findProjectFiles(cwd);
+
+    // ownProject = the cwd-matched project (or null on a MISS, per
+    // foreignUncommittedNotice's docstring). Late-appended into `notices` /
+    // `noticePrefix`, same pattern the MISS branch's suggestLine uses below —
+    // both need `hit` first, which isn't resolved until this line.
+    const foreignNotice = foreignUncommittedNotice(HYPO_DIR, hit ? hit.proj : null);
+    if (foreignNotice) {
+      notices.push(foreignNotice);
+      noticePrefix = notices.length ? `${notices.join('\n\n')}\n\n` : '';
+      process.stderr.write(`\n\x1b[33m${foreignNotice}\x1b[0m\n`);
+    }
 
     // Observed-base snapshot for the write=proposal gate. Deliberately AFTER gitPull: the base must
     // describe the tree this session actually starts from, remote merges

--- a/scripts/resume.mjs
+++ b/scripts/resume.mjs
@@ -28,9 +28,15 @@
 
 import { existsSync, readFileSync, readdirSync, statSync, realpathSync } from 'fs';
 import { join } from 'path';
+import { spawnSync } from 'child_process';
 import { resolveHypoRoot, expandHome } from './lib/hypo-root.mjs';
 import { pickProjectByCwd, collectProjectWorkingDirs } from './lib/wd-match.mjs';
-import { currentDevice, scopeVisible, readVisibilityScope } from '../hooks/hypo-shared.mjs';
+import {
+  currentDevice,
+  scopeVisible,
+  readVisibilityScope,
+  sanitizeProjForPrompt,
+} from '../hooks/hypo-shared.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
@@ -188,6 +194,162 @@ function resolveActiveProject(hypoDir, cwd = null) {
   return latest;
 }
 
+// ── foreign-project uncommitted notice ──────────────────────────────────────
+// resume is a bare CLI script (invoked from a slash command via bash) and
+// never receives a session_id or transcript, so unlike the SessionStart hook
+// it has no accountable-scope to compare against. It always has a resolved
+// `project` by the time this runs (the caller exits earlier when none is
+// found), so that resolved project stands in as "own project" here.
+
+const FOREIGN_GIT_TIMEOUT_MS = 5000;
+// Cap on how many foreign project names the notice spells out. Past this the
+// rest collapse into a count, so one session cannot grow the prompt by however
+// many projects are dirty.
+const FOREIGN_NAME_CAP = 5;
+
+/** `projects/<slug>/...` → `<slug>`; everything else → null. `null` here does
+ * not mean "not one project's work": the caller below folds every non-null
+ * hit into a per-name foreign count and every null hit into a nameless
+ * "unattributed" count, and both feed the same notice. Local duplicate of
+ * hypo-shared.mjs's private (non-exported) `projectOfPath`. Not the same
+ * classification as hypo-auto-commit.mjs's commit-message counter (also in
+ * hypo-shared.mjs): that one folds a non-`projects/` path to its first path
+ * segment (`extensions`, `hot.md`, ...) for a "(N paths across M projects)"
+ * tally; this one folds it to `null` because attribution, not tallying, is
+ * the job here. A top-level segment is not a project name, and this notice
+ * must not present it as one.
+ */
+function projectOfPath(relPath) {
+  const parts = relPath.split('/');
+  return parts[0] === 'projects' && parts.length > 1 && parts[1] ? parts[1] : null;
+}
+
+/** Vault-relative dirty paths (tracked + untracked), normalized to be
+ * relative to `hypoDir` itself via `git rev-parse --show-prefix` (empty when
+ * `hypoDir` IS the repo top level), the same normalization
+ * hypo-shared.mjs's `gitDirtyFiles` applies for staging correctness: without
+ * it, a vault nested under a larger host repo reports paths relative to that
+ * repo's top level, and every one of them would fail to classify as this
+ * vault's own. NUL-separated porcelain so Korean project/page names survive
+ * intact. Local duplicate of hypo-shared.mjs's private `gitDirtyFiles`: this
+ * caller also re-attributes a rename/copy's `from` path (codex 3rd-round
+ * review follow-up), the same as that caller does for staging
+ * correctness, so a rename OUT of a foreign project is not silently lost
+ * just because its destination happens to land under `ownProject`.
+ *
+ * Returns `null`, not `[]`, on any git failure (repo missing, `rev-parse` or
+ * `status` non-zero, or a timeout): folding "cannot enumerate" into the same
+ * empty array a truly clean repo returns would render the two identically,
+ * which is the silent failure this notice exists to catch (mirrors
+ * `gitDirtyFiles`'s own contract: "an empty return here just means 'cannot
+ * attribute', not 'clean'"). A clean repo returns `[]`.
+ */
+function listDirtyPaths(hypoDir) {
+  const prefixRes = spawnSync('git', ['-C', hypoDir, 'rev-parse', '--show-prefix'], {
+    encoding: 'utf-8',
+    timeout: FOREIGN_GIT_TIMEOUT_MS,
+  });
+  if (prefixRes.status !== 0) return null;
+  // trimEnd(), not trim(): the prefix is a real path segment, and a leading
+  // space or control char in a directory name is valid there. trim() would
+  // strip it off the front, so the stripped prefix no longer matches the
+  // (untouched) start of every path `git status` reports, and every path
+  // under that directory would wrongly read as "outside the vault" (the
+  // notice going silent for exactly the same reason a missing rename `from`
+  // does below). Only the trailing `\n` `--show-prefix` always appends needs
+  // stripping.
+  const prefix = (prefixRes.stdout || '').trimEnd();
+
+  const r = spawnSync('git', ['-C', hypoDir, 'status', '--porcelain', '-uall', '-z'], {
+    encoding: 'utf-8',
+    timeout: FOREIGN_GIT_TIMEOUT_MS,
+  });
+  if (r.status !== 0) return null;
+  const out = [];
+  const records = (r.stdout || '').split('\0');
+  const toVaultRelative = (f) => {
+    if (!f) return null;
+    if (!prefix) return f; // hypoDir IS the repo top level, nothing to strip
+    return f.startsWith(prefix) ? f.slice(prefix.length) : null; // outside the vault
+  };
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i];
+    if (!rec) continue;
+    const xy = rec.slice(0, 2);
+    const file = rec.slice(3); // destination path for a rename/copy
+    const isRenameOrCopy = xy[0] === 'R' || xy[1] === 'R' || xy[0] === 'C' || xy[1] === 'C';
+    // A rename/copy emits a paired `to\0from` record. Attribute BOTH: the
+    // origin project lost a file just as surely as the destination gained
+    // one, and dropping `from` (as this used to) silently loses that origin
+    // whenever it differs from the destination's project (a rename INTO
+    // ownProject from a foreign one would otherwise vanish entirely). One
+    // rename/copy is therefore counted as up to 2 dirty paths, inflating
+    // foreignCount/unattributedCount by one per cross-project rename; the
+    // name Set below still de-dupes, so the project NAME list does not grow.
+    let fromFile = null;
+    if (isRenameOrCopy) {
+      i++;
+      fromFile = records[i] || null;
+    }
+    const rel = toVaultRelative(file);
+    if (rel) out.push(rel);
+    const relFrom = toVaultRelative(fromFile);
+    if (relFrom) out.push(relFrom);
+  }
+  return out;
+}
+
+/** One-line notice covering two counts: uncommitted paths under a named
+ * project other than `ownProject` (`projects/<slug>/...`), and uncommitted
+ * paths this classifier cannot attribute to any project at all (everything
+ * else, root vault infra, `extensions/`, `_specs/`, ...). This is
+ * attribution, not narrowing, so the unattributed bucket is surfaced with a
+ * count rather than silently dropped just because it has no project name to
+ * show. '' only when enumeration succeeded and both counts are zero, so the
+ * quiet path stays quiet exactly there. A `null` from `listDirtyPaths`
+ * (enumeration failed) gets its own distinct line instead: the caller must
+ * not read "could not tell" as "nothing foreign".
+ */
+function foreignUncommittedNotice(hypoDir, ownProject) {
+  const dirty = listDirtyPaths(hypoDir);
+  if (dirty === null) {
+    return '[WIKI: 미커밋 변경의 귀속을 확인하지 못했습니다. git 상태를 근거로 작업 범위를 정하지 마십시오.]';
+  }
+  const foreignProjects = new Set();
+  let foreignCount = 0;
+  let unattributedCount = 0;
+  for (const f of dirty) {
+    const slug = projectOfPath(f);
+    if (slug === ownProject) continue;
+    if (slug) {
+      foreignProjects.add(slug);
+      foreignCount++;
+    } else {
+      unattributedCount++;
+    }
+  }
+  if (foreignCount === 0 && unattributedCount === 0) return '';
+  const clauses = [];
+  if (foreignCount > 0) {
+    // The slug comes from a directory name in `git status` output, so it is
+    // untrusted text on its way into a prompt. sanitizeProjForPrompt is the same
+    // guard the hot-cache notices in this file already use; skipping it here would
+    // let a newline or a control char in a project directory name break the
+    // one-line notice apart and inject into the surrounding context. The name list
+    // is also capped, because an unbounded one grows the context by however many
+    // projects happen to be dirty.
+    const all = [...foreignProjects].sort();
+    const shown = all.slice(0, FOREIGN_NAME_CAP).map((s) => `projects/${sanitizeProjForPrompt(s)}`);
+    const names =
+      all.length > FOREIGN_NAME_CAP
+        ? `${shown.join(', ')} 외 ${all.length - FOREIGN_NAME_CAP}개`
+        : shown.join(', ');
+    clauses.push(`현재 프로젝트 외 ${names} 변경 ${foreignCount}건`);
+  }
+  if (unattributedCount > 0) clauses.push(`귀속 불명 변경 ${unattributedCount}건`);
+  return `[WIKI: ${clauses.join(', ')}이 있습니다. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오.]`;
+}
+
 // ── read session state ────────────────────────────────────────────────────────
 
 // Visibility guard: same contract as hypo-file-watch / hypo-session-start /
@@ -224,6 +386,7 @@ if (!project) {
   process.exit(1);
 }
 
+const foreignNotice = foreignUncommittedNotice(args.hypoDir, project);
 const device = currentDevice();
 
 const state = readSessionState(args.hypoDir, project, device);
@@ -243,10 +406,22 @@ const sessionState = state.content;
 const hotContent = readHot(args.hypoDir, project, device).content;
 
 if (args.json) {
-  console.log(JSON.stringify({ project, sessionState, hot: hotContent }, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        project,
+        sessionState,
+        hot: hotContent,
+        ...(foreignNotice ? { notice: foreignNotice } : {}),
+      },
+      null,
+      2,
+    ),
+  );
   process.exit(0);
 }
 
+if (foreignNotice) console.log(foreignNotice + '\n');
 console.log(`Project: ${project}`);
 console.log(`State: projects/${project}/session-state.md\n`);
 console.log('─'.repeat(60));

--- a/tests/query-resume.test.mjs
+++ b/tests/query-resume.test.mjs
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
   mkdirSync,
+  mkdtempSync,
   rmSync,
   writeFileSync,
   readFileSync,
@@ -16,9 +17,10 @@ import {
   realpathSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { resolveActiveProject } from '../hooks/hypo-shared.mjs';
 import { test, suite } from './harness.mjs';
-import { HOME, SCRIPTS, SESSION_TMP_HOME, run, withTmpDir } from './helpers.mjs';
+import { HOME, SCRIPTS, SESSION_TMP_HOME, run, withGrowthWiki, withTmpDir } from './helpers.mjs';
 
 // ── query.mjs smoke tests ────────────────────────────────────────────────────
 
@@ -117,6 +119,19 @@ test('resume picks real project over _template fallback (even when _template is 
     const fooMtime = statSync(fooSS).mtimeMs;
     const newer = new Date(fooMtime + 5000);
     utimesSync(templateSS, newer, newer);
+    // Committed to git here, not because a real vault must always be one
+    // (init --no-git-init is a supported flag; see the non-git-vault
+    // contract test below for what that case actually surfaces), but
+    // because the ISSUE-99 foreign-notice check reports "cannot attribute"
+    // for a non-repo hypoDir, and this fixture used --no-git-init above.
+    // Commit a clean tree here (after the mtime tweak, since git commit does
+    // not touch mtimes) so this unrelated _template-fallback test sees no
+    // notice.
+    spawnSync('git', ['init', '-q'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: hypoDir });
+    spawnSync('git', ['add', '-A'], { cwd: hypoDir });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: hypoDir });
     const r = run('resume.mjs', [`--hypo-dir=${hypoDir}`]);
     assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr=${r.stderr}`);
     assert.ok(r.stdout.startsWith('Project: foo'), `expected 'Project: foo', got: ${r.stdout}`);
@@ -365,6 +380,17 @@ test('resume.mjs honors process.cwd() for same-date tie (ISSUE-1 wiring)', () =>
     }
     const cwd = betaWd;
     mkdirSync(cwd, { recursive: true });
+    // Committed to git here, not because a real vault must always be one
+    // (init --no-git-init is a supported flag; see the non-git-vault
+    // contract test below for what that case actually surfaces), but
+    // because the ISSUE-99 foreign-notice check reports "cannot attribute"
+    // for a non-repo hypoDir); commit a clean
+    // tree here so this unrelated cwd-tie-break test sees no notice.
+    spawnSync('git', ['init', '-q'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: hypoDir });
+    spawnSync('git', ['add', '-A'], { cwd: hypoDir });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: hypoDir });
     const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
       encoding: 'utf-8',
       cwd,
@@ -394,6 +420,17 @@ test('resume.mjs cwd-first: cwd-matched older project wins over a newer non-matc
       );
     }
     mkdirSync(betaWd, { recursive: true });
+    // Committed to git here, not because a real vault must always be one
+    // (init --no-git-init is a supported flag; see the non-git-vault
+    // contract test below for what that case actually surfaces), but
+    // because the ISSUE-99 foreign-notice check reports "cannot attribute"
+    // for a non-repo hypoDir); commit a clean
+    // tree here so this unrelated cwd-first-wins test sees no notice.
+    spawnSync('git', ['init', '-q'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: hypoDir });
+    spawnSync('git', ['add', '-A'], { cwd: hypoDir });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: hypoDir });
     const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
       encoding: 'utf-8',
       cwd: betaWd,
@@ -481,6 +518,17 @@ test('resume.mjs mtime-fallback branch cwd no-match: emits the fallback diagnost
     );
     const unrelatedCwd = join(realDir, 'code/elsewhere');
     mkdirSync(unrelatedCwd, { recursive: true });
+    // Committed to git here, not because a real vault must always be one
+    // (init --no-git-init is a supported flag; see the non-git-vault
+    // contract test below for what that case actually surfaces), but
+    // because the ISSUE-99 foreign-notice check reports "cannot attribute"
+    // for a non-repo hypoDir); commit a clean
+    // tree here so this unrelated mtime-fallback test sees no notice.
+    spawnSync('git', ['init', '-q'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: hypoDir });
+    spawnSync('git', ['add', '-A'], { cwd: hypoDir });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: hypoDir });
     const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
       encoding: 'utf-8',
       cwd: unrelatedCwd,
@@ -560,6 +608,17 @@ test('resume.mjs md-link branch cwd no-match: emits the fallback diagnostic (ISS
       join(hypoDir, 'projects', 'beta', 'index.md'),
       `---\ntitle: beta\ntype: project-index\nupdated: 2026-06-08\nworking_dir: "${join(realDir, 'code/beta')}"\n---\n# beta\n`,
     );
+    // Committed to git here, not because a real vault must always be one
+    // (init --no-git-init is a supported flag; see the non-git-vault
+    // contract test below for what that case actually surfaces), but
+    // because the ISSUE-99 foreign-notice check reports "cannot attribute"
+    // for a non-repo hypoDir); commit a clean
+    // tree here so this unrelated project-resolution test sees no notice.
+    spawnSync('git', ['init', '-q'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: hypoDir });
+    spawnSync('git', ['add', '-A'], { cwd: hypoDir });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: hypoDir });
     const unrelatedCwd = join(realDir, 'code/elsewhere');
     mkdirSync(unrelatedCwd, { recursive: true });
     const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
@@ -614,6 +673,17 @@ test('resume.mjs cwd-first applies to the legacy markdown-link branch (ADR 0044 
       `---\ntitle: beta\ntype: project-index\nupdated: 2026-06-08\nworking_dir: "${betaWd}"\n---\n# beta\n`,
     );
     mkdirSync(betaWd, { recursive: true });
+    // Committed to git here, not because a real vault must always be one
+    // (init --no-git-init is a supported flag; see the non-git-vault
+    // contract test below for what that case actually surfaces), but
+    // because the ISSUE-99 foreign-notice check reports "cannot attribute"
+    // for a non-repo hypoDir); commit a clean
+    // tree here so this unrelated project-resolution test sees no notice.
+    spawnSync('git', ['init', '-q'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: hypoDir });
+    spawnSync('git', ['add', '-A'], { cwd: hypoDir });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: hypoDir });
     const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
       encoding: 'utf-8',
       cwd: betaWd,
@@ -656,6 +726,18 @@ test('resume.mjs cwd-first applies to the mtime fallback (no hot.md rows, ADR 00
     const newer = new Date(betaMtime + 5000);
     utimesSync(join(hypoDir, 'projects', 'alpha', 'session-state.md'), newer, newer);
     mkdirSync(betaWd, { recursive: true });
+    // Committed to git here, not because a real vault must always be one
+    // (init --no-git-init is a supported flag; see the non-git-vault
+    // contract test below for what that case actually surfaces), but
+    // because the ISSUE-99 foreign-notice check reports "cannot attribute"
+    // for a non-repo hypoDir); commit a clean
+    // tree here (after the mtime tweak above, since git commit does not touch
+    // mtimes) so this unrelated project-resolution test sees no notice.
+    spawnSync('git', ['init', '-q'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: hypoDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: hypoDir });
+    spawnSync('git', ['add', '-A'], { cwd: hypoDir });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: hypoDir });
     const r = spawnSync(process.execPath, [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${hypoDir}`], {
       encoding: 'utf-8',
       cwd: betaWd,
@@ -665,6 +747,249 @@ test('resume.mjs cwd-first applies to the mtime fallback (no hot.md rows, ADR 00
     assert.ok(
       r.stdout.startsWith('Project: beta'),
       `mtime fallback must honor cwd; got: ${r.stdout}`,
+    );
+  });
+});
+
+// ── resume.mjs — foreign-project uncommitted notice (ISSUE-99) ─────────────
+// A different project's own uncommitted work is not this session's to fix.
+// resume never receives a session_id, so unlike the SessionStart hook it uses
+// the resolved --project as the "own project" boundary instead of an
+// accountable-scope from a transcript.
+
+suite('resume.mjs — foreign-project uncommitted notice (ISSUE-99)');
+
+function withTwoProjectResumeWiki(fn) {
+  withGrowthWiki((dir) => {
+    for (const slug of ['mine', 'theirs']) {
+      const pdir = join(dir, 'projects', slug);
+      mkdirSync(pdir, { recursive: true });
+      writeFileSync(
+        join(pdir, 'session-state.md'),
+        `---\ntitle: ss — ${slug}\ntype: session-state\nupdated: 2026-06-28\n---\n\n## 다음\n- t\n`,
+      );
+    }
+    spawnSync('git', ['add', '-A'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'projects'], { cwd: dir });
+    fn(dir);
+  });
+}
+
+function runResume(dir, extraArgs = []) {
+  return spawnSync(
+    process.execPath,
+    [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${dir}`, '--project=mine', ...extraArgs],
+    { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+  );
+}
+
+test('resume.mjs: a foreign project surfaces a one-line notice (count + name)', () => {
+  withTwoProjectResumeWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'theirs', 'draft.md'), 'uncommitted draft\n');
+    const r = runResume(dir);
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /^\[WIKI: 현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected foreign notice as the first line, got: ${r.stdout}`,
+    );
+  });
+});
+
+test('resume.mjs: own-project changes are excluded from the foreign count', () => {
+  withTwoProjectResumeWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'mine', 'draft.md'), 'my own uncommitted work\n');
+    const r = runResume(dir);
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.ok(
+      !/\[WIKI: 현재 프로젝트 외|\[WIKI: 귀속 불명/.test(r.stdout),
+      `own uncommitted change must not read as foreign or unattributed: ${r.stdout}`,
+    );
+  });
+});
+
+test('resume.mjs --json: foreign notice carried as a notice field, absent when clean', () => {
+  withTwoProjectResumeWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'theirs', 'draft.md'), 'uncommitted draft\n');
+    const dirty = runResume(dir, ['--json']);
+    assert.equal(dirty.status, 0, `expected exit 0; stderr=${dirty.stderr}`);
+    const dirtyOut = JSON.parse(dirty.stdout);
+    assert.match(
+      dirtyOut.notice,
+      /현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다/,
+      `expected notice field, got: ${JSON.stringify(dirtyOut)}`,
+    );
+
+    spawnSync('git', ['add', '-A'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'settle'], { cwd: dir });
+    const clean = runResume(dir, ['--json']);
+    assert.equal(clean.status, 0, `expected exit 0; stderr=${clean.stderr}`);
+    const cleanOut = JSON.parse(clean.stdout);
+    assert.ok(
+      !('notice' in cleanOut),
+      `clean vault must carry no notice field: ${JSON.stringify(cleanOut)}`,
+    );
+  });
+});
+
+// Reproduces the 2026-08-27 incident directly (extensions/ai-tone/, not a
+// projects/<slug>/ path) via the resume.mjs CLI: before this fix
+// projectOfPath's null return meant "not one project's work" and got
+// dropped; now it feeds a nameless unattributed count instead.
+test('resume.mjs: an extensions/ai-tone dirty file surfaces as unattributed, not silence', () => {
+  withTwoProjectResumeWiki((dir) => {
+    const toneDir = join(dir, 'extensions', 'ai-tone');
+    mkdirSync(toneDir, { recursive: true });
+    writeFileSync(join(toneDir, 'x.sh'), '#!/bin/sh\necho hi\n');
+    const r = runResume(dir);
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /^\[WIKI: 귀속 불명 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected the original-incident file to surface as unattributed, got: ${r.stdout}`,
+    );
+  });
+});
+
+test('resume.mjs: git enumeration failure (not a git repo) yields a distinct notice, not silence', () => {
+  const notARepo = mkdtempSync(join(tmpdir(), 'hypo-issue99-resume-notrepo-'));
+  const pdir = join(notARepo, 'projects', 'mine');
+  mkdirSync(pdir, { recursive: true });
+  writeFileSync(
+    join(pdir, 'session-state.md'),
+    '---\ntitle: ss — mine\ntype: session-state\nupdated: 2026-06-28\n---\n\n## 다음\n- t\n',
+  );
+  try {
+    const r = runResume(notARepo);
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /^\[WIKI: 미커밋 변경의 귀속을 확인하지 못했습니다\. git 상태를 근거로 작업 범위를 정하지 마십시오\.\]/,
+      `expected a distinct enumeration-failure notice instead of silence, got: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(notARepo, { recursive: true, force: true });
+  }
+});
+
+// codex 3rd-round review: `listDirtyPaths` used to skip a rename/copy's
+// paired `from` record entirely, keeping only the destination path. A rename
+// OUT of a foreign project and INTO ownProject then vanished completely: the
+// destination reads as "own" and gets excluded, and the origin (the one path
+// that WAS actually foreign) was never looked at.
+test('resume.mjs: a rename OUT of a foreign project (into own) is not silently lost (codex 3rd-round review)', () => {
+  withTwoProjectResumeWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'theirs', 'a.md'), 'seed\n');
+    spawnSync('git', ['add', '-A'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'seed'], { cwd: dir });
+    spawnSync('git', ['mv', 'projects/theirs/a.md', 'projects/mine/a.md'], { cwd: dir });
+    const r = runResume(dir);
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /^\[WIKI: 현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `a rename OUT of a foreign project must still surface theirs, got: ${r.stdout}`,
+    );
+  });
+});
+
+// A leading space (or other control char) right above the vault is a valid
+// path segment. `--show-prefix`'s output must only lose its trailing `\n`,
+// never a leading byte that is actually part of the path. trim() strips both
+// ends and would silently break every startsWith(prefix) match below it.
+test('resume.mjs: a leading-space path component above the vault does not silence the notice (prefix trimEnd)', () => {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-issue99-resume-prefixspace-'));
+  try {
+    const vault = join(base, ' weird', 'vault');
+    mkdirSync(join(vault, 'projects', 'mine'), { recursive: true });
+    writeFileSync(
+      join(vault, 'projects', 'mine', 'session-state.md'),
+      '---\ntitle: ss — mine\ntype: session-state\nupdated: 2026-06-28\n---\n\n## 다음\n- t\n',
+    );
+    const theirsDir = join(vault, 'projects', 'theirs');
+    mkdirSync(theirsDir, { recursive: true });
+    writeFileSync(join(theirsDir, 'index.md'), '# theirs\n');
+    spawnSync('git', ['init', '-q'], { cwd: base });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: base });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: base });
+    spawnSync('git', ['add', '-A'], { cwd: base });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: base });
+    writeFileSync(join(theirsDir, 'draft.md'), 'uncommitted draft\n');
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'resume.mjs'), `--hypo-dir=${vault}`, '--project=mine'],
+      { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+    );
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /^\[WIKI: 현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected the foreign notice despite the leading-space path component, got: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// A project directory name with a REAL embedded newline (shell command
+// substitution swallows a trailing \n, so this must be built directly with
+// mkdirSync, never `$(printf '\n')`). Without sanitizeProjForPrompt this
+// splits the one-line notice into two printed lines, which is the injection
+// surface the guard exists to close.
+test('resume.mjs: a project directory name with a real newline stays a single-line notice (sanitizeProjForPrompt regression)', () => {
+  withGrowthWiki((dir) => {
+    mkdirSync(join(dir, 'projects', 'mine'), { recursive: true });
+    writeFileSync(
+      join(dir, 'projects', 'mine', 'session-state.md'),
+      '---\ntitle: ss — mine\ntype: session-state\nupdated: 2026-06-28\n---\n\n## 다음\n- t\n',
+    );
+    spawnSync('git', ['add', '-A'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'mine'], { cwd: dir });
+    const evilSlug = 'ev\nil';
+    const evilDir = join(dir, 'projects', evilSlug);
+    mkdirSync(evilDir, { recursive: true });
+    writeFileSync(join(evilDir, 'draft.md'), 'uncommitted draft\n');
+    const r = runResume(dir);
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    const firstLine = r.stdout.split('\n')[0];
+    assert.match(
+      firstLine,
+      /^\[WIKI: 현재 프로젝트 외 projects\/ev il 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]$/,
+      `expected the whole notice on one line with the embedded newline sanitized, got: ${JSON.stringify(r.stdout)}`,
+    );
+  });
+});
+
+// ISSUE-99 follow-up (codex 2nd-round review): `init --no-git-init` is a
+// documented, supported layout (scripts/init.mjs), not an edge case. This
+// pins what resume.mjs actually shows on it today: the enumeration-failure
+// notice fires on EVERY session for a non-git vault, not only when something
+// is genuinely foreign, because `git status` cannot be asked at all. That is
+// a deliberate, accepted tradeoff (see the sibling test above for why
+// checking `.git` existence instead was tried and reverted: it re-silences a
+// vault nested inside a larger host repo). This is not a claim that the
+// behavior is right, only that it is current; changing it starts by making
+// this assertion red.
+test('resume.mjs: init --no-git-init vault reports "cannot attribute" on every session, not silence (documents the accepted tradeoff)', () => {
+  withTmpDir((dir) => {
+    const hypoDir = join(dir, 'wiki');
+    const initR = run('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-hooks', '--no-git-init']);
+    assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
+    assert.ok(
+      !existsSync(join(hypoDir, '.git')),
+      'fixture sanity: --no-git-init must not create .git',
+    );
+    mkdirSync(join(hypoDir, 'projects', 'mine'), { recursive: true });
+    writeFileSync(
+      join(hypoDir, 'projects', 'mine', 'session-state.md'),
+      '---\ntitle: ss — mine\ntype: session-state\nupdated: 2026-06-28\n---\n\n## 다음\n- t\n',
+    );
+    const r = run('resume.mjs', [`--hypo-dir=${hypoDir}`, '--project=mine']);
+    assert.equal(r.status, 0, `expected exit 0; stderr=${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /^\[WIKI: 미커밋 변경의 귀속을 확인하지 못했습니다\. git 상태를 근거로 작업 범위를 정하지 마십시오\.\]/,
+      `expected the cannot-attribute notice on a supported non-git vault, got: ${r.stdout}`,
     );
   });
 });

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -3901,3 +3901,290 @@ test('opt-out (CI=true) suppresses the PKG_ROOT-null notice', () => {
     rmSync(dirname(standaloneDir), { recursive: true, force: true });
   }
 });
+
+// ── foreign-project uncommitted notice (ISSUE-99) ───────────────────────────
+// The session sees the whole vault's `git status`, but is only accountable
+// for one project (or none). Another project's own uncommitted work must
+// surface as a heads-up, never be silently absorbed into this session's view.
+
+suite('hypo-session-start.mjs — foreign-project uncommitted notice (ISSUE-99)');
+
+function withTwoProjectWiki(fn) {
+  withGrowthWiki((dir) => {
+    const work = mkdtempSync(join(tmpdir(), 'hypo-issue99-work-'));
+    const mineDir = join(dir, 'projects', 'mine');
+    mkdirSync(mineDir, { recursive: true });
+    writeFileSync(
+      join(mineDir, 'index.md'),
+      `---\ntitle: mine\ntype: project-index\nupdated: 2026-06-28\nworking_dir: "${work}"\n---\n# mine\n`,
+    );
+    const theirsDir = join(dir, 'projects', 'theirs');
+    mkdirSync(theirsDir, { recursive: true });
+    writeFileSync(join(theirsDir, 'index.md'), '# theirs (no working_dir, another project)\n');
+    spawnSync('git', ['add', '-A'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'projects'], { cwd: dir });
+    try {
+      fn(dir, work);
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
+  });
+}
+
+function runSessionStartFor(dir, cwd, sessionId) {
+  return spawnSync(process.execPath, [join(HOOKS, 'hypo-session-start.mjs')], {
+    input: JSON.stringify({ cwd, session_id: sessionId }),
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: dir },
+  });
+}
+
+test('a different project surfaces a foreign notice with count and name', () => {
+  withTwoProjectWiki((dir, work) => {
+    writeFileSync(join(dir, 'projects', 'theirs', 'draft.md'), 'uncommitted draft\n');
+    const r = runSessionStartFor(dir, work, 'issue99-foreign');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /\[WIKI: 현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected foreign notice, got: ${r.stdout}`,
+    );
+  });
+});
+
+test('own-project changes are excluded from the foreign count', () => {
+  withTwoProjectWiki((dir, work) => {
+    writeFileSync(join(dir, 'projects', 'mine', 'draft.md'), 'my own uncommitted work\n');
+    const r = runSessionStartFor(dir, work, 'issue99-own');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !/\[WIKI: 현재 프로젝트 외|\[WIKI: 귀속 불명/.test(r.stdout),
+      `own uncommitted change must not read as foreign or unattributed: ${r.stdout}`,
+    );
+  });
+});
+
+// New contract (ISSUE-99 follow-up): "projects/<slug>/" is named-foreign;
+// everything else that is dirty is "unattributed", not silently dropped. A
+// root-level vault file is "everything else" too. Narrowing it away would
+// repeat the exact silent failure this notice exists to prevent (ADR 0098:
+// attribution surfaces what it cannot place a name on, it does not discard
+// it).
+test('root-level uncommitted changes (shared vault infra) count as unattributed, not silently dropped', () => {
+  withTwoProjectWiki((dir, work) => {
+    writeFileSync(join(dir, 'hot.md'), '---\ntitle: Hot\nupdated: today\n---\n## edited\n');
+    const r = runSessionStartFor(dir, work, 'issue99-root');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !/\[WIKI: 현재 프로젝트 외/.test(r.stdout),
+      `a root-level dirty file must not be misread as a NAMED foreign project: ${r.stdout}`,
+    );
+    assert.match(
+      r.stdout,
+      /\[WIKI: 귀속 불명 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected the root-level file to count in the unattributed bucket, got: ${r.stdout}`,
+    );
+  });
+});
+
+// Reproduces the 2026-08-27 incident directly: the file set that slipped
+// through was extensions/ai-tone/, not a projects/<slug>/ path. Before this
+// fix projectOfPath's null return meant "not one project's work" and the
+// caller dropped it; now null feeds the unattributed count instead.
+test('extensions/ai-tone dirty file surfaces as an unattributed count (2026-08-27 incident)', () => {
+  withTwoProjectWiki((dir, work) => {
+    const toneDir = join(dir, 'extensions', 'ai-tone');
+    mkdirSync(toneDir, { recursive: true });
+    writeFileSync(join(toneDir, 'x.sh'), '#!/bin/sh\necho hi\n');
+    const r = runSessionStartFor(dir, work, 'issue99-aitone');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /\[WIKI: 귀속 불명 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected the original-incident file to surface as unattributed, got: ${r.stdout}`,
+    );
+  });
+});
+
+test('a _specs/ scratch dirty file also surfaces as unattributed', () => {
+  withTwoProjectWiki((dir, work) => {
+    const specsDir = join(dir, '_specs', 'some-work');
+    mkdirSync(specsDir, { recursive: true });
+    writeFileSync(join(specsDir, 'plan.md'), '# plan\n');
+    const r = runSessionStartFor(dir, work, 'issue99-specs');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /\[WIKI: 귀속 불명 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected the _specs scratch file to surface as unattributed, got: ${r.stdout}`,
+    );
+  });
+});
+
+test('git enumeration failure (not a git repo) yields a distinct notice, not silence', () => {
+  const notARepo = mkdtempSync(join(tmpdir(), 'hypo-issue99-notrepo-'));
+  const work = mkdtempSync(join(tmpdir(), 'hypo-issue99-notrepo-work-'));
+  try {
+    const r = runSessionStartFor(notARepo, work, 'issue99-norepo');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /\[WIKI: 미커밋 변경의 귀속을 확인하지 못했습니다\. git 상태를 근거로 작업 범위를 정하지 마십시오\.\]/,
+      `expected a distinct enumeration-failure notice instead of silence, got: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(notARepo, { recursive: true, force: true });
+    rmSync(work, { recursive: true, force: true });
+  }
+});
+
+// codex review (foreign-notice follow-up): "any" was previously proven with
+// a single dirty project, which cannot distinguish "counts every foreign
+// project" from "counts the first one found". Two foreign projects, both
+// must appear.
+test('MISS (no cwd match): any project-scoped uncommitted change counts as foreign', () => {
+  withTwoProjectWiki((dir) => {
+    writeFileSync(join(dir, 'projects', 'theirs', 'draft.md'), 'uncommitted draft\n');
+    writeFileSync(join(dir, 'projects', 'mine', 'draft.md'), 'uncommitted draft too\n');
+    const unrelatedCwd = mkdtempSync(join(tmpdir(), 'hypo-issue99-unrelated-'));
+    try {
+      const r = runSessionStartFor(dir, unrelatedCwd, 'issue99-miss');
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.match(
+        r.stdout,
+        /\[WIKI: 현재 프로젝트 외 projects\/mine, projects\/theirs 변경 2건이 있습니다\./,
+        `expected BOTH foreign projects counted (not just the first found), got: ${r.stdout}`,
+      );
+    } finally {
+      rmSync(unrelatedCwd, { recursive: true, force: true });
+    }
+  });
+});
+
+// codex pre-commit review BLOCKER 2 companion: `git status --porcelain`
+// reports paths relative to the repo TOP LEVEL even under `-C`, not to
+// hypoDir. Without stripping `--show-prefix`, a vault nested under a bigger
+// host repo would never match its own `projects/` paths (permanent silence),
+// and a projects/ directory living OUTSIDE the vault in that same host repo
+// would get misattributed as one of the vault's own projects.
+test('git rev-parse --show-prefix normalization: a vault-outside projects/ path is not misattributed', () => {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-issue99-nested-'));
+  const work = mkdtempSync(join(tmpdir(), 'hypo-issue99-nested-work-'));
+  try {
+    const vault = join(base, 'vault');
+    mkdirSync(vault, { recursive: true });
+    spawnSync('git', ['init', '-q'], { cwd: base });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: base });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: base });
+    const theirsDir = join(vault, 'projects', 'theirs');
+    mkdirSync(theirsDir, { recursive: true });
+    writeFileSync(join(theirsDir, 'index.md'), '# theirs\n');
+    const outsideDir = join(base, 'projects', 'outsider');
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, 'file.md'), '# outside the vault entirely\n');
+    spawnSync('git', ['add', '-A'], { cwd: base });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: base });
+    writeFileSync(join(theirsDir, 'draft.md'), 'uncommitted draft\n');
+    appendFileSync(join(outsideDir, 'file.md'), '\ndirty outside\n');
+    const r = runSessionStartFor(vault, work, 'issue99-nested');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /\[WIKI: 현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected only the in-vault "theirs" change counted, not the outside-vault "outsider" path: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+    rmSync(work, { recursive: true, force: true });
+  }
+});
+
+// codex 3rd-round review: `listDirtyPaths` used to skip a rename/copy's
+// paired `from` record entirely, keeping only the destination path. A rename
+// OUT of a foreign project and INTO the cwd-matched project then vanished
+// completely: the destination reads as "own" and gets excluded, and the
+// origin (the one path that WAS actually foreign) was never looked at.
+test('a rename OUT of a foreign project (into own) is not silently lost (codex 3rd-round review)', () => {
+  withTwoProjectWiki((dir, work) => {
+    writeFileSync(join(dir, 'projects', 'theirs', 'a.md'), 'seed\n');
+    spawnSync('git', ['add', '-A'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'seed'], { cwd: dir });
+    spawnSync('git', ['mv', 'projects/theirs/a.md', 'projects/mine/a.md'], { cwd: dir });
+    const r = runSessionStartFor(dir, work, 'issue99-rename');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /\[WIKI: 현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `a rename OUT of a foreign project must still surface theirs, got: ${r.stdout}`,
+    );
+  });
+});
+
+// A leading space right above the vault is a valid path segment.
+// `--show-prefix`'s output must only lose its trailing `\n`, never a leading
+// byte that is actually part of the path. trim() strips both ends and would
+// silently break every startsWith(prefix) match below it.
+test('a leading-space path component above the vault does not silence the notice (prefix trimEnd)', () => {
+  const base = mkdtempSync(join(tmpdir(), 'hypo-issue99-prefixspace-'));
+  const work = mkdtempSync(join(tmpdir(), 'hypo-issue99-prefixspace-work-'));
+  try {
+    const vault = join(base, ' weird', 'vault');
+    mkdirSync(join(vault, 'projects', 'mine'), { recursive: true });
+    writeFileSync(
+      join(vault, 'projects', 'mine', 'index.md'),
+      `---\ntitle: mine\ntype: project-index\nupdated: 2026-06-28\nworking_dir: "${work}"\n---\n# mine\n`,
+    );
+    const theirsDir = join(vault, 'projects', 'theirs');
+    mkdirSync(theirsDir, { recursive: true });
+    writeFileSync(join(theirsDir, 'index.md'), '# theirs\n');
+    spawnSync('git', ['init', '-q'], { cwd: base });
+    spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: base });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: base });
+    spawnSync('git', ['add', '-A'], { cwd: base });
+    spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: base });
+    writeFileSync(join(theirsDir, 'draft.md'), 'uncommitted draft\n');
+    const r = runSessionStartFor(vault, work, 'issue99-prefixspace');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(
+      r.stdout,
+      /\[WIKI: 현재 프로젝트 외 projects\/theirs 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected the foreign notice despite the leading-space path component, got: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+    rmSync(work, { recursive: true, force: true });
+  }
+});
+
+// A project directory name with a REAL embedded newline (shell command
+// substitution swallows a trailing \n, so this must be built directly with
+// mkdirSync, never `$(printf '\n')`). Without sanitizeProjForPrompt this
+// splits the one-line notice into two printed lines, which is the injection
+// surface the guard exists to close.
+test('a project directory name with a real newline stays a single-line notice (sanitizeProjForPrompt regression)', () => {
+  withTwoProjectWiki((dir, work) => {
+    const evilSlug = 'ev\nil';
+    const evilDir = join(dir, 'projects', evilSlug);
+    mkdirSync(evilDir, { recursive: true });
+    writeFileSync(join(evilDir, 'draft.md'), 'uncommitted draft\n');
+    const r = runSessionStartFor(dir, work, 'issue99-newline');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const firstLine = r.stdout.split('\n')[0];
+    assert.match(
+      firstLine,
+      /\[WIKI: 현재 프로젝트 외 projects\/ev il 변경 1건이 있습니다\. 사용자 명시 지시 없이는 이 세션 작업으로 편입하지 마십시오\.\]/,
+      `expected the whole notice on one line with the embedded newline sanitized, got: ${JSON.stringify(r.stdout)}`,
+    );
+  });
+});
+
+test('clean vault: no foreign notice at all (quiet at zero)', () => {
+  withTwoProjectWiki((dir, work) => {
+    const r = runSessionStartFor(dir, work, 'issue99-clean');
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(
+      !/\[WIKI: 현재 프로젝트 외|\[WIKI: 귀속 불명|\[WIKI: 미커밋 변경의 귀속을/.test(r.stdout),
+      `a clean vault must emit no foreign/unattributed/enumeration-failure notice: ${r.stdout}`,
+    );
+  });
+});


### PR DESCRIPTION
# English

## What changed

`/hypo:resume` and the SessionStart injection now print one line when the vault has
uncommitted work outside the project this session resolved to. Changes under
`projects/<slug>/` are counted with their name; everything else is counted without one.
The line does not block anything.

## Why

An agent that runs `git status` in the vault sees every project's uncommitted changes as
one undifferentiated pile. That is not hypothetical: a session's resume surfaced 12
uncommitted files, three of which belonged to another project's shell hooks, and those
three went into that session's plan. A person caught it.

A neighbouring issue covers the loud version of this, where a gate stops on someone
else's dirty file. This is the quiet one: nothing breaks, the agent simply adopts work it
does not own. A hard block is the wrong shape here, because a maintainer editing the whole
vault in one session is a legitimate thing to do.

## How

Two decisions in the vault's own records shaped the boundary, and they are the reason the
first attempt at this was wrong.

The first attempt classified anything outside `projects/<slug>/` as `null` and then
dropped it, which silently excluded the exact directory the original incident lived in.
`null` from a judge means "could not decide", not "there is nothing there", so those paths
are now counted without a name instead of discarded. The same rule separates narrowing
from attributing: a check that must tell a person about something may not delete what it
cannot label.

Enumeration failure is likewise kept distinct from a count of zero. Silence now means one
thing only: git answered, and both counts were zero.

Paths are normalized through `git rev-parse --show-prefix`, because `git status
--porcelain` reports relative to the repository root, not to the directory passed with
`-C`. Without it, a vault nested inside a larger repository would carry a prefix on every
path and the notice would go permanently silent.

Project names are sanitized before they reach the prompt and the printed list is capped.
A directory name containing a newline would otherwise split the one-line notice in two and
inject into the surrounding context.

## Manual verification

```
npm test        # 2143 passed, 0 failed
node tests/runner.mjs --file=session-hooks    # 180 passed, 0 failed
node tests/runner.mjs --file=query-resume     # 35 passed, 0 failed
node scripts/check-tracker-ids.mjs            # ok
```

Each of the three defenses was turned off and watched to fail:

- dropping the origin path of a rename again makes the "rename out of a foreign project"
  test fail
- restoring `trim()` on the prefix makes the leading-space-path test fail
- removing the name sanitizer makes the newline-in-a-directory-name test fail

All three were restored and the working tree greps clean of the mutations.

The sanitizer check was verified by hand first, against a directory whose name holds a
real newline. Without the sanitizer the notice arrives as two lines; with it, one. Note
that a shell `$(printf '\n')` cannot build that fixture, because command substitution
strips the trailing newline; the test builds it through `mkdirSync` instead.

A vault created with `init --no-git-init` now shows the "cannot attribute" line on every
session. That is a supported layout, so the tradeoff is pinned by its own test rather than
left implicit: a future change that makes such a vault quiet starts by turning that
assertion red. Distinguishing "not a repository" from "git could not answer" is not
reachable by exit code alone, since both are 128.

## Migration notes

None.

---

# 한국어

## 변경 내용

`/hypo:resume` 출력과 SessionStart 주입이, 이 세션이 해석한 프로젝트 밖에 미커밋 작업이
있으면 한 줄을 낸다. `projects/<slug>/` 아래는 이름과 함께 세고, 그 밖은 이름 없이 센다.
차단하지 않는다.

## 이유

볼트에서 `git status` 를 치는 에이전트는 모든 프로젝트의 미커밋 변경을 구별 없는 한 덩어리로
본다. 가정이 아니다. 한 세션의 resume 이 미커밋 12 건을 냈고 그중 셋이 다른 프로젝트의 셸
훅이었는데, 그 셋이 그 세션의 계획에 들어갔다. 사람이 잡았다.

인접한 이슈가 이것의 시끄러운 판본을 다룬다. 게이트가 남의 더러운 파일을 보고 멈추는
경우다. 이쪽은 조용한 쪽이다. 아무것도 안 터지고 에이전트가 남의 일을 자기 것으로 삼을 뿐이다.
여기서 하드 차단은 틀린 모양이다. 유지보수자가 한 세션에서 볼트 전체를 손보는 것은 정당한
일이기 때문이다.

## 방법

볼트 자신의 기록 둘이 경계를 정했고, 그것이 첫 시도가 틀렸던 이유다.

첫 시도는 `projects/<slug>/` 밖을 전부 `null` 로 분류하고 버렸는데, 그러면 원 사고가 살던
바로 그 디렉터리가 조용히 빠진다. 판정 함수의 `null` 은 "못 정했다" 이지 "거기 아무것도
없다" 가 아니므로, 이제 그 경로들은 버려지지 않고 이름 없이 세어진다. 같은 규칙이 좁히는
것과 귀속시키는 것을 가른다. 사람에게 알려야 하는 검사는 이름을 못 붙인다고 지우면 안 된다.

열거 실패도 0 건과 구별해 둔다. 조용한 것은 이제 한 가지만 뜻한다. git 이 답했고 두 수가 다
0 이었다는 것이다.

경로는 `git rev-parse --show-prefix` 로 정규화한다. `git status --porcelain` 이 `-C` 로 준
디렉터리가 아니라 저장소 최상위 기준으로 보고하기 때문이다. 이것이 없으면 더 큰 저장소 안에
든 볼트는 모든 경로에 접두가 붙어 알림이 영구히 침묵한다.

프로젝트 이름은 프롬프트에 닿기 전에 정규화하고 나열 개수를 제한한다. 개행이 든 디렉터리
이름이면 한 줄 알림이 둘로 쪼개지고 그 자리로 주입된다.

## 수동 검증

```
npm test        # 2143 passed, 0 failed
node tests/runner.mjs --file=session-hooks    # 180 passed, 0 failed
node tests/runner.mjs --file=query-resume     # 35 passed, 0 failed
node scripts/check-tracker-ids.mjs            # ok
```

방어 셋을 각각 꺼서 실패하는 것을 봤다.

- rename 의 출처 경로를 다시 버리면 "남의 프로젝트에서 빠져나간 rename" 테스트가 실패한다
- 접두에 `trim()` 을 되돌리면 선행 공백 경로 테스트가 실패한다
- 이름 정규화를 빼면 디렉터리 이름의 개행 테스트가 실패한다

셋 다 원상복구했고 워킹트리에 무력화 흔적이 남지 않았다.

정규화 확인은 실제 개행이 든 디렉터리 이름으로 손으로 먼저 했다. 정규화가 없으면 알림이 두
줄로 오고 있으면 한 줄이다. 셸의 `$(printf '\n')` 으로는 그 픽스처를 못 만든다. 명령 치환이
끝 개행을 버리기 때문이고, 그래서 테스트는 `mkdirSync` 로 짓는다.

`init --no-git-init` 으로 만든 볼트는 이제 매 세션 "확인하지 못했습니다" 줄을 본다. 지원되는
배치이므로 그 대가를 암묵으로 두지 않고 테스트로 고정했다. 그런 볼트를 조용하게 만드는 변경은
그 단언을 빨갛게 만드는 데서 시작한다. "저장소가 아님" 과 "git 이 답을 못 함" 은 종료 코드만으로
갈리지 않는다. 둘 다 128 이다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: `/hypo:resume` and SessionStart now surface uncommitted vault work that belongs to another project, so a session does not silently adopt it (#280).
- KO: `/hypo:resume` 과 SessionStart 가 다른 프로젝트 소관의 미커밋 변경을 한 줄로 알려, 세션이 그것을 조용히 자기 일로 삼지 않게 한다 (#280).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
