### PR TITLE
fix(close,doctor): record what the gate actually verified in the close marker

### DIFF
--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -1592,8 +1592,11 @@ export function sessionCloseGlobalStatus(hypoDir, opts = {}) {
   // invariant that once justified keeping the writer paths fully unscoped
   // ("marker == compact-ready", codex design review) is superseded by that
   // partition, not restored by it — a marker's own `verified_scope`, attesting
-  // exactly what it checked, is still missing (session-close-scope-boundary
-  // spec §3, next wave).
+  // exactly what this function's caller evaluated (never `markerProjects`'
+  // evidence-based attribution), now ships (session-close-scope-boundary
+  // spec §3). The writer is `scripts/lib/crystallize-close-apply.mjs`
+  // (`runMarkSessionClosed` and `runMarkerPhase`); the reader is
+  // `markerCoversArtifact` in `scripts/doctor.mjs`.
   if (opts.projectOverride) {
     const s = sessionCloseFileStatus(hypoDir, { projectOverride: opts.projectOverride });
     return {
@@ -1634,6 +1637,13 @@ export function sessionCloseGlobalStatus(hypoDir, opts = {}) {
     hasTodayCloseActivity(hypoDir, p, dates),
   );
 
+  // This branch drops `mustEvaluate` on the floor and reports the recency
+  // project instead, so `projects` here can name a DIFFERENT project than the
+  // caller asked for. No marker is ever written from it, though: `close.fallback`
+  // is an unconditional gate blocker (see the fail-closed guards in the partition
+  // below) and both marker writers only stamp on a green gate. So a marker whose
+  // `verified_scope` names the recency project instead of the requested one is
+  // unreachable, not merely fail-safe — do not write code defending that state.
   if (activeCandidates.length === 0) {
     const legacy = sessionCloseFileStatus(hypoDir);
     return {
@@ -3166,6 +3176,33 @@ export function sessionClosedMarkerPath(hypoDir, sessionId) {
   return join(hypoDir, '.cache', `session-closed-${sanitizeSessionId(sessionId)}.marker`);
 }
 
+// verified_scope (session-close-scope-boundary spec §3) records the scope the
+// gate ABOVE this write actually verified, not merely the attribution the
+// marker's `projects` field carries — those can diverge whenever a gate run
+// widens attribution beyond what it narrowed the check to. The caller
+// decides `kind`: this function only refuses to persist a shape it cannot
+// stand behind. Exported so scripts/doctor.mjs's reader runs the SAME
+// collapse instead of a hand-rolled copy — an unrecognized shape, or a
+// 'project'/'global' scope with an empty `projects` (a narrower-than-nothing
+// claim), reads back as "field absent", never as a false claim.
+export function normalizeVerifiedScope(verifiedScope) {
+  if (!verifiedScope || typeof verifiedScope !== 'object') return null;
+  if (verifiedScope.kind === 'log-only') return { kind: 'log-only' };
+  if (verifiedScope.kind === 'project' || verifiedScope.kind === 'global') {
+    const projects = Array.isArray(verifiedScope.projects)
+      ? [...new Set(verifiedScope.projects.filter((p) => typeof p === 'string' && p))]
+      : [];
+    // An empty projects list under 'project'/'global' asserts a verified
+    // boundary with nothing in it — that is not a narrower claim, it is a
+    // malformed one. Drop it rather than persist a scope nothing can satisfy
+    // by design (verified_scope must only ever tighten, never silently gate
+    // out everything).
+    if (projects.length === 0) return null;
+    return { kind: verifiedScope.kind, projects };
+  }
+  return null;
+}
+
 /**
  * Persist a per-session close proof. Caller MUST verify
  * `sessionCloseFileStatus(hypoDir).ok` before invoking — this helper does NOT
@@ -3175,7 +3212,7 @@ export function sessionClosedMarkerPath(hypoDir, sessionId) {
  *
  * @param {string} hypoDir
  * @param {string} sessionId
- * @param {{project?: string, scope?: string, transcript_path?: string}} info
+ * @param {{project?: string, scope?: string, transcript_path?: string, verifiedScope?: {kind: 'log-only'|'project'|'global', projects?: string[]}}} info
  */
 export function writeSessionClosedMarker(hypoDir, sessionId, info = {}) {
   if (!sessionId) return;
@@ -3199,6 +3236,7 @@ export function writeSessionClosedMarker(hypoDir, sessionId, info = {}) {
       : info.project
         ? [info.project]
         : [];
+    const verifiedScope = normalizeVerifiedScope(info.verifiedScope);
     const payload = {
       session_id: sessionId,
       project: info.project || projects[0] || null,
@@ -3207,6 +3245,11 @@ export function writeSessionClosedMarker(hypoDir, sessionId, info = {}) {
       transcript_path: info.transcript_path || null,
       closed_at: new Date().toISOString(),
       verification: scope === 'log-only' ? 'log-only-close:ok' : 'session-close-file-status:ok',
+      // Omitted entirely (not even `null`) when the caller passes nothing or
+      // an unrecognized shape, so a marker written by a caller that hasn't
+      // adopted this field reads back byte-identical to before it existed —
+      // doctor's reader treats "field absent" as "no additional scope check".
+      ...(verifiedScope ? { verified_scope: verifiedScope } : {}),
     };
     writeFileSync(sessionClosedMarkerPath(hypoDir, sessionId), JSON.stringify(payload) + '\n');
   } catch (err) {
@@ -3711,8 +3754,12 @@ export function resolveCloseScope(hypoDir, opts = {}, marker = null) {
  * below can tell their own incomplete close from someone else's debt. The
  * invariant that once justified keeping those paths fully unscoped ("marker ==
  * compact-ready", codex design review) is replaced by that partition, not
- * restored by it — a marker's own `verified_scope`, attesting exactly what it
- * checked, is still missing (session-close-scope-boundary spec §3, next wave).
+ * restored by it — a marker's own `verified_scope`, attesting exactly what
+ * this status's caller evaluated (never the marker's `projects`, which is
+ * evidence-based attribution), now ships (session-close-scope-boundary
+ * spec §3). The writer is `scripts/lib/crystallize-close-apply.mjs`
+ * (`runMarkSessionClosed` and `runMarkerPhase`); the reader is
+ * `markerCoversArtifact` in `scripts/doctor.mjs`.
  * Either key ALSO feeds the git-dirty partition (spec §2b): with an untrusted
  * transcript (missing/corrupt), a dirty file structurally under a DIFFERENT
  * eligible project's own directory is demoted to a notice, because the path

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -34,6 +34,7 @@ import {
   collectProjectWorkingDirs,
   detectSessionCloseArtifact,
   localAndUtcDates,
+  normalizeVerifiedScope,
   SESSION_CLOSED_MARKER_STALE_MS,
   isUsablePkgRootLocal,
   selfLocationPkgRootFrom,
@@ -916,14 +917,32 @@ function deriveCommitProjects(hypoDir, hash) {
 //     an artifact with no verifiable scope, so this never matches, ever.
 //   • 'projects' — a project file, or a commit that touched one or more
 //     identifiable projects/<slug>/ paths. EVERY named project must appear
-//     in the marker's own `projects` list.
+//     in the marker's own `projects` list, AND, when the marker carries a
+//     `verified_scope` (session-close-scope-boundary spec §3), in that
+//     scope's own `projects` too — an AND, never an OR. `projects` is
+//     evidence-based attribution; `verified_scope` is what the gate that
+//     wrote this marker actually checked, and the two can diverge (an
+//     unnarrowed gate run can attribute to more projects than it verified).
+//     A `verified_scope` of kind 'log-only' verified no project at all, so it
+//     can never cover a 'projects'-scoped artifact. A marker with NO
+//     `verified_scope` (every marker before this field existed) skips this
+//     extra check entirely — it neither tightens nor loosens the membership
+//     check above, so old markers read back byte-for-byte as before.
 function markerCoversArtifact(marker, artifact) {
   if (!marker.dates.includes(artifact.date)) return false;
   switch (artifact.scope.kind) {
     case 'root-universal':
       return true;
     case 'projects':
-      return artifact.scope.projects.every((p) => marker.projects.includes(p));
+      if (!artifact.scope.projects.every((p) => marker.projects.includes(p))) return false;
+      if (!marker.verifiedScope) return true;
+      // Unreachable for a 'projects' artifact today: a log-only close writes
+      // `projects: []`, so the membership check above already returned false.
+      // Kept deliberately, not by oversight — it states the kind's meaning
+      // (log-only verified no project at all) so this stays correct if
+      // `projects` ever carries something for a log-only close.
+      if (marker.verifiedScope.kind === 'log-only') return false;
+      return artifact.scope.projects.every((p) => marker.verifiedScope.projects.includes(p));
     default:
       return false; // 'unscoped'
   }
@@ -1035,7 +1054,17 @@ function checkSessionCloseArtifacts(hypoDir) {
       // and doctor has no corroborating signal of its own to add, so it
       // must refuse it too rather than re-opening the same hole standalone.
       const projects = Array.isArray(data?.projects) ? data.projects.filter(Boolean) : [];
-      markers.push({ projects: [...new Set(projects)], dates: localAndUtcDates(new Date(ts)) });
+      // verified_scope (session-close-scope-boundary spec §3): the SAME
+      // collapse the writer runs (hooks/hypo-shared.mjs), not a hand-rolled
+      // copy — a shape this reader doesn't recognize, or a 'project'/'global'
+      // scope with an empty `projects`, reads back as "field absent" (`null`),
+      // never as a false claim.
+      const verifiedScope = normalizeVerifiedScope(data?.verified_scope);
+      markers.push({
+        projects: [...new Set(projects)],
+        dates: localAndUtcDates(new Date(ts)),
+        verifiedScope,
+      });
     } catch {
       // corrupt marker — not this check's job to clean up
     }

--- a/scripts/lib/crystallize-close-apply.mjs
+++ b/scripts/lib/crystallize-close-apply.mjs
@@ -472,10 +472,31 @@ export function runMarkSessionClosed(args) {
     process.exit(1);
   }
   const markerProject = !args.logOnly && args.project ? args.project : markerProjects[0];
+  // verified_scope (session-close-scope-boundary spec §3, revised 2026-09-07):
+  // records the set the gate ABOVE actually made a row for and evaluated —
+  // never `markerProjects` (evidence-based attribution, `projects` above).
+  // `closeScope: [args.project]` widens resolveCloseScope's mine/foreign
+  // partition (it feeds `opts.closeScope`, never `opts.projectOverride`), so
+  // it does NOT narrow `sessionCloseGlobalStatus`: the gate ran unnarrowed
+  // regardless of --project (resolveGateProjectOverride's own doc comment;
+  // hypo-shared.mjs's sessionCloseGlobalStatus/precompactGateStatus doc
+  // comments). `kind` is therefore always 'global' here. 'project' stays a
+  // shape normalizeVerifiedScope and doctor's reader accept — for a future
+  // writer that DOES pass opts.projectOverride, which none of the four
+  // marker-writing paths do today. The earlier premise here (an explicit
+  // --project earns 'project') was a doctor regression: a transcript-widened
+  // scope can attribute a project the gate never put a row for, and stamping
+  // markerProjects verbatim let that project's close artifacts pass doctor's
+  // correlation unchecked.
+  const evaluatedProjects = (status.projects || []).map((p) => p.project).filter(Boolean);
+  const verifiedScope = args.logOnly
+    ? { kind: 'log-only' }
+    : { kind: 'global', projects: evaluatedProjects };
   writeSessionClosedMarker(args.hypoDir, args.sessionId, {
     project: markerProject,
     projects: args.logOnly ? [] : markerProjects,
     ...(args.logOnly ? { scope: 'log-only' } : {}),
+    verifiedScope,
   });
   // Marker writer swallows IO errors (best-effort, see hypo-shared.mjs). Verify
   // the file actually landed before claiming success — otherwise CLI exits 0
@@ -1613,6 +1634,12 @@ function runMarkerPhase(args, project, appliedPaths, ok) {
     }
     let closeTranscript = null;
     let gateOk = false;
+    // verified_scope evidence (session-close-scope-boundary spec §3, revised
+    // 2026-09-07): the set the gate below actually put a row for, filled in
+    // once the gate below runs. Stays [] on any path that never reaches it
+    // (uncommitted, no transcript) — normalizeVerifiedScope drops an empty
+    // 'global' scope to "field absent" rather than persist a false claim.
+    let gateEvaluatedProjects = [];
     if (commitOutcome.committed) {
       closeTranscript = resolveTranscriptBySessionId(args.sessionId);
       // closeScope: apply KNOWS which project it just closed, and it wrote
@@ -1633,11 +1660,19 @@ function runMarkerPhase(args, project, appliedPaths, ok) {
       // `project` alone, going green on a foreign project's incomplete close
       // instead of demoting it to a notice.
       const autoMarkerOverride = resolveGateProjectOverride(args.hypoDir, { project });
-      gateOk = precompactGateStatus(args.hypoDir, {
+      const gateStatus = precompactGateStatus(args.hypoDir, {
         closeScope: [project],
         ...(closeTranscript ? { transcriptPath: closeTranscript } : {}),
         ...(autoMarkerOverride ? { attributionScope: autoMarkerOverride } : {}),
-      }).ok;
+      });
+      gateOk = gateStatus.ok;
+      // `closeScope` above widens the partition, it never narrows
+      // sessionCloseGlobalStatus (only opts.projectOverride does, and this
+      // call never sets it) — so gate.close.projects is the actual evaluated
+      // set, not necessarily just `[project]`.
+      gateEvaluatedProjects = (gateStatus.close.projects || [])
+        .map((p) => p.project)
+        .filter(Boolean);
     }
     const decision = planMarkerDecision({
       ok,
@@ -1664,7 +1699,17 @@ function runMarkerPhase(args, project, appliedPaths, ok) {
     if (decision.write) {
       // apply KNOWS its authoritative payload.project — stamp it as the v4
       // evidence set so PreCompact trusts this marker's scope directly (session-close attribution).
-      writeSessionClosedMarker(args.hypoDir, args.sessionId, { project, projects: [project] });
+      // verified_scope (revised 2026-09-07): `closeScope: [project]` above
+      // widens resolveCloseScope's partition, it does not narrow
+      // sessionCloseGlobalStatus — only opts.projectOverride does, and this
+      // call never sets it. The gate ran unnarrowed, so `kind` is 'global',
+      // with `projects` the set gate.close actually evaluated
+      // (gateEvaluatedProjects), never `[project]` verbatim.
+      writeSessionClosedMarker(args.hypoDir, args.sessionId, {
+        project,
+        projects: [project],
+        verifiedScope: { kind: 'global', projects: gateEvaluatedProjects },
+      });
       // Codex CONCERN: the writer swallows IO errors (best-effort).
       // Verify the file actually landed — mirroring the standalone path — instead of
       // asserting markerWritten=true, so a .cache permission/disk problem surfaces

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -1891,6 +1891,38 @@ test('--mark-session-closed stamps the v4 projects discriminator', () => {
   });
 });
 
+// session-close-scope-boundary spec §3 (revised 2026-09-07): --project=<slug>
+// passes `closeScope: [args.project]`, which widens resolveCloseScope's
+// mine/foreign partition (opts.closeScope) — it does NOT narrow
+// sessionCloseGlobalStatus (only opts.projectOverride does, and this call
+// never sets it). So the gate ran unnarrowed, and verified_scope.kind must
+// read 'global', with `projects` the set the gate actually evaluated. This
+// runs the real CLI and reads the marker off disk, unlike the
+// doctor.test.mjs assertions that only exercise markerCoversArtifact against a
+// hand-built payload.
+test('--mark-session-closed --project=<slug>: verified_scope is {kind: global, projects: [<gate-evaluated set>]}', () => {
+  withWiki(null, (dir) => {
+    const cleanup = seedCloseTranscript('s-vs-project');
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--mark-session-closed',
+      '--session-id=s-vs-project',
+      '--project=test-project',
+      '--json',
+    ]);
+    cleanup();
+    assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
+    const marker = JSON.parse(
+      readFileSync(join(dir, '.cache', 'session-closed-s-vs-project.marker'), 'utf-8'),
+    );
+    assert.deepEqual(
+      marker.verified_scope,
+      { kind: 'global', projects: ['test-project'] },
+      `--project never narrows the gate itself, so verified_scope must read 'global': ${JSON.stringify(marker)}`,
+    );
+  });
+});
+
 // ADR 0055 (codex re-review): the exact prior bypass — a model forging
 // <tmpdir>/<sessionId>.jsonl with a close phrase and passing it via
 // --transcript-path. The marker gate resolves STRICTLY from the session id, so
@@ -2009,6 +2041,48 @@ test('--mark-session-closed --transcript-path: lint error only in an UNTOUCHED f
   );
 });
 
+// session-close-scope-boundary spec §3: with NO --project, precompactGateStatus
+// runs unnarrowed above (no closeScope key passed) — the gate ran the global
+// judgment, so verified_scope.kind must read 'global', never 'project'.
+// Attribution still comes from evidence: the transcript edits a mandatory
+// close file (session-state.md), which resolveCloseScope's touched-file signal
+// adds to scope even with no --project flag.
+test('--mark-session-closed with no --project (evidence via touched close file): verified_scope.kind is global', () => {
+  withWiki(null, (dir) => {
+    const closeFileAbs = join(dir, 'projects', 'test-project', 'session-state.md');
+    const cleanup = seedCloseTranscript('s-vs-global', {
+      toolUseLines: [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', name: 'Edit', input: { file_path: closeFileAbs } }],
+          },
+        }),
+      ],
+    });
+    const r = run('crystallize.mjs', [
+      `--hypo-dir=${dir}`,
+      '--mark-session-closed',
+      '--session-id=s-vs-global',
+      '--json',
+    ]);
+    cleanup();
+    assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
+    const marker = JSON.parse(
+      readFileSync(join(dir, '.cache', 'session-closed-s-vs-global.marker'), 'utf-8'),
+    );
+    assert.equal(
+      marker.verified_scope?.kind,
+      'global',
+      `no --project must leave verified_scope.kind as global: ${JSON.stringify(marker)}`,
+    );
+    assert.ok(
+      (marker.verified_scope?.projects || []).includes('test-project'),
+      `verified_scope.projects must carry the evidence-attributed project: ${JSON.stringify(marker)}`,
+    );
+  });
+});
+
 test('--apply-session-close --session-id with an unresolvable transcript → refused before any write (no partial commit)', () => {
   // ADR 0056 used to let apply commit its own payload first and only withhold the
   // marker on a bad transcript. The fix that closed the gate (verifyCloseAuthority,
@@ -2116,6 +2190,255 @@ test('--apply-session-close --session-id WITH user-close signal → commits payl
       existsSync(join(dir, '.cache', 'session-closed-s-apply-land.marker')),
       'marker file must exist after a verified close with a user-close signal',
     );
+  });
+});
+
+// A second project with a COMPLETE, fresh close (today session-log heading +
+// today log.md entry), added alongside test-project so the gate-evaluated set
+// has two members and can be told apart from `payload.project` (one member).
+// A single-project fixture cannot regression-test this: gateEvaluatedProjects
+// and `[payload.project]` are the same array, so a writer that stamped the
+// payload's project verbatim instead of the gate's own evaluated set would
+// pass unnoticed. Every close file mirrors buildCleanWikiTree's own
+// test-project shape (same session-state heading lint requires) so this
+// project stays complete and never becomes a lint/close blocker in its own
+// right.
+function addSecondCloseProject(dir, today) {
+  const ym = today.slice(0, 7);
+  const pdir = join(dir, 'projects', 'second-project');
+  mkdirSync(join(pdir, 'session-log'), { recursive: true });
+  writeFileSync(
+    join(pdir, 'session-state.md'),
+    `---\ntitle: session-state\ntype: session-state\nupdated: ${today}\n---\n\n## 다음 작업\n\n- next\n`,
+  );
+  writeFileSync(
+    join(pdir, 'hot.md'),
+    `---\ntitle: hot\ntype: reference\nupdated: ${today}\n---\n\n# Hot\n`,
+  );
+  writeFileSync(
+    join(pdir, 'session-log', `${ym}.md`),
+    `---\ntitle: Session Log\ntype: session-log\nupdated: ${today}\n---\n\n## [${today}] test session\n`,
+  );
+  const logPath = join(dir, 'log.md');
+  writeFileSync(
+    logPath,
+    readFileSync(logPath, 'utf-8') + `## [${today}] session | second-project\n`,
+  );
+  const hotPath = join(dir, 'hot.md');
+  writeFileSync(
+    hotPath,
+    readFileSync(hotPath, 'utf-8') +
+      `| second-project | ${today} | [[projects/second-project/hot]] |\n`,
+  );
+}
+
+// session-close-scope-boundary spec §3 (revised 2026-09-07): runMarkerPhase
+// (apply's auto marker) passes `closeScope: [project]`, which widens
+// resolveCloseScope's partition (opts.closeScope) — it does not narrow
+// sessionCloseGlobalStatus (only opts.projectOverride does, and this call
+// never sets it). So the gate runs unnarrowed and verified_scope.kind must
+// read 'global', with `projects` the set the gate actually evaluated — never
+// `[project]` stamped verbatim from the payload.
+test('--apply-session-close auto marker: verified_scope is {kind: global, projects: [<gate-evaluated set>]}', () => {
+  withWiki(addSecondCloseProject, (dir, today) => {
+    const payload = {
+      project: 'test-project',
+      date: today,
+      sessionState: {
+        content: readFileSync(join(dir, 'projects', 'test-project', 'session-state.md'), 'utf-8'),
+      },
+      projectHot: {
+        content: readFileSync(join(dir, 'projects', 'test-project', 'hot.md'), 'utf-8'),
+      },
+      rootHot: { content: readFileSync(join(dir, 'hot.md'), 'utf-8') },
+      sessionLog: { entry: `## [${today}] verified-scope auto-marker test\n` },
+      log: { entry: `## [${today}] session | test-project — verified-scope auto-marker\n` },
+    };
+    const payloadPath = join(
+      tmpdir(),
+      `hypo-payload-${process.pid}-${Math.random().toString(36).slice(2, 10)}.json`,
+    );
+    writeFileSync(payloadPath, JSON.stringify(payload));
+    const cleanup = seedCloseTranscript('s-vs-apply');
+    try {
+      const r = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--apply-session-close',
+        `--payload=${payloadPath}`,
+        '--session-id=s-vs-apply',
+        '--json',
+      ]);
+      assert.equal(r.status, 0, `apply failed: ${r.stdout}\n${r.stderr}`);
+      const marker = JSON.parse(
+        readFileSync(join(dir, '.cache', 'session-closed-s-vs-apply.marker'), 'utf-8'),
+      );
+      assert.equal(
+        marker.verified_scope?.kind,
+        'global',
+        `apply never narrows the gate itself, so verified_scope must read 'global': ${JSON.stringify(marker)}`,
+      );
+      // Sorted comparison: the gate's own evaluation order is not this test's
+      // concern, only membership is — both projects the gate evaluated must be
+      // present, and neither payload.project alone nor an empty set passes.
+      assert.deepEqual(
+        [...(marker.verified_scope?.projects || [])].sort(),
+        ['second-project', 'test-project'],
+        `verified_scope must carry every project the gate evaluated, not just payload.project: ${JSON.stringify(marker)}`,
+      );
+    } finally {
+      cleanup();
+      rmSync(payloadPath, { force: true });
+    }
+  });
+});
+
+// session-close-scope-boundary spec §3 (fix 4, end-to-end): both directions
+// doctor's markerCoversArtifact AND must distinguish, driven by the REAL
+// writer, never a hand-built marker. Pass case: the marker's own
+// verified_scope covers its own project's close artifact.
+test('E2E verified_scope: a real marker with the gate-evaluated project passes doctor', () => {
+  withClosePartitionWiki(
+    [{ slug: 'mine', date: todayLocal() }],
+    [],
+    (dir, _transcript, home, today) => {
+      const sessionId = 's-vs-e2e-pass';
+      const ssPath = join(dir, 'projects', 'mine', 'session-state.md');
+      writeFileSync(
+        ssPath,
+        readFileSync(ssPath, 'utf-8') + `\n> **${today} 마감(1번째 세션).** 첫 마감.\n`,
+      );
+      // HOME pinned to the test's own tmp home: a bare `spawnSync('git', ...)`
+      // would otherwise inherit the developer's real HOME, and git can read
+      // per-user config from there (CLAUDE.md conventions, "every process a
+      // test spawns gets HOME pinned").
+      const gitEnv = { env: { ...process.env, HOME: home } };
+      spawnSync('git', ['-C', dir, 'add', '-A'], gitEnv);
+      spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'close narrative'], gitEnv);
+      spawnSync('git', ['-C', dir, 'push', '-q', 'origin', 'HEAD'], gitEnv);
+      const cleanup = seedCloseTranscript(sessionId, { home });
+      try {
+        const r = runWithHome(
+          'crystallize.mjs',
+          [
+            `--hypo-dir=${dir}`,
+            '--mark-session-closed',
+            `--session-id=${sessionId}`,
+            '--project=mine',
+            '--json',
+          ],
+          home,
+        );
+        assert.equal(r.status, 0, `expected a clean close: ${r.stdout}\n${r.stderr}`);
+        const marker = JSON.parse(
+          readFileSync(join(dir, '.cache', `session-closed-${sessionId}.marker`), 'utf-8'),
+        );
+        assert.ok(
+          (marker.verified_scope?.projects || []).includes('mine'),
+          `the gate evaluated mine, so verified_scope must include it: ${JSON.stringify(marker)}`,
+        );
+        const dr = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+        const out = JSON.parse(dr.stdout);
+        const check = out.find((c) => c.label === 'Session-close artifacts');
+        assert.ok(check, 'doctor check not found');
+        assert.equal(
+          check.status,
+          'pass',
+          `a real writer's verified_scope covering mine's own close artifact must pass doctor: ${check?.detail}`,
+        );
+      } finally {
+        cleanup();
+      }
+    },
+  );
+});
+
+// Warn case: the only reachable way this codebase's writers can attribute a
+// project (`marker.projects`) outside the set the gate evaluated
+// (`verified_scope.projects`) is a transcript naming a projects/<slug>/...
+// close file for a slug with NO directory on disk at gate time —
+// isProjectSlugDirectory then drops it from mustEvaluate/activeCandidates, so
+// it never reaches gate.close.projects, while doctor's git-log scan
+// (deriveCommitProjects) still finds it because that reads the commit TREE,
+// not the current filesystem. A still-present project can never diverge this
+// way: the same existence check that lets a transcript name it also forces it
+// into mustEvaluate.
+test('E2E verified_scope: a real marker attributing a project the gate never evaluated warns in doctor', () => {
+  withClosePartitionWiki([{ slug: 'mine', date: todayLocal() }], [], (dir, _transcript, home) => {
+    const sessionId = 's-vs-e2e-warn';
+    const ghostDir = join(dir, 'projects', 'ghost');
+    mkdirSync(ghostDir, { recursive: true });
+    writeFileSync(
+      join(ghostDir, 'session-state.md'),
+      '---\ntitle: ss\ntype: session-state\nupdated: 2000-01-01\n---\n\n## 다음 작업\n',
+    );
+    // HOME pinned to the test's own tmp home, same reason as the pass case above.
+    const gitEnv = { env: { ...process.env, HOME: home } };
+    spawnSync('git', ['-C', dir, 'add', '-A'], gitEnv);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'closes the session for ghost'], gitEnv);
+    // Remove ghost from the CURRENT tree: isProjectSlugDirectory sees no
+    // directory at gate time, but the commit above still exists in history for
+    // doctor's git-log scan to find.
+    rmSync(ghostDir, { recursive: true, force: true });
+    spawnSync('git', ['-C', dir, 'add', '-A'], gitEnv);
+    spawnSync('git', ['-C', dir, 'commit', '-q', '-m', 'remove ghost'], gitEnv);
+    spawnSync('git', ['-C', dir, 'push', '-q', 'origin', 'HEAD'], gitEnv);
+    // The transcript names ghost's (now-gone) close file directly —
+    // projectsFromTouchedCloseFiles never checks the filesystem, so this is
+    // the one signal that can attribute a slug without also forcing it into
+    // mustEvaluate.
+    const cleanup = seedCloseTranscript(sessionId, {
+      home,
+      toolUseLines: [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: join(dir, 'projects', 'ghost', 'session-state.md') },
+              },
+            ],
+          },
+        }),
+      ],
+    });
+    try {
+      const r = runWithHome(
+        'crystallize.mjs',
+        [
+          `--hypo-dir=${dir}`,
+          '--mark-session-closed',
+          `--session-id=${sessionId}`,
+          '--project=mine',
+          '--json',
+        ],
+        home,
+      );
+      assert.equal(r.status, 0, `expected a clean close: ${r.stdout}\n${r.stderr}`);
+      const marker = JSON.parse(
+        readFileSync(join(dir, '.cache', `session-closed-${sessionId}.marker`), 'utf-8'),
+      );
+      assert.ok(
+        (marker.projects || []).includes('ghost'),
+        `transcript evidence for ghost's close file must attribute the marker to it: ${JSON.stringify(marker)}`,
+      );
+      assert.ok(
+        !(marker.verified_scope?.projects || []).includes('ghost'),
+        `ghost has no directory at gate time, so the gate never evaluated it: ${JSON.stringify(marker)}`,
+      );
+      const dr = run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']);
+      const out = JSON.parse(dr.stdout);
+      const check = out.find((c) => c.label === 'Session-close artifacts');
+      assert.ok(check, 'doctor check not found');
+      assert.equal(
+        check.status,
+        'warn',
+        `ghost's marker-attributed-but-never-evaluated close must not pass doctor: ${check?.detail}`,
+      );
+    } finally {
+      cleanup();
+    }
   });
 });
 
@@ -2750,6 +3073,52 @@ test('--log-only: active project not closed today → marker written, project:nu
         'log-only marker must NOT attribute to a project (clobber-safe)',
       );
       assert.equal(marker.scope, 'log-only');
+    },
+  );
+});
+
+// session-close-scope-boundary spec §3: --log-only skips the compact gate's
+// project-close check entirely, so verified_scope must read exactly
+// {kind: 'log-only'} with no `projects` key — there is nothing this path
+// verified a project scope against.
+test('--log-only: verified_scope is exactly {kind: log-only}, no projects key', () => {
+  withWiki(
+    (dir) => {
+      const stale = '2000-01-01';
+      const projDir = join(dir, 'projects', 'test-project');
+      writeFileSync(
+        join(projDir, 'session-state.md'),
+        `---\ntitle: session-state\ntype: session-state\nupdated: ${stale}\n---\n\n## 다음 작업\n\n- next\n`,
+      );
+      writeFileSync(
+        join(projDir, 'hot.md'),
+        `---\ntitle: hot\ntype: reference\nupdated: ${stale}\n---\n\n# Hot\n`,
+      );
+      const ym = todayLocal().slice(0, 7);
+      writeFileSync(
+        join(projDir, 'session-log', `${ym}.md`),
+        `---\ntitle: Session Log\ntype: session-log\nupdated: ${stale}\n---\n\n## [${stale}] old session\n`,
+      );
+    },
+    (dir) => {
+      const cleanup = seedCloseTranscript('s-vs-logonly');
+      const r = run('crystallize.mjs', [
+        `--hypo-dir=${dir}`,
+        '--mark-session-closed',
+        '--log-only',
+        '--session-id=s-vs-logonly',
+        '--json',
+      ]);
+      cleanup();
+      assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
+      const marker = JSON.parse(
+        readFileSync(join(dir, '.cache', 'session-closed-s-vs-logonly.marker'), 'utf-8'),
+      );
+      assert.deepEqual(
+        marker.verified_scope,
+        { kind: 'log-only' },
+        `log-only verified_scope must carry no projects key: ${JSON.stringify(marker)}`,
+      );
     },
   );
 });

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -864,6 +864,106 @@ test('doctor-close-artifacts: legacy marker with ONLY a flat `project` (no `proj
   });
 });
 
+// verified_scope (session-close-scope-boundary spec §3) is an ADDITIONAL
+// requirement on top of the `projects` membership check above, never a
+// replacement for it. A marker's `projects` is evidence-based attribution;
+// `verified_scope` is what the gate that wrote the marker actually checked,
+// and the two can diverge whenever an unnarrowed gate run attributes to more
+// projects than it verified. These three pin that AND, on the same fixture
+// shape as the pass test above (807) so the only variable is `verified_scope`.
+test('doctor-close-artifacts: verified_scope covering the artifact project → pass', () => {
+  withTmpDir((dir) => {
+    baseWiki(dir);
+    const projDir = join(dir, 'projects', 'demo');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'session-state.md'),
+      `> **${recentUtcDate(1)} 마감(13번째 세션).** 세 스트림을 처음으로 병렬로 굴렸다.\n`,
+    );
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'session-closed-abc123.marker'),
+      JSON.stringify({
+        session_id: 'abc123',
+        project: 'demo',
+        projects: ['demo'],
+        verified_scope: { kind: 'project', projects: ['demo'] },
+        closed_at: recentUtcIso(1),
+      }),
+    );
+    const check = doctorCloseArtifactCheck(dir);
+    assert.ok(check, 'check not found');
+    assert.equal(check.status, 'pass', `expected pass: ${check?.detail}`);
+  });
+});
+
+// The marker's `projects` (evidence) names `demo`, but `verified_scope` — what
+// the gate that wrote this marker actually checked — names a DIFFERENT
+// project. If the AND were dropped (an OR, or the membership check alone),
+// this would wrongly pass on `projects` alone.
+test('doctor-close-artifacts: verified_scope NOT covering the artifact project → warn (regression: AND, not OR)', () => {
+  withTmpDir((dir) => {
+    baseWiki(dir);
+    const projDir = join(dir, 'projects', 'demo');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'session-state.md'),
+      `> **${recentUtcDate(1)} 마감(13번째 세션).** 세 스트림을 처음으로 병렬로 굴렸다.\n`,
+    );
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'session-closed-abc123.marker'),
+      JSON.stringify({
+        session_id: 'abc123',
+        project: 'demo',
+        projects: ['demo'],
+        verified_scope: { kind: 'global', projects: ['other'] },
+        closed_at: recentUtcIso(1),
+      }),
+    );
+    const check = doctorCloseArtifactCheck(dir);
+    assert.ok(check, 'check not found');
+    assert.equal(
+      check.status,
+      'warn',
+      `a verified_scope that never named this project must not vouch for it: ${check?.detail}`,
+    );
+  });
+});
+
+// A `log-only` verified_scope means the gate verified no project at all —
+// it can never cover a project-scoped artifact, even if `projects` (evidence)
+// happens to name it.
+test('doctor-close-artifacts: log-only verified_scope never covers a project artifact → warn', () => {
+  withTmpDir((dir) => {
+    baseWiki(dir);
+    const projDir = join(dir, 'projects', 'demo');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'session-state.md'),
+      `> **${recentUtcDate(1)} 마감(13번째 세션).** 세 스트림을 처음으로 병렬로 굴렸다.\n`,
+    );
+    mkdirSync(join(dir, '.cache'), { recursive: true });
+    writeFileSync(
+      join(dir, '.cache', 'session-closed-abc123.marker'),
+      JSON.stringify({
+        session_id: 'abc123',
+        project: 'demo',
+        projects: ['demo'],
+        verified_scope: { kind: 'log-only' },
+        closed_at: recentUtcIso(1),
+      }),
+    );
+    const check = doctorCloseArtifactCheck(dir);
+    assert.ok(check, 'check not found');
+    assert.equal(
+      check.status,
+      'warn',
+      `a log-only verified_scope must not vouch for a project artifact: ${check?.detail}`,
+    );
+  });
+});
+
 // The marker exists specifically for per-session/per-project precision
 // (hooks/hypo-shared.mjs SESSION_CLOSED_MARKER_STALE_MS comment) — a
 // same-day marker for an UNRELATED project must not silence an unapproved


### PR DESCRIPTION
# English

## What changed

The session-closed marker now records `verified_scope`: the set of projects the close gate actually built a row for and evaluated. `/hypo:doctor`'s close-artifact correlation requires an artifact's project to appear in that set **in addition to** the marker's existing `projects` membership, an AND rather than an OR.

Markers written before this field existed behave byte-for-byte as they did: an absent `verified_scope` skips the new condition entirely.

## Why

The marker's `projects` field is evidence-based attribution, and it is not the same set as what the gate examined. Attribution takes a slug from a close-file path in the transcript without checking that `projects/<slug>/` exists; the gate filters its evaluation set by directory existence and by whether the project has close activity today. So a slug can reach the marker and vouch for that project's close artifacts in a later audit while the gate never looked at it once.

The gap is already named in the code: "a slug that reaches the marker but never reached this evaluation would be attested as closed without ever being checked". The fix at the time dropped such a slug from evaluation. Nothing stopped the marker from continuing to vouch for it. This closes that half.

## How

`writeSessionClosedMarker` takes a `verifiedScope` from its caller and refuses to persist a shape it cannot stand behind; an unrecognised shape or an empty project list is dropped so the marker reads back as if the field were never written. `scripts/doctor.mjs` reuses that same exported normalizer rather than re-implementing the collapse, so the writer and the reader cannot drift apart.

Both callers pass the gate's own evaluated set, `close.projects`, never the attribution set. `runMarkerPhase` previously kept only `.ok` from its gate call and discarded the rest; it now holds the status long enough to read that set. `kind` is `global` on both paths because neither narrows the gate: `closeScope` widens the mine/foreign partition and only `projectOverride` narrows evaluation, which no marker-writing path passes.

## Manual verification

Beyond the suite, each new assertion was checked by disabling what it is supposed to pin and confirming it goes red, then restoring:

- Removing the `verified_scope` AND from `markerCoversArtifact`: 3 of 9 red, including the end-to-end warn case.
- Reverting either caller to the attribution set: the matching end-to-end assertion goes red, and its failure message prints the marker that was actually written to disk.

The end-to-end assertions spawn the real CLI to produce a marker and then spawn the real `doctor.mjs` to read its verdict, rather than hand-building a marker payload. Gates run individually so each exit code is its own:

```
npm test                   rc=0   2164 passed, 0 failed
npm run lint               rc=0   0 error(s)
npm run format:check       rc=0
npm run check:tracker-ids  rc=0
```

No hook file changed, so the live-session hook verification does not apply here.

## Migration notes

None. An existing marker without the field keeps its current behaviour, and the field is written only by the two paths that already wrote markers.

---

# 한국어

## 변경 내용

session-closed 마커가 `verified_scope` 를 기록합니다. close 게이트가 실제로 행을 만들어 평가한 프로젝트 집합입니다. `/hypo:doctor` 의 close 산출물 상관 검사가 마커의 기존 `projects` 멤버십 **에 더해** 그 집합에도 드는지를 요구합니다. OR 가 아니라 AND 입니다.

이 필드가 생기기 전에 쓰인 마커는 동작이 한 바이트도 안 바뀝니다. `verified_scope` 가 없으면 새 조건을 아예 안 겁니다.

## 이유

마커의 `projects` 는 증거 기반 귀속이고, 게이트가 들여다본 집합과 같지 않습니다. 귀속은 transcript 의 close 파일 경로에서 slug 를 뽑을 뿐 `projects/<slug>/` 가 실재하는지 안 봅니다. 반면 게이트는 디렉터리 존재와 오늘 close 활동으로 평가 집합을 거릅니다. 그래서 게이트가 한 번도 안 본 slug 가 마커에 실려, 나중 감사에서 그 프로젝트의 close 산출물을 보증할 수 있습니다.

이 틈은 코드가 이미 이름으로 적고 있습니다. "a slug that reaches the marker but never reached this evaluation would be attested as closed without ever being checked." 그때의 처방은 그런 slug 를 평가에서 떨어뜨리는 것이었고, 마커가 계속 그것을 보증하는 자리는 안 닫혔습니다. 이 변경이 그 나머지를 닫습니다.

## 방법

`writeSessionClosedMarker` 가 호출자에게서 `verifiedScope` 를 받고, 자기가 책임질 수 없는 형태는 저장하지 않습니다. 알아볼 수 없는 형태나 빈 프로젝트 목록은 버려서 마커가 그 필드를 쓴 적 없는 것처럼 읽히게 합니다. `scripts/doctor.mjs` 는 같은 정규화를 다시 구현하지 않고 export 된 그 함수를 부릅니다. writer 와 reader 가 갈라질 수 없게 하려는 것입니다.

호출부 둘 다 귀속 집합이 아니라 게이트 자신의 평가 집합인 `close.projects` 를 넘깁니다. `runMarkerPhase` 는 게이트 결과에서 `.ok` 만 취하고 나머지를 버렸는데, 이제 그 집합을 읽을 수 있을 만큼 상태를 들고 있습니다. `kind` 는 두 경로 모두 `global` 입니다. 어느 쪽도 게이트를 안 좁히기 때문입니다. `closeScope` 는 mine/foreign 파티션을 넓히고, 평가를 좁히는 것은 `projectOverride` 뿐인데 마커를 쓰는 경로는 그것을 넘기지 않습니다.

## 수동 검증

스위트 외에, 새 단언마다 그것이 고정한다는 것을 무력화해 red 를 확인하고 되돌렸습니다.

- `markerCoversArtifact` 에서 `verified_scope` AND 를 제거: 9 건 중 3 건 red, end-to-end warn 경우 포함.
- 호출부 어느 한쪽을 귀속 집합으로 되돌림: 해당 end-to-end 단언이 red 이고, 실패 메시지가 디스크에 실제로 쓰인 마커를 찍습니다.

end-to-end 단언은 마커 payload 를 손으로 짓지 않고, 실제 CLI 를 띄워 마커를 만든 뒤 실제 `doctor.mjs` 를 띄워 그 판정을 읽습니다. 게이트는 종료 코드가 각자의 것이 되도록 하나씩 단독으로 돌렸습니다.

```
npm test                   rc=0   2164 passed, 0 failed
npm run lint               rc=0   0 error(s)
npm run format:check       rc=0
npm run check:tracker-ids  rc=0
```

훅 파일은 하나도 안 바뀌었으므로 실세션 훅 검증 요구는 걸리지 않습니다.

## 마이그레이션 노트

None. 필드가 없는 기존 마커는 지금 동작을 그대로 유지하고, 이 필드는 원래 마커를 쓰던 두 경로에서만 쓰입니다.

---

## Changelog

- EN: `/hypo:doctor` no longer accepts a session-closed marker as proof for a project the close gate never evaluated: the marker now records the set the gate actually checked, and the audit requires an artifact's project to be in that set as well as in the marker's attribution.
- KO: `/hypo:doctor` 가 close 게이트가 한 번도 평가하지 않은 프로젝트에 대해 session-closed 마커를 증거로 받지 않습니다. 마커가 게이트의 실제 검사 집합을 기록하고, 감사가 산출물의 프로젝트를 귀속뿐 아니라 그 집합에서도 요구합니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
