### PR TITLE
fix(cli): reject flags the read commands never parsed

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -85,9 +85,11 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs \
   --apply-session-close \
   --payload=/tmp/hypo-session-close-<session-id>.json \
   --session-id=<current-session-id> \
-  --hypo-dir="<path>" \
   --json
 ```
+
+Add `--hypo-dir="<path>"` only when the user specified a Hypomnema directory explicitly;
+otherwise omit it and the script resolves the root itself.
 
 **`--session-id` is required for any close that carries a `--payload`.** It is not a
 switch that turns a check on; omitting it fails the check. Before a single byte is
@@ -182,8 +184,13 @@ If the user says stop, end here. Otherwise continue to Step 5.
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` (or `/hypo:upgrade` on a plugin install) or reinstall instead of guessing the cache layout.
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs [--hypo-dir="<path>"] [--min-group=2]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs --min-group=2
 ```
+
+Add `--hypo-dir="<path>"` only when the user specified a Hypomnema directory explicitly;
+otherwise omit it.
+
+An unrecognized flag exits 2 instead of being ignored.
 
 Show the output to the user. If no candidates are found, tell them Hypomnema looks well-connected and no crystallization is needed.
 
@@ -255,10 +262,15 @@ Show what was created or modified, and offer to run `/hypo:lint` to verify all n
 `--check-session-close` (read-only strict gate, same check PreCompact runs) is still supported as a probe-only verification. Use it when you only want to verify that today's session-close is complete without applying anything:
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs --check-session-close [--hypo-dir="<path>"]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/crystallize.mjs --check-session-close
 ```
 
-It reports any file as `missing` or `stale`. For an actual close, prefer `--apply-session-close --payload=<path>` (Step 3) — it bundles freshness + lint into one gate and is the documented dogfood path. (`parseArgs` only accepts the `--payload=<path>` spelling; a space-separated `--payload <path>` is silently ignored and triggers "payload is required".)
+Add `--hypo-dir="<path>"` only when the user specified a Hypomnema directory explicitly;
+otherwise omit it.
+
+An unrecognized flag exits 2 instead of being ignored.
+
+It reports any file as `missing` or `stale`. For an actual close, prefer `--apply-session-close --payload=<path>` (Step 3): it bundles freshness and lint into one gate and is the documented dogfood path. `parseArgs` only accepts the `--payload=<path|->` spelling (a path, or `-` for stdin); a space-separated `--payload <path>` is rejected outright with exit 2, not silently dropped.
 
 Add `--project=<slug>` to scope the check to one project (close status + lint scope) when recency picks the wrong one. This is a project-scoped diagnostic only: a green scoped result (JSON `scope: "project"`) attests that slug is close-complete, **not** that `/compact` is unblocked globally.
 

--- a/commands/graph.md
+++ b/commands/graph.md
@@ -23,11 +23,14 @@ If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. O
 ## Step 2 — Run the graph script
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/graph.mjs \
-  [--hypo-dir="<path>"] \
-  [--format=json|mermaid|dot] \
-  [--min-edges=<n>]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/graph.mjs
 ```
+
+Add `--hypo-dir="<path>"` only when the user gave one (per Step 1). Add `--format=<fmt>`
+and `--min-edges=<n>` only with one concrete value from the Options list below, for
+example `--format=mermaid`; the defaults (`json`, `0`) apply when they are omitted.
+
+An unrecognized flag exits 2 instead of being ignored.
 
 Options:
 - `--format=json` (default) — adjacency list with in/out degree counts

--- a/commands/lint.md
+++ b/commands/lint.md
@@ -25,10 +25,17 @@ If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. O
 ## Step 2 — Run lint
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.mjs [--hypo-dir="<path>"] [--json] [--fix]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/lint.mjs --json
 ```
 
+Add `--hypo-dir="<path>"` only when the user gave one (per Step 1); otherwise leave it
+out and the script resolves the root itself.
+
+An unrecognized flag exits 2 instead of being ignored. Do not add `--fix` on this first
+pass; Step 4 covers when to offer it and re-run with it only after the user agrees.
+
 Options:
+- `--hypo-dir=<path>` (optional): Hypomnema root, pass only when the user specified one explicitly
 - `--json` — output results as JSON (useful for tooling)
 - `--fix` — auto-add missing `updated` field (safe repairs only; no other fields are modified)
 

--- a/commands/query.md
+++ b/commands/query.md
@@ -22,14 +22,16 @@ Ask the user what they want to know if it was not provided in the command invoca
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` (or `/hypo:upgrade` on a plugin install) or reinstall instead of guessing the cache layout.
 
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise
+omit the flag.
+
 Run full-text search:
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/query.mjs \
-  --q="<query terms>" \
-  [--hypo-dir="<path>"] \
-  [--limit=10]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/query.mjs --q="<query terms>" --limit=10
 ```
+
+An unrecognized flag exits 2 instead of being ignored.
 
 ---
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -15,11 +15,22 @@ You are running `/hypo:verify`. Audit wiki pages for overdue or missing `verify_
 
 Bundled scripts here run via `${CLAUDE_PLUGIN_ROOT}/scripts/`. To resolve that package root: if `${CLAUDE_PLUGIN_ROOT}` is already an absolute path, use it; otherwise read `pkgRoot` from `~/.claude/hypo-pkg.json` (only when non-empty and the target script exists under it); otherwise use the `hypo@hypomnema` (or legacy `hypomnema@hypomnema`) installPath in `~/.claude/plugins/installed_plugins.json`; if none resolve, stop and tell the user to run `hypomnema upgrade --apply` (or `/hypo:upgrade` on a plugin install) or reinstall instead of guessing the cache layout.
 
+If the user specified a Hypomnema directory, pass it as `--hypo-dir="<path>"`. Otherwise
+omit the flag.
+
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/verify.mjs [--hypo-dir="<path>"] [--file=<path>]
+node ${CLAUDE_PLUGIN_ROOT}/scripts/verify.mjs
 ```
 
+Add `--file="<path>"` only to check a single page (for example, right after editing it).
+Omitting it scans the whole vault (`pages/` and `projects/`); the script skips a `--file`
+path it cannot read rather than erroring, so passing one that does not exist reports
+"nothing to verify" instead of failing loudly.
+
+An unrecognized flag exits 2 instead of being ignored.
+
 Options:
+- `--hypo-dir=<path>` (optional): Hypomnema root, pass only when the user specified one explicitly
 - `--file=<path>` — check a single page only (useful after editing a page)
 
 ---

--- a/scripts/graph.mjs
+++ b/scripts/graph.mjs
@@ -22,12 +22,32 @@ import { collectPagesGraph, extractWikilinks } from './lib/wikilink.mjs';
 
 // ── arg parsing ───────────────────────────────────────────────────────────────
 
+const ALLOWED_FLAGS = ['--hypo-dir=<path>', '--format=<fmt>', '--min-edges=<n>'];
+
 function parseArgs(argv) {
   const args = { hypoDir: null, format: 'json', minEdges: 0 };
   for (const arg of argv.slice(2)) {
-    if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
-    else if (arg.startsWith('--format=')) args.format = arg.slice(9);
+    if (arg.startsWith('--hypo-dir=')) {
+      // See lint.mjs's parseArgs for why an empty raw value (--hypo-dir=,
+      // or --hypo-dir="$VAULT" with VAULT unset) is rejected instead of
+      // falling through to the default-resolution branch below.
+      const raw = arg.slice(11);
+      if (!raw) {
+        console.error(`graph.mjs: --hypo-dir requires a non-empty value (got '${arg}')`);
+        console.error(`graph.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+        process.exit(2);
+      }
+      args.hypoDir = expandHome(raw);
+    } else if (arg.startsWith('--format=')) args.format = arg.slice(9);
     else if (arg.startsWith('--min-edges=')) args.minEdges = parseInt(arg.slice(12), 10) || 0;
+    else {
+      // No positional arguments here either, so an unmatched arg is rejected
+      // rather than dropped. See lint.mjs's parseArgs for the background
+      // this closes.
+      console.error(`graph.mjs: unrecognized argument '${arg}'`);
+      console.error(`graph.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+      process.exit(2);
+    }
   }
   if (!args.hypoDir) {
     const info = resolveHypoRootInfo();

--- a/scripts/lib/crystallize-args.mjs
+++ b/scripts/lib/crystallize-args.mjs
@@ -3,6 +3,22 @@ import { isValidProjectName } from './project-create.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
+const ALLOWED_FLAGS = [
+  '--hypo-dir=<path>',
+  '--min-group=<n>',
+  '--check-session-close',
+  '--apply-session-close',
+  '--mark-session-closed',
+  '--log-only',
+  '--session-id=<id>',
+  '--payload=<path|->',
+  '--transcript-path=<path>',
+  '--session-cwd=<path>',
+  '--project=<slug>',
+  '--force',
+  '--json',
+];
+
 export function parseArgs(argv) {
   const args = {
     hypoDir: null,
@@ -19,8 +35,20 @@ export function parseArgs(argv) {
     project: null,
   };
   for (const arg of argv.slice(2)) {
-    if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
-    else if (arg.startsWith('--min-group=')) args.minGroup = parseInt(arg.slice(12), 10) || 2;
+    if (arg.startsWith('--hypo-dir=')) {
+      // See scripts/lint.mjs's parseArgs for why an empty raw value
+      // (--hypo-dir=, or --hypo-dir="$VAULT" with VAULT unset) is rejected
+      // instead of falling through to resolveHypoRoot() below. For this
+      // script specifically, a silent fallback here means a session-close
+      // apply writes to the wrong vault.
+      const raw = arg.slice(11);
+      if (!raw) {
+        console.error(`crystallize.mjs: --hypo-dir requires a non-empty value (got '${arg}')`);
+        console.error(`crystallize.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+        process.exit(2);
+      }
+      args.hypoDir = expandHome(raw);
+    } else if (arg.startsWith('--min-group=')) args.minGroup = parseInt(arg.slice(12), 10) || 2;
     else if (arg === '--check-session-close') args.checkSessionClose = true;
     else if (arg === '--apply-session-close') args.applySessionClose = true;
     else if (arg === '--mark-session-closed') args.markSessionClosed = true;
@@ -32,6 +60,14 @@ export function parseArgs(argv) {
     else if (arg.startsWith('--project=')) args.project = arg.slice(10);
     else if (arg === '--force') args.force = true;
     else if (arg === '--json') args.json = true;
+    else {
+      // No positional arguments here either, so an unmatched arg is rejected
+      // rather than dropped. See scripts/lint.mjs's parseArgs for the
+      // background this closes.
+      console.error(`crystallize.mjs: unrecognized argument '${arg}'`);
+      console.error(`crystallize.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+      process.exit(2);
+    }
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   // --project=<slug> override (check/mark only). Validate the SYNTAX here so a

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -36,13 +36,39 @@ import { buildSlugMap } from './lib/slug-resolver.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
+const ALLOWED_FLAGS = ['--hypo-dir=<path>', '--json', '--fix', '--strict'];
+
 function parseArgs(argv) {
   const args = { hypoDir: null, json: false, fix: false, strict: false };
   for (const arg of argv.slice(2)) {
-    if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
-    else if (arg === '--json') args.json = true;
+    if (arg.startsWith('--hypo-dir=')) {
+      // A raw value of '' (either `--hypo-dir=` typed directly or a shell
+      // variable that expanded to nothing, e.g. --hypo-dir="$VAULT" with
+      // VAULT unset) must not fall through to expandHome('') → '' → the
+      // `!args.hypoDir` default-resolution branch below. That silent
+      // fallback is exactly the bug this flag exists to close: a caller who
+      // believes they pointed at a specific vault ends up reading/writing
+      // the default one instead.
+      const raw = arg.slice(11);
+      if (!raw) {
+        console.error(`lint.mjs: --hypo-dir requires a non-empty value (got '${arg}')`);
+        console.error(`lint.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+        process.exit(2);
+      }
+      args.hypoDir = expandHome(raw);
+    } else if (arg === '--json') args.json = true;
     else if (arg === '--fix') args.fix = true;
     else if (arg === '--strict') args.strict = true;
+    else {
+      // lint.mjs takes no positional arguments, so anything unmatched above
+      // (a typo'd flag, "--", a bare "-", a stray word) is a mistake, not a
+      // no-op. Silently dropping it let a wrong flag point at the wrong
+      // vault for months: docs told models to pass --wiki-dir, but no
+      // script here ever parsed that flag.
+      console.error(`lint.mjs: unrecognized argument '${arg}'`);
+      console.error(`lint.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+      process.exit(2);
+    }
   }
   if (!args.hypoDir) {
     const info = resolveHypoRootInfo();

--- a/scripts/query.mjs
+++ b/scripts/query.mjs
@@ -24,13 +24,33 @@ import { currentDevice, scopeVisible, readVisibilityScope } from '../hooks/hypo-
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
+const ALLOWED_FLAGS = ['--hypo-dir=<path>', '--q=<query>', '--limit=<n>', '--json'];
+
 function parseArgs(argv) {
   const args = { hypoDir: null, query: null, limit: 10, json: false };
   for (const arg of argv.slice(2)) {
-    if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
-    else if (arg.startsWith('--q=')) args.query = arg.slice(4);
+    if (arg.startsWith('--hypo-dir=')) {
+      // See lint.mjs's parseArgs for why an empty raw value (--hypo-dir=,
+      // or --hypo-dir="$VAULT" with VAULT unset) is rejected instead of
+      // falling through to the default-resolution branch below.
+      const raw = arg.slice(11);
+      if (!raw) {
+        console.error(`query.mjs: --hypo-dir requires a non-empty value (got '${arg}')`);
+        console.error(`query.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+        process.exit(2);
+      }
+      args.hypoDir = expandHome(raw);
+    } else if (arg.startsWith('--q=')) args.query = arg.slice(4);
     else if (arg.startsWith('--limit=')) args.limit = parseInt(arg.slice(8), 10) || 10;
     else if (arg === '--json') args.json = true;
+    else {
+      // No positional arguments here either, so an unmatched arg is rejected
+      // rather than dropped. See lint.mjs's parseArgs for the background
+      // this closes.
+      console.error(`query.mjs: unrecognized argument '${arg}'`);
+      console.error(`query.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+      process.exit(2);
+    }
   }
   if (!args.hypoDir) {
     const info = resolveHypoRootInfo();

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -22,12 +22,32 @@ import { loadHypoIgnore, isScanIgnored } from './lib/hypo-ignore.mjs';
 
 // ── arg parsing ──────────────────────────────────────────────────────────────
 
+const ALLOWED_FLAGS = ['--hypo-dir=<path>', '--file=<path>', '--json'];
+
 function parseArgs(argv) {
   const args = { hypoDir: null, file: null, json: false };
   for (const arg of argv.slice(2)) {
-    if (arg.startsWith('--hypo-dir=')) args.hypoDir = expandHome(arg.slice(11));
-    else if (arg.startsWith('--file=')) args.file = expandHome(arg.slice(7));
+    if (arg.startsWith('--hypo-dir=')) {
+      // See lint.mjs's parseArgs for why an empty raw value (--hypo-dir=,
+      // or --hypo-dir="$VAULT" with VAULT unset) is rejected instead of
+      // falling through to the default-resolution branch below.
+      const raw = arg.slice(11);
+      if (!raw) {
+        console.error(`verify.mjs: --hypo-dir requires a non-empty value (got '${arg}')`);
+        console.error(`verify.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+        process.exit(2);
+      }
+      args.hypoDir = expandHome(raw);
+    } else if (arg.startsWith('--file=')) args.file = expandHome(arg.slice(7));
     else if (arg === '--json') args.json = true;
+    else {
+      // No positional arguments here either, so an unmatched arg is rejected
+      // rather than dropped. See lint.mjs's parseArgs for the background
+      // this closes.
+      console.error(`verify.mjs: unrecognized argument '${arg}'`);
+      console.error(`verify.mjs accepts: ${ALLOWED_FLAGS.join(', ')}`);
+      process.exit(2);
+    }
   }
   if (!args.hypoDir) args.hypoDir = resolveHypoRoot();
   return args;

--- a/tests/lib-core.test.mjs
+++ b/tests/lib-core.test.mjs
@@ -410,6 +410,308 @@ test('graph.mjs --format=mermaid: real (empty) vault still renders the normal di
   }
 });
 
+// ── reject unspecified flags (ISSUE-121 F2) ──────────────────────────────────
+//
+// Five SKILL.md files told models to pass --wiki-dir=<path>; no script here
+// ever parsed that flag, so it was silently dropped and every call fell
+// through to the default hypo-dir resolution instead. None of these five
+// CLIs take positional arguments, so any unmatched argv item (a typo'd flag,
+// not just a leading "--" one) is now a hard error (exit 2) rather than a
+// silent no-op.
+
+const { parseArgs: parseCrystallizeArgs } = await import(`${SCRIPTS}/lib/crystallize-args.mjs`);
+
+suite('reject unspecified flags: exit 2, matching flags still work');
+
+test('lint.mjs: typo flag (--wiki-dir) is rejected with exit 2', () => {
+  const r = spawnCli('lint.mjs', ['--wiki-dir=/tmp/nonexistent'], { HOME: SESSION_TMP_HOME });
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stderr: ${r.stderr}`);
+  assert.ok(r.stderr.includes('--wiki-dir'), `stderr should name the rejected flag: ${r.stderr}`);
+  assert.ok(r.stderr.includes('--hypo-dir'), `stderr should list accepted flags: ${r.stderr}`);
+});
+
+test('lint.mjs: known flags (--hypo-dir, --json, --fix, --strict) still parse and exit 0', () => {
+  const validDir = mkdtempSync(join(tmpdir(), 'hypo-reject-flags-lint-'));
+  try {
+    writeFileSync(join(validDir, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('lint.mjs', [`--hypo-dir=${validDir}`, '--json', '--fix', '--strict'], {
+      HOME: SESSION_TMP_HOME,
+    });
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. stderr: ${r.stderr}`);
+  } finally {
+    rmSync(validDir, { recursive: true, force: true });
+  }
+});
+
+test('verify.mjs: typo flag (--wiki-dir) is rejected with exit 2', () => {
+  const r = spawnCli('verify.mjs', ['--wiki-dir=/tmp/nonexistent'], { HOME: SESSION_TMP_HOME });
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stderr: ${r.stderr}`);
+  assert.ok(r.stderr.includes('--wiki-dir'), `stderr should name the rejected flag: ${r.stderr}`);
+});
+
+test('verify.mjs: known flags (--hypo-dir, --json) still parse and exit 0', () => {
+  const validDir = mkdtempSync(join(tmpdir(), 'hypo-reject-flags-verify-'));
+  try {
+    writeFileSync(join(validDir, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('verify.mjs', [`--hypo-dir=${validDir}`, '--json'], {
+      HOME: SESSION_TMP_HOME,
+    });
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. stderr: ${r.stderr}`);
+  } finally {
+    rmSync(validDir, { recursive: true, force: true });
+  }
+});
+
+test('graph.mjs: typo flag (--wiki-dir) is rejected with exit 2', () => {
+  const r = spawnCli('graph.mjs', ['--wiki-dir=/tmp/nonexistent'], { HOME: SESSION_TMP_HOME });
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stderr: ${r.stderr}`);
+  assert.ok(r.stderr.includes('--wiki-dir'), `stderr should name the rejected flag: ${r.stderr}`);
+});
+
+test('graph.mjs: known flags (--hypo-dir, --format, --min-edges) still parse and exit 0', () => {
+  const validDir = mkdtempSync(join(tmpdir(), 'hypo-reject-flags-graph-'));
+  try {
+    writeFileSync(join(validDir, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('graph.mjs', [`--hypo-dir=${validDir}`, '--format=json', '--min-edges=0'], {
+      HOME: SESSION_TMP_HOME,
+    });
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. stderr: ${r.stderr}`);
+  } finally {
+    rmSync(validDir, { recursive: true, force: true });
+  }
+});
+
+test('query.mjs: typo flag (--wiki-dir) is rejected with exit 2', () => {
+  const r = spawnCli('query.mjs', ['--wiki-dir=/tmp/nonexistent', '--q=x'], {
+    HOME: SESSION_TMP_HOME,
+  });
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stderr: ${r.stderr}`);
+  assert.ok(r.stderr.includes('--wiki-dir'), `stderr should name the rejected flag: ${r.stderr}`);
+});
+
+test('query.mjs: known flags (--hypo-dir, --q, --limit, --json) still parse and exit 0', () => {
+  const validDir = mkdtempSync(join(tmpdir(), 'hypo-reject-flags-query-'));
+  try {
+    writeFileSync(join(validDir, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli(
+      'query.mjs',
+      [`--hypo-dir=${validDir}`, '--q=anything', '--limit=5', '--json'],
+      { HOME: SESSION_TMP_HOME },
+    );
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. stderr: ${r.stderr}`);
+  } finally {
+    rmSync(validDir, { recursive: true, force: true });
+  }
+});
+
+test('crystallize-args.mjs parseArgs: typo flag (--wiki-dir) is rejected with exit 2', () => {
+  const r = spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `import('${SCRIPTS}/lib/crystallize-args.mjs').then(m => m.parseArgs(['node','crystallize.mjs','--wiki-dir=/tmp/nonexistent']))`,
+    ],
+    { encoding: 'utf-8', env: { ...process.env, HOME: SESSION_TMP_HOME } },
+  );
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stderr: ${r.stderr}`);
+  assert.ok(r.stderr.includes('--wiki-dir'), `stderr should name the rejected flag: ${r.stderr}`);
+});
+
+test('crystallize-args.mjs parseArgs: known flags still parse without exiting', () => {
+  const args = parseCrystallizeArgs([
+    'node',
+    'crystallize.mjs',
+    '--hypo-dir=/tmp/some-vault',
+    '--min-group=3',
+    '--json',
+    '--force',
+  ]);
+  assert.equal(args.hypoDir, '/tmp/some-vault');
+  assert.equal(args.minGroup, 3);
+  assert.equal(args.json, true);
+  assert.equal(args.force, true);
+});
+
+// A space-separated `--payload <path>` (two argv entries) is not a recognized
+// flag spelling: argv[i] is the bare token `--payload`, which matches nothing
+// in parseArgs' if/else chain and falls to the reject branch. Before this
+// fix, the allowed-list string printed here still called it `--payload=<json>`,
+// which never matched the script's actual contract (a file path, or `-` for
+// stdin) either. Both must now read `<path|->`.
+test('crystallize-args.mjs parseArgs: space-separated --payload <path> is rejected with exit 2, not silently dropped', () => {
+  const r = spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `import('${SCRIPTS}/lib/crystallize-args.mjs').then(m => m.parseArgs(['node','crystallize.mjs','--apply-session-close','--payload','/tmp/x.json']))`,
+    ],
+    { encoding: 'utf-8', env: { ...process.env, HOME: SESSION_TMP_HOME } },
+  );
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stderr: ${r.stderr}`);
+  assert.ok(r.stderr.includes('--payload'), `stderr should name the rejected flag: ${r.stderr}`);
+  assert.ok(
+    r.stderr.includes('<path|->'),
+    `stderr's allowed-flag list should describe --payload as <path|-> (file path or stdin), not <json>: ${r.stderr}`,
+  );
+});
+
+// ── --hypo-dir actually overrides default resolution (not just parsed) ──────
+
+test('lint.mjs --hypo-dir: the specified vault is read, not the default-resolved one', () => {
+  const noVaultHome = mkdtempSync(join(tmpdir(), 'hypo-dir-wins-lint-home-'));
+  const explicitVault = mkdtempSync(join(tmpdir(), 'hypo-dir-wins-lint-explicit-'));
+  try {
+    // HOME/HYPO_DIR resolve to nothing; only --hypo-dir points at a real vault.
+    writeFileSync(join(explicitVault, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('lint.mjs', [`--hypo-dir=${explicitVault}`, '--json'], {
+      HOME: noVaultHome,
+      HYPO_DIR: '',
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(
+      JSON.parse(r.stdout).vaultFound,
+      true,
+      `--hypo-dir must be the vault actually scanned, not the unresolved default: ${r.stdout}`,
+    );
+  } finally {
+    rmSync(noVaultHome, { recursive: true, force: true });
+    rmSync(explicitVault, { recursive: true, force: true });
+  }
+});
+
+test('crystallize-args.mjs parseArgs: --hypo-dir wins over HYPO_DIR env default', () => {
+  const orig = process.env.HYPO_DIR;
+  process.env.HYPO_DIR = '/tmp/default-vault-should-not-be-used';
+  try {
+    const args = parseCrystallizeArgs([
+      'node',
+      'crystallize.mjs',
+      '--hypo-dir=/tmp/explicit-vault',
+    ]);
+    assert.equal(
+      args.hypoDir,
+      '/tmp/explicit-vault',
+      'an explicit --hypo-dir must win over the HYPO_DIR env default',
+    );
+  } finally {
+    if (orig === undefined) delete process.env.HYPO_DIR;
+    else process.env.HYPO_DIR = orig;
+  }
+});
+
+// ── empty --hypo-dir= must not silently fall back to the default vault ──────
+//
+// `--hypo-dir="$VAULT"` with VAULT unset (or `--hypo-dir=` typed directly)
+// expands to the empty string. expandHome('') returns '' unchanged, and '' is
+// falsey, so every one of these five parsers used to read that as "no
+// --hypo-dir was given" and fall through to its own default resolution
+// (HYPO_DIR env / marker scan / ~/hypomnema). A crystallize apply that hit
+// this wrote its session close into the wrong vault. Each test below seeds a
+// REAL, different vault at HYPO_DIR so a silent fallback would exit 0 against
+// that vault instead of failing loudly; the fix requires exit 2 regardless.
+
+test('lint.mjs --hypo-dir= (empty value): rejected with exit 2, not silently defaulted', () => {
+  const defaultVault = mkdtempSync(join(tmpdir(), 'hypo-empty-hypodir-default-lint-'));
+  try {
+    writeFileSync(join(defaultVault, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('lint.mjs', ['--hypo-dir=', '--json'], {
+      HOME: SESSION_TMP_HOME,
+      HYPO_DIR: defaultVault,
+    });
+    assert.equal(
+      r.status,
+      2,
+      `expected exit 2 (empty --hypo-dir must not fall back to the HYPO_DIR default), got ${r.status}. stdout: ${r.stdout} stderr: ${r.stderr}`,
+    );
+    assert.ok(r.stderr.includes('--hypo-dir'), `stderr should name the flag: ${r.stderr}`);
+  } finally {
+    rmSync(defaultVault, { recursive: true, force: true });
+  }
+});
+
+test('verify.mjs --hypo-dir= (empty value): rejected with exit 2, not silently defaulted', () => {
+  const defaultVault = mkdtempSync(join(tmpdir(), 'hypo-empty-hypodir-default-verify-'));
+  try {
+    writeFileSync(join(defaultVault, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('verify.mjs', ['--hypo-dir=', '--json'], {
+      HOME: SESSION_TMP_HOME,
+      HYPO_DIR: defaultVault,
+    });
+    assert.equal(
+      r.status,
+      2,
+      `expected exit 2 (empty --hypo-dir must not fall back to the HYPO_DIR default), got ${r.status}. stdout: ${r.stdout} stderr: ${r.stderr}`,
+    );
+    assert.ok(r.stderr.includes('--hypo-dir'), `stderr should name the flag: ${r.stderr}`);
+  } finally {
+    rmSync(defaultVault, { recursive: true, force: true });
+  }
+});
+
+test('graph.mjs --hypo-dir= (empty value): rejected with exit 2, not silently defaulted', () => {
+  const defaultVault = mkdtempSync(join(tmpdir(), 'hypo-empty-hypodir-default-graph-'));
+  try {
+    writeFileSync(join(defaultVault, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('graph.mjs', ['--hypo-dir='], {
+      HOME: SESSION_TMP_HOME,
+      HYPO_DIR: defaultVault,
+    });
+    assert.equal(
+      r.status,
+      2,
+      `expected exit 2 (empty --hypo-dir must not fall back to the HYPO_DIR default), got ${r.status}. stdout: ${r.stdout} stderr: ${r.stderr}`,
+    );
+    assert.ok(r.stderr.includes('--hypo-dir'), `stderr should name the flag: ${r.stderr}`);
+  } finally {
+    rmSync(defaultVault, { recursive: true, force: true });
+  }
+});
+
+test('query.mjs --hypo-dir= (empty value): rejected with exit 2, not silently defaulted', () => {
+  const defaultVault = mkdtempSync(join(tmpdir(), 'hypo-empty-hypodir-default-query-'));
+  try {
+    writeFileSync(join(defaultVault, 'hypo-config.md'), '# marker\n');
+    const r = spawnCli('query.mjs', ['--hypo-dir=', '--q=anything'], {
+      HOME: SESSION_TMP_HOME,
+      HYPO_DIR: defaultVault,
+    });
+    assert.equal(
+      r.status,
+      2,
+      `expected exit 2 (empty --hypo-dir must not fall back to the HYPO_DIR default), got ${r.status}. stdout: ${r.stdout} stderr: ${r.stderr}`,
+    );
+    assert.ok(r.stderr.includes('--hypo-dir'), `stderr should name the flag: ${r.stderr}`);
+  } finally {
+    rmSync(defaultVault, { recursive: true, force: true });
+  }
+});
+
+test('crystallize-args.mjs parseArgs: --hypo-dir= (empty value) rejected with exit 2, not silently defaulted', () => {
+  const defaultVault = mkdtempSync(join(tmpdir(), 'hypo-empty-hypodir-default-crystallize-'));
+  try {
+    writeFileSync(join(defaultVault, 'hypo-config.md'), '# marker\n');
+    const r = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        `import('${SCRIPTS}/lib/crystallize-args.mjs').then(m => m.parseArgs(['node','crystallize.mjs','--hypo-dir=']))`,
+      ],
+      {
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: SESSION_TMP_HOME, HYPO_DIR: defaultVault },
+      },
+    );
+    assert.equal(
+      r.status,
+      2,
+      `expected exit 2 (empty --hypo-dir must not fall back to the HYPO_DIR default), got ${r.status}. stdout: ${r.stdout} stderr: ${r.stderr}`,
+    );
+    assert.ok(r.stderr.includes('--hypo-dir'), `stderr should name the flag: ${r.stderr}`);
+  } finally {
+    rmSync(defaultVault, { recursive: true, force: true });
+  }
+});
+
 // ── lib/wd-match.mjs (cross-machine project matcher) ─────────────────────────
 
 const { pickProjectByCwd, normalizeWorkingDir } = await import(`${SCRIPTS}/lib/wd-match.mjs`);


### PR DESCRIPTION
# English

## What changed

`lint`, `verify`, `graph`, `query` and the `crystallize` argument parser now exit 2 on an argument they do not recognise, and on an empty `--hypo-dir=`. The command docs stopped printing placeholder syntax as if it were a real argument.

## Why

Five command docs told the model to pass a vault flag their scripts never parsed. No script rejected it either, so the flag was dropped without a word and the run continued against whatever vault the default resolution happened to find, then reported success.

The spelling was corrected in an earlier PR. The silence is what let the mismatch live for four months, and the silence is what this PR closes: a flag that is not understood should stop the run, not be discarded.

The weight sits on `crystallize`. A session close that silently resolves a different vault writes its payload somewhere the caller did not ask for, and says it worked.

The empty value is the same failure wearing a different coat. A shell that expands an unset variable leaves `--hypo-dir=`, and every parser read that as "not supplied" and fell back to the default vault. Rejecting unknown flags while still accepting an empty one would have closed the front door and left the back one open.

The doc side was found during review. Removing the brackets left the placeholders standing in the command as real arguments, and three of them were worse than cosmetic: a literal `<path>` reaches the script, `verify`'s optional file filter turns a skipped read into an empty pass that looks green, and `json|mermaid|dot` is read by the shell as a pipe.

## How

Each parser carries its own allow-list, and the rejection message names the offending argument and prints that list, so the next drift is visible the first time someone hits it. None of the five takes a positional argument, so a bare `--` or `-` lands on the same rejection path.

The five scripts keep their own copies rather than sharing a helper. The duplicated part is ten to twelve lines each and the allow-lists themselves differ, while a new file under `scripts/` has to be added to `package.json`'s `files` and to the pack snapshot or it never ships.

In the docs, conditional options moved out of the runnable command and into the option tables and prose, so a copied line runs as written. `lint` no longer shows a mutating flag in the command it runs first: its own Step 4 covers when to offer `--fix` and re-run after the user agrees.

## Manual verification

Gates, run on this branch alone:

```
npm test                     rc=0   2182 passed, 0 failed
npm run lint                 rc=0   0 error
npm run check:tracker-ids    rc=0
npm run check:pack-surface   rc=0   136 files, 0 closure violations
```

Direct runs, with `HYPO_DIR` pointed at a different vault than the one under test so a silent fallback would be visible:

```
node scripts/lint.mjs --wiki-dir=/tmp/nonexistent    rc=2   names the flag, lists what it accepts
node scripts/{lint,verify,graph,query}.mjs --hypo-dir=   rc=2 each
node scripts/crystallize.mjs --hypo-dir=                 rc=2
node scripts/crystallize.mjs ... --check-session-close --payload /tmp/x.json   rc=2, message reads --payload=<path|->
```

All five previously exited 0 on the empty value and scanned the default vault.

Docs were checked by counting inside fenced blocks rather than by eye: zero bare `|`, zero `<path>` placeholders, and no brackets reintroduced across the five files.

The review that produced these fixes also confirmed that no caller in `hooks/`, `scripts/`, `commands/`, `skills/`, `tests/` or `.git/hooks` passes an empty `--hypo-dir=`, so the rejection breaks nothing that exists today.

## Migration notes

None for a normal install. A caller that was passing an unparsed flag to one of these five scripts, or relying on `--hypo-dir=` with an empty value to mean "use the default", now gets exit 2 instead of a silent fallback. That is the intended change: the previous behaviour could operate on the wrong vault.

---

# 한국어

## 변경 내용

`lint`·`verify`·`graph`·`query`와 `crystallize` 인자 파서가 못 알아보는 인자와 빈 `--hypo-dir=`에 exit 2를 냅니다. 명령 문서는 placeholder 문법을 실제 인자인 것처럼 찍던 것을 그만뒀습니다.

## 이유

명령 문서 다섯이 모델에게 볼트 플래그를 넘기라고 지시했는데 그 스크립트들은 그 플래그를 파싱한 적이 없습니다. 거부도 안 해서 플래그가 말없이 버려졌고, 기본 해석이 찾아낸 아무 볼트에 대고 실행을 계속한 뒤 성공을 보고했습니다.

철자는 앞선 PR에서 고쳤습니다. 이 어긋남을 넉 달 살려 둔 것은 침묵이고, 이 PR이 닫는 것도 그 침묵입니다. 못 알아듣는 플래그는 실행을 멈춰야지 버려질 것이 아닙니다.

무게는 `crystallize`에 있습니다. 세션 close가 조용히 다른 볼트를 잡으면 호출자가 시키지 않은 곳에 payload를 쓰고서 잘됐다고 말합니다.

빈 값은 같은 실패가 옷만 바꿔 입은 것입니다. 셸이 설정 안 된 변수를 펼치면 `--hypo-dir=`가 남고, 파서 전부가 그걸 "안 넘어왔다"로 읽어 기본 볼트로 갔습니다. 미지정 플래그를 거부하면서 빈 값을 받아 주면 앞문을 닫고 뒷문을 열어 둔 셈입니다.

문서 쪽은 검토 중에 나왔습니다. 대괄호를 걷으니 placeholder가 명령 안에 실제 인자로 남았고, 그중 셋은 겉모습 문제가 아니었습니다. 리터럴 `<path>`가 스크립트까지 가고, `verify`의 선택 파일 필터는 건너뛴 읽기를 초록으로 보이는 빈 통과로 만들며, `json|mermaid|dot`는 셸이 파이프로 읽습니다.

## 방법

파서마다 자기 허용 목록을 갖고, 거부 메시지가 문제의 인자를 지목하고 그 목록을 함께 찍습니다. 다음 드리프트가 처음 부딪히는 사람에게 바로 보이게 하려는 것입니다. 다섯 다 positional 인자를 안 받으므로 `--` 단독과 `-`도 같은 거부 경로로 갑니다.

공유 헬퍼로 빼지 않고 각자 사본을 뒀습니다. 겹치는 부분이 파일당 열에서 열두 줄이고 허용 목록 자체가 서로 다른데, `scripts/` 아래 새 파일은 `package.json`의 `files`와 pack 스냅샷에 등재하지 않으면 아예 출하되지 않습니다.

문서에서는 조건부 옵션을 실행 가능한 명령에서 빼 옵션 표와 산문으로 옮겼습니다. 복사한 줄이 적힌 그대로 돌아갑니다. `lint`는 처음 돌리는 명령에 상태를 바꾸는 플래그를 더 이상 보여 주지 않습니다. 언제 `--fix`를 제안하고 사용자가 동의한 뒤 다시 돌릴지는 그 문서의 Step 4가 다룹니다.

## 수동 검증

이 브랜치 단독으로 돌린 게이트입니다.

```
npm test                     rc=0   2182 passed, 0 failed
npm run lint                 rc=0   0 error
npm run check:tracker-ids    rc=0
npm run check:pack-surface   rc=0   136 files, 0 closure violations
```

직접 실행은 `HYPO_DIR`를 시험 대상과 다른 볼트로 두고 했습니다. 조용한 폴백이 일어나면 드러나게 하려는 것입니다.

```
node scripts/lint.mjs --wiki-dir=/tmp/nonexistent    rc=2   플래그를 지목하고 허용 목록을 찍는다
node scripts/{lint,verify,graph,query}.mjs --hypo-dir=   각각 rc=2
node scripts/crystallize.mjs --hypo-dir=                 rc=2
node scripts/crystallize.mjs ... --check-session-close --payload /tmp/x.json   rc=2, 안내가 --payload=<path|->
```

다섯 다 전에는 빈 값에 exit 0을 내고 기본 볼트를 훑었습니다.

문서는 눈으로 보지 않고 코드 블록 안을 세어 확인했습니다. 벌거벗은 `|` 0건, `<path>` placeholder 0건, 다섯 파일 어디에도 대괄호가 되돌아오지 않았습니다.

이 수정을 낳은 검토가 `hooks/`·`scripts/`·`commands/`·`skills/`·`tests/`·`.git/hooks` 어디에도 빈 `--hypo-dir=`를 넘기는 호출부가 없음을 함께 확인했습니다. 지금 있는 것 중 이 거부로 깨지는 것은 없습니다.

## 마이그레이션 노트

보통 설치에는 없습니다. 다섯 스크립트에 파싱되지 않는 플래그를 넘기던 호출자, 또는 빈 값 `--hypo-dir=`를 "기본값을 쓰라"는 뜻으로 쓰던 호출자는 이제 조용한 폴백 대신 exit 2를 받습니다. 그것이 의도한 변경입니다. 이전 동작은 엉뚱한 볼트에 대고 일할 수 있었습니다.

---

## Changelog

- EN: `lint`, `verify`, `graph`, `query` and `crystallize` now exit 2 on an unrecognised flag or an empty `--hypo-dir=` instead of silently dropping it and falling back to the default vault, and their command docs no longer print placeholder syntax as runnable arguments.
- KO: `lint`·`verify`·`graph`·`query`·`crystallize`가 못 알아보는 플래그와 빈 `--hypo-dir=`를 조용히 버리고 기본 볼트로 가는 대신 exit 2를 냅니다. 명령 문서도 placeholder 문법을 실행 가능한 인자처럼 찍지 않습니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
