### PR TITLE
fix(hooks): stop the chat-side close notice from going silent

### DIFF
--- a/hooks/hypo-compact-guard.mjs
+++ b/hooks/hypo-compact-guard.mjs
@@ -9,19 +9,45 @@
  * PreCompact event at all, so this hook is the only chat-side gate that can
  * prompt session-close before a context wipe.
  *
- * Behavior: if session close is incomplete → instruct Claude to run session close
- * immediately before /compact or /clear.
+ * Behavior: if session close is incomplete, tell Claude so (a description, not
+ * an instruction — session-close-scope-boundary spec §5) before /compact or
+ * /clear runs.
+ *
+ * This hook never calls precompactGateStatus: its own hooks.json timeout is
+ * 10s and the gate's lint spawn alone budgets 30s, three times over. Instead
+ * it re-checks only the cheap axes (session log, git, hot.md) directly, and
+ * narrows the git axis with the SAME project-vs-foreign path rule the gate
+ * uses (isForeignProjectFile / classifyForeignOnlyDirty in hypo-shared.mjs), so
+ * a different project's dangling close file does not fire a false alarm here
+ * either. Unlike the gate, this hook never passes transcriptTouched into that
+ * rule: parsing the transcript is exactly the evidence spec §5 excludes to
+ * stay inside the 10s budget, so only the cheap path-prefix axis runs here.
  */
 
 import {
   lastSubstantialOpIsSession,
   hypoIsClean,
+  gitDirtyFiles,
   hotMdIsClean,
   readChecklist,
   isClearCommand,
   isCompactOrClearCommand,
   isGateSkipped,
+  resolveGateProjectOverride,
+  classifyForeignOnlyDirty,
+  HYPO_DIR,
 } from './hypo-shared.mjs';
+
+// A fixed slice of this hook's own 10s hooks.json budget (hooks.json:60),
+// shared as ONE deadline across every git spawn hypoIsClean and
+// gitDirtyFiles make below (up to four): each call re-checks the time left
+// and skips its own spawn once the shared budget is spent, so no NEW spawn
+// starts once this budget is gone. That bounds the git-spawn total, not the
+// hook's wall-clock time end to end: measured 145ms on a normal run and
+// 6273ms with a slow fsmonitor in the mix, both inside the 10s hooks.json
+// timeout, but a spawnSync child that outlives a SIGTERM has no coded upper
+// bound here.
+const GIT_DEADLINE_BUDGET_MS = 6000;
 
 let input = '';
 process.stdin.setEncoding('utf-8');
@@ -40,23 +66,97 @@ process.stdin.on('end', () => {
 
     const detected = isClearCommand(prompt) ? '/clear' : '/compact';
 
-    const hasSession = lastSubstantialOpIsSession();
-    const gitStatus = hypoIsClean();
-    const hotStatus = hotMdIsClean();
+    // These two run on EVERY /compact or /clear, unlike resolveGateProjectOverride
+    // below (which only runs when gitStatus.uncommitted is already true). A
+    // throw here would reach the outermost catch on every single prompt, not
+    // just the git-dirty ones, so the exposure is wider than the resolveGate
+    // case: fail closed locally instead ("reason present"), never fail open
+    // ("looks clean"). A read failure on either file is not the same fact as
+    // that file being genuinely absent or well-formed, so the fallback reason
+    // says "unreadable", not "missing" or "invalid", to keep the two causes
+    // tellable apart from the additionalContext text alone.
+    // lastSubstantialOpIsSession() now reads a MISSING log.md (ENOENT) as
+    // `false`, and reads only via a single readFileSync call (no separate
+    // existsSync precheck), so there is no check-then-read window where the
+    // file is deleted between the two and falls back to the old fail-open
+    // `true`. That keeps state-table row 1 (spec §5, "session log entry
+    // missing") surfaced: a brand-new vault with an all-foreign dirty tree
+    // and a clean hot.md still reports the missing log instead of going
+    // fully silent. Any OTHER read failure (EISDIR, EACCES, ...) is a real
+    // problem, so the function rethrows it, and the try/catch below turns
+    // that into the same fail-closed `hasSession = false` plus a stderr line.
+    let hasSession;
+    try {
+      hasSession = lastSubstantialOpIsSession();
+    } catch (err) {
+      process.stderr.write(
+        `[hypo-compact-guard] error: lastSubstantialOpIsSession failed, treating as session log entry missing: ${err?.message ?? String(err)}\n`,
+      );
+      hasSession = false;
+    }
+    const deadline = { end: performance.now() + GIT_DEADLINE_BUDGET_MS };
+    const gitStatus = hypoIsClean(undefined, { deadline });
+    let hotStatus;
+    try {
+      hotStatus = hotMdIsClean();
+    } catch (err) {
+      process.stderr.write(
+        `[hypo-compact-guard] error: hotMdIsClean failed, treating as hot.md unreadable: ${err?.message ?? String(err)}\n`,
+      );
+      hotStatus = { clean: false, reason: `hot.md unreadable: ${err?.message ?? String(err)}` };
+    }
 
-    // Block on uncommitted (real unsaved work); unpushed commits (ahead)
-    // are a soft, auto-synced state and must not block /compact or /clear — mirrors
-    // the precompactGateStatus demote so the chat-side gate stays consistent.
-    if (hasSession && !gitStatus.uncommitted && hotStatus.clean) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
-      return;
+    // Uncommitted (real unsaved work) blocks; unpushed commits (ahead) are a
+    // soft, auto-synced state and never reach `gitStatus.reason` here, since
+    // `uncommitted` is what gates it — mirrors the precompactGateStatus
+    // demote so the chat-side gate stays consistent.
+    let gitReason = gitStatus.uncommitted ? gitStatus.reason : '';
+    if (gitStatus.uncommitted) {
+      // resolveGateProjectOverride (session-close-scope-boundary spec §2):
+      // the same cwd-to-project resolution PreCompact and Stop already use.
+      // null just means "no project this cwd unambiguously owns" — that
+      // keeps the git axis judged globally, exactly like today. Scoped
+      // inside `uncommitted` on purpose: it only narrows the git notice, so
+      // a clean /compact has no reason to pay for a projects/ scan.
+      //
+      // Unlike classifyForeignOnlyDirty, this call is NOT contract-bound to
+      // stay silent: it walks through collectProjectWorkingDirs' own
+      // readdirSync, which sits outside that function's try/catch. Left
+      // uncaught here, that throw would escape past this hook's git-axis
+      // logic into the outermost catch and come back as a FULLY suppressed
+      // {suppressOutput:true} — silently dropping the session-log and
+      // hot.md reasons too, not just this one. Catch it locally and demote
+      // to null (its own "no project" sentinel) so a broken vault still
+      // gets every reason it is due.
+      let attributionScope = null;
+      try {
+        attributionScope = resolveGateProjectOverride(HYPO_DIR, {
+          sessionCwd: data.cwd ?? null,
+        });
+      } catch (err) {
+        process.stderr.write(
+          `[hypo-compact-guard] error: resolveGateProjectOverride failed, treating as no override: ${err?.message ?? String(err)}\n`,
+        );
+      }
+      if (attributionScope) {
+        const dirty = gitDirtyFiles(HYPO_DIR, { deadline });
+        const classification = classifyForeignOnlyDirty(HYPO_DIR, dirty, {
+          effectiveOverride: attributionScope,
+        });
+        if (classification === 'foreign-only') gitReason = '';
+      }
     }
 
     const reasons = [
       !hasSession ? 'session log entry missing' : '',
-      gitStatus.uncommitted ? gitStatus.reason : '',
+      gitReason,
       !hotStatus.clean ? hotStatus.reason : '',
     ].filter(Boolean);
+
+    if (reasons.length === 0) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
 
     const today = new Date().toISOString().slice(0, 10);
     const checklist = readChecklist(today);
@@ -68,8 +168,7 @@ process.stdin.on('end', () => {
       JSON.stringify({
         continue: true,
         additionalContext: [
-          `[WIKI_AUTOCLOSE] ${detected} detected — session close incomplete (${reasons.join(', ')}).`,
-          `Do NOT wait for user input. Run wiki session close NOW, then retry ${detected}.`,
+          `[WIKI_AUTOCLOSE] ${detected} detected: session close incomplete (${reasons.join(', ')}).`,
           ``,
           body,
           ``,

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -396,8 +396,23 @@ export function isGateSkipped() {
 // ── state checkers ─────────────────────────────────────────────────────────
 
 export function lastSubstantialOpIsSession() {
-  if (!existsSync(LOG_PATH)) return true;
-  const log = readFileSync(LOG_PATH, 'utf-8');
+  // Single read, no existsSync precheck: a check-then-read pair leaves a race
+  // window where the file exists at the check and is gone by the read, and
+  // the old code treated that ENOENT the same as a stably-missing file
+  // (fail-open, `true`). Only a genuinely absent log.md (ENOENT) folds to
+  // `false` here; any other read failure (EISDIR, EACCES, ...) is a real
+  // problem the caller needs to see, not a silent "no session", so it is
+  // rethrown. hypo-compact-guard.mjs is the only in-repo caller (verified via
+  // grep) and its own try/catch already turns any throw here into
+  // fail-closed ("session log entry missing") plus a stderr line, so this
+  // fail-open-to-fail-closed flip needed no other caller to be re-audited.
+  let log;
+  try {
+    log = readFileSync(LOG_PATH, 'utf-8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    throw err;
+  }
   const substantial = log
     .split('\n')
     .filter((l) => /^## \[\d{4}-\d{2}-\d{2}\] (session|ingest)/.test(l));
@@ -414,12 +429,61 @@ export function lastSubstantialOpIsSession() {
 // read it. Callers that gate session-close / compact distinguish the two: they
 // block on `uncommitted` and demote `ahead` to a notice (precompactGateStatus,
 // hypo-compact-guard) so a committed-but-unpushed close is still "compact-ready".
-export function hypoIsClean(dir = HYPO_DIR) {
+// A deadline shared across every git spawn one "am I clean" check can make:
+// `{ end: <performance.now()-based timestamp> }`, built once by a caller that
+// needs to bound hypoIsClean and gitDirtyFiles to a slice of its own hook
+// timeout (session-close-scope-boundary spec §5). remainingSpawnTimeoutMs
+// turns "time left" into what spawnSync's own `timeout` option actually
+// requires — verified on Node 26: `timeout: 0` DISABLES the timeout (waits
+// forever) rather than firing immediately, and a negative or fractional value
+// THROWS ERR_OUT_OF_RANGE. A throw here would escape as an exception through
+// a hook's outermost catch and come back silent, so a caller must never pass
+// a value this function did not produce, and must never spawn once it
+// returns 0.
+// A deadline built from a bad `end` (Infinity, NaN, or already past) must
+// also fold to 0, not just a plain negative one: a caller-supplied
+// `{ end: Infinity }` produces `remaining = Infinity`, and `Infinity` is
+// exactly as unsafe a `timeout` value as a negative or fractional one, same
+// `ERR_OUT_OF_RANGE` throw, just via a different guard. `Number.isFinite`
+// alone is not enough, though: it also passes `Number.MAX_VALUE`, which is
+// finite but still outside spawnSync's documented `timeout` range (0 through
+// `Number.MAX_SAFE_INTEGER`) and throws the same `ERR_OUT_OF_RANGE` (verified
+// directly: `gitDirtyFiles(cwd, { deadline: { end: Number.MAX_VALUE } })`
+// threw before this guard, since MAX_SAFE_INTEGER is exactly spawnSync's
+// upper bound, `Number.isSafeInteger` is the one predicate that matches it.
+//   undefined — no deadline given: omit `timeout` entirely (today's behavior)
+//   0         — budget exhausted, or the deadline itself was not a safe
+//               positive integer: do not spawn
+//   >0        — a whole positive integer number of ms safe to pass as `timeout`
+function remainingSpawnTimeoutMs(deadline) {
+  if (!deadline) return undefined;
+  const remaining = Math.floor(deadline.end - performance.now());
+  return Number.isSafeInteger(remaining) && remaining > 0 ? remaining : 0;
+}
+
+// `opts.deadline` is optional (session-close-scope-boundary spec §5): when
+// omitted, both spawns run exactly as before, no timeout, no status/error
+// check on the second one. hypo-compact-guard.mjs is the only caller that
+// passes one; precompactGateStatus (`:3872`) and all six direct test call
+// sites still pass a bare `dir` and must see byte-identical behavior.
+export function hypoIsClean(dir = HYPO_DIR, opts = {}) {
+  const { deadline } = opts;
   try {
-    const porcelain = spawnSync('git', ['-C', dir, 'status', '--porcelain'], {
-      encoding: 'utf-8',
-    });
-    if (porcelain.status !== 0)
+    const t1 = remainingSpawnTimeoutMs(deadline);
+    if (t1 === 0) {
+      return {
+        clean: false,
+        uncommitted: true,
+        ahead: false,
+        reason: `git check deadline exhausted in ${dir}`,
+      };
+    }
+    const porcelain = spawnSync(
+      'git',
+      ['-C', dir, 'status', '--porcelain'],
+      t1 === undefined ? { encoding: 'utf-8' } : { encoding: 'utf-8', timeout: t1 },
+    );
+    if (porcelain.error || porcelain.status !== 0)
       return {
         clean: false,
         uncommitted: true,
@@ -427,9 +491,38 @@ export function hypoIsClean(dir = HYPO_DIR) {
         reason: `git check failed in ${dir}`,
       };
     const uncommitted = porcelain.stdout.trim() !== '';
-    const aheadRes = spawnSync('git', ['-C', dir, 'status', '--branch', '--porcelain'], {
-      encoding: 'utf-8',
-    });
+
+    const t2 = remainingSpawnTimeoutMs(deadline);
+    if (t2 === 0) {
+      return {
+        clean: false,
+        uncommitted: true,
+        ahead: false,
+        reason: `git check deadline exhausted in ${dir}`,
+      };
+    }
+    const aheadRes = spawnSync(
+      'git',
+      ['-C', dir, 'status', '--branch', '--porcelain'],
+      t2 === undefined ? { encoding: 'utf-8' } : { encoding: 'utf-8', timeout: t2 },
+    );
+    // Only enforced when a deadline is in play. Without one this spawn cannot
+    // time out, and its `stdout` (empty on any other kind of failure too) was
+    // already read as "not ahead" before this change — harmless when nothing
+    // can kill the process out from under it. WITH a deadline this spawn CAN
+    // now die from the same budget the first spawn already spent, and a
+    // silent "not ahead" would make the caller's own notification vanish
+    // (spec §5's own regression). The first spawn already fails closed this
+    // way (`porcelain.status !== 0` above); this brings the second spawn to
+    // the same contract, but only where a deadline made it possible to break.
+    if (deadline && (aheadRes.error || aheadRes.status !== 0)) {
+      return {
+        clean: false,
+        uncommitted: true,
+        ahead: false,
+        reason: `git check failed in ${dir}`,
+      };
+    }
     const ahead = /\[ahead \d+\]/.test(aheadRes.stdout || '');
     const reasons = [];
     if (uncommitted) reasons.push(`uncommitted changes in ${dir}`);
@@ -473,18 +566,33 @@ export function hypoIsClean(dir = HYPO_DIR) {
  *   failure (the caller already has its own git-status result via
  *   hypoIsClean and treats that failure as an unconditional blocker; an
  *   empty return here just means "cannot attribute", not "clean").
+ *
+ * `opts.deadline` (session-close-scope-boundary spec §5): the SAME shared
+ * deadline object passed to hypoIsClean, so the two functions' spawns split
+ * one budget instead of each getting their own (which would let the pair
+ * together run twice as long as intended). Omitted, both spawns run exactly
+ * as before — precompactGateStatus's own call (`:3874`) does not pass one.
  */
-function gitDirtyFiles(dir) {
-  const prefixRes = spawnSync('git', ['-C', dir, 'rev-parse', '--show-prefix'], {
-    encoding: 'utf-8',
-  });
-  if (prefixRes.status !== 0) return []; // can't resolve the repo → cannot attribute
+export function gitDirtyFiles(dir = HYPO_DIR, opts = {}) {
+  const { deadline } = opts;
+  const t1 = remainingSpawnTimeoutMs(deadline);
+  if (t1 === 0) return []; // budget exhausted before the first spawn → cannot attribute
+  const prefixRes = spawnSync(
+    'git',
+    ['-C', dir, 'rev-parse', '--show-prefix'],
+    t1 === undefined ? { encoding: 'utf-8' } : { encoding: 'utf-8', timeout: t1 },
+  );
+  if (prefixRes.error || prefixRes.status !== 0) return []; // can't resolve the repo → cannot attribute
   const prefix = (prefixRes.stdout || '').trim();
 
-  const porcelain = spawnSync('git', ['-C', dir, 'status', '--porcelain', '-uall', '-z'], {
-    encoding: 'utf-8',
-  });
-  if (porcelain.status !== 0) return [];
+  const t2 = remainingSpawnTimeoutMs(deadline);
+  if (t2 === 0) return [];
+  const porcelain = spawnSync(
+    'git',
+    ['-C', dir, 'status', '--porcelain', '-uall', '-z'],
+    t2 === undefined ? { encoding: 'utf-8' } : { encoding: 'utf-8', timeout: t2 },
+  );
+  if (porcelain.error || porcelain.status !== 0) return [];
   const out = [];
   const records = (porcelain.stdout || '').split('\0');
   const toDirRelative = (f) => {
@@ -509,6 +617,74 @@ function gitDirtyFiles(dir) {
     if (relFrom) out.push(relFrom);
   }
   return out;
+}
+
+// session-close-scope-boundary spec §2b/§5: the ONE path-prefix rule that
+// decides a dirty file structurally belongs to a DIFFERENT eligible project
+// than the one this call is scoped to. Extracted from precompactGateStatus's
+// former inline closure so hypo-compact-guard.mjs (spec §5) can call the
+// exact same predicate instead of duplicating it — a closure over the gate's
+// local variables cannot be called, or asserted against, from anywhere else.
+//
+// Lexical, on the RAW git-porcelain path `f`, BEFORE posixPath()'s
+// unconditional `\` -> `/` conversion: a file whose actual NAME contains a
+// literal backslash (`projects\other\x.md`, one path segment, no real
+// subdirectory) must not be reinterpreted as living under `projects/other/`
+// just because posixPath() would rewrite it that way — testing the raw
+// string means it never matches the regex below and falls through to
+// "not foreign", the fail-closed default. `transcriptTouched` IS keyed by
+// posix paths (it comes from extractTouchedWikiFiles), so that one check
+// still normalizes `f` before the lookup.
+//
+// @param {string} f - a raw dirty path from gitDirtyFiles/git porcelain
+// @param {{eligibleSlugs: Set<string>|null, effectiveOverride: string|null,
+//   transcriptTouched?: Set<string>}} ctx
+// @returns {boolean}
+export function isForeignProjectFile(
+  f,
+  { eligibleSlugs, effectiveOverride, transcriptTouched = new Set() },
+) {
+  // Transcript evidence outranks the path-prefix heuristic below: it PROVES
+  // this session edited f, whatever its path prefix says. The heuristic only
+  // exists to cover files an untrusted (or absent) transcript could not
+  // vouch for either way.
+  if (transcriptTouched.has(posixPath(f))) return false;
+  if (!eligibleSlugs) return false;
+  const m = /^projects\/([^/]+)\/.+$/.exec(f);
+  if (!m) return false;
+  const slug = m[1];
+  return slug !== effectiveOverride && eligibleSlugs.has(slug);
+}
+
+// session-close-scope-boundary spec §5: hypo-compact-guard.mjs only needs a
+// yes/no on "may I drop my git notice line", never precompactGateStatus's
+// full per-file partition, and the answer must never escape as a throw — this
+// hook's outermost catch turns ANY exception into a fully suppressed
+// {suppressOutput:true}, so a failure inside collectProjectWorkingDirs (a
+// readdirSync it does not itself catch) must come back as data instead.
+//
+// Returns one of two sentinels, never throws:
+//   'foreign-only'   — dirty is non-empty, at least one eligible project is
+//                       known, and EVERY dirty file is provably someone
+//                       else's under isForeignProjectFile.
+//   'unattributable' — anything short of that full proof (no dirty files, no
+//                       eligible project known, project enumeration failed,
+//                       or a mix of foreign and non-foreign files). The
+//                       caller must treat this exactly like today's unscoped
+//                       git blocker/notice — this is the fail-closed default.
+export function classifyForeignOnlyDirty(hypoDir, dirty, { effectiveOverride = null } = {}) {
+  if (!dirty || dirty.length === 0) return 'unattributable'; // vacuous every() must not pass
+  let eligibleSlugs;
+  try {
+    eligibleSlugs = new Set(collectProjectWorkingDirs(hypoDir).map((p) => p.slug));
+  } catch {
+    return 'unattributable';
+  }
+  if (eligibleSlugs.size === 0) return 'unattributable';
+  const allForeign = dirty.every((f) =>
+    isForeignProjectFile(f, { eligibleSlugs, effectiveOverride }),
+  );
+  return allForeign ? 'foreign-only' : 'unattributable';
 }
 
 export function hotMdIsClean(dir = HYPO_DIR) {
@@ -3895,33 +4071,19 @@ export function precompactGateStatus(hypoDir, opts = {}) {
       // exception, the PreCompact hook's outermost catch would turn that
       // into a silent, fully-suppressed gate result, the opposite of "fail
       // closed". Treat any failure as "no eligible projects known", which
-      // makes isForeign() below always false and every dirty file falls
-      // through to the unconditional blocker.
+      // makes isForeignProjectFile() below always false and every dirty file
+      // falls through to the unconditional blocker.
       let eligibleSlugs = null;
       try {
         eligibleSlugs = new Set(collectProjectWorkingDirs(hypoDir).map((p) => p.slug));
       } catch {
         eligibleSlugs = null;
       }
-      // Lexical, on the RAW git-porcelain path, BEFORE posixPath()'s
-      // unconditional `\` -> `/` conversion. A file whose actual NAME
-      // contains a literal backslash (`projects\other\x.md`, one path
-      // segment, no real subdirectory) must not be reinterpreted as living
-      // under `projects/other/` just because posixPath() would rewrite it
-      // that way; testing the raw string here means it never matches this
-      // regex and falls through to fail-closed instead.
-      const isForeign = (f) => {
-        // The transcript already PROVES this session edited f, whatever its
-        // path prefix says: transcript evidence outranks the path-prefix
-        // heuristic below, which only exists to cover files the (untrusted)
-        // transcript could not vouch for either way.
-        if (transcriptTouched.has(posixPath(f))) return false;
-        if (!eligibleSlugs) return false;
-        const m = /^projects\/([^/]+)\/.+$/.exec(f);
-        if (!m) return false;
-        const slug = m[1];
-        return slug !== effectiveOverride && eligibleSlugs.has(slug);
-      };
+      // isForeignProjectFile is the extracted, exported predicate (spec §5):
+      // hypo-compact-guard.mjs calls the exact same function on its own git
+      // axis, instead of a second, silently-diverging copy of this rule.
+      const isForeign = (f) =>
+        isForeignProjectFile(f, { eligibleSlugs, effectiveOverride, transcriptTouched });
       const foreign = dirty.filter(isForeign);
       const rest = dirty.filter((f) => !isForeign(f));
       if (rest.length > 0) {

--- a/tests/close-hooks-gate.test.mjs
+++ b/tests/close-hooks-gate.test.mjs
@@ -19,6 +19,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { test, suite } from './harness.mjs';
 import { recordGateClosed, resolutionStamp } from '../hooks/close-gate-store.mjs';
+import { gitDirtyFiles, hypoIsClean } from '../hooks/hypo-shared.mjs';
 import {
   HOME,
   HOOKS,
@@ -375,6 +376,501 @@ test('/clearfoo (no word boundary) → pass-through (not /clear)', () => {
   const out = JSON.parse(r.stdout);
   assert.equal(out.continue, true);
   assert.equal(out.suppressOutput, true);
+});
+
+// ── hypo-compact-guard.mjs — state-table reason assembly ─────────────────
+// (session-close-scope-boundary spec §5): each `reasons` slot (session, git,
+// hot) is dropped or kept independently. The git slot is the new one — it
+// drops only when EVERY dirty file is provably a DIFFERENT eligible
+// project's, via the same classifyForeignOnlyDirty/isForeignProjectFile
+// predicate hypo-shared.mjs's own gate uses. Two DISTINCT registered
+// projects in the fixture below, never one: a single-project fixture cannot
+// tell "mine" and "foreign" apart, so it cannot pin this contract.
+suite('hypo-compact-guard.mjs — state-table reason assembly (spec §5)');
+
+const CG_CWD = join(tmpdir(), 'hypo-cg-spec5-workdir-mine');
+
+// test-project (buildCleanWikiTree's own project) gets a working_dir anchor at
+// CG_CWD so resolveGateProjectOverride({sessionCwd: CG_CWD}) resolves it as
+// `attributionScope`; `other` is a second, DISTINCT registered project (index.md
+// present) that owns none of this session's cwd. Mirrors the CWD/index.md
+// fixture pattern from the spec §4 hypo-personal-check.mjs tests above, kept
+// local here since this suite is hypo-compact-guard.mjs's own hook contract.
+function seedForeignFixture(dir) {
+  writeFileSync(
+    join(dir, 'projects', 'test-project', 'index.md'),
+    `---\ntitle: test-project\ntype: project-index\nupdated: 2026-01-01\nworking_dir: "${CG_CWD}"\n---\n# test-project\n`,
+  );
+  mkdirSync(join(dir, 'projects', 'other'), { recursive: true });
+  writeFileSync(
+    join(dir, 'projects', 'other', 'index.md'),
+    '---\ntitle: other\ntype: project-index\nupdated: 2026-01-01\n---\n# other\n',
+  );
+}
+
+test('state table row: last substantial op is ingest, not session (log.md exists) + all-foreign dirty -> session reason kept, git reason dropped', () => {
+  withWiki(
+    (dir, today) => {
+      seedForeignFixture(dir);
+      // Last substantial log.md entry is "ingest", not "session" ->
+      // lastSubstantialOpIsSession() reads false.
+      writeFileSync(join(dir, 'log.md'), `## [${today}] ingest | test-project\n`);
+    },
+    (dir) => {
+      writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other work\n');
+      const r = runHook(
+        'hypo-compact-guard.mjs',
+        { prompt: '/compact', cwd: CG_CWD },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.ok('additionalContext' in out, `hook must not go silent: ${r.stdout}`);
+      assert.ok(
+        /session log entry missing/.test(out.additionalContext || ''),
+        `session reason must survive: ${r.stdout}`,
+      );
+      assert.ok(
+        !/scratch\.md|uncommitted/.test(out.additionalContext || ''),
+        `an all-foreign dirty set must drop the git reason: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+// This is the OTHER axis of the same state-table row, distinct from the test
+// above. lastSubstantialOpIsSession() reads a MISSING log.md as `true`
+// (fail-open); without the guard added for this fix, that fail-open combined
+// with an all-foreign dirty tree and a clean hot.md would go fully silent
+// instead of surfacing the missing log, in direct contradiction of spec §5
+// row 1 ("session 없음 + all-foreign -> session log entry missing 유지").
+test('state table row: log.md itself does not exist (not just a non-session last entry) + all-foreign dirty + hot clean -> session reason kept, hook is not silent', () => {
+  withWiki(
+    (dir) => {
+      seedForeignFixture(dir);
+      unlinkSync(join(dir, 'log.md'));
+    },
+    (dir) => {
+      writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other work\n');
+      const r = runHook(
+        'hypo-compact-guard.mjs',
+        { prompt: '/compact', cwd: CG_CWD },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        'additionalContext' in out,
+        `hook must not go fully silent when log.md is absent: ${r.stdout}`,
+      );
+      assert.ok(
+        /session log entry missing/.test(out.additionalContext || ''),
+        `session reason must survive when log.md is absent: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('state table row: hot.md invalid + all-foreign dirty -> hot reason kept, git reason dropped', () => {
+  withWiki(
+    (dir) => {
+      seedForeignFixture(dir);
+      // Mutated pre-commit so hot.md itself is NOT part of the dirty set below
+      // (the row under test is "hot bad + all-foreign dirty", not "hot bad AND
+      // hot dirty too" — the latter would mix a non-foreign dirty file in and
+      // test a different row).
+      const hotPath = join(dir, 'hot.md');
+      writeFileSync(
+        hotPath,
+        readFileSync(hotPath, 'utf-8').replace(/^---\n/, '---\nlast_session: forbidden\n'),
+      );
+    },
+    (dir) => {
+      writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other work\n');
+      const r = runHook(
+        'hypo-compact-guard.mjs',
+        { prompt: '/compact', cwd: CG_CWD },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        /last_session/.test(out.additionalContext || ''),
+        `hot reason must survive: ${r.stdout}`,
+      );
+      assert.ok(
+        !/scratch\.md|uncommitted/.test(out.additionalContext || ''),
+        `an all-foreign dirty set must drop the git reason: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('state table row: attributionScope resolved but dirty mixes own + foreign -> git reason kept (fail-closed)', () => {
+  withWiki(
+    (dir) => {
+      seedForeignFixture(dir);
+    },
+    (dir) => {
+      writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other work\n');
+      writeFileSync(join(dir, 'projects', 'test-project', 'own.md'), '# own work\n');
+      const r = runHook(
+        'hypo-compact-guard.mjs',
+        { prompt: '/compact', cwd: CG_CWD },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        /WIKI_AUTOCLOSE/.test(out.additionalContext || ''),
+        `a mixed foreign+own dirty set must still block: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('state table row: attributionScope resolved but a dirty file lives outside any project -> git reason kept', () => {
+  withWiki(
+    (dir) => {
+      seedForeignFixture(dir);
+    },
+    (dir) => {
+      writeFileSync(join(dir, 'root-scratch.md'), '# not under any project\n');
+      const r = runHook(
+        'hypo-compact-guard.mjs',
+        { prompt: '/compact', cwd: CG_CWD },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        /WIKI_AUTOCLOSE/.test(out.additionalContext || ''),
+        `an unattributable dirty file must still block: ${r.stdout}`,
+      );
+    },
+  );
+});
+
+test('state table row (regression): session ok + hot clean + all-foreign dirty -> silent, no additionalContext', () => {
+  withWiki(
+    (dir) => {
+      seedForeignFixture(dir);
+    },
+    (dir) => {
+      writeFileSync(join(dir, 'projects', 'other', 'scratch.md'), '# other work\n');
+      const r = runHook(
+        'hypo-compact-guard.mjs',
+        { prompt: '/compact', cwd: CG_CWD },
+        { HYPO_DIR: dir },
+      );
+      const out = JSON.parse(r.stdout);
+      assert.equal(out.continue, true);
+      assert.equal(
+        out.suppressOutput,
+        true,
+        `every reason demoted must yield silence, not a nudge: ${r.stdout}`,
+      );
+      assert.ok(!('additionalContext' in out), `must not emit additionalContext: ${r.stdout}`);
+    },
+  );
+});
+
+// (cross-review BLOCKER, first-tier cross-review) resolveGateProjectOverride
+// (through collectProjectWorkingDirs' own readdirSync, outside that
+// function's try/catch) can throw on a structurally broken vault, unlike
+// classifyForeignOnlyDirty which is contract-bound to never throw. Before
+// the fix, that throw escaped this hook's git-axis logic straight into the
+// outermost catch, which turns ANY exception into a fully suppressed
+// {suppressOutput:true} — wiping the session-log and hot.md reasons too,
+// not just the git one. `projects` as a FILE (not a directory) is the
+// reproduction: existsSync(projectsDir) passes, then readdirSync throws
+// ENOTDIR. No `.git` directory at all, so hypoIsClean's own git spawn also
+// fails and reports uncommitted:true — the git axis must stay a candidate
+// so this exercises the `if (gitStatus.uncommitted)` branch, not skip it.
+test('resolveGateProjectOverride throwing on a broken vault must not silence the OTHER reasons', () => {
+  withTmpDir((dir) => {
+    writeFileSync(join(dir, 'hypo-config.md'), '# config');
+    // `projects` is a file, not a directory: collectProjectWorkingDirs'
+    // readdirSync(projectsDir) throws ENOTDIR once resolveGateProjectOverride
+    // reaches it.
+    writeFileSync(join(dir, 'projects'), 'not a directory\n');
+    const today = todayLocal();
+    // "ingest", not "session" -> lastSubstantialOpIsSession() reads false,
+    // so the session-log reason is the one this BLOCKER also swallowed.
+    writeFileSync(join(dir, 'log.md'), `## [${today}] ingest | test-project\n`);
+    const r = runHook(
+      'hypo-compact-guard.mjs',
+      { prompt: '/compact', cwd: join(dir, 'somewhere') },
+      { HYPO_DIR: dir },
+    );
+    assert.equal(r.status, 0, `hook must never exit non-zero: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    // Must come before the content assertions: a hook that silently
+    // suppresses (the exact BLOCKER this pins) has no additionalContext at
+    // all, and `(out.additionalContext || '').test(...)` on the reasons
+    // below would then pass vacuously instead of catching the regression.
+    assert.ok('additionalContext' in out, `must not go silent on a broken vault: ${r.stdout}`);
+    assert.ok(
+      /session log entry missing/.test(out.additionalContext),
+      `session-log reason must survive a resolveGateProjectOverride throw: ${r.stdout}`,
+    );
+    assert.ok(
+      /git check failed/.test(out.additionalContext),
+      `git reason must survive too, not just session-log: ${r.stdout}`,
+    );
+  });
+});
+
+// A second, separate defense from the one above: resolveGateProjectOverride
+// is scoped INSIDE `if (gitStatus.uncommitted)` because it only ever narrows
+// the git notice — a clean /compact has no git reason to narrow, so it has
+// no business running at all, broken `projects/` entry or not. `projects` is
+// committed as a FILE here (inside withWiki's `mutate`, before the commit),
+// so the working tree is clean at hook time and this test exercises the
+// branch NOT taken, unlike the throw test above which needs uncommitted:true
+// to even reach the call.
+test('a clean /compact never invokes resolveGateProjectOverride, even with a broken projects/ entry sitting there', () => {
+  withWiki(
+    (dir, today) => {
+      // "ingest", not "session": the session reason is the only one this
+      // fixture carries, so seeing it survive proves the hook still ran its
+      // other checks even though it skipped the projects/ scan below.
+      writeFileSync(join(dir, 'log.md'), `## [${today}] ingest | test-project\n`);
+      rmSync(join(dir, 'projects'), { recursive: true, force: true });
+      writeFileSync(join(dir, 'projects'), 'not a directory\n');
+    },
+    (dir) => {
+      const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' }, { HYPO_DIR: dir });
+      const out = JSON.parse(r.stdout);
+      assert.ok('additionalContext' in out, `session reason must still surface: ${r.stdout}`);
+      assert.ok(
+        /session log entry missing/.test(out.additionalContext),
+        `session reason must still surface: ${r.stdout}`,
+      );
+      assert.ok(
+        !/resolveGateProjectOverride failed/.test(r.stderr),
+        `a clean /compact must never invoke resolveGateProjectOverride at all: ${r.stderr}`,
+      );
+    },
+  );
+});
+
+// (cross-review BLOCKER, second-tier cross-review) lastSubstantialOpIsSession()
+// and hotMdIsClean() are the other two calls that run on EVERY /compact or
+// /clear, same as resolveGateProjectOverride above but with no `if
+// (gitStatus.uncommitted)` guard around them at all — so an unguarded throw
+// here was reachable on every single prompt, not just the dirty-git ones,
+// wiping ALL THREE reasons (session, git, hot) into the outermost catch's
+// {suppressOutput:true}. A directory in place of the file forces a real
+// EISDIR read failure (not just "file absent", which lastSubstantialOpIsSession
+// already treats as fail-open true — a plain rmSync fixture would not exercise
+// this defect at all).
+test('log.md is a directory (read failure, not "missing") -> hook stays non-silent with the session-log reason', () => {
+  withWiki(
+    (dir) => {
+      rmSync(join(dir, 'log.md'), { force: true });
+      mkdirSync(join(dir, 'log.md'));
+      writeFileSync(join(dir, 'log.md', 'placeholder.md'), '# not a real log.md\n');
+    },
+    (dir) => {
+      const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' }, { HYPO_DIR: dir });
+      assert.equal(r.status, 0, `hook must never exit non-zero: ${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      // Must come first: a silently-suppressed hook has no additionalContext,
+      // and the regex assertion below would then pass vacuously.
+      assert.ok(
+        'additionalContext' in out,
+        `must not go silent when log.md is unreadable: ${r.stdout}`,
+      );
+      assert.ok(
+        /session log entry missing/.test(out.additionalContext),
+        `a read failure on log.md must fall back fail-closed to the session-log reason: ${r.stdout}`,
+      );
+      assert.ok(
+        /lastSubstantialOpIsSession failed/.test(r.stderr),
+        `stderr must name which axis failed: ${r.stderr}`,
+      );
+    },
+  );
+});
+
+test('hot.md is a directory (read failure, not "invalid") -> hook stays non-silent with an "unreadable" hot reason', () => {
+  withWiki(
+    (dir) => {
+      rmSync(join(dir, 'hot.md'), { force: true });
+      mkdirSync(join(dir, 'hot.md'));
+      writeFileSync(join(dir, 'hot.md', 'placeholder.md'), '# not a real hot.md\n');
+    },
+    (dir) => {
+      const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' }, { HYPO_DIR: dir });
+      assert.equal(r.status, 0, `hook must never exit non-zero: ${r.stderr}`);
+      const out = JSON.parse(r.stdout);
+      assert.ok(
+        'additionalContext' in out,
+        `must not go silent when hot.md is unreadable: ${r.stdout}`,
+      );
+      assert.ok(
+        /hot\.md unreadable/.test(out.additionalContext),
+        `a read failure on hot.md must say "unreadable", distinct from a format violation like "unexpected H2" or "forbidden field": ${r.stdout}`,
+      );
+      assert.ok(
+        /hotMdIsClean failed/.test(r.stderr),
+        `stderr must name which axis failed: ${r.stderr}`,
+      );
+    },
+  );
+});
+
+// lastSubstantialOpIsSession() reads the module-level LOG_PATH constant
+// (computed once from process.env.HYPO_DIR at import time), so pinning it to
+// a fixture directory in THIS process would have no effect once
+// hypo-shared.mjs is already imported above. Each case runs in a fresh child
+// process instead, exactly like lib-core.test.mjs's resolveHypoRootInfo
+// probes, so HYPO_DIR is read cold.
+function probeLastSubstantialOpIsSession(hypoDir) {
+  const script = `
+    const { lastSubstantialOpIsSession } = await import(${JSON.stringify(join(HOOKS, 'hypo-shared.mjs'))});
+    try {
+      console.log(JSON.stringify({ ok: true, result: lastSubstantialOpIsSession() }));
+    } catch (err) {
+      console.log(JSON.stringify({ ok: false, code: err && err.code, message: err && err.message }));
+    }
+  `;
+  return spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: hypoDir },
+  });
+}
+
+// Pins the single-read TOCTOU fix directly on the function that owns it,
+// independent of the hook's own JSON envelope: a missing log.md (ENOENT)
+// must read `false` now, not the old fail-open `true` that forced
+// hypo-compact-guard.mjs to precheck existsSync(LOG_PATH) ahead of the call
+// (the precheck this round removes, since it is what left the check-then-
+// read race open in the first place).
+test('lastSubstantialOpIsSession(): log.md absent (ENOENT) reads false, not the old fail-open true', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-toctou-'));
+  try {
+    const r = probeLastSubstantialOpIsSession(dir);
+    assert.equal(r.status, 0, `probe process should exit 0: ${r.stderr}`);
+    assert.deepEqual(JSON.parse(r.stdout.trim()), { ok: true, result: false });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Only ENOENT folds to `false`. A directory in place of log.md is a real
+// read failure (EISDIR), not "genuinely absent", and must rethrow so the
+// caller's own try/catch (not this function) decides how to fail closed.
+test('lastSubstantialOpIsSession(): log.md is a directory (EISDIR) rethrows, does not fold to a return value', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hypo-toctou-'));
+  try {
+    mkdirSync(join(dir, 'log.md'));
+    const r = probeLastSubstantialOpIsSession(dir);
+    assert.equal(r.status, 0, `probe process should exit 0: ${r.stderr}`);
+    const out = JSON.parse(r.stdout.trim());
+    assert.equal(out.ok, false, `EISDIR must rethrow, not resolve to a value: ${r.stdout}`);
+    assert.equal(out.code, 'EISDIR', `error code must be EISDIR: ${r.stdout}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('additionalContext never carries imperative "Run ... NOW" or "Do NOT wait" phrasing', () => {
+  const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' });
+  const out = JSON.parse(r.stdout);
+  // Guard the negative assertions below against a silently-suppressed hook:
+  // without this, a bug that drops additionalContext entirely (empty string)
+  // would make both regexes below pass vacuously, on a run with nothing to
+  // check phrasing in at all.
+  assert.ok('additionalContext' in out, r.stdout);
+  assert.ok(!/Run .* NOW/i.test(out.additionalContext || ''), r.stdout);
+  assert.ok(!/Do NOT wait/i.test(out.additionalContext || ''), r.stdout);
+});
+
+// ── hypoIsClean / gitDirtyFiles: opts.deadline (session-close-scope-boundary
+//    spec §5). Called directly, no hook process: both spawn `git` themselves,
+//    exactly as hypo-compact-guard.mjs's own call does, and asserting on the
+//    return value pins the contract without also depending on the hook's own
+//    JSON envelope. ──────────────────────────────────────────────────────
+suite('hypoIsClean / gitDirtyFiles: opts.deadline (spec §5)');
+
+test('hypoIsClean(dir): single-arg call is unchanged (no timeout, no second-spawn failure check)', () => {
+  withCleanWiki((dir) => {
+    assert.deepEqual(hypoIsClean(dir), {
+      clean: true,
+      uncommitted: false,
+      ahead: false,
+      reason: undefined,
+    });
+  });
+});
+
+test('hypoIsClean(dir, {deadline}) with a healthy budget returns the identical verdict to the no-deadline call', () => {
+  withCleanWiki((dir) => {
+    const withDeadline = hypoIsClean(dir, { deadline: { end: performance.now() + 5000 } });
+    assert.deepEqual(withDeadline, hypoIsClean(dir));
+  });
+});
+
+test('hypoIsClean(dir, {deadline}) with an already-exhausted budget converts to fail-closed uncommitted:true, not a throw', () => {
+  withCleanWiki((dir) => {
+    const status = hypoIsClean(dir, { deadline: { end: performance.now() - 1 } });
+    assert.equal(status.clean, false);
+    assert.equal(status.uncommitted, true);
+    assert.ok(/deadline exhausted/.test(status.reason || ''), `reason: ${status.reason}`);
+  });
+});
+
+test('gitDirtyFiles(dir, {deadline}) with an already-exhausted budget returns [] (cannot attribute)', () => {
+  withCleanWiki((dir) => {
+    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    assert.deepEqual(gitDirtyFiles(dir, { deadline: { end: performance.now() - 1 } }), []);
+  });
+});
+
+// A deadline built from a non-finite `end` (Infinity or NaN) must fold to the
+// same "budget exhausted, do not spawn" path as an already-past one, not
+// reach spawnSync's `timeout` option as-is. Node throws ERR_OUT_OF_RANGE for
+// a non-finite `timeout`, and neither gitDirtyFiles nor its hook caller
+// catches that: it would escape to the hook's outermost catch and come back
+// as full silence, dropping every other reason in the same reasons array.
+test('gitDirtyFiles(dir, {deadline: {end: Infinity}}) does not throw, returns [] (cannot attribute)', () => {
+  withCleanWiki((dir) => {
+    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    assert.deepEqual(gitDirtyFiles(dir, { deadline: { end: Infinity } }), []);
+  });
+});
+
+// `end: NaN` alone does not distinguish remainingSpawnTimeoutMs's predicate:
+// both Number.isFinite(NaN) and Number.isSafeInteger(NaN) are false, so this
+// assertion passed identically before and after the isFinite->isSafeInteger
+// fix and pinned nothing about it (cross-review-2nd finding). `Number.MAX_VALUE`
+// is the case that actually separates the two: it IS finite (isFinite passes
+// it through) but exceeds Number.MAX_SAFE_INTEGER, spawnSync's own upper
+// bound (only isSafeInteger rejects it). With the guard reverted to
+// isFinite, this reaches spawnSync as an out-of-range `timeout` and throws
+// ERR_OUT_OF_RANGE uncaught (gitDirtyFiles has no try/catch of its own).
+test('gitDirtyFiles(dir, {deadline: {end: Number.MAX_VALUE}}) does not throw, returns [] (cannot attribute)', () => {
+  withCleanWiki((dir) => {
+    writeFileSync(join(dir, 'dirty.md'), '# dirty\n');
+    assert.deepEqual(gitDirtyFiles(dir, { deadline: { end: Number.MAX_VALUE } }), []);
+  });
+});
+
+// Same MAX_VALUE boundary as above, but through hypoIsClean, which DOES wrap
+// its spawns in a try/catch (`:516-518` area) — so an uncaught throw there
+// still comes back as a return value, not an exception. Asserting only
+// `uncommitted: true` (the old form) cannot tell "guard folded this to 0
+// before ever spawning" apart from "spawnSync threw ERR_OUT_OF_RANGE and the
+// generic catch below caught it": both produce `uncommitted: true`. The
+// `reason` string is what differs — "deadline exhausted" only appears on the
+// guard's own early-return branch, before any spawn — so asserting on it is
+// what makes this test go red when the guard is reverted to isFinite.
+test('hypoIsClean(dir, {deadline: {end: Number.MAX_VALUE}}) folds to the deadline-exhausted branch, never reaches spawnSync', () => {
+  withCleanWiki((dir) => {
+    const status = hypoIsClean(dir, { deadline: { end: Number.MAX_VALUE } });
+    assert.equal(status.uncommitted, true);
+    assert.ok(
+      /deadline exhausted/.test(status.reason || ''),
+      `must fold before spawning, not reach spawnSync and get caught by the generic "git check failed" branch: ${JSON.stringify(status)}`,
+    );
+  });
 });
 
 suite('hypo-personal-check.mjs — close-intent enrichment (#20)');

--- a/tests/crystallize-apply.test.mjs
+++ b/tests/crystallize-apply.test.mjs
@@ -27,7 +27,7 @@ import {
   withWiki,
 } from './helpers.mjs';
 
-// ── fix #38: --apply-session-close --payload <json> ───────────────────────────
+// ── fix #38: --apply-session-close --payload=<path|-> ─────────────────────────
 // @fix #38: clean-wiki payload → ok:true, new entries appended (apply dedup is exact-entry, not date-based)
 // @fix #38: idempotent: re-running same payload produces no new bytes (file mtimes unchanged)
 // Idempotent payload-driven entrypoint that writes the 5 mandatory memory files

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -30,6 +30,8 @@ import {
   readSyncLastSuccess,
   classifySyncOp,
   freshDates,
+  isForeignProjectFile,
+  classifyForeignOnlyDirty,
 } from '../hooks/hypo-shared.mjs';
 import {
   snapshotBase,
@@ -3392,6 +3394,99 @@ test('precompactGateStatus: projectOverride + a partially-parsed transcript prov
     assert.ok(
       (gate.blockers || []).some((b) => b.type === 'git'),
       `transcript evidence of THIS session's own edit must outrank the foreign-path heuristic: ${JSON.stringify(gate.blockers)}`,
+    );
+  });
+});
+
+// ── isForeignProjectFile / classifyForeignOnlyDirty (extracted predicates,
+//    session-close-scope-boundary spec §5) ──────────────────────────────────
+//
+// Direct, hook-free unit tests: both predicates are pure fs-sync + string
+// logic with no git spawn, so a plain withTmpDir fixture is enough. Every
+// fixture below registers TWO distinct projects, never one — a single-project
+// fixture cannot tell "mine" from "foreign" apart, which is exactly the shape
+// this repo's own git-attribution tests were flipped-assertion blind with
+// before.
+
+suite('isForeignProjectFile / classifyForeignOnlyDirty (extracted predicates, spec §5)');
+
+test('isForeignProjectFile: a raw literal-backslash filename is never reinterpreted as projects/<slug>/ (regression)', () => {
+  const ctx = { eligibleSlugs: new Set(['other']), effectiveOverride: 'mine' };
+  assert.equal(isForeignProjectFile('projects\\other\\x.md', ctx), false);
+});
+
+test('isForeignProjectFile: a real projects/<slug>/ path IS foreign when slug is a DIFFERENT eligible project', () => {
+  const ctx = { eligibleSlugs: new Set(['mine', 'other']), effectiveOverride: 'mine' };
+  assert.equal(isForeignProjectFile('projects/other/scratch.md', ctx), true);
+});
+
+test("isForeignProjectFile: the override's own project is never foreign", () => {
+  const ctx = { eligibleSlugs: new Set(['mine', 'other']), effectiveOverride: 'mine' };
+  assert.equal(isForeignProjectFile('projects/mine/session-state.md', ctx), false);
+});
+
+test('isForeignProjectFile: transcriptTouched proof outranks the path heuristic', () => {
+  const ctx = {
+    eligibleSlugs: new Set(['mine', 'other']),
+    effectiveOverride: 'mine',
+    transcriptTouched: new Set(['projects/other/hot.md']),
+  };
+  assert.equal(isForeignProjectFile('projects/other/hot.md', ctx), false);
+});
+
+test('classifyForeignOnlyDirty: dirty.length===0 is NOT vacuous-true (fails closed, never "foreign-only")', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'projects', 'mine'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'mine', 'index.md'), '---\ntitle: mine\n---\n# mine\n');
+    assert.equal(
+      classifyForeignOnlyDirty(dir, [], { effectiveOverride: 'mine' }),
+      'unattributable',
+    );
+  });
+});
+
+test('classifyForeignOnlyDirty: an unlistable projects/ dir (not a directory) returns "unattributable", never throws', () => {
+  withTmpDir((dir) => {
+    // 'projects' exists but is a FILE: existsSync passes, readdirSync inside
+    // collectProjectWorkingDirs throws ENOTDIR. Any hook calling this (the
+    // PreCompact/UserPromptSubmit outermost catch) turns an escaped throw
+    // into a fully suppressed, silent {suppressOutput:true} — exactly the
+    // gap this function's no-throw contract exists to close.
+    writeFileSync(join(dir, 'projects'), 'not a directory');
+    let result;
+    assert.doesNotThrow(() => {
+      result = classifyForeignOnlyDirty(dir, ['projects/mine/x.md'], { effectiveOverride: 'mine' });
+    });
+    assert.equal(result, 'unattributable');
+  });
+});
+
+test('classifyForeignOnlyDirty: two distinct registered projects, dirty all under the OTHER slug -> "foreign-only"', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'projects', 'mine'), { recursive: true });
+    mkdirSync(join(dir, 'projects', 'other'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'mine', 'index.md'), '---\ntitle: mine\n---\n# mine\n');
+    writeFileSync(join(dir, 'projects', 'other', 'index.md'), '---\ntitle: other\n---\n# other\n');
+    assert.equal(
+      classifyForeignOnlyDirty(dir, ['projects/other/scratch.md'], { effectiveOverride: 'mine' }),
+      'foreign-only',
+    );
+  });
+});
+
+test('classifyForeignOnlyDirty: two distinct registered projects, dirty mixes own + foreign -> "unattributable"', () => {
+  withTmpDir((dir) => {
+    mkdirSync(join(dir, 'projects', 'mine'), { recursive: true });
+    mkdirSync(join(dir, 'projects', 'other'), { recursive: true });
+    writeFileSync(join(dir, 'projects', 'mine', 'index.md'), '---\ntitle: mine\n---\n# mine\n');
+    writeFileSync(join(dir, 'projects', 'other', 'index.md'), '---\ntitle: other\n---\n# other\n');
+    assert.equal(
+      classifyForeignOnlyDirty(
+        dir,
+        ['projects/other/scratch.md', 'projects/mine/session-state.md'],
+        { effectiveOverride: 'mine' },
+      ),
+      'unattributable',
     );
   });
 });


### PR DESCRIPTION
# English

## What changed

The `UserPromptSubmit` guard that runs before `/compact` and `/clear` stopped ordering an action and stopped raising a false alarm over another project's files.

Three things moved together, because none of them stands alone:

- The notice describes the state instead of telling Claude to run session close immediately.
- The git axis is narrowed with the same project-vs-foreign path rule the close gate uses. That rule left the gate as two named exports, `isForeignProjectFile` and `classifyForeignOnlyDirty`, and the gate now calls the predicate it used to inline. `gitDirtyFiles` is exported alongside them.
- Every read the guard makes is folded to a value. The judgment never throws.

## Why

Two separate problems, both visible to anyone running more than one session against one vault.

The old text was an instruction: run session close NOW, do not wait for user input. That is a decision the person should make, not a command a notice should issue.

The false alarm is the sharper one. The guard judged the whole working tree, so a second session with its own close file still dirty made the first session's `/compact` announce that its close was incomplete. Nothing was wrong with the first session.

Underneath both sat a quieter failure. A hook's outermost catch turns any throw into a fully suppressed result. That is the exact opposite of a notice: a vault broken enough to be worth reporting produced silence instead. Four reads could reach it, and each was found by a different review round.

## How

The judgment returns `foreign-only` or `unattributable`, never an exception. `foreign-only` requires all three of: a non-empty dirty list (an empty `every()` must not pass as vacuous truth), an eligible-project list that both succeeded and is non-empty, and a deadline that has not run out.

Reasons are assembled per axis, so dropping the git reason leaves the session and hot.md reasons intact. Silence happens only when no reason survives.

Four reads fold instead of throwing: the eligible-project list, `log.md`, `hot.md`, and the resolver that walks a broken `projects/` directory. Each fold writes one stderr line naming the axis it lost, so a broken vault leaves a trace rather than vanishing. `log.md` absence resolves inside a single read, so no check-then-read window can reopen the old fail-open.

Four git spawns share one deadline sliced from this hook's own 10s budget. `spawnSync` disables its timeout when given 0 and throws `ERR_OUT_OF_RANGE` on a negative, fractional, or unsafe value, and that throw would land in the outermost catch as silence. The remaining time is therefore handed over only as a positive safe integer, and the spawn is skipped otherwise.

This hook never calls the close gate. The gate's lint spawn alone budgets 30s against this hook's 10s.

## Manual verification

Gates, run on this branch alone:

```
npm test                          rc=0   2192 passed, 0 failed
node tests/parallel.mjs --shards=4 rc=0  green
npm run lint                      rc=0   0 error
npm run check:tracker-ids         rc=0
npm run check:pack-surface        rc=0   136 files
```

Each defect was reproduced against the hook binary before and after the fix. A vault whose `projects` entry is a file, whose `log.md` is a directory, whose `hot.md` is a directory, and one with no `log.md` at all: each produced `{"continue":true,"suppressOutput":true}` before, and afterwards produced a notice carrying the reason for the axis that failed, plus an stderr line naming it. `gitDirtyFiles` with a deadline of `Infinity` and of `Number.MAX_VALUE` threw `ERR_OUT_OF_RANGE` before and returns `[]` after.

Timing was measured rather than argued: four git spawns totalled 145ms on a normal run, and 6273ms end to end with a slow `core.fsmonitor` helper injected that ignores SIGTERM for 8s. Both are inside the 10s budget. A `spawnSync` child that outlives a SIGTERM still has no bound that the code can guarantee, and the comment above the budget constant now says so instead of claiming the pair never runs longer.

**A limitation this PR does not fix, found while verifying it.** The notice is emitted as a top-level `additionalContext`. The hooks guide states that for `UserPromptSubmit` hooks, `additionalContext` must be nested inside `hookSpecificOutput`, and that Claude Code silently ignores it at the top level. `buildOutput` in `hooks/hypo-shared.mjs` produces the top-level shape, so this notice does not currently reach the model, and neither do the notices from `hypo-first-prompt` or `hypo-lookup`. The behavior this PR fixes is correct and pinned by tests; the delivery path is a separate defect across four hooks and one shared helper, and it is filed on its own rather than folded in here. The repo verified the top-level shape against the docs in May 2026 and the contract has moved since.

## Migration notes

None.

---

# 한국어

## 변경 내용

`/compact`와 `/clear` 앞에서 도는 `UserPromptSubmit` 가드가 행동을 지시하지 않게 됐고, 남의 프로젝트 파일로 거짓 알림을 내지 않게 됐습니다.

셋이 같이 움직였습니다. 어느 하나도 혼자 서지 못합니다.

- 알림이 세션 close를 지금 실행하라고 지시하는 대신 상태를 서술합니다.
- git 축을 close 게이트가 쓰는 것과 같은 프로젝트 대 외부 경로 규칙으로 좁힙니다. 그 규칙이 게이트에서 `isForeignProjectFile`과 `classifyForeignOnlyDirty` 두 export로 나왔고, 게이트도 인라인으로 갖고 있던 그 판정을 이제 불러 씁니다. `gitDirtyFiles`도 함께 export했습니다.
- 가드가 하는 모든 읽기가 값으로 접힙니다. 판정은 던지지 않습니다.

## 이유

문제가 둘이고, 한 볼트에 세션을 둘 이상 굴리는 사람에게 둘 다 보입니다.

옛 문구는 지시였습니다. 세션 close를 지금 실행하라, 사용자 입력을 기다리지 마라. 그건 사람이 내릴 결정이지 알림이 내릴 명령이 아닙니다.

거짓 알림 쪽이 더 아픕니다. 가드가 워킹트리 전체를 판정해서, 두 번째 세션이 자기 close 파일을 아직 커밋 안 한 상태이면 첫 번째 세션의 `/compact`가 자기 close가 미완결이라고 알렸습니다. 첫 세션은 아무 문제가 없는데도 그랬습니다.

둘 밑에 더 조용한 실패가 있었습니다. 훅의 최외곽 catch가 어떤 throw든 완전 무음으로 바꿉니다. 알림의 정반대입니다. 보고할 값어치가 있을 만큼 망가진 볼트가 오히려 침묵을 냈습니다. 거기 닿는 읽기가 넷이었고, 검토 라운드마다 하나씩 나왔습니다.

## 방법

판정은 `foreign-only` 아니면 `unattributable`을 돌려주고 예외를 던지지 않습니다. `foreign-only`는 셋을 전부 만족해야 나옵니다. dirty 목록이 비어 있지 않고(빈 `every()`가 공허한 참으로 통과하면 안 됩니다), 적격 프로젝트 목록이 성공했고 비어 있지 않으며, deadline이 남아 있어야 합니다.

사유는 축별로 조립하므로 git 사유를 빼도 session과 hot.md 사유는 남습니다. 무음은 남은 사유가 하나도 없을 때만입니다.

읽기 넷이 던지는 대신 접힙니다. 적격 프로젝트 목록, `log.md`, `hot.md`, 그리고 망가진 `projects/` 디렉터리를 훑는 resolver입니다. 접을 때마다 어느 축을 잃었는지 이름을 담은 stderr 한 줄을 남겨서, 망가진 볼트가 사라지지 않고 흔적을 남깁니다. `log.md` 부재는 읽기 한 번 안에서 판정하므로 확인과 읽기 사이의 창으로 옛 fail-open이 다시 열리지 않습니다.

git spawn 넷이 이 훅 자신의 10초 예산에서 잘라 낸 deadline 하나를 공유합니다. `spawnSync`는 0을 주면 timeout을 끄고, 음수·소수·안전하지 않은 정수에는 `ERR_OUT_OF_RANGE`를 던지는데, 그 throw는 최외곽 catch로 가서 무음이 됩니다. 그래서 남은 시간은 양의 safe integer일 때만 넘기고 아니면 spawn을 건너뜁니다.

이 훅은 close 게이트를 부르지 않습니다. 게이트의 lint spawn 하나만으로 30초라 이 훅의 10초를 넘깁니다.

## 수동 검증

이 브랜치 단독으로 돌린 게이트입니다.

```
npm test                          rc=0   2192 passed, 0 failed
node tests/parallel.mjs --shards=4 rc=0  green
npm run lint                      rc=0   0 error
npm run check:tracker-ids         rc=0
npm run check:pack-surface        rc=0   136 files
```

결함마다 훅 바이너리에 직접 재현을 걸어 수정 전후를 대조했습니다. `projects` 항목이 파일인 볼트, `log.md`가 디렉터리인 볼트, `hot.md`가 디렉터리인 볼트, `log.md`가 아예 없는 볼트 넷입니다. 전부 수정 전에는 `{"continue":true,"suppressOutput":true}`만 냈고, 수정 후에는 실패한 축의 사유를 담은 알림과 그 축 이름이 든 stderr 한 줄을 냈습니다. `gitDirtyFiles`에 deadline `Infinity`와 `Number.MAX_VALUE`를 주면 전에는 `ERR_OUT_OF_RANGE`를 던졌고 지금은 `[]`를 돌려줍니다.

시간은 주장이 아니라 측정으로 확인했습니다. 정상 실행에서 git spawn 넷이 합쳐 145ms였고, SIGTERM을 8초 무시하는 `core.fsmonitor` 보조 프로세스를 주입하면 훅 전체가 6273ms였습니다. 둘 다 10초 안입니다. SIGTERM을 넘긴 `spawnSync` 자식의 상한은 여전히 코드로 보장되지 않고, 예산 상수 위 주석이 "이 둘은 절대 이보다 오래 안 돈다"고 하던 것을 그 사실대로 고쳤습니다.

**이 PR이 고치지 않는 한계 하나를 검증 중에 찾았습니다.** 이 알림은 top-level `additionalContext`로 나갑니다. hooks 가이드는 `UserPromptSubmit` 훅의 `additionalContext`가 `hookSpecificOutput` 안에 중첩돼야 하고, top-level에 두면 Claude Code가 조용히 무시한다고 적습니다. `hooks/hypo-shared.mjs`의 `buildOutput`이 top-level 형태를 만들기 때문에 이 알림은 현재 모델에 닿지 않고, `hypo-first-prompt`와 `hypo-lookup`의 알림도 마찬가지입니다. 이 PR이 고친 동작 자체는 옳고 테스트가 고정합니다. 전달 경로는 훅 넷과 공유 헬퍼 하나에 걸친 별개 결함이라 여기 얹지 않고 따로 올립니다. 레포는 2026년 5월에 top-level 형태를 문서와 대조해 확인했고 그 뒤 계약이 바뀌었습니다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: The `/compact` and `/clear` notice no longer orders a session close, no longer fires on another project's uncommitted files, and no longer goes silent when the vault is broken enough to be worth reporting (`decisions/0101`).
- KO: `/compact`·`/clear` 알림이 세션 close를 지시하지 않고, 다른 프로젝트의 미커밋 파일로 뜨지 않으며, 보고할 값어치가 있을 만큼 볼트가 망가졌을 때 조용해지지 않습니다 (`decisions/0101`).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [ ] README / ARCHITECTURE / docs updated if user-facing behavior changed (no doc quotes the notice text, so nothing needed an edit; `docs/ARCHITECTURE.md` still calls this hook a `/compact` blocker, which was already wrong before this PR and is tracked separately)
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
