### PR TITLE
fix(hooks): nest additionalContext so injected notices reach the model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,15 +240,29 @@ jobs:
             const d = JSON.parse(require('fs').readFileSync('/tmp/cg-pass.json', 'utf-8'));
             if (d.continue !== true) { console.error('expected continue:true'); process.exit(1); }
           "
-      - name: compact-guard — /compact with no wiki produces additionalContext
+      # The shape matters as much as the presence. A top-level additionalContext
+      # is silently ignored for UserPromptSubmit, so a hook can emit the right
+      # text on a channel nobody reads and still exit zero. This step is the one
+      # place CI runs a hook and reads what it actually wrote, so it checks both
+      # that the context is nested and that no top-level copy rode along.
+      - name: compact-guard — /compact with no wiki nests additionalContext
         run: |
           echo '{"prompt":"/compact"}' \
             | HYPO_DIR=/tmp/no-wiki-$RANDOM node hooks/hypo-compact-guard.mjs \
             > /tmp/cg-compact.json
           node -e "
             const d = JSON.parse(require('fs').readFileSync('/tmp/cg-compact.json', 'utf-8'));
-            if (!('additionalContext' in d)) { console.error('missing additionalContext'); process.exit(1); }
-            if (d.continue !== true)         { console.error('expected continue:true');    process.exit(1); }
+            const hso = d.hookSpecificOutput;
+            if (!hso || typeof hso.additionalContext !== 'string' || !hso.additionalContext) {
+              console.error('missing hookSpecificOutput.additionalContext'); process.exit(1);
+            }
+            if (hso.hookEventName !== 'UserPromptSubmit') {
+              console.error('wrong hookEventName: ' + hso.hookEventName); process.exit(1);
+            }
+            if ('additionalContext' in d) {
+              console.error('top-level additionalContext is ignored by Claude Code'); process.exit(1);
+            }
+            if (d.continue !== true) { console.error('expected continue:true'); process.exit(1); }
           "
       # PreCompact reports, it does not block (session-close-scope-boundary §1).
       # The contract worth replaying is that it still SAYS something: a bare

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,7 +163,7 @@ Scripts in `scripts/` are not deployed — they run from the package install pat
 | `hypoIsClean()` | Check git status + unpushed commits |
 | `hotMdIsClean()` | Validate `hot.md` structure |
 | `isCompactCommand(prompt)` | Detect `/compact` invocations |
-| `buildOutput(...)` | Format hook output for Claude Code's `additionalContext` channel |
+| `buildOutput(hookEventName, context, extra)` | Build hook output that nests `additionalContext` under `hookSpecificOutput`, keeping control fields as top-level siblings. The event name is required: Claude Code drops a payload whose `hookEventName` does not match the firing event |
 | `SESSION_STATE_NEXT_HEADINGS` | Allowed headings for "next tasks" — `## 다음 이어받기` / `## 다음 작업`. Lint reuses this constant (DRY) |
 
 ---

--- a/hooks/hypo-compact-guard.mjs
+++ b/hooks/hypo-compact-guard.mjs
@@ -35,6 +35,7 @@ import {
   isGateSkipped,
   resolveGateProjectOverride,
   classifyForeignOnlyDirty,
+  buildOutput,
   HYPO_DIR,
 } from './hypo-shared.mjs';
 
@@ -165,16 +166,19 @@ process.stdin.on('end', () => {
       : 'See hypo-guide.md for the session-close checklist.';
 
     console.log(
-      JSON.stringify({
-        continue: true,
-        additionalContext: [
-          `[WIKI_AUTOCLOSE] ${detected} detected: session close incomplete (${reasons.join(', ')}).`,
-          ``,
-          body,
-          ``,
-          `To bypass: set HYPO_SKIP_GATE=1`,
-        ].join('\n'),
-      }),
+      JSON.stringify(
+        buildOutput(
+          'UserPromptSubmit',
+          [
+            `[WIKI_AUTOCLOSE] ${detected} detected: session close incomplete (${reasons.join(', ')}).`,
+            ``,
+            body,
+            ``,
+            `To bypass: set HYPO_SKIP_GATE=1`,
+          ].join('\n'),
+          { continue: true },
+        ),
+      ),
     );
   } catch (err) {
     // Fail-open: any parse/runtime error must not block the user's prompt.

--- a/hooks/hypo-cwd-change.mjs
+++ b/hooks/hypo-cwd-change.mjs
@@ -10,7 +10,6 @@ import { readFileSync, writeFileSync, existsSync, realpathSync } from 'fs';
 import { join } from 'path';
 import {
   HYPO_DIR,
-  buildOutput,
   loadHypoIgnore,
   isIgnored,
   sessionMarkerPath,
@@ -153,16 +152,17 @@ process.stdin.on('end', () => {
       // working_dir distinct from the vault, surface where wiki files live.
       const vaultOrientation = buildVaultOrientation(newCwd);
       const orientPrefix = vaultOrientation ? `${vaultOrientation}\n\n` : '';
+      // Built inline rather than through buildOutput(): CwdChanged has no
+      // documented context-injection path, so the nested hookSpecificOutput
+      // shape buildOutput() now emits would be wrong for this event. The
+      // follow-up that moves this hook to systemMessage removes these three
+      // literals; until then they keep today's behaviour unchanged.
       console.log(
-        JSON.stringify(
-          buildOutput(
-            `${orientPrefix}[WIKI: cwd changed → project=${sanitizeProjForPrompt(newHit.proj)}]\n\n${content}`,
-            {
-              continue: true,
-              suppressOutput: true,
-            },
-          ),
-        ),
+        JSON.stringify({
+          continue: true,
+          suppressOutput: true,
+          additionalContext: `${orientPrefix}[WIKI: cwd changed → project=${sanitizeProjForPrompt(newHit.proj)}]\n\n${content}`,
+        }),
       );
       return;
     }
@@ -199,9 +199,11 @@ process.stdin.on('end', () => {
     if (!globalContent) {
       if (suggestPrefix) {
         console.log(
-          JSON.stringify(
-            buildOutput(suggestPrefix.trimEnd(), { continue: true, suppressOutput: true }),
-          ),
+          JSON.stringify({
+            continue: true,
+            suppressOutput: true,
+            additionalContext: suggestPrefix.trimEnd(),
+          }),
         );
       } else {
         console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -209,12 +211,11 @@ process.stdin.on('end', () => {
       return;
     }
     console.log(
-      JSON.stringify(
-        buildOutput(
-          `${suggestPrefix}[WIKI: cwd changed → no project match, injecting global hot]\n\n${globalContent}`,
-          { continue: true, suppressOutput: true },
-        ),
-      ),
+      JSON.stringify({
+        continue: true,
+        suppressOutput: true,
+        additionalContext: `${suggestPrefix}[WIKI: cwd changed → no project match, injecting global hot]\n\n${globalContent}`,
+      }),
     );
   } catch (err) {
     process.stderr.write(`[hypo-cwd-change] error: ${err?.message ?? String(err)}\n`);

--- a/hooks/hypo-first-prompt.mjs
+++ b/hooks/hypo-first-prompt.mjs
@@ -8,9 +8,12 @@
  * resume summary into the reply (the old "answer only if related"
  * conditional is removed; the line is injected unconditionally).
  *
- * hot.md / session-state.md content is NOT re-injected here — the upstream
- * hook already placed it in additionalContext. This hook only forces the LLM
- * to lead with the summary line drawn from that context.
+ * hot.md / session-state.md content is NOT re-injected here. On the SessionStart
+ * path the upstream hook already put it in the model's context, and this hook
+ * only forces the LLM to lead with a summary line drawn from it. On the
+ * cwd-change path nothing was injected at all (CwdChanged has no documented
+ * injection path), so that branch asks for a verbatim line instead of a
+ * summary.
  * Marker expires after 10 minutes.
  */
 
@@ -71,23 +74,35 @@ process.stdin.on('end', () => {
     // for the model to fill the placeholders with. Provide a concrete fallback
     // line so the model doesn't leak literal `[one-line summary]` text on a
     // first-ever session (codex v2 review 2026-05-26).
-    const exampleLine = hasSnapshot
-      ? `${verb} ${projSafe}: [one-line summary]. Continue with [next task]?`
-      : scopedOut
-        ? `${projSafe}: this project has a prior snapshot, but it is scoped to another machine and is not visible here. What would you like to work on?`
-        : `${verb} ${projSafe}: no prior snapshot yet — first session. What would you like to start with?`;
-    const fillNote = hasSnapshot
-      ? `Replace the bracketed placeholders using the [HOT] / [SESSION STATE] ` +
-        `context already injected this session — do NOT emit the literal brackets.`
-      : scopedOut
-        ? `Use the line above verbatim. The project has prior work; its snapshot ` +
-          `simply belongs to another machine, so treat it as an existing project ` +
-          `whose history you cannot see from here.`
-        : `Use the line above verbatim — there is no prior snapshot to summarize.`;
+    // A cwd-change marker arms this hook, but CwdChanged has no documented
+    // context-injection path, so no [HOT] / [SESSION STATE] ever reached the
+    // model for that move. Asking for a summary would make the model invent
+    // one, or emit the literal brackets. This is not a temporary branch: the
+    // follow-up that moves the hook to systemMessage sends that text to the
+    // user, not the model, so the model still gets nothing for a cwd move.
+    const cwdMove = marker.source === 'cwd-change';
+    const exampleLine = cwdMove
+      ? `${verb} ${projSafe}. What would you like to work on here?`
+      : hasSnapshot
+        ? `${verb} ${projSafe}: [one-line summary]. Continue with [next task]?`
+        : scopedOut
+          ? `${projSafe}: this project has a prior snapshot, but it is scoped to another machine and is not visible here. What would you like to work on?`
+          : `${verb} ${projSafe}: no prior snapshot yet — first session. What would you like to start with?`;
+    const fillNote = cwdMove
+      ? `Use the line above verbatim. No prior context was injected for this move.`
+      : hasSnapshot
+        ? `Replace the bracketed placeholders using the [HOT] / [SESSION STATE] ` +
+          `context already injected this session — do NOT emit the literal brackets.`
+        : scopedOut
+          ? `Use the line above verbatim. The project has prior work; its snapshot ` +
+            `simply belongs to another machine, so treat it as an existing project ` +
+            `whose history you cannot see from here.`
+          : `Use the line above verbatim — there is no prior snapshot to summarize.`;
 
     console.log(
       JSON.stringify(
         buildOutput(
+          'UserPromptSubmit',
           `<hypomnema-session-resume>\n` +
             `[WIKI SESSION START: project=${projSafe}${snapshotNote}]\n` +
             `\n` +

--- a/hooks/hypo-lookup.mjs
+++ b/hooks/hypo-lookup.mjs
@@ -293,10 +293,14 @@ process.stdin.on('end', () => {
         .join(', ');
       console.log(
         JSON.stringify(
-          buildOutput(`[WIKI LOOKUP: miss] "${topic}" — no match. Closest: ${closest || 'none'}`, {
-            continue: true,
-            suppressOutput: true,
-          }),
+          buildOutput(
+            'UserPromptSubmit',
+            `[WIKI LOOKUP: miss] "${topic}" — no match. Closest: ${closest || 'none'}`,
+            {
+              continue: true,
+              suppressOutput: true,
+            },
+          ),
         ),
       );
       return;
@@ -336,7 +340,7 @@ process.stdin.on('end', () => {
         .join(', ');
       console.log(
         JSON.stringify(
-          buildOutput(`[WIKI LOOKUP: index hit but files missing] ${slugs}`, {
+          buildOutput('UserPromptSubmit', `[WIKI LOOKUP: index hit but files missing] ${slugs}`, {
             continue: true,
             suppressOutput: true,
           }),
@@ -362,6 +366,7 @@ process.stdin.on('end', () => {
     console.log(
       JSON.stringify(
         buildOutput(
+          'UserPromptSubmit',
           `[WIKI LOOKUP: ${injected.length} page(s) matched]\n\n` +
             injected.join('\n\n') +
             overflow,

--- a/hooks/hypo-session-start.mjs
+++ b/hooks/hypo-session-start.mjs
@@ -848,6 +848,7 @@ process.stdin.on('end', () => {
         console.log(
           JSON.stringify(
             buildOutput(
+              'SessionStart',
               `${noticePrefix}${hitPrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}]\n\n${parts.join('\n\n')}`,
               outExtra,
             ),
@@ -911,6 +912,7 @@ process.stdin.on('end', () => {
         console.log(
           JSON.stringify(
             buildOutput(
+              'SessionStart',
               `${noticePrefix}${hitPrefix}[WIKI HOT CACHE: project=${sanitizeProjForPrompt(hit.proj)}, ${reason}]`,
               outExtra,
             ),
@@ -935,7 +937,7 @@ process.stdin.on('end', () => {
     if (!existsSync(GLOBAL_HOT)) {
       const notice = notices.join('\n\n');
       if (notice) {
-        console.log(JSON.stringify(buildOutput(notice, outExtra)));
+        console.log(JSON.stringify(buildOutput('SessionStart', notice, outExtra)));
       } else {
         console.log(JSON.stringify(outExtra));
       }
@@ -950,7 +952,7 @@ process.stdin.on('end', () => {
       // would otherwise be silently dropped here.
       const notice = notices.join('\n\n');
       if (notice) {
-        console.log(JSON.stringify(buildOutput(notice, outExtra)));
+        console.log(JSON.stringify(buildOutput('SessionStart', notice, outExtra)));
       } else {
         console.log(JSON.stringify(outExtra));
       }
@@ -959,6 +961,7 @@ process.stdin.on('end', () => {
     console.log(
       JSON.stringify(
         buildOutput(
+          'SessionStart',
           `${noticePrefix}[WIKI HOT CACHE: global — no project matched cwd=${cwd}]\n\n${globalContent}`,
           outExtra,
         ),

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -5515,12 +5515,36 @@ export function isCloseReconfirmDeclined(transcriptPath) {
   return declined;
 }
 
+// Events Claude Code actually reads additionalContext from, per the "Add
+// context for Claude" docs. A hookEventName outside this set has no
+// documented injection path, so buildOutput still emits the nested shape
+// (the caller may be adding a NEW event later) but warns to stderr.
+const INJECTABLE_EVENTS = new Set(['UserPromptSubmit', 'SessionStart', 'PostToolUse', 'Stop']);
+
 /**
- * Build hook output for Claude Code (additionalContext channel).
- * Codex hooks write systemMessage directly in their own files.
+ * Build hook output for Claude Code (nested hookSpecificOutput.additionalContext
+ * channel). Codex hooks write systemMessage directly in their own files.
+ *
+ * @param {string} hookEventName - the event this hook fires on, e.g. 'UserPromptSubmit'.
+ * @param {string} context - the text to inject.
+ * @param {object} [extra] - control fields (continue, suppressOutput, ...) that
+ *   stay top-level siblings of hookSpecificOutput.
  */
-export function buildOutput(context, extra = {}) {
-  return { ...extra, additionalContext: context };
+export function buildOutput(hookEventName, context, extra = {}) {
+  if (!INJECTABLE_EVENTS.has(hookEventName)) {
+    process.stderr.write(
+      `[hypo] buildOutput: ${hookEventName} has no documented context-injection path\n`,
+    );
+  }
+  // `extra` carries control fields, never context. Dropping the key here is
+  // what makes the nested shape the only channel: without it a caller could
+  // pass `{ additionalContext }` and the spread would put a top-level copy
+  // right back, which is the exact bug this function exists to prevent.
+  const { additionalContext: _shadowed, ...control } = extra;
+  return {
+    ...control,
+    hookSpecificOutput: { hookEventName, additionalContext: context },
+  };
 }
 
 // ── growth metrics (F2 + E4) ───────────────────────────────────────────────

--- a/hooks/hypo-web-fetch-ingest.mjs
+++ b/hooks/hypo-web-fetch-ingest.mjs
@@ -15,11 +15,11 @@
  *     graph before adding a new source.
  *
  * Output contract — Claude Code docs, "Add context for Claude":
- *   PostToolUse uses **nested** hookSpecificOutput.additionalContext, NOT
- *   the top-level additionalContext that UserPromptSubmit hooks use.
- *   buildOutput() in hypo-shared.mjs is the top-level helper used by
- *   hypo-first-prompt / hypo-lookup; intentionally not reused here. See
- *   commit 515458f for the per-event matrix this codebase follows.
+ *   PostToolUse uses **nested** hookSpecificOutput.additionalContext, the
+ *   same shape every other injecting event in this codebase now uses.
+ *   buildOutput() in hypo-shared.mjs emits that nested shape given the
+ *   hookEventName, so this hook calls it too instead of building the
+ *   object by hand.
  *
  * URL redaction:
  *   additionalContext lands in the transcript. Query strings and
@@ -41,7 +41,7 @@
  * in-hook failure branch is needed.
  */
 
-import { isGateSkipped } from './hypo-shared.mjs';
+import { isGateSkipped, buildOutput } from './hypo-shared.mjs';
 
 let input = {};
 try {
@@ -58,13 +58,9 @@ try {
 }
 
 const context = buildContext(input);
-const output = { continue: true, suppressOutput: true };
-if (context) {
-  output.hookSpecificOutput = {
-    hookEventName: 'PostToolUse',
-    additionalContext: context,
-  };
-}
+const output = context
+  ? buildOutput('PostToolUse', context, { continue: true, suppressOutput: true })
+  : { continue: true, suppressOutput: true };
 console.log(JSON.stringify(output));
 
 function buildContext(data) {

--- a/tests/close-hooks-gate.test.mjs
+++ b/tests/close-hooks-gate.test.mjs
@@ -27,7 +27,9 @@ import {
   buildCleanWikiTree,
   commitTouchedPaths,
   extractTouchedWikiFiles,
+  injectedContext,
   makeMultiProjectWiki,
+  modelContexts,
   payloadForCleanWiki,
   peekTouchedPaths,
   recordTouchedPaths,
@@ -268,11 +270,17 @@ test('HYPO_SKIP_GATE=1 + /compact → pass-through', () => {
   assert.equal(out.suppressOutput, true);
 });
 
-test('/compact with incomplete wiki → additionalContext, not systemMessage', () => {
+test('/compact with incomplete wiki → model channel (nested additionalContext), not systemMessage', () => {
   const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' });
   const out = JSON.parse(r.stdout);
-  assert.ok('additionalContext' in out, 'missing additionalContext field');
-  assert.ok(!('systemMessage' in out), 'must not use deprecated systemMessage field');
+  assert.ok(modelContexts(out).length > 0, 'missing hookSpecificOutput.additionalContext');
+  // systemMessage is a real, correct field on other hooks (PreCompact uses it
+  // below) — it is simply the wrong channel for UserPromptSubmit, which the
+  // model reads from, not the user-facing side channel.
+  assert.ok(
+    !('systemMessage' in out),
+    'UserPromptSubmit must use the model channel, not systemMessage',
+  );
 });
 
 test('/compact with incomplete wiki → continue:true (soft nudge, not block)', () => {
@@ -284,7 +292,7 @@ test('/compact with incomplete wiki → continue:true (soft nudge, not block)', 
 test('/compact with incomplete wiki → additionalContext contains WIKI_AUTOCLOSE', () => {
   const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' });
   const out = JSON.parse(r.stdout);
-  assert.ok(out.additionalContext.includes('WIKI_AUTOCLOSE'), 'missing WIKI_AUTOCLOSE marker');
+  assert.ok(injectedContext(out).includes('WIKI_AUTOCLOSE'), 'missing WIKI_AUTOCLOSE marker');
 });
 
 test('/compact with clean wiki → pass-through', () => {
@@ -322,7 +330,7 @@ test('/compact with uncommitted change → blocks (git axis still enforced, ADR 
     const out = JSON.parse(r.stdout);
     assert.equal(out.continue, true);
     assert.ok(
-      /WIKI_AUTOCLOSE/.test(out.additionalContext || ''),
+      /WIKI_AUTOCLOSE/.test(injectedContext(out) || ''),
       `uncommitted work must still block /compact: ${r.stdout}`,
     );
   });
@@ -342,17 +350,17 @@ suite('replay-compact-guard-detects-slash-clear (ADR 0022 Layer 2)');
 test('replay-compact-guard-detects-slash-clear: /clear with incomplete wiki → WIKI_AUTOCLOSE', () => {
   const r = runHook('hypo-compact-guard.mjs', { prompt: '/clear' });
   const out = JSON.parse(r.stdout);
-  assert.ok('additionalContext' in out, 'missing additionalContext field on /clear');
+  assert.ok(modelContexts(out).length > 0, 'missing additionalContext field on /clear');
   assert.equal(out.continue, true);
-  assert.ok(out.additionalContext.includes('WIKI_AUTOCLOSE'), 'missing WIKI_AUTOCLOSE marker');
-  assert.ok(out.additionalContext.includes('/clear'), 'message must reference /clear');
+  assert.ok(injectedContext(out).includes('WIKI_AUTOCLOSE'), 'missing WIKI_AUTOCLOSE marker');
+  assert.ok(injectedContext(out).includes('/clear'), 'message must reference /clear');
 });
 
 test('/clear with trailing args → still detected', () => {
   const r = runHook('hypo-compact-guard.mjs', { prompt: '/clear something' });
   const out = JSON.parse(r.stdout);
-  assert.ok('additionalContext' in out);
-  assert.ok(out.additionalContext.includes('/clear'));
+  assert.ok(modelContexts(out).length > 0);
+  assert.ok(injectedContext(out).includes('/clear'));
 });
 
 test('HYPO_SKIP_GATE=1 + /clear → pass-through', () => {
@@ -424,13 +432,13 @@ test('state table row: last substantial op is ingest, not session (log.md exists
         { HYPO_DIR: dir },
       );
       const out = JSON.parse(r.stdout);
-      assert.ok('additionalContext' in out, `hook must not go silent: ${r.stdout}`);
+      assert.ok(modelContexts(out).length > 0, `hook must not go silent: ${r.stdout}`);
       assert.ok(
-        /session log entry missing/.test(out.additionalContext || ''),
+        /session log entry missing/.test(injectedContext(out) || ''),
         `session reason must survive: ${r.stdout}`,
       );
       assert.ok(
-        !/scratch\.md|uncommitted/.test(out.additionalContext || ''),
+        !/scratch\.md|uncommitted/.test(injectedContext(out) || ''),
         `an all-foreign dirty set must drop the git reason: ${r.stdout}`,
       );
     },
@@ -458,11 +466,11 @@ test('state table row: log.md itself does not exist (not just a non-session last
       );
       const out = JSON.parse(r.stdout);
       assert.ok(
-        'additionalContext' in out,
+        modelContexts(out).length > 0,
         `hook must not go fully silent when log.md is absent: ${r.stdout}`,
       );
       assert.ok(
-        /session log entry missing/.test(out.additionalContext || ''),
+        /session log entry missing/.test(injectedContext(out) || ''),
         `session reason must survive when log.md is absent: ${r.stdout}`,
       );
     },
@@ -492,11 +500,11 @@ test('state table row: hot.md invalid + all-foreign dirty -> hot reason kept, gi
       );
       const out = JSON.parse(r.stdout);
       assert.ok(
-        /last_session/.test(out.additionalContext || ''),
+        /last_session/.test(injectedContext(out) || ''),
         `hot reason must survive: ${r.stdout}`,
       );
       assert.ok(
-        !/scratch\.md|uncommitted/.test(out.additionalContext || ''),
+        !/scratch\.md|uncommitted/.test(injectedContext(out) || ''),
         `an all-foreign dirty set must drop the git reason: ${r.stdout}`,
       );
     },
@@ -518,7 +526,7 @@ test('state table row: attributionScope resolved but dirty mixes own + foreign -
       );
       const out = JSON.parse(r.stdout);
       assert.ok(
-        /WIKI_AUTOCLOSE/.test(out.additionalContext || ''),
+        /WIKI_AUTOCLOSE/.test(injectedContext(out) || ''),
         `a mixed foreign+own dirty set must still block: ${r.stdout}`,
       );
     },
@@ -539,7 +547,7 @@ test('state table row: attributionScope resolved but a dirty file lives outside 
       );
       const out = JSON.parse(r.stdout);
       assert.ok(
-        /WIKI_AUTOCLOSE/.test(out.additionalContext || ''),
+        /WIKI_AUTOCLOSE/.test(injectedContext(out) || ''),
         `an unattributable dirty file must still block: ${r.stdout}`,
       );
     },
@@ -565,7 +573,7 @@ test('state table row (regression): session ok + hot clean + all-foreign dirty -
         true,
         `every reason demoted must yield silence, not a nudge: ${r.stdout}`,
       );
-      assert.ok(!('additionalContext' in out), `must not emit additionalContext: ${r.stdout}`);
+      assert.ok(modelContexts(out).length === 0, `must not emit additionalContext: ${r.stdout}`);
     },
   );
 });
@@ -602,15 +610,15 @@ test('resolveGateProjectOverride throwing on a broken vault must not silence the
     const out = JSON.parse(r.stdout);
     // Must come before the content assertions: a hook that silently
     // suppresses (the exact BLOCKER this pins) has no additionalContext at
-    // all, and `(out.additionalContext || '').test(...)` on the reasons
+    // all, and `(injectedContext(out) || '').test(...)` on the reasons
     // below would then pass vacuously instead of catching the regression.
-    assert.ok('additionalContext' in out, `must not go silent on a broken vault: ${r.stdout}`);
+    assert.ok(modelContexts(out).length > 0, `must not go silent on a broken vault: ${r.stdout}`);
     assert.ok(
-      /session log entry missing/.test(out.additionalContext),
+      /session log entry missing/.test(injectedContext(out)),
       `session-log reason must survive a resolveGateProjectOverride throw: ${r.stdout}`,
     );
     assert.ok(
-      /git check failed/.test(out.additionalContext),
+      /git check failed/.test(injectedContext(out)),
       `git reason must survive too, not just session-log: ${r.stdout}`,
     );
   });
@@ -637,9 +645,9 @@ test('a clean /compact never invokes resolveGateProjectOverride, even with a bro
     (dir) => {
       const r = runHook('hypo-compact-guard.mjs', { prompt: '/compact' }, { HYPO_DIR: dir });
       const out = JSON.parse(r.stdout);
-      assert.ok('additionalContext' in out, `session reason must still surface: ${r.stdout}`);
+      assert.ok(modelContexts(out).length > 0, `session reason must still surface: ${r.stdout}`);
       assert.ok(
-        /session log entry missing/.test(out.additionalContext),
+        /session log entry missing/.test(injectedContext(out)),
         `session reason must still surface: ${r.stdout}`,
       );
       assert.ok(
@@ -674,11 +682,11 @@ test('log.md is a directory (read failure, not "missing") -> hook stays non-sile
       // Must come first: a silently-suppressed hook has no additionalContext,
       // and the regex assertion below would then pass vacuously.
       assert.ok(
-        'additionalContext' in out,
+        modelContexts(out).length > 0,
         `must not go silent when log.md is unreadable: ${r.stdout}`,
       );
       assert.ok(
-        /session log entry missing/.test(out.additionalContext),
+        /session log entry missing/.test(injectedContext(out)),
         `a read failure on log.md must fall back fail-closed to the session-log reason: ${r.stdout}`,
       );
       assert.ok(
@@ -701,11 +709,11 @@ test('hot.md is a directory (read failure, not "invalid") -> hook stays non-sile
       assert.equal(r.status, 0, `hook must never exit non-zero: ${r.stderr}`);
       const out = JSON.parse(r.stdout);
       assert.ok(
-        'additionalContext' in out,
+        modelContexts(out).length > 0,
         `must not go silent when hot.md is unreadable: ${r.stdout}`,
       );
       assert.ok(
-        /hot\.md unreadable/.test(out.additionalContext),
+        /hot\.md unreadable/.test(injectedContext(out)),
         `a read failure on hot.md must say "unreadable", distinct from a format violation like "unexpected H2" or "forbidden field": ${r.stdout}`,
       );
       assert.ok(
@@ -778,9 +786,9 @@ test('additionalContext never carries imperative "Run ... NOW" or "Do NOT wait" 
   // without this, a bug that drops additionalContext entirely (empty string)
   // would make both regexes below pass vacuously, on a run with nothing to
   // check phrasing in at all.
-  assert.ok('additionalContext' in out, r.stdout);
-  assert.ok(!/Run .* NOW/i.test(out.additionalContext || ''), r.stdout);
-  assert.ok(!/Do NOT wait/i.test(out.additionalContext || ''), r.stdout);
+  assert.ok(modelContexts(out).length > 0, r.stdout);
+  assert.ok(!/Run .* NOW/i.test(injectedContext(out) || ''), r.stdout);
+  assert.ok(!/Do NOT wait/i.test(injectedContext(out) || ''), r.stdout);
 });
 
 // ── hypoIsClean / gitDirtyFiles: opts.deadline (session-close-scope-boundary

--- a/tests/close-signals.test.mjs
+++ b/tests/close-signals.test.mjs
@@ -4,11 +4,12 @@
 // build on each other; suites may not — that is what lets the runner shard.
 
 import assert from 'node:assert/strict';
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { test, suite } from './harness.mjs';
 import {
+  HOOKS,
   REPO,
   askCloseReconfirmToolUse,
   buildOutput,
@@ -2428,15 +2429,253 @@ test('no env var → false', () => {
 
 suite('buildOutput()');
 
-test('wraps context in additionalContext field', () => {
-  const out = buildOutput('test context');
-  assert.equal(out.additionalContext, 'test context');
+test('wraps context in nested hookSpecificOutput.additionalContext', () => {
+  const out = buildOutput('UserPromptSubmit', 'test context');
+  assert.equal(out.hookSpecificOutput.additionalContext, 'test context');
 });
 
-test('merges extra fields alongside additionalContext', () => {
-  const out = buildOutput('ctx', { continue: true });
+test('merges extra fields alongside hookSpecificOutput, not inside it', () => {
+  const out = buildOutput('UserPromptSubmit', 'ctx', { continue: true });
   assert.equal(out.continue, true);
-  assert.equal(out.additionalContext, 'ctx');
+  assert.equal(out.hookSpecificOutput.additionalContext, 'ctx');
+});
+
+// ── buildOutput() nested contract + hook wiring (wave 2 of the nested-output
+// migration) ─────────────────────────────────────────────────────────────
+// Claude Code docs, "Add context for Claude": UserPromptSubmit/SessionStart/
+// PostToolUse/Stop all read additionalContext from
+// hookSpecificOutput.additionalContext, never from the top level. Wave 1
+// moved every producing hook onto that shape; this suite pins the shape
+// itself and then scans every hook file so a later edit cannot quietly
+// reopen the top-level channel.
+suite('buildOutput() — nested contract + hook wiring (wave 2)');
+
+test('control fields stay top-level siblings of hookSpecificOutput, never nested inside it', () => {
+  const out = buildOutput('UserPromptSubmit', 'ctx', { continue: true, suppressOutput: true });
+  assert.equal(out.continue, true);
+  assert.equal(out.suppressOutput, true);
+  assert.equal(out.hookSpecificOutput.hookEventName, 'UserPromptSubmit');
+  assert.equal(out.hookSpecificOutput.additionalContext, 'ctx');
+  // The control fields must not have leaked into the nested object too.
+  assert.equal('continue' in out.hookSpecificOutput, false);
+  assert.equal('suppressOutput' in out.hookSpecificOutput, false);
+});
+
+test('an undocumented event name still gets the nested shape, plus a stderr warning', () => {
+  const undo = captureStderr();
+  try {
+    const out = buildOutput('NotARealEvent', 'ctx');
+    assert.equal(out.hookSpecificOutput.hookEventName, 'NotARealEvent');
+    assert.equal(out.hookSpecificOutput.additionalContext, 'ctx');
+    assert.match(undo.text(), /NotARealEvent has no documented context-injection path/);
+  } finally {
+    undo.restore();
+  }
+});
+
+test('each of the four documented injectable events produces the same nested shape', () => {
+  for (const event of ['UserPromptSubmit', 'SessionStart', 'PostToolUse', 'Stop']) {
+    const undo = captureStderr();
+    try {
+      const out = buildOutput(event, 'x');
+      assert.equal(out.hookSpecificOutput.hookEventName, event);
+      assert.equal(undo.text(), '', `${event} is documented, must not warn: ${undo.text()}`);
+    } finally {
+      undo.restore();
+    }
+  }
+});
+
+// Swaps process.stderr.write for the duration of one check so a stderr-side
+// assertion doesn't have to shell out to a child process just to observe it.
+function captureStderr() {
+  const original = process.stderr.write;
+  let buf = '';
+  process.stderr.write = (chunk) => {
+    buf += chunk;
+    return true;
+  };
+  return {
+    text: () => buf,
+    restore: () => {
+      process.stderr.write = original;
+    },
+  };
+}
+
+// Hooks are copied standalone into ~/.claude/hooks/ (see CLAUDE.md), so a
+// buildOutput(someVariable, ...) call cannot be told apart from a correct one
+// by reading the code at deploy time — the only thing that catches it is
+// scanning the source for the literal shape. A variable first argument slips
+// past every unit test above (they call buildOutput directly with whatever
+// string they like), so this is the only net that catches a hook wiring the
+// wrong argument in.
+const ALLOWED_TOP_LEVEL_ADDITIONAL_CONTEXT = new Set([
+  // Both still build the pre-nested {continue, suppressOutput, additionalContext}
+  // shape by hand and do not call buildOutput at all. A follow-up PR moves both
+  // onto systemMessage, which removes this exception entirely.
+  'hypo-cwd-change.mjs',
+  'hypo-file-watch.mjs',
+]);
+
+test('buildOutput never puts additionalContext at the top level, for any event or extra', () => {
+  // The source scans above read text, so every one of them has some shape that
+  // slips past. This one reads what the function actually returns, which is the
+  // contract itself: no caller and no formatting trick can satisfy it while
+  // emitting a top-level copy.
+  for (const evt of ['UserPromptSubmit', 'SessionStart', 'PostToolUse', 'Stop', 'CwdChanged']) {
+    for (const extra of [
+      {},
+      { continue: true },
+      { continue: true, suppressOutput: true },
+      // The one key that can actually collide. Without it this test's name
+      // ("for any extra") is a claim it does not check: the spread would put a
+      // top-level copy back and every assertion here would still pass.
+      { continue: true, additionalContext: 'shadow' },
+    ]) {
+      const out = buildOutput(evt, 'ctx', extra);
+      assert.equal(
+        'additionalContext' in out,
+        false,
+        `top-level additionalContext leaked for ${evt} with extra ${JSON.stringify(extra)}`,
+      );
+      assert.equal(out.hookSpecificOutput.additionalContext, 'ctx');
+    }
+  }
+});
+
+// file basename -> set of events it is registered on, straight out of
+// hooks/hooks.json. Files absent from the map (the `shared` modules) are simply
+// not checked, so no separate skip list can rot.
+function hookEventMap() {
+  const cfg = JSON.parse(readFileSync(join(HOOKS, 'hooks.json'), 'utf-8'));
+  const map = new Map();
+  for (const [event, matchers] of Object.entries(cfg.hooks ?? {})) {
+    for (const matcher of matchers) {
+      for (const h of matcher.hooks ?? []) {
+        const file = String(h.command ?? '')
+          .split('/')
+          .pop();
+        if (!file?.endsWith('.mjs')) continue;
+        if (!map.has(file)) map.set(file, new Set());
+        map.get(file).add(event);
+      }
+    }
+  }
+  return map;
+}
+
+test('every buildOutput() call in hooks/ passes its own registered event name as a quoted literal', () => {
+  const offenders = [];
+  const eventsByHook = hookEventMap();
+  // hypo-shared.mjs is buildOutput's own definition, not a call site: its
+  // `export function buildOutput(hookEventName, ...)` matches the same
+  // `buildOutput(` pattern and would be a false positive here.
+  for (const file of readdirSync(HOOKS).filter(
+    (f) => f.endsWith('.mjs') && f !== 'hypo-shared.mjs',
+  )) {
+    const src = readFileSync(join(HOOKS, file), 'utf-8');
+    for (const m of src.matchAll(/buildOutput\(\s*([^,)]+)/g)) {
+      const arg = m[1].trim();
+      if (!/^'[^']*'$/.test(arg)) {
+        offenders.push(`${file}: buildOutput(${arg}, ...)`);
+        continue;
+      }
+      // A quoted literal is not enough. Claude Code drops a hookSpecificOutput
+      // whose hookEventName does not match the event the hook actually fires
+      // on, and it does so silently, which is the exact failure this whole
+      // change exists to close. hooks.json is the source of truth for that
+      // mapping, so read it rather than restating it here.
+      const declared = eventsByHook.get(file);
+      if (!declared) {
+        // Unregistered files are shared modules, which never call buildOutput.
+        // One that does is either a hook missing from hooks.json (it would
+        // never be deployed) or a shared module emitting hook output; both
+        // want a human, not a silent skip.
+        offenders.push(
+          `${file}: calls buildOutput but hooks.json does not register it on any event`,
+        );
+        continue;
+      }
+      if (!declared.has(arg.slice(1, -1))) {
+        offenders.push(
+          `${file}: buildOutput(${arg}, ...) but hooks.json registers it on ${[...declared].join(', ')}`,
+        );
+      }
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `buildOutput's first argument must be a quoted event-name literal, found: ${offenders.join(', ')}`,
+  );
+});
+
+test('hypo-shared.mjs mentions additionalContext exactly twice: the strip out of extra and the nested return', () => {
+  // ponytail: line-based comment strip, not a real JS parser. A '//' inside a
+  // string or template literal reads as a comment start here, so anything after
+  // it on that line vanishes from the scan. Zero such literals in this file
+  // today (checked), but if one ever lands next to an additionalContext line
+  // this scan goes quiet: parse properly at that point.
+  const src = readFileSync(join(HOOKS, 'hypo-shared.mjs'), 'utf-8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  // Counted by occurrence, not by line. Counting lines lets a top-level copy
+  // ride along inside the nested return's own line: that stays one "hit" and
+  // fits under prettier's printWidth, so both this scan and lint go green.
+  const hits = src.match(/additionalContext/g) ?? [];
+  assert.equal(
+    hits.length,
+    2,
+    `hypo-shared.mjs must mention additionalContext exactly twice in code, found ${hits.length}. ` +
+      `The two are buildOutput's destructure that strips the key out of extra, and its own nested ` +
+      `return. A third means someone put the top-level channel back.`,
+  );
+  // Which two matters as much as how many: the pair above is only benign
+  // because one strips the key and the other nests it. Two top-level copies
+  // would also count as two.
+  assert.match(src, /const \{ additionalContext: _shadowed, \.\.\.control \} = extra;/);
+  assert.match(src, /hookSpecificOutput: \{ hookEventName, additionalContext: context \}/);
+});
+
+// Asserted in both directions on purpose. A one-way "nobody outside the list
+// offends" check goes quiet the moment the follow-up PR migrates these two: the
+// entries survive as a permanent hole that would wave a future top-level literal
+// straight through. Comparing the full set makes that PR fail here until it
+// deletes them.
+test('exactly the two known legacy hooks emit a top-level additionalContext literal', () => {
+  const emitters = [];
+  for (const file of readdirSync(HOOKS).filter((f) => f.endsWith('.mjs'))) {
+    if (file === 'hypo-shared.mjs') continue;
+    const src = readFileSync(join(HOOKS, file), 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    if (/additionalContext\s*:/.test(src)) emitters.push(file);
+  }
+  // The regex above sees a property name, not its depth: a nested
+  // `hookSpecificOutput: { additionalContext }` matches it too. So the set
+  // comparison alone would still pass if a legacy hook grew a nested emitter
+  // while keeping its top-level one. Asserting these two carry no
+  // hookSpecificOutput at all is what makes "matched, therefore top-level"
+  // true for them, without needing to parse the file.
+  for (const file of ALLOWED_TOP_LEVEL_ADDITIONAL_CONTEXT) {
+    const src = readFileSync(join(HOOKS, file), 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    assert.equal(
+      /hookSpecificOutput/.test(src),
+      false,
+      `${file} is on the top-level allow list, so its additionalContext must be the top-level one. ` +
+        `A hookSpecificOutput here means the file now emits both and the set comparison below stops proving anything.`,
+    );
+  }
+  assert.deepEqual(
+    emitters.sort(),
+    [...ALLOWED_TOP_LEVEL_ADDITIONAL_CONTEXT].sort(),
+    `top-level additionalContext emitters drifted from the expected legacy pair. ` +
+      `A new name means a hook regressed; a missing name means the follow-up migrated it ` +
+      `and must delete it from ALLOWED_TOP_LEVEL_ADDITIONAL_CONTEXT too. Found: ${emitters.join(', ')}`,
+  );
 });
 
 // ── A1: overdue verify_by_date predicate + STALE marker (freshness) ──────────

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -391,6 +391,40 @@ function runApply(dir, payload, { force = false, sessionId = undefined } = {}) {
   }
 }
 
+// ── hookSpecificOutput.additionalContext channel (wave 2 of the nested-output
+// migration) ──────────────────────────────────────────────────────────────
+//
+// buildOutput() (hooks/hypo-shared.mjs) now nests additionalContext under
+// hookSpecificOutput; a couple of not-yet-migrated hooks (hypo-cwd-change.mjs,
+// hypo-file-watch.mjs) still emit it top-level. A test asserting "no context
+// was injected" must check BOTH channels, not just one: a single `??`-based
+// helper that prefers nested would let a real top-level leak hide behind an
+// unrelated nested value, and vice versa. Returns every channel that actually
+// carries a value, so `.length === 0` is the honest "nothing was injected"
+// check regardless of which channel the hook under test uses.
+// The two helpers disagree on an empty or undefined value, and that is
+// deliberate. modelContexts uses `in`, so a present-but-empty key counts as a
+// channel that carried something; injectedContext reads the value, so it reads
+// as nothing. A leak assertion should err toward red, a reachability assertion
+// toward the actual text. Do not "fix" this into a value check: that would stop
+// the leak assertions from catching an empty payload going out.
+function modelContexts(out) {
+  const found = [];
+  if (out?.hookSpecificOutput && 'additionalContext' in out.hookSpecificOutput) {
+    found.push(out.hookSpecificOutput.additionalContext);
+  }
+  if (out && 'additionalContext' in out) found.push(out.additionalContext);
+  return found;
+}
+
+// Positive-assertion counterpart: the first context found, or null when
+// neither channel carries one. Callers that already know exactly one channel
+// applies (the common case) read the actual injected text through this
+// instead of hardcoding which field to look at.
+function injectedContext(out) {
+  return modelContexts(out)[0] ?? null;
+}
+
 function writeExt(hypoDir, type, name, content, manifest) {
   const dir = join(hypoDir, 'extensions', type);
   mkdirSync(dir, { recursive: true });
@@ -783,6 +817,7 @@ export {
   hasSymlinkAncestor,
   hasTypedUserApproval,
   hypoIsClean,
+  injectedContext,
   isCaptureCandidate,
   isClearCommand,
   isCloseGateOpen,
@@ -800,6 +835,7 @@ export {
   makeGitRepo,
   makeMultiProjectWiki,
   markerPath,
+  modelContexts,
   normalizeSkillRelPath,
   pageUsageGuardCachePath,
   pageUsageLoggingAllowed,

--- a/tests/lookup-usage.test.mjs
+++ b/tests/lookup-usage.test.mjs
@@ -9,7 +9,7 @@ import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { readPageUsage, aggregateColdCandidates } from '../scripts/lib/page-usage.mjs';
 import { test, suite } from './harness.mjs';
-import { run, runHook, withTmpDir } from './helpers.mjs';
+import { injectedContext, run, runHook, withTmpDir } from './helpers.mjs';
 
 suite('hypo-lookup.mjs — type-prior boost');
 
@@ -31,7 +31,7 @@ test('PRD entry ranked above plain entry with same keyword', () => {
     writeFileSync(join(dir, 'index.md'), indexContent);
     const r = runHook('hypo-lookup.mjs', { prompt: 'search feature' }, { HYPO_DIR: dir });
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     const prdPos = ctx.indexOf('prd-search');
     const plainPos = ctx.indexOf('search-notes');
     assert.ok(prdPos !== -1, 'PRD entry should appear in context');
@@ -53,7 +53,7 @@ test('ADR entry ranked above plain entry with same keyword', () => {
     writeFileSync(join(dir, 'index.md'), indexContent);
     const r = runHook('hypo-lookup.mjs', { prompt: 'bm25 scoring' }, { HYPO_DIR: dir });
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     const adrPos = ctx.indexOf('decisions/0001-use-bm25');
     const plainPos = ctx.indexOf('bm25-notes');
     assert.ok(adrPos !== -1, 'ADR entry should appear in context');
@@ -84,7 +84,7 @@ test('overdue verify_by_date page gets STALE marker injected', () => {
     stalePageVault(dir, 'verify_by_date: 2020-01-01');
     const r = runHook('hypo-lookup.mjs', { prompt: 'widget calibration' }, { HYPO_DIR: dir });
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     assert.ok(ctx.includes('freshness-notes'), `page should be a HIT: ${ctx}`);
     assert.ok(
       ctx.includes('[STALE verify_by_date=2020-01-01]'),
@@ -98,7 +98,7 @@ test('future verify_by_date page gets no STALE marker', () => {
     stalePageVault(dir, 'verify_by_date: 2099-01-01');
     const r = runHook('hypo-lookup.mjs', { prompt: 'widget calibration' }, { HYPO_DIR: dir });
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     assert.ok(ctx.includes('freshness-notes'), `page should be a HIT: ${ctx}`);
     assert.ok(!/\[STALE/.test(ctx), `future date must not be STALE: ${ctx}`);
   });
@@ -111,7 +111,7 @@ test('legacy date in verify_by (not verify_by_date) gets no STALE marker', () =>
     stalePageVault(dir, 'verify_by: 2020-01-01');
     const r = runHook('hypo-lookup.mjs', { prompt: 'widget calibration' }, { HYPO_DIR: dir });
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     assert.ok(ctx.includes('freshness-notes'), `page should be a HIT: ${ctx}`);
     assert.ok(!/\[STALE/.test(ctx), `verify_by date must not be STALE: ${ctx}`);
   });
@@ -149,7 +149,7 @@ test('HIT in a guard-passing vault appends a well-formed page-usage record', () 
       { HYPO_DIR: dir },
     );
     const out = JSON.parse(r.stdout);
-    assert.ok((out.additionalContext ?? '').includes('freshness-notes'), 'expected HIT');
+    assert.ok((injectedContext(out) ?? '').includes('freshness-notes'), 'expected HIT');
     const logPath = join(dir, '.cache', 'page-usage.jsonl');
     assert.ok(existsSync(logPath), 'page-usage.jsonl must be written on guarded HIT');
     const lines = readFileSync(logPath, 'utf-8').trim().split('\n');
@@ -173,7 +173,7 @@ test('fail-closed logging: no coverage → no log, injection still succeeds', ()
     const out = JSON.parse(r.stdout);
     assert.equal(r.status, 0);
     assert.ok(
-      (out.additionalContext ?? '').includes('freshness-notes'),
+      (injectedContext(out) ?? '').includes('freshness-notes'),
       'injection must still work',
     );
     assert.ok(
@@ -196,7 +196,7 @@ test('fail-open injection: append failure does not break the HIT', () => {
     const out = JSON.parse(r.stdout);
     assert.equal(r.status, 0);
     assert.ok(
-      (out.additionalContext ?? '').includes('freshness-notes'),
+      (injectedContext(out) ?? '').includes('freshness-notes'),
       'injection must survive a logging failure',
     );
   });

--- a/tests/notifier.test.mjs
+++ b/tests/notifier.test.mjs
@@ -28,6 +28,7 @@ import {
   REPO,
   SCRIPTS,
   SESSION_TMP_HOME,
+  injectedContext,
   run,
   runHook,
   runWithHome,
@@ -903,7 +904,7 @@ test('session-start (D3): stale PATH sibling surfaces a one-shot notice, then th
       assert.match(first.stderr, /1\.1\.0/);
       // additionalContext (LLM-visible) carries it too
       const out = JSON.parse(first.stdout);
-      assert.match(out.additionalContext || '', /Stale install on PATH/);
+      assert.match(injectedContext(out) || '', /Stale install on PATH/);
       // ISSUE-5: and the user-visible channel (systemMessage) carries it as well
       // — stderr alone is invisible on a SessionStart hook that exits 0.
       assert.match(out.systemMessage || '', /Stale install on PATH/);
@@ -1016,7 +1017,7 @@ test('session-start: fresh npm update → systemMessage carries the banner (dual
       `update banner missing from systemMessage: ${JSON.stringify(out.systemMessage)}`,
     );
     // dual emit: the model still sees the same state via additionalContext
-    assert.match(out.additionalContext || '', /Update available! 0\.0\.0 → 999\.0\.0/);
+    assert.match(injectedContext(out) || '', /Update available! 0\.0\.0 → 999\.0\.0/);
   });
 });
 
@@ -1475,7 +1476,7 @@ test('session-start: pkgRoot drift surfaces a one-shot notice, then throttles', 
       const first = runSessionStartAt(hook, home, 'pkgdrift-test');
       assert.match(first.stderr, /Package metadata drift/);
       const out = JSON.parse(first.stdout);
-      assert.match(out.additionalContext || '', /Package metadata drift/);
+      assert.match(injectedContext(out) || '', /Package metadata drift/);
       assert.match(out.systemMessage || '', /Package metadata drift/);
 
       // second start: same tuple already notified → suppressed
@@ -1682,8 +1683,8 @@ test('hooks-stderr-log-format: forced catch emits [hypo-auto-stage] error: + pre
 //
 // Coverage Matrix id (spec §9.1.1): `hook replay (PostToolUse WebFetch)`.
 // PostToolUse uses **nested** hookSpecificOutput.additionalContext (Claude
-// Code docs "Add context for Claude" + 515458f per-event matrix), unlike the
-// UserPromptSubmit hooks that use top-level additionalContext via buildOutput().
+// Code docs "Add context for Claude"), the same shape every injecting hook in
+// this codebase now emits through buildOutput() in hooks/hypo-shared.mjs.
 suite('hypo-web-fetch-ingest.mjs — PostToolUse auto-ingest signal (fix #2)');
 
 function runWebFetchHook(payload, env = {}) {

--- a/tests/session-hooks.test.mjs
+++ b/tests/session-hooks.test.mjs
@@ -52,7 +52,9 @@ import {
   drainTouchedPaths,
   formatGrowthMetrics,
   hypoIsClean,
+  injectedContext,
   markerPath,
+  modelContexts,
   payloadForCleanWiki,
   peekTouchedPaths,
   precompactGateStatus,
@@ -976,9 +978,9 @@ test('file-watch refuses to inject .hypoignore-matched file (e.g. .env)', () => 
     const out = JSON.parse(r.stdout);
     assert.equal(out.continue, true);
     assert.equal(
-      out.additionalContext,
-      undefined,
-      `.hypoignore-matched secret leaked into additionalContext: ${out.additionalContext}`,
+      modelContexts(out).length,
+      0,
+      `.hypoignore-matched secret leaked into an injection channel: ${JSON.stringify(modelContexts(out))}`,
     );
     assert.ok(!/sk-leakedvalue/.test(r.stdout), `secret value leaked in stdout: ${r.stdout}`);
   });
@@ -997,8 +999,8 @@ test('file-watch still injects non-ignored wiki file (e.g. hot.md)', () => {
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const out = JSON.parse(r.stdout);
     assert.ok(
-      out.additionalContext && /active project state/.test(out.additionalContext),
-      `expected hot.md injection, got: ${out.additionalContext}`,
+      injectedContext(out) && /active project state/.test(injectedContext(out)),
+      `expected hot.md injection, got: ${injectedContext(out)}`,
     );
   });
 });
@@ -1751,7 +1753,7 @@ test('replay-first-prompt-forces-summary: fresh marker forces unconditional summ
   try {
     const r = runFirstPrompt(sid);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const out = JSON.parse(r.stdout).additionalContext || '';
+    const out = injectedContext(JSON.parse(r.stdout)) || '';
     assert.match(out, /Previously working on demo/, 'must force the resume summary line');
     assert.match(out, /unconditionally/, 'directive must be unconditional (fix #3)');
     // The old "answer only if related / no mention" escape must be gone.
@@ -1767,9 +1769,24 @@ test('replay-first-prompt-forces-summary: cwd-change marker says "Resuming"', ()
   try {
     const r = runFirstPrompt(sid);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const out = JSON.parse(r.stdout).additionalContext || '';
+    const out = injectedContext(JSON.parse(r.stdout)) || '';
     assert.match(out, /Resuming demo/, 'cwd-change source must phrase as Resuming (fix #13)');
     assert.doesNotMatch(out, /Previously working on/, 'must not use the session-start verb');
+    // The two assertions above only read `verb`, which is set independently of
+    // the cwd-change branch: they pass whether that branch exists or not. These
+    // two are what actually pin it. CwdChanged has no context-injection path, so
+    // nothing was ever placed for the model to summarize; asking it to fill
+    // placeholders from context it never received makes it invent one.
+    assert.doesNotMatch(
+      out,
+      /\[one-line summary\]/,
+      'a cwd move injected no context, so the model must not be handed a placeholder to fill',
+    );
+    assert.doesNotMatch(
+      out,
+      /already injected/,
+      'must not claim context was injected for a cwd move: CwdChanged cannot inject',
+    );
   } finally {
     if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
   }
@@ -1780,7 +1797,7 @@ test('replay-first-prompt-forces-summary: no marker → silent pass-through', ()
   const r = runFirstPrompt(sid); // no marker written
   assert.equal(r.status, 0);
   const out = JSON.parse(r.stdout);
-  assert.equal(out.additionalContext, undefined, 'no marker → no injected directive');
+  assert.equal(modelContexts(out).length, 0, 'no marker → no injected directive');
   assert.equal(out.suppressOutput, true);
 });
 
@@ -1792,7 +1809,7 @@ test('replay-first-prompt-forces-summary: expired marker (>10min) → no directi
   );
   const r = runFirstPrompt(sid);
   assert.equal(r.status, 0);
-  assert.equal(JSON.parse(r.stdout).additionalContext, undefined, 'expired marker injects nothing');
+  assert.equal(modelContexts(JSON.parse(r.stdout)).length, 0, 'expired marker injects nothing');
   assert.equal(existsSync(markerPath(sid)), false, 'expired marker is unlinked');
 });
 
@@ -1815,7 +1832,7 @@ test('replay-cwd-change-triggers-first-prompt: entering a project arms the marke
       assert.equal(m.source, 'cwd-change');
       // The armed marker drives first-prompt to force a "Resuming" line.
       const fp = runFirstPrompt(sid);
-      const out = JSON.parse(fp.stdout).additionalContext || '';
+      const out = injectedContext(JSON.parse(fp.stdout)) || '';
       assert.match(out, /Resuming private/, 'armed marker forces Resuming on next prompt');
     } finally {
       if (existsSync(markerPath(sid))) unlinkSync(markerPath(sid));
@@ -1829,7 +1846,7 @@ test('replay-first-prompt-forces-summary: no snapshot → fallback line (no lite
   try {
     const r = runFirstPrompt(sid);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const out = JSON.parse(r.stdout).additionalContext || '';
+    const out = injectedContext(JSON.parse(r.stdout)) || '';
     assert.match(
       out,
       /no prior snapshot yet/,
@@ -1859,7 +1876,7 @@ test('replay-first-prompt-forces-summary: marker.proj is sanitized before interp
   try {
     const r = runFirstPrompt(sid);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const out = JSON.parse(r.stdout).additionalContext || '';
+    const out = injectedContext(JSON.parse(r.stdout)) || '';
     // The legitimate wrapper close tag appears exactly once at the end of the
     // directive. A smuggled close tag from proj would push that count to ≥2.
     const closes = (out.match(/<\/hypomnema-session-resume>/g) || []).length;
@@ -2003,7 +2020,7 @@ test('file-watch ignores file outside HYPO_DIR even without .hypoignore', () => 
     });
     assert.equal(r.status, 0);
     const out = JSON.parse(r.stdout);
-    assert.equal(out.additionalContext, undefined);
+    assert.equal(modelContexts(out).length, 0);
   });
 });
 
@@ -2102,7 +2119,7 @@ test('session-start injects growth line when cache exists', () => {
     );
     const r = runStart(dir);
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext || '';
+    const ctx = injectedContext(out) || '';
     assert.ok(
       ctx.includes('직전 세션: +4 pages, ~2 updated, 7 wikilinks'),
       `growth prefix missing in additionalContext: ${ctx}`,
@@ -2114,7 +2131,7 @@ test('session-start emits no growth line when cache absent', () => {
   withGrowthWiki((dir) => {
     const r = runStart(dir);
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext || '';
+    const ctx = injectedContext(out) || '';
     assert.ok(!ctx.includes('직전 세션'), `unexpected growth line: ${ctx}`);
   });
 });
@@ -2166,7 +2183,7 @@ test('replay-session-start-exposes-sync-state: open entry surfaces in additional
       }) + '\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(ctx.includes('last sync failed'), `sync notice missing: ${ctx}`);
     assert.ok(ctx.includes('network timeout'), `error detail missing: ${ctx}`);
   });
@@ -2186,7 +2203,7 @@ test('replay-session-start-clears-resolved-sync-state: healthy repo clears the e
       }) + '\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(!ctx.includes('last sync failed'), `resolved sync should not surface: ${ctx}`);
     assert.ok(!existsSync(p), 'sync-state.json must be cleared once sync is healthy');
   });
@@ -2202,7 +2219,7 @@ test('replay-session-start-surfaces-unreadable-sync-state: corrupt JSONL is not 
         '\nnot-json\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(ctx.includes('last sync failed'), `corrupt sync-state must still surface: ${ctx}`);
     assert.ok(existsSync(p), 'unreadable sync-state.json must be preserved for inspection');
   });
@@ -2226,7 +2243,7 @@ test('replay-session-start-preserves-sync-state-when-ahead: unpushed commit keep
       }) + '\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(
       ctx.includes('last sync failed'),
       `unresolved push failure must stay surfaced: ${ctx}`,
@@ -2329,7 +2346,7 @@ test('session-start surfaces a conflict entry with manual-merge guidance', () =>
       }) + '\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(ctx.includes('remote diverged'), `conflict notice missing: ${ctx}`);
     assert.ok(ctx.includes('pull --no-rebase'), `manual-merge guidance missing: ${ctx}`);
   });
@@ -2354,7 +2371,7 @@ test('session-start surfaces a conflict-unresolved entry with half-merged-tree g
       }) + '\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(ctx.includes('remote diverged'), `conflict-unresolved notice missing: ${ctx}`);
     assert.ok(
       /half-merged/.test(ctx),
@@ -2390,7 +2407,7 @@ test("session-start treats an unrecognized conflict-* op as unresolved, without 
       }) + '\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(ctx.includes('remote diverged'), `unknown-conflict notice missing: ${ctx}`);
     assert.ok(
       /unresolved/.test(ctx),
@@ -2420,7 +2437,7 @@ test('session-start emits no conflict/half-merged guidance for an unrelated op (
       }) + '\n',
     );
     const r = runStart(dir);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(ctx.includes('last sync failed'), `generic sync notice missing: ${ctx}`);
     assert.ok(
       !ctx.includes('remote diverged'),
@@ -2468,7 +2485,7 @@ test('session-start and doctor render the same wording family for every sync-sta
         join(dir, '.cache', 'sync-state.json'),
         JSON.stringify({ timestamp: '2026-06-19T00:00:00Z', op, error: 'x', host: 'test' }) + '\n',
       );
-      const startCtx = JSON.parse(runStart(dir).stdout).additionalContext || '';
+      const startCtx = injectedContext(JSON.parse(runStart(dir).stdout)) || '';
       const doctorOut = JSON.parse(run('doctor.mjs', [`--hypo-dir=${dir}`, '--json']).stdout);
       const doctorDetail = doctorOut.find((c) => c.label === 'Sync state')?.detail || '';
 
@@ -2747,7 +2764,7 @@ test('session-start: a successful startup pull records sync-last-success without
     );
     // Silent: the existing failure-notice contract is unchanged — no new
     // success line is injected into additionalContext.
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(!ctx.includes('sync-last-success'), `startup pull success must stay silent: ${ctx}`);
   });
 });
@@ -3773,7 +3790,7 @@ test('replay-session-start-injects-clear-recovery-on-source-clear: marker drives
       }) + '\n',
     );
     const r = runStartWithSource(dir, 'clear');
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(ctx.includes('[WIKI_AUTOCLOSE]'), `recovery line missing: ${ctx}`);
     assert.ok(ctx.includes('dying-session-42'), `prev_session_id missing: ${ctx}`);
     assert.ok(ctx.includes('/tmp/transcript-42.jsonl'), `prev_transcript_path missing: ${ctx}`);
@@ -3809,7 +3826,7 @@ test('replay-session-start-removes-corrupt-marker: invalid JSON triggers self-cl
     writeFileSync(p, '{not valid json');
     const r = runStartWithSource(dir, 'clear');
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `corrupt marker must not fire: ${ctx}`);
     assert.ok(!existsSync(p), 'corrupt marker must be unlinked on read failure');
   });
@@ -3837,7 +3854,7 @@ test('replay-session-start-graceful-when-source-clear-but-no-marker: missing mar
   withGrowthWiki((dir) => {
     const r = runStartWithSource(dir, 'clear');
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `recovery line should not fire: ${ctx}`);
   });
 });
@@ -3855,7 +3872,7 @@ test('replay-session-start-ignores-clear-marker-on-source-startup: marker only c
       }) + '\n',
     );
     const r = runStartWithSource(dir, 'startup');
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `marker must not fire on source=startup: ${ctx}`);
     assert.ok(existsSync(p), 'marker must be preserved when source !== clear');
   });
@@ -3875,7 +3892,7 @@ test('replay-session-start-drops-stale-clear-marker: >7 day marker is discarded'
       }) + '\n',
     );
     const r = runStartWithSource(dir, 'clear');
-    const ctx = JSON.parse(r.stdout).additionalContext || '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) || '';
     assert.ok(!ctx.includes('[WIKI_AUTOCLOSE]'), `stale marker must not fire: ${ctx}`);
     assert.ok(!existsSync(p), 'stale marker must be cleaned up');
   });
@@ -3920,7 +3937,7 @@ test('PKG_ROOT null (no provenance sidecar): the banner fires once, then throttl
       assert.match(first.stderr, /Package root unresolved/, `stderr: ${first.stderr}`);
       const out = JSON.parse(first.stdout);
       assert.match(out.systemMessage || '', /Package root unresolved/);
-      assert.match(out.additionalContext || '', /Package root unresolved/);
+      assert.match(injectedContext(out) || '', /Package root unresolved/);
 
       // Same PKG_ROOT-null state, same session cache under the same HOME →
       // notify-once must suppress the second showing.

--- a/tests/visibility-scope.test.mjs
+++ b/tests/visibility-scope.test.mjs
@@ -20,6 +20,7 @@ import { tmpdir } from 'node:os';
 import { aggregateColdCandidates } from '../scripts/lib/page-usage.mjs';
 import { test, suite } from './harness.mjs';
 import {
+  injectedContext,
   HOME,
   SCRIPTS,
   SESSION_TMP_HOME,
@@ -187,7 +188,7 @@ test('non-owning device: machine-scoped slug excluded from injection, fieldless 
       { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
     );
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     assert.ok(!ctx.includes('devA-secret'), `machine:devA slug must not leak on devB: ${ctx}`);
     assert.ok(ctx.includes('plain-notes'), `fieldless page must still be injected: ${ctx}`);
   });
@@ -202,7 +203,7 @@ test('owning device: machine-scoped slug is injected', () => {
       { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
     );
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     assert.ok(ctx.includes('devA-secret'), `machine:devA slug must be injected on devA: ${ctx}`);
   });
 });
@@ -216,7 +217,7 @@ test('non-owning device whose only match is machine-scoped: clean miss, no leak,
       { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
     );
     const out = JSON.parse(r.stdout);
-    const ctx = out.additionalContext ?? '';
+    const ctx = injectedContext(out) ?? '';
     assert.ok(!ctx.includes('devA-only'), `machine:devA slug must not leak: ${ctx}`);
     assert.ok(
       !ctx.includes('files missing'),
@@ -237,7 +238,7 @@ test('owning device whose only match is machine-scoped: page is injected', () =>
       { prompt: 'quibbleflux widgetry' },
       { HYPO_DIR: dir, HYPO_DEVICE: 'devA' },
     );
-    const ctx = JSON.parse(r.stdout).additionalContext ?? '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) ?? '';
     assert.ok(ctx.includes('devA-only'), `machine:devA page must inject on devA: ${ctx}`);
   });
 });
@@ -259,7 +260,7 @@ test('miss path survives an unstat-able entry in the page tree (buildPageMap ski
       { prompt: 'zzqqxx nomatch' },
       { HYPO_DIR: dir, HYPO_DEVICE: 'devB' },
     );
-    const ctx = JSON.parse(r.stdout).additionalContext ?? '';
+    const ctx = injectedContext(JSON.parse(r.stdout)) ?? '';
     assert.ok(
       ctx.includes('LOOKUP: miss'),
       `a dangling symlink must not suppress the clean miss message: ${JSON.stringify(ctx)}`,
@@ -553,7 +554,7 @@ function lookupCtxX10(dir, device) {
     { prompt: 'xyzzy plover' },
     { HYPO_DIR: dir, HYPO_DEVICE: device },
   );
-  return JSON.parse(r.stdout).additionalContext ?? '';
+  return injectedContext(JSON.parse(r.stdout)) ?? '';
 }
 
 function withDeviceX10(device, fn) {
@@ -964,7 +965,7 @@ test('first-prompt does not call a scoped-out project a first session', () => {
   try {
     const r = runFirstPrompt(sid);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const out = JSON.parse(r.stdout).additionalContext || '';
+    const out = injectedContext(JSON.parse(r.stdout)) || '';
     assert.match(out, /scoped to another machine/, 'must name the scope as the reason');
     assert.doesNotMatch(out, /first session/, 'a scoped-out project is not a first session');
   } finally {
@@ -978,7 +979,7 @@ test('first-prompt still calls a genuinely snapshot-less project a first session
   try {
     const r = runFirstPrompt(sid);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    const out = JSON.parse(r.stdout).additionalContext || '';
+    const out = injectedContext(JSON.parse(r.stdout)) || '';
     assert.match(
       out,
       /first session/,
@@ -1023,7 +1024,7 @@ test('session-start injects a shared state while withholding a scoped-out hot, a
       assert.equal(marker.hasSnapshot, true, 'a partially visible snapshot is still a snapshot');
 
       const fp = runFirstPrompt(sid);
-      const out = JSON.parse(fp.stdout).additionalContext || '';
+      const out = injectedContext(JSON.parse(fp.stdout)) || '';
       assert.ok(
         !/SCOPED_HOT_BODY/.test(out),
         `first-prompt must not read the hidden hotPath for content: ${out}`,
@@ -1082,7 +1083,7 @@ test('session-start stamps scopedOut on the marker it hands to first-prompt', ()
       );
 
       const fp = runFirstPrompt(sid);
-      const out = JSON.parse(fp.stdout).additionalContext || '';
+      const out = injectedContext(JSON.parse(fp.stdout)) || '';
       assert.doesNotMatch(
         out,
         /first session/,


### PR DESCRIPTION
# English

## What changed

`buildOutput()` now takes the firing event name and nests the injected text under
`hookSpecificOutput.additionalContext`. Nine call sites across four hooks move to the new
signature, and two hooks that assembled the payload by hand now go through the helper, so one
function owns the shape instead of three places drifting apart.

Two hooks are deliberately untouched. `hypo-cwd-change` and `hypo-file-watch` fire on events
that have no documented context-injection path at all, so nesting would not help them; a
follow-up moves those to `systemMessage`. Their calls went back to inline literals, because the
new signature would have swallowed their `continue` and `suppressOutput` fields.

## Why

The docs are explicit: for `UserPromptSubmit`, an `additionalContext` placed at the top level of
the JSON is silently ignored. Every notice this plugin injects went out that way, so the close
gate, the resume contract, and lookup results have all been dropped on the floor. The behaviour
was correct and the tests pinned it. The channel carrying it was severed, and nothing failed,
because a wrong shape still exits zero.

Three hypotheses were killed before the shape turned out to be the cause: stale installed bytes
(sha matched), vault path resolution (`HYPO_DIR` reaches the hook), and `suppressOutput`
swallowing the payload (flipping it changed nothing, and the docs since confirmed the field has
no effect at all).

## How

`first-prompt` gets a `cwd-change` branch, and it is the part worth reading. That path arms a
marker, and the hook told the model to summarise "the [HOT] / [SESSION STATE] context already
injected" from it. Both halves were dropped before, so they agreed with each other. Fixing only
`first-prompt` leaves an instruction pointing at context that never arrived, and a model asked to
summarise nothing will invent something. The branch asks for a verbatim line instead. It is not
a temporary workaround: once the follow-up moves `cwd-change` to `systemMessage`, that text goes
to the user, so the model still receives nothing for a directory move.

Tests read what a hook actually emits rather than scanning the source for a field name, because
top-level and nested are the same line of text in source. Three static sweeps back that up: every
`buildOutput` call must name the event its hook is registered on in `hooks.json`, `hypo-shared.mjs`
must mention the field exactly twice (the strip out of `extra`, and the nested return), and the
set of files still emitting a top-level literal is compared against the allow list in both
directions, so the follow-up cannot migrate those hooks and quietly leave the exemption behind.

## Manual verification

Eight sabotage runs, each reverted and diffed back against a copy:

| Sabotage | Assertion that went red |
|---|---|
| top-level copy on its own line in `buildOutput` | source sweep |
| call site's first argument switched from a literal to a variable | `hooks.json` sweep |
| top-level copy on the *same* line as the nested return | contract assertion and source sweep |
| a quoted literal naming the wrong event for that hook | `hooks.json` sweep |
| a legacy hook migrated while its allow-list entry stayed | two-way comparison |
| the `cwd-change` branch disabled | the two new regression assertions |
| the strip of `additionalContext` out of `extra` removed | contract assertion and source sweep |
| a legacy hook growing a nested emitter beside its top-level one | allow-list guard |

`npm test` and `node tests/parallel.mjs --shards=4` both exit 0 with 2217 passing;
`npm run lint` exits 0 with no errors.

**A live-session QA has not been run yet, and it is the one thing the suite cannot cover.** Unit
tests fix the bytes a hook writes; whether Claude Code actually reads them is only observable
inside a real session. The design for it is a nonce written into a project `hot.md`, deleted right
after SessionStart so the file can no longer supply it, then asked for in the first prompt. Reading
the transcript is not a substitute: hook stdout is recorded there verbatim inside a `hook_success`
attachment, so a channel that never reached the model looks identical to one that did.

## Migration notes

None for existing vaults. Nothing on disk changes.

Worth stating plainly: this is the first of three. Until the other two land,
`hypo-cwd-change` and `hypo-file-watch` still write to a channel nobody reads, and the README
still lists them as injecting hooks. **Releasing this alone would ship a partial migration**, so
the version string is deliberately left where it is.

---

# 한국어

## 변경 내용

`buildOutput()` 이 발화 이벤트 이름을 받아 주입 텍스트를 `hookSpecificOutput.additionalContext`
아래로 감싼다. 훅 넷에 걸친 호출부 아홉이 새 시그니처로 옮겨갔고, payload 를 손으로 조립하던 훅
둘도 이 헬퍼를 거치게 해서 형태를 아는 자리를 셋에서 하나로 줄였다.

훅 둘은 일부러 그대로 뒀다. `hypo-cwd-change` 와 `hypo-file-watch` 가 발화하는 이벤트에는 문서화된
컨텍스트 주입 경로가 아예 없어서 감싸도 닿지 않는다. 후속 변경이 그 둘을 `systemMessage` 로 옮긴다.
그 호출들은 인라인 리터럴로 되돌렸는데, 새 시그니처를 그대로 두면 `continue` 와 `suppressOutput` 이
통째로 사라지기 때문이다.

## 이유

문서가 명시한다. `UserPromptSubmit` 에서 JSON 최상단에 놓인 `additionalContext` 는 조용히 무시된다.
이 플러그인의 알림이 전부 그 경로로 나갔으므로 close 게이트, 세션 재개 계약, lookup 결과가 모두
바닥에 떨어졌다. 동작은 옳았고 테스트도 그것을 고정하고 있었다. 끊긴 것은 그것을 나르는 채널이었고,
형태가 틀려도 훅은 정상 종료하니 아무것도 실패하지 않았다.

형태가 원인으로 남기까지 가설 셋이 죽었다. 낡은 설치 바이트(sha 일치), 볼트 경로 해석(`HYPO_DIR` 이
훅에 닿는다), 그리고 `suppressOutput` 이 삼킨다는 것(뒤집어도 그대로였고, 문서가 그 필드에 아무 효과가
없다고 뒤이어 확인해 줬다).

## 방법

`first-prompt` 에 `cwd-change` 분기가 생겼고 이 부분이 읽을 값이 있다. 그 경로는 마커를 세우고,
훅은 모델에게 "이미 주입된 [HOT] / [SESSION STATE] 컨텍스트" 로 요약을 채우라고 지시했다. 예전에는
양쪽 다 떨어졌으니 서로 짝이 맞았다. `first-prompt` 만 고치면 도착한 적 없는 컨텍스트를 가리키는
지시가 남고, 없는 것을 요약하라고 받은 모델은 지어낸다. 그래서 이 분기는 자구 그대로 쓸 한 줄을
요구한다. 임시 우회가 아니다. 후속 변경이 `cwd-change` 를 `systemMessage` 로 옮기면 그 텍스트는
사용자에게 가므로, 디렉터리 이동에 대해 모델이 받는 것은 여전히 없다.

시험은 소스에서 필드 이름을 찾는 대신 훅이 실제로 내보내는 것을 읽는다. 소스에서는 최상단과 중첩이
같은 한 줄이기 때문이다. 정적 훑기 셋이 그것을 받친다. 모든 `buildOutput` 호출은 그 훅이
`hooks.json` 에 등록된 이벤트를 이름으로 대야 하고, `hypo-shared.mjs` 는 그 필드를 정확히 두 번
언급해야 하며(`extra` 에서 걷어내는 자리와 중첩 반환), 최상단 리터럴을 아직 가진 파일의 집합을 허용
목록과 양방향으로 비교해서 후속 변경이 그 훅들을 옮기면서 면제만 조용히 남기는 일을 막는다.

## 수동 검증

무력화 여덟 번, 각각 되돌린 뒤 사본과 대조했다.

| 무력화 | red 가 난 단언 |
|---|---|
| `buildOutput` 반환에 별도 줄로 최상단 사본 | 소스 훑기 |
| 호출부 첫 인자를 리터럴에서 변수로 | `hooks.json` 훑기 |
| 중첩 반환과 **같은 줄**에 최상단 사본 | 계약 단언과 소스 훑기 |
| 따옴표 리터럴이지만 그 훅의 이벤트가 아닌 이름 | `hooks.json` 훑기 |
| 레거시 훅을 옮겼는데 허용 목록 항목은 유지 | 양방향 비교 |
| `cwd-change` 분기를 죽임 | 새 회귀 단언 둘 |
| `extra` 에서 `additionalContext` 를 걷어내는 자리 제거 | 계약 단언과 소스 훑기 |
| 레거시 훅이 최상단 옆에 중첩 발신을 추가 | 허용 목록 가드 |

`npm test` 와 `node tests/parallel.mjs --shards=4` 가 둘 다 2217 통과로 종료 코드 0,
`npm run lint` 도 오류 0 으로 종료 코드 0 이다.

**실세션 QA 는 아직 안 돌렸고, 그것이 스위트가 못 덮는 유일한 자리다.** 단위 시험은 훅이 쓰는
바이트를 고정하지만, Claude Code 가 그것을 실제로 읽는지는 살아 있는 세션 안에서만 관측된다. 설계는
프로젝트 `hot.md` 에 난수를 적고 SessionStart 직후 지워 파일로는 더 못 얻게 만든 뒤 첫 프롬프트에서
묻는 것이다. 트랜스크립트를 읽는 것은 대체가 안 된다. 훅 stdout 이 `hook_success` attachment 안에
원문 그대로 기록되어서, 모델에 닿은 적 없는 채널과 닿은 채널이 똑같이 보인다.

## 마이그레이션 노트

기존 볼트에 필요한 것은 없다. 디스크의 어떤 것도 바뀌지 않는다.

분명히 적어 둘 것이 하나 있다. 이것은 셋 중 첫째다. 나머지 둘이 착지하기 전까지
`hypo-cwd-change` 와 `hypo-file-watch` 는 아무도 읽지 않는 채널에 쓰고, README 는 그 둘을 여전히
주입 훅으로 나열한다. **이것만 릴리스하면 반쪽 마이그레이션이 나가므로** 버전 문자열을 일부러
그대로 뒀다.

---

## Changelog

- EN: Hook notices now reach the model again: they were emitted with a top-level `additionalContext`, which Claude Code silently ignores, so the close gate, resume contract, and lookup results never arrived (#287).
- KO: 훅 알림이 다시 모델에 닿는다. 최상단 `additionalContext` 로 나가고 있었는데 Claude Code 가 그것을 조용히 무시해서 close 게이트, 세션 재개 계약, lookup 결과가 도착한 적이 없었다 (#287).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
