### PR TITLE
fix(lint,close): check the frontmatter of the root files a close writes

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -173,7 +173,11 @@ Init options:
   --lint-strict          Opt-in: also gate the wiki pre-commit hook on
                          \`lint --strict\` (promotes STRICT_PROMOTE_IDS warnings
                          to a blocking error), sequenced after the .hypoignore
-                         guard. Off by default; re-run init to add or drop it.
+                         guard. Exception: root hot.md/log.md's own
+                         no-frontmatter warning stays a warn even under this
+                         flag, so a legacy vault predating the frontmatter
+                         convention still commits. Off by default; re-run init
+                         to add or drop it.
   --dry-run              Show what would be done without making changes
   --version              Print the installed package version and exit
   --help, -h             Show this help message

--- a/scripts/lib/crystallize-close-apply.mjs
+++ b/scripts/lib/crystallize-close-apply.mjs
@@ -1018,18 +1018,45 @@ function runPreflight(args, payload, project, date) {
   const blockingErrors = preflightLint.errors.filter(
     (e) => payloadScope.has(e.file) && !overwriteTargets.has(e.file),
   );
-  if (blockingErrors.length > 0) {
+  // W9 (invalid-YAML frontmatter) legacy-debt policy: the SAME append-target
+  // rule as blockingErrors above, applied to W9 specifically. A pre-existing
+  // broken frontmatter block on an append target (log.md, the session-log
+  // shard) can never be healed by this close, because appendIfAbsent only adds
+  // bytes below the block and never rewrites it. Leaving it unblocked would let
+  // every future close keep appending onto (and reporting success over) a file
+  // post-apply lint can never certify clean, so it is blocked HERE, before a
+  // single byte is written, exactly like a pre-existing lint ERROR in an
+  // append target already does two lines above. Overwrite targets are exempt
+  // for the same reason blockingErrors exempts them: this close is about to
+  // replace their bytes outright, so their PRE-existing frontmatter is moot
+  // (the post-apply check below is what catches a payload that writes its own
+  // broken YAML into one of those). Out-of-scope W9 debt elsewhere in the
+  // vault (this repo's own maintainer vault carries one, under
+  // pages/feedback/) is untouched by this filter and stays a plain warn.
+  //
+  // W9 carries no `id` in the default (non-strict) --json warns lint.mjs
+  // returns, only W8 does (see lint.mjs's `toOut`), so it is matched by its
+  // fixed message prefix instead, the same technique registerPendingTags
+  // above already uses for W10.
+  const blockingW9 = (preflightLint.warns || []).filter(
+    (w) =>
+      INVALID_YAML_WARN_RE.test(w.message || '') &&
+      payloadScope.has(w.file) &&
+      !overwriteTargets.has(w.file),
+  );
+  const allPreflightBlocking = [...blockingErrors, ...blockingW9];
+  if (allPreflightBlocking.length > 0) {
     const out = {
       ok: false,
       stage: 'preflight-lint',
       error: 'lint preflight failed — apply aborted (no payload bytes written)',
-      lint: { ...summarizeLintForOutput(preflightLint), blockingErrors },
+      lint: { ...summarizeLintForOutput(preflightLint), blockingErrors: allPreflightBlocking },
     };
     if (args.json) {
       console.log(JSON.stringify(out, null, 2));
     } else {
       console.log('✗ lint preflight failed — apply aborted (no payload bytes written):');
-      for (const e of blockingErrors) console.log(`  ✗ ${e.file}: ${e.message}`);
+      for (const e of allPreflightBlocking) console.log(`  ✗ ${e.file}: ${e.message}`);
       console.log('  Fix the wiki (run `node scripts/lint.mjs`) and retry.');
     }
     process.exit(1);
@@ -1411,6 +1438,14 @@ function parkOverwriteConflicts(args, conflicts) {
 // than truncated at its first quote (codex stage-2 CONCERN).
 const unknownTagRe = /^Unknown tag: "(.+)" \(not in SCHEMA\.md Tag Vocabulary\)/;
 
+// W9 (invalid-YAML frontmatter) is warn-severity in lint.mjs's default,
+// non-strict classification, and its `id` is stripped from the --json warns
+// this apply reads (only W8 survives toOut without --strict, see lint.mjs).
+// Matched by its fixed message prefix instead, same technique as
+// unknownTagRe above. Shared by runPreflight's append-target legacy-debt
+// check and runPostApplyLint's payload-scope promotion below.
+const INVALID_YAML_WARN_RE = /^Invalid YAML frontmatter: /;
+
 function registerPendingTags(args, preflightLint, hasConflicts) {
   const pendingTags = [];
   for (const w of preflightLint.warns || []) {
@@ -1459,10 +1494,32 @@ function runPostApplyLint(args, payloadScope) {
     postBlocking = postApplyLint.errors;
     postNotice = [];
   } else {
-    ({ blocking: postBlocking, notice: postNotice } = partitionLintScope(
+    const { blocking: errBlocking, notice: errNotice } = partitionLintScope(
       postApplyLint.errors || [],
       payloadScope,
-    ));
+    );
+    // W9 promotion (codex pre-commit review): invalid-YAML frontmatter is
+    // warn-severity, not error, in lint.mjs's default classification, so it
+    // never reached `errors` above without an operator opting into --strict.
+    // A wiki with no --lint-strict pre-commit hook installed could then reach
+    // ok:true and exit 0 with corrupt frontmatter sitting in a file this very
+    // close just wrote. Promote it here to a close-blocking finding, but ONLY
+    // inside payloadScope: this partition is the single source of "this
+    // close's own neighborhood" already used for errors above, so a W9 warn
+    // anywhere else in the vault (this repo's own maintainer vault carries
+    // one, under pages/feedback/) is discarded outright below and never
+    // folded into `postNotice` either. That is untouched, not merely
+    // non-blocking, matching runPreflight's identical scope contract for the
+    // append-target legacy-debt case above. W1 (no-frontmatter) is
+    // deliberately NOT promoted here: a legacy vault's frontmatter-less
+    // log.md is the documented shape --strict itself exempts, and this close
+    // path must keep accepting it.
+    const w9Blocking = partitionLintScope(
+      (postApplyLint.warns || []).filter((w) => INVALID_YAML_WARN_RE.test(w.message || '')),
+      payloadScope,
+    ).blocking;
+    postBlocking = [...errBlocking, ...w9Blocking];
+    postNotice = errNotice;
   }
   const postLintOk = !postApplyCrashed && postBlocking.length === 0;
   return { postApplyLint, postBlocking, postNotice, postLintOk };

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -287,6 +287,9 @@ const issues = [];
 // defects only.
 //   W1 no-frontmatter / W2 unknown-type / W4 broken-wikilink → promote.
 //   W9 invalid-YAML → promote (frontmatter a real YAML parser rejects).
+//   Exception: the closeRootTargets loop's own W1 findings (hot.md/log.md)
+//   are exempted from this promotion below, scoped by id and by that file
+//   set only; see the comment at that loop and at the promotion site.
 //   W3 missing-updated  → excluded (auto-repaired by --fix).
 //   W8 design-history-stale → excluded (hypo-personal-check handles it; would
 //                             double-gate).
@@ -298,10 +301,12 @@ const issues = [];
 //                             PreCompact hook no longer blocks /compact, so
 //                             that set is what --check-session-close and
 //                             --mark-session-closed read, not a compact stop.
-// NOTE: no gate currently passes --strict (npm run lint / CI / release.yml /
-// crystallize / the close-gate all run plain lint), so promotion is
-// forward-looking: these surface as warnings today. The deliverable is
-// "stop silently green-passing invalid YAML"; the W9 warning satisfies that.
+// NOTE: npm run lint / CI / release.yml / crystallize / the close-gate all
+// run plain lint, not --strict, so promotion is forward-looking there: these
+// still surface as warnings on those paths. But --strict is not unused —
+// init.mjs's --lint-strict wires `lint --strict` into a vault's own
+// pre-commit hook (scripts/init.mjs, pinned by tests/init.test.mjs), so a
+// vault that opts in does gate a commit on these IDs today.
 const STRICT_PROMOTE_IDS = new Set(['W1', 'W2', 'W4', 'W9']);
 
 function issue(severity, rel, msg, fullPath = null, id = null) {
@@ -544,31 +549,55 @@ const validTypes = new Set([...VALID_TYPES, ...parseSchemaTypes(args.hypoDir)]);
 
 for (const page of pages) lintPage(page, slugMap, tagVocab, pageDirs, validTypes);
 
-// W4 (broken-wikilink only, NOT the full lintPage) for close's root-level
-// write targets that fall outside pages/projects/journal: hot.md and log.md
-// today. closeFileTargetsGlobal is the one list of what close writes
-// (hooks/hypo-shared.mjs), reused here instead of re-derived, so a future
-// close target is covered automatically. Only the entries NOT already under
-// a scanDir are new; closeFileTargetsGlobal's projects/<slug>/* entries are
-// already linted in full above.
+// W4 (broken-wikilink) plus a reduced W1 (closed frontmatter block presence)
+// and W9 (invalid YAML inside that block), NOT the full lintPage, for close's
+// root-level write targets that fall outside pages/projects/journal: hot.md
+// and log.md today. closeFileTargetsGlobal is the one list of what close
+// writes (hooks/hypo-shared.mjs), reused here instead of re-derived, so a
+// future close target is covered automatically. Only the entries NOT already
+// under a scanDir are new; closeFileTargetsGlobal's projects/<slug>/* entries
+// are already linted in full above.
 //
-// Why link-only and not the full lintPage: measured, not assumed. On the
-// packaged templates/ (hot.md type:reference, log.md type:log, both declared
-// in templates/SCHEMA.md's taxonomy), full lintPage on both files comes back
-// completely clean, so "these types trip W2" is not the reason to hold back.
-// The real reason is that live vaults do not all match the template. A vault
-// whose SCHEMA.md predates the `log` type row (or has none) gets a fresh
-// "Unknown type: log" W2 the moment log.md is run through lintPage, and a
-// vault whose root log.md predates the frontmatter convention entirely (no
-// leading `---` block at all, confirmed against a real maintainer vault)
-// gets a fresh "No frontmatter found" W1. Both W1 and W2 are in
-// STRICT_PROMOTE_IDS, so under --strict a vault that lint has always passed
-// would start failing on a file whose content this fix never touched. Full
-// lintPage stays reserved for pages/projects/journal, where every file was
-// already being linted before this change and there is no such newly-exposed
-// vault. W4 itself stays warn-only outside --strict, and postApply
-// (crystallize.mjs) gates only on errors, so this addition can add a new
-// warning to a close's lint output but can never fail one.
+// Why link-only (plus these two frontmatter checks) and not the full
+// lintPage: measured, not assumed. On the packaged templates/ (hot.md
+// type:reference, log.md type:log, both declared in templates/SCHEMA.md's
+// taxonomy), full lintPage on both files comes back completely clean, so
+// "these types trip W2" is not the reason to hold back. The real reason is
+// that live vaults do not all match the template. A vault whose SCHEMA.md
+// predates the `log` type row (or has none) gets a fresh "Unknown type: log"
+// W2 the moment log.md is run through lintPage. W2 (and the rest of
+// lintPage's field checks) stays out of this loop for exactly that reason:
+// it does not catch a close's whole-file overwrite any better than W4
+// already does, and it would trip on vault-local type taxonomy the write
+// never touched.
+//
+// W1 (no closed frontmatter block) and W9 (invalid YAML inside that block)
+// are the two lintPage checks pulled in on purpose: close's crystallize path
+// overwrites hot.md/log.md wholesale, and a write that drops the frontmatter
+// delimiters or leaves broken YAML behind is exactly the corruption this
+// scan exists to catch, one write earlier than doctor. The W1 predicate here
+// matches hooks/hypo-shared.mjs's frontmatterUpdated exactly (a *closed*
+// `---`...`---` block, not just an opening fence) so this scan and the
+// close-gate's own staleness check agree on what counts as "has frontmatter";
+// an unclosed fence fails both the same way, instead of lint calling it clean
+// while the close gate hard-fails on it. The same measurement above shows why
+// this stays narrow rather than becoming full lintPage: a vault whose root
+// log.md predates the frontmatter convention entirely (no leading `---`
+// block at all, confirmed against a real maintainer vault) would get a fresh
+// W1 the instant this check exists, on content this change never touched.
+// W1 is in STRICT_PROMOTE_IDS, so that vault would start failing `--strict`
+// for a file it always had. The strict-promotion loop below carries a narrow
+// exemption for exactly this case (W1 + this file set only, NOT W9), so a
+// shaped-like-legacy vault keeps passing `--strict` while W1 still fires as a
+// warning here and a genuinely broken close-time write still promotes under
+// `--strict` on pages/projects/journal, where it was always covered. W9 is
+// deliberately NOT exempted: a legacy vault with no frontmatter block at all
+// never reaches the YAML check (there is no block to inspect), so the
+// exemption never needed to cover it, and a root file whose block IS present
+// but broken is exactly the defect this loop exists to promote. W4 and W1
+// both stay warn-only outside `--strict`, and postApply (crystallize.mjs)
+// gates only on errors, so this loop can add a new warning to a close's lint
+// output but can never fail one on its own.
 const closeRootTargets = [...closeFileTargetsGlobal(args.hypoDir)].filter(
   (f) => !f.startsWith('pages/') && !f.startsWith('projects/') && !f.startsWith('journal/'),
 );
@@ -580,6 +609,14 @@ for (const rel of closeRootTargets) {
     content = readFileSync(full, 'utf-8');
   } catch {
     continue;
+  }
+  const fmBlock = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmBlock) {
+    issue('warn', rel, 'No closed frontmatter block found', null, 'W1');
+  } else {
+    for (const reason of checkYamlInvalid(fmBlock[1])) {
+      issue('warn', rel, `Invalid YAML frontmatter: ${reason}`, null, 'W9');
+    }
   }
   for (const link of extractWikilinks(content)) {
     if (!slugMap.has(link)) {
@@ -699,9 +736,20 @@ if (args.fix) {
 // --strict: promote selected warnings (by stable ID) to errors *before* the
 // errors/warns split, so exit code, counts, plain-text icons, and --json `ok`
 // all derive from the post-promotion severities through the existing paths.
+//
+// Exemption for the closeRootTargets loop's own W1 (see the comment there):
+// a root hot.md/log.md that predates the frontmatter convention is a
+// pre-existing vault shape, not a defect this scan introduced, so promoting
+// it under --strict would fail vaults that lint has always passed. Scoped by
+// BOTH id (W1 only, not W2/W4/W9) AND file (closeRootTargets, the short
+// hot.md/log.md list, not the full closeFileTargetsGlobal) so a future close
+// target under pages/projects/journal stays fully promotable: it is already
+// linted through lintPage above, where this exemption does not apply.
+const closeRootTargetSet = new Set(closeRootTargets);
 if (args.strict) {
   for (const iss of issues) {
     if (iss.severity === 'warn' && iss.id && STRICT_PROMOTE_IDS.has(iss.id)) {
+      if (iss.id === 'W1' && closeRootTargetSet.has(iss.file)) continue;
       iss.severity = 'error';
     }
   }

--- a/tests/crystallize-apply.test.mjs
+++ b/tests/crystallize-apply.test.mjs
@@ -573,6 +573,93 @@ test('preflight (#40 codex-P2): post-apply-lint failure + fixed payload retry �
   });
 });
 
+// ── W9 promotion: payload-scope invalid-YAML frontmatter blocks close ─────────
+// W9 (invalid-YAML frontmatter) is warn-severity in lint.mjs's default
+// classification, not error, so it never reached the errors-only preflight/
+// post-apply gate above without an operator opting into --strict. A wiki with
+// no --lint-strict pre-commit hook installed could reach ok:true and exit 0
+// with corrupt frontmatter sitting in a file this very close just wrote.
+// runPreflight/runPostApplyLint (crystallize-close-apply.mjs) now promote a
+// W9 warn to a close-blocking finding, but ONLY inside this close's own
+// payload scope: legacy debt elsewhere in the vault (or a legacy vault's
+// frontmatter-less log.md, W1) must stay untouched.
+suite('W9 promotion: payload-scope invalid-YAML frontmatter blocks close');
+
+test('post-apply: broken YAML in a payload-scope root file (hot.md) → ok:false, exit 1', () => {
+  // "title: hot: broken" is an unquoted top-level value containing ": ", the
+  // exact shape lint.mjs's checkYamlInvalid (W9) narrow detector flags. Not
+  // W1: the frontmatter block itself opens and closes cleanly, only its
+  // content is invalid YAML.
+  withWiki(null, (dir, today) => {
+    const sid = 'w9-promotion-session';
+    snapshotBase(dir, sid, overwriteTargets('test-project'));
+    const payload = payloadForCleanWiki(dir, today);
+    payload.rootHot = {
+      content: `---\ntitle: hot: broken\ntype: hot\nupdated: ${today}\n---\n\nbody\n`,
+    };
+    const r = runApply(dir, payload, { sessionId: sid });
+    assert.equal(
+      r.status,
+      1,
+      `broken YAML in a payload-scope file must abort the close: ${r.stdout}`,
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+    assert.equal(out.stage, 'post-apply-lint', `stage should be post-apply-lint: ${r.stdout}`);
+    const onDisk = readFileSync(join(dir, 'hot.md'), 'utf-8');
+    assert.ok(
+      onDisk.includes('title: hot: broken'),
+      'apply still writes the payload bytes to disk (post-apply lint runs AFTER the write)',
+    );
+  });
+});
+
+test('post-apply: pre-existing W9 debt OUTSIDE payload scope does not block close', () => {
+  // The promotion is scoped exactly like the existing errors-only gate: a W9
+  // warn under pages/ (this close never wrote there) must stay a non-blocking
+  // notice, never swept into ok:false. Guards the promotion's own scope from
+  // silently widening to the whole vault.
+  withWiki(
+    (dir) => {
+      mkdirSync(join(dir, 'pages'), { recursive: true });
+      writeFileSync(
+        join(dir, 'pages', 'w9-debt.md'),
+        '---\ntitle: pre-existing debt\ntype: concept\nupdated: 2026-06-28\nnote: has: a colon\n---\n\nbody\n',
+      );
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      const r = runApply(dir, payload);
+      assert.equal(r.status, 0, `out-of-scope W9 debt must not block the close: ${r.stdout}`);
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, true);
+    },
+  );
+});
+
+test('append target with no frontmatter at all (W1, legacy log.md) still does not block close', () => {
+  // The promotion matches ONLY the W9 message prefix. A legacy vault's
+  // frontmatter-less log.md (W1, "No closed frontmatter block found") is a
+  // documented, intentionally-unpromoted shape; this close path must keep
+  // accepting it exactly as before.
+  withWiki(
+    (dir) => {
+      writeFileSync(join(dir, 'log.md'), '# Wiki Log\n\nlegacy, no frontmatter\n');
+    },
+    (dir, today) => {
+      const payload = payloadForCleanWiki(dir, today);
+      const r = runApply(dir, payload);
+      assert.equal(
+        r.status,
+        0,
+        `W1 in a payload-scope append target must not block the close: ${r.stdout}`,
+      );
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.ok, true);
+    },
+  );
+});
+
 // ── ISSUE-61: payload↔session binding (cross-session guard) ───────────────────
 // The session-close payload temp path used to be date-based, so two same-day
 // sessions clobbered each other's file; the winner's payload then applied under

--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -1667,6 +1667,131 @@ test('.hyposcanignore flips the same broken link from reported to unscanned', ()
   }
 });
 
+// ── root close targets: W1 no-frontmatter reduced check (ISSUE-98) ──────────
+// close overwrites hot.md/log.md wholesale, and nothing was checking whether
+// that write left a frontmatter block behind at all. These pair with the
+// strict-exemption tests below: this suite proves the check fires (a), the
+// Track E suite proves it stays a warning for a legacy vault under --strict
+// (b), and both directions matter for the same fixture to mean anything.
+
+test('a root close target with no frontmatter block at all is caught as W1', () => {
+  const { warns } = lintWiki({
+    'hot.md': '# Hot Cache\n\nclose overwrote this without a frontmatter block\n',
+  });
+  assert.ok(
+    warns.some((w) => w.file === 'hot.md' && /No closed frontmatter block found/.test(w.message)),
+    `root hot.md missing its frontmatter block must be reported: ${JSON.stringify(warns)}`,
+  );
+});
+
+test('a root close target with an unclosed frontmatter fence is caught as W1', () => {
+  // Same predicate as hooks/hypo-shared.mjs's frontmatterUpdated: a closed
+  // `---`...`---` block, not just an opening fence. An unclosed fence used to
+  // slip past this loop's old open-fence-only check and only fail at the
+  // close gate, with no lint signal pointing at why.
+  const { warns } = lintWiki({
+    'hot.md': '---\ntitle: Hot\n',
+  });
+  assert.ok(
+    warns.some((w) => w.file === 'hot.md' && /No closed frontmatter block found/.test(w.message)),
+    `root hot.md with an unclosed fence must be reported: ${JSON.stringify(warns)}`,
+  );
+});
+
+test('a root close target with an empty frontmatter block is caught as W1', () => {
+  // `---\n---\n` is caught, not skipped. The shared closed-block regex (both
+  // here and in hooks/hypo-shared.mjs's frontmatterUpdated) needs a line of
+  // content between the two fences: its lazy `([\s\S]*?)\r?\n---` requires a
+  // newline before the closing `---` that is not the opening fence's own
+  // newline, and an empty block has none. So `---\n---\n` does not match and
+  // this loop reports it exactly like a missing block, agreeing with the
+  // close gate's own reading of the same bytes rather than silently passing
+  // a frontmatter block with nothing in it.
+  const { warns } = lintWiki({
+    'hot.md': '---\n---\n\n# Hot\n',
+  });
+  assert.ok(
+    warns.some((w) => w.file === 'hot.md' && /No closed frontmatter block found/.test(w.message)),
+    `an empty frontmatter block must trip W1: ${JSON.stringify(warns)}`,
+  );
+});
+
+test('a root close target with a closed fence but broken YAML is caught as W9, and promotes under --strict', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-w9root-'));
+  try {
+    writeFileSync(join(dir, 'SCHEMA.md'), VOCAB_SCHEMA);
+    writeFileSync(join(dir, 'hot.md'), '---\ntitle: Hot\ntitle: Hot Again\n---\n\n# Hot\n');
+    const plain = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${dir}`, '--json'],
+      { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+    );
+    const plainOut = JSON.parse(plain.stdout);
+    assert.equal(plain.status, 0, `W9 is a warn, not an error, by default: ${plain.stdout}`);
+    assert.ok(
+      (plainOut.warns || []).some(
+        (w) => w.file === 'hot.md' && /Invalid YAML frontmatter/.test(w.message),
+      ),
+      `root hot.md with a closed-but-broken block must surface W9: ${JSON.stringify(plainOut.warns)}`,
+    );
+
+    const strict = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${dir}`, '--json', '--strict'],
+      { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+    );
+    const strictOut = JSON.parse(strict.stdout);
+    assert.equal(strict.status, 1, `W9 must promote under --strict: ${strict.stdout}`);
+    assert.ok(
+      (strictOut.errors || []).some((e) => e.file === 'hot.md' && e.id === 'W9'),
+      `root hot.md's W9 must promote to an error under --strict (not exempted): ${JSON.stringify(strictOut.errors)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a legacy root log.md with no frontmatter at all still passes --strict', () => {
+  // Mirrors a real maintainer vault: log.md predates the frontmatter
+  // convention entirely, starting with a heading, not `---`.
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-lint-legacy-'));
+  try {
+    writeFileSync(join(dir, 'SCHEMA.md'), VOCAB_SCHEMA);
+    writeFileSync(join(dir, 'log.md'), '# Wiki Log\n\nappend-only history, no frontmatter\n');
+    const r = spawnSync(
+      process.execPath,
+      [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${dir}`, '--json', '--strict'],
+      { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+    );
+    const out = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, `a legacy log.md must not fail --strict: ${r.stdout}`);
+    assert.ok(
+      (out.warns || []).some((w) => w.file === 'log.md' && w.id === 'W1'),
+      `log.md must still surface W1 as a warning under --strict: ${JSON.stringify(out.warns)}`,
+    );
+    assert.ok(
+      !(out.errors || []).some((e) => e.file === 'log.md'),
+      `log.md must not be promoted to an error under --strict: ${JSON.stringify(out.errors)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the packaged templates/ vault stays errors:0 warns:0', () => {
+  // Stock hot.md/log.md both carry a real frontmatter block, so the new W1
+  // check must not add a single finding to a vault it was never aimed at.
+  const r = spawnSync(
+    process.execPath,
+    [join(SCRIPTS, 'lint.mjs'), `--hypo-dir=${join(REPO, 'templates')}`, '--json'],
+    { encoding: 'utf-8', env: { ...process.env, HYPO_DIR: '', HOME: SESSION_TMP_HOME } },
+  );
+  const out = JSON.parse(r.stdout);
+  assert.equal(r.status, 0, `packaged templates/ must stay clean: ${r.stdout}`);
+  assert.equal((out.errors || []).length, 0, `templates/ errors: ${JSON.stringify(out.errors)}`);
+  assert.equal((out.warns || []).length, 0, `templates/ warns: ${JSON.stringify(out.warns)}`);
+});
+
 suite('fix #49: findDesignHistoryStale()');
 
 test('w8-stale: flat session-log.md newer than design-history → stale', () => {
@@ -2247,5 +2372,33 @@ test('strict: W1 no-frontmatter promotes and preserves early-return skip', () =>
     const errs = parsed.errors || [];
     assert.equal(errs.length, 1, `early-return preserved → only W1: ${JSON.stringify(errs)}`);
     assert.equal(errs[0].id, 'W1');
+  });
+});
+
+test('strict: the closeRootTargets W1 exemption does not leak to pages/ (ISSUE-98)', () => {
+  // Same run, same warning id, two files: a legacy root log.md (exempted) and
+  // a pages/ file with the identical defect (not exempted). Only pairing them
+  // in one run proves the exemption is scoped by file, not just by id — a
+  // disabled exemption would fail on log.md too, and a too-wide exemption
+  // would silently pass pages/a.md instead of failing.
+  withTmpDir((root) => {
+    writeFileSync(join(root, 'log.md'), '# Wiki Log\n\nlegacy, no frontmatter\n');
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(join(root, 'pages', 'a.md'), 'plain body, no frontmatter\n');
+    const r = runLintE(root, ['--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 1, `pages/a.md's W1 must still fail --strict: ${r.stdout}`);
+    const errIds = (parsed.errors || []).map((e) => `${e.file}:${e.id}`);
+    assert.deepEqual(
+      errIds,
+      ['pages/a.md:W1'],
+      `only pages/a.md may promote: ${JSON.stringify(parsed.errors)}`,
+    );
+    const warnW1Files = (parsed.warns || []).filter((w) => w.id === 'W1').map((w) => w.file);
+    assert.deepEqual(
+      warnW1Files,
+      ['log.md'],
+      `log.md's W1 must stay a warn: ${JSON.stringify(parsed.warns)}`,
+    );
   });
 });


### PR DESCRIPTION
# English

## What changed

The lint scan of the root files a session-close overwrites now checks whether their
frontmatter block is intact, not only whether their wikilinks resolve. Broken YAML inside
an intact block is reported too, and inside the close's own payload scope it fails the
close outright.

## Why

The close path writes root `hot.md` whole and appends to root `log.md`. The lint that runs
around it looked only for broken wikilinks in those two files, so a write that damaged the
frontmatter went unreported.

Investigating that gap moved it. For `hot.md` the damage was already caught: the freshness
check parses a closed frontmatter block to read `updated:`, gets nothing when the block is
gone, marks the file stale, and the close fails. So the original framing, that nobody
checks, was false for the file it was mostly about.

What remained was narrower and real. The first version of this check tested only for an
opening fence, while the freshness check requires a closed block, so the two disagreed
about the same bytes: an unterminated fence passed lint and failed the close, leaving the
operator with a failure that says nothing about frontmatter. An empty block and valid
fences wrapping invalid YAML were invisible to lint entirely.

## How

The probe now uses the same closed-block predicate as the freshness check, so one file
gets one answer. Invalid YAML is reported with the existing warning that the page scan
already emits, reusing its checker rather than adding a second one.

That warning is where the enforcement actually lives. The no-frontmatter warning is
exempted from strict promotion for these two files, because a vault whose `log.md`
predates the frontmatter convention is a real shape and append cannot introduce the
problem there. The invalid-YAML warning is not exempted, so it promotes like anywhere
else.

Warnings alone would not have stopped a close, since the close path runs lint without
`--strict` and gates on errors only. So invalid YAML is promoted to a close-blocking
finding, but strictly inside the payload scope: existing debt elsewhere in a vault is left
alone, not merely non-blocking. On an append target the block happens before any byte is
written, matching how a pre-existing error on an append target is already handled, because
appending cannot repair either one.

The `--lint-strict` help text claimed unconditional promotion and now names the exception.
A stale note claiming no gate passes `--strict` now names the one that does.

## Manual verification

```
npm test                                       # see below
node tests/runner.mjs --file=lint              # 147 passed, 0 failed
node tests/runner.mjs --file=crystallize-apply # 33 passed, 0 failed
node tests/runner.mjs --file=close-global      # 145 passed, 0 failed
node scripts/lint.mjs --hypo-dir=templates --json   # errors 0, warns 0
node scripts/check-tracker-ids.mjs             # ok
```

Run against a large real vault before and after: errors 0 either way, and the single
invalid-YAML warning in it sits under `pages/feedback/`, not on a close target, so it
neither promotes nor blocks. That vault's `log.md` has no frontmatter at all and still
passes `--strict` on that count, which is the exemption doing its job.

Four defenses were turned off and watched to fail: reverting the predicate to an opening
fence, removing the invalid-YAML emission, removing the close-blocking promotion, and
widening the promotion past the payload scope. Each produced a specific red, all were
restored, and the tree greps clean of the mutations.

## Migration notes

A vault carrying invalid YAML in the frontmatter of a file the close appends to will now
be refused at preflight, before anything is written, until that file is repaired. The
refusal names the file and points at `node scripts/lint.mjs`. This matches the existing
treatment of a pre-existing lint error on the same kind of target.

---

# 한국어

## 변경 내용

session-close 가 통째로 덮어쓰는 루트 파일에 대한 lint 스캔이, 이제 wikilink 해석뿐 아니라
프론트매터 블록이 온전한지도 본다. 블록이 멀쩡한데 YAML 이 깨진 경우도 보고하고, 그것이 이번
close 의 payload 범위 안이면 close 자체를 실패시킨다.

## 이유

close 경로는 루트 `hot.md` 를 통째로 쓰고 루트 `log.md` 에 덧붙인다. 그 둘레에서 도는 lint 는
그 두 파일에서 깨진 wikilink 만 찾았고, 그래서 프론트매터를 망가뜨린 쓰기는 보고되지 않았다.

그 갭을 조사하니 자리가 옮겨졌다. `hot.md` 는 이미 잡히고 있었다. 신선도 검사가 닫힌
프론트매터 블록을 파싱해 `updated:` 를 읽는데, 블록이 사라지면 아무것도 못 얻어 파일을 stale 로
표시하고 close 가 실패한다. 즉 "아무도 검사하지 않는다" 는 원래 진술은 이 항목이 주로 겨눈 그
파일에 대해 거짓이었다.

남은 것은 더 좁고 실재했다. 이 검사의 첫 판본은 여는 펜스만 봤는데 신선도 검사는 닫힌 블록을
요구한다. 그래서 같은 바이트를 두고 둘이 다른 답을 냈다. 닫히지 않은 펜스는 lint 를 통과하고
close 에서 실패해, 운영자에게 프론트매터에 대해 아무 말도 안 하는 실패만 남긴다. 빈 블록과,
펜스는 멀쩡한데 YAML 이 깨진 경우는 lint 에 아예 안 보였다.

## 방법

프로브가 이제 신선도 검사와 같은 닫힌 블록 술어를 쓴다. 한 파일에 한 답이 나온다. 깨진 YAML 은
페이지 스캔이 이미 내는 기존 경고로 보고하고, 그 검사기를 재사용한다. 두 번째 검사기를 만들지
않는다.

집행이 실제로 사는 자리가 그 경고다. 프론트매터 없음 경고는 이 두 파일에 한해 strict 승격에서
빼 둔다. `log.md` 가 프론트매터 규약보다 오래된 볼트가 실재하는 모양이고, 거기서는 append 가 그
문제를 만들 수 없기 때문이다. 깨진 YAML 경고는 면제하지 않으므로 다른 곳과 똑같이 승격한다.

경고만으로는 close 를 못 막는다. close 경로가 `--strict` 없이 lint 를 돌리고 errors 로만
게이트하기 때문이다. 그래서 깨진 YAML 을 close 를 막는 판정으로 올리되 payload 범위 안으로만
한정한다. 볼트 다른 곳의 기존 부채는 안 막는 정도가 아니라 아예 건드리지 않는다. append 대상에
대해서는 한 바이트도 쓰기 전에 막는데, 그 대상의 기존 error 를 이미 그렇게 다루고 있기
때문이다. append 로는 둘 다 못 고친다.

`--lint-strict` 도움말이 무조건 승격한다고 단정하고 있어 예외를 명시했다. `--strict` 를 넘기는
게이트가 없다던 낡은 주석도 실제로 넘기는 하나를 가리키게 고쳤다.

## 수동 검증

```
npm test                                       # 아래 참조
node tests/runner.mjs --file=lint              # 147 passed, 0 failed
node tests/runner.mjs --file=crystallize-apply # 33 passed, 0 failed
node tests/runner.mjs --file=close-global      # 145 passed, 0 failed
node scripts/lint.mjs --hypo-dir=templates --json   # errors 0, warns 0
node scripts/check-tracker-ids.mjs             # ok
```

큰 실제 볼트에 변경 전후로 돌렸다. 양쪽 다 errors 0 이고, 그 볼트의 깨진 YAML 경고 1 건은
`pages/feedback/` 아래이지 close 대상이 아니라 승격도 차단도 안 된다. 그 볼트의 `log.md` 는
프론트매터가 아예 없는데 그 항목으로는 여전히 `--strict` 를 통과한다. 면제가 제 일을 하고 있다.

방어 넷을 꺼서 실패하는 것을 봤다. 술어를 여는 펜스로 되돌리기, 깨진 YAML 발행 없애기, close
차단 승격 없애기, 승격을 payload 범위 밖으로 넓히기. 각각 특정한 red 가 났고 전부 원상복구했으며
워킹트리에 무력화 흔적이 없다.

## 마이그레이션 노트

close 가 덧붙이는 파일의 프론트매터에 깨진 YAML 을 지닌 볼트는, 이제 그 파일을 고칠 때까지
preflight 에서 거절된다. 아무것도 쓰이기 전이다. 거절 메시지가 그 파일을 지목하고
`node scripts/lint.mjs` 를 가리킨다. 같은 종류의 대상에 있는 기존 lint error 를 이미 그렇게
다루고 있다.

---

## Changelog

- EN: A session-close now checks that the root files it writes still have a usable frontmatter block, and refuses a close that would leave invalid YAML in one of them (#281).
- KO: session-close 가 자기가 쓰는 루트 파일의 프론트매터 블록이 쓸 만한지 검사하고, 그중 하나에 깨진 YAML 을 남길 close 를 거절한다 (#281).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
