### PR TITLE
chore(release): v1.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "hypo",
       "source": "./",
       "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "homepage": "https://github.com/sk-lim19f/Hypomnema"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hypo",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "LLM-native personal wiki system — session-aware knowledge base for Claude Code",
   "author": {
     "name": "sk-lim19f",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Hypomnema are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-09-07
+
+### Bug Fixes
+
+#### English
+
+- Six slash names (`crystallize`, `graph`, `ingest`, `lint`, `query`, `verify`) shipped as both a `commands/*.md` file and a `skills/*/SKILL.md` directory, so each registered twice as a component and the command palette repeated them. Only the `commands/` half ever loaded, so the duplicates are removed with no behavior change, and `smoke:plugin` now fails on a name present in both directories (decisions/0100). ([#282](https://github.com/sk-lim19f/Hypomnema/pull/282))
+- A session close now checks that the root files it writes still carry a usable frontmatter block, and refuses a close that would leave invalid YAML in one of them. ([#281](https://github.com/sk-lim19f/Hypomnema/pull/281))
+- `/hypo:resume` and SessionStart now surface uncommitted vault work that belongs to another project, so a session does not silently adopt it. ([#280](https://github.com/sk-lim19f/Hypomnema/pull/280))
+
+#### 한국어
+
+- 여섯 슬래시 이름(`crystallize`, `graph`, `ingest`, `lint`, `query`, `verify`)이 `commands/*.md` 파일과 `skills/*/SKILL.md` 디렉터리로 둘 다 출하되어 component 가 두 번씩 등록되고 명령 팔레트가 그만큼 반복됐습니다. 실제로 로드된 것은 `commands/` 쪽뿐이라 중복을 동작 변화 없이 지웠고, 이제 한 이름이 두 디렉터리에 다 있으면 `smoke:plugin` 이 실패합니다 (decisions/0100). ([#282](https://github.com/sk-lim19f/Hypomnema/pull/282))
+- 세션 마무리가 자기가 쓰는 루트 파일에 쓸 만한 프론트매터 블록이 남는지 검사하고, 그중 하나에 깨진 YAML 을 남길 마무리를 거절합니다. ([#281](https://github.com/sk-lim19f/Hypomnema/pull/281))
+- `/hypo:resume` 과 SessionStart 가 다른 프로젝트 소관의 미커밋 변경을 한 줄로 알려, 세션이 그것을 조용히 자기 일로 삼지 않게 합니다. ([#280](https://github.com/sk-lim19f/Hypomnema/pull/280))
+
 ## [1.8.0] - 2026-09-03
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypomnema",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypomnema",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "bin": {
         "hypomnema": "scripts/init.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypomnema",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "LLM-native personal wiki system for Claude Code",
   "type": "module",
   "license": "MIT",

--- a/templates/hypo-config.md
+++ b/templates/hypo-config.md
@@ -1,7 +1,7 @@
 ---
 title: Hypomnema Config
 type: config
-version: "1.8.0"
+version: "1.8.1"
 created: YYYY-MM-DD
 ---
 


### PR DESCRIPTION
# English

## What changed

Cuts the v1.8.1 patch release. Bumps the version across `package.json`, `package-lock.json`, `.claude-plugin/{plugin,marketplace}.json` and `templates/hypo-config.md`, and adds the `## [1.8.1]` section to `CHANGELOG.md` from the merged PRs' Changelog blocks.

Three user-visible bug fixes ship: #280, #281 and #282. #279 was an internal refactor with no user-visible effect, so it carries no CHANGELOG line.

## Why

A merge to `main` is not a release on either channel. The plugin installer names its cache directory after the manifest version string, so an unchanged version means the copy is skipped and existing installs keep running the old bytes. #282 is exactly the kind of fix that stays invisible without a release: the duplicate component removal only reaches a palette once the version moves.

## How

Followed the "Cutting a release" checklist in `docs/CONTRIBUTING.md`. Step 0 and step 8 (the version spec lifecycle) are exempt for a patch release.

`node scripts/collect-changelog.mjs --strict` produced a Chores section containing only `- None` for #279. That entry was dropped rather than shipped, per the checklist's instruction to drop anything not user-relevant.

## Manual verification

No hook, `hypo-shared.mjs`, template or init-flow change is in this PR, so the manual verification requirement does not apply. The release gate set was run locally, each command alone so its exit code is its own:

```
npm test                   rc=0   2155 passed, 0 failed (287.0s)
npm run lint               rc=0   0 error(s), 448 warning(s)
npm run check:versions     rc=0
npm run check:bilingual    rc=0
npm run smoke:plugin       rc=0
npm run smoke-pack         rc=0
npm run check:tracker-ids  rc=0
npm run check:pack-surface rc=0   136 files, 0 closure violations
npm run format:check       rc=0
```

## Migration notes

None.

---

# 한국어

## 변경 내용

v1.8.1 패치 릴리스를 자릅니다. `package.json`, `package-lock.json`, `.claude-plugin/{plugin,marketplace}.json`, `templates/hypo-config.md` 의 버전을 올리고, 머지된 PR 들의 Changelog 블록에서 모은 `## [1.8.1]` 절을 `CHANGELOG.md` 에 넣습니다.

사용자에게 보이는 버그 수정 셋이 실립니다. #280, #281, #282 입니다. #279 는 사용자에게 보이는 변화가 없는 내부 리팩터라 CHANGELOG 줄을 갖지 않습니다.

## 이유

`main` 에 머지하는 것은 두 채널 어느 쪽에서도 릴리스가 아닙니다. 플러그인 설치기가 매니페스트 버전 문자열로 캐시 디렉터리 이름을 짓기 때문에, 버전이 안 움직이면 복사가 건너뛰어지고 기존 설치는 옛 바이트를 계속 돌립니다. #282 가 정확히 릴리스 없이는 안 보이는 종류의 수정입니다. 중복 component 제거는 버전이 움직여야 팔레트에 닿습니다.

## 방법

`docs/CONTRIBUTING.md` 의 "Cutting a release" 체크리스트를 따랐습니다. 0 단계와 8 단계(버전 스펙 생애주기)는 패치 릴리스에 면제됩니다.

`node scripts/collect-changelog.mjs --strict` 가 #279 에 대해 `- None` 하나만 담긴 Chores 절을 냈습니다. 사용자와 무관한 항목은 빼라는 체크리스트 지시에 따라 그 절을 출하하지 않고 지웠습니다.

## 수동 검증

이 PR 에는 훅, `hypo-shared.mjs`, 템플릿, init 흐름 변경이 없어 수동 검증 요구가 걸리지 않습니다. 릴리스 게이트 묶음을 로컬에서 돌렸고, 종료 코드가 각자의 것이 되도록 명령을 하나씩 단독으로 실행했습니다.

```
npm test                   rc=0   2155 passed, 0 failed (287.0s)
npm run lint               rc=0   0 error(s), 448 warning(s)
npm run check:versions     rc=0
npm run check:bilingual    rc=0
npm run smoke:plugin       rc=0
npm run smoke-pack         rc=0
npm run check:tracker-ids  rc=0
npm run check:pack-surface rc=0   136 files, 0 closure violations
npm run format:check       rc=0
```

## 마이그레이션 노트

None.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
