### PR TITLE
docs(schema): define what the updated field means

### DIFF
--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -85,6 +85,16 @@ tags: [tag1, tag2]
 ---
 ```
 
+**`updated` is the day the content or structure changed**, not the day the file was
+last written. Adding a backlink, fixing a typo, or reflowing a line does not move it.
+Staleness comparisons read this field, so a date bumped for a cross-link makes the
+page look fresher than its claims are.
+
+**Nothing enforces this.** `lint` checks only that the field exists (W3), and `--fix`
+fills a missing one with today's date, which records when the gap was closed rather
+than when the content changed. The rule holds only where whoever edits the page
+applies it.
+
 Optional fields (add as needed):
 
 ```yaml


### PR DESCRIPTION
# English

## What changed

`templates/SCHEMA.md` now says what the `updated` frontmatter field means: the day the
content or structure changed, not the day the file was last written. A backlink, a typo
fix, or a reflowed line does not move it. The same paragraph records that nothing
enforces the rule.

## Why

The field's meaning was never written down, so a backlink-only edit and a content rewrite
were indistinguishable. Staleness comparisons read this field, and a date bumped for a
cross-link made a page look fresher than its claims were. Whoever edits a page had no
rule to apply, so the answer moved every time the question came up.

## How

Ten lines added to the frontmatter section, next to the field list that declares
`updated`. The enforcement gap is stated in the same place rather than left implied:
`lint` checks only that the field exists (W3), and `--fix` fills a missing one with
today's date, which records when the gap was closed rather than when the content changed.
Writing the rule without that caveat would read as if the tooling backed it.

The vault's own `SCHEMA.md` carries the same convention in its own words. The two files
are deliberately split (upgrade does not overwrite a vault's `SCHEMA.md`), so neither is
a copy of the other and this PR touches only the shipped template.

## Manual verification

None beyond CI. This PR changes one prose block in a template and no code path reads it.
`templates/` is output rather than source, so the change reaches newly-created vaults
only; existing vaults keep the `SCHEMA.md` they already have.

## Migration notes

None. Existing vaults are unaffected by design.

---

# 한국어

## 변경 내용

`templates/SCHEMA.md` 가 `updated` frontmatter 필드의 뜻을 명시한다. 파일을 마지막으로 쓴
날이 아니라 내용이나 구조가 바뀐 날이다. backlink 추가, 오타 수정, 줄 흐름 정리는 이 값을
올리지 않는다. 같은 문단이 이 규약을 집행하는 장치가 없다는 사실도 함께 적는다.

## 이유

필드의 뜻이 어디에도 안 적혀 있어서 backlink 하나만 단 편집과 내용을 다시 쓴 편집이 구별되지
않았다. 신선도 비교가 이 필드를 읽는데, cross-link 때문에 올라간 날짜가 그 페이지의 주장보다
페이지를 더 새것으로 보이게 만들었다. 페이지를 고치는 사람이 적용할 규칙이 없어서 같은 질문이
나올 때마다 답이 흔들렸다.

## 방법

`updated` 를 선언하는 필드 목록 옆, frontmatter 절에 열 줄을 더했다. 집행 부재를 암시로 남기지
않고 같은 자리에 적었다. `lint` 는 필드의 존재만 보고(W3), `--fix` 가 채우는 오늘 날짜는 내용이
바뀐 날이 아니라 빈칸을 메운 날이다. 이 단서 없이 규칙만 적으면 도구가 그것을 받쳐 준다는
뜻으로 읽힌다.

볼트 자신의 `SCHEMA.md` 는 같은 규약을 그쪽 언어로 갖고 있다. 두 파일은 의도적으로 갈라져 있고
(upgrade 가 볼트의 `SCHEMA.md` 를 덮어쓰지 않는다) 서로의 사본이 아니라서, 이 PR 은 출하되는
템플릿만 건드린다.

## 수동 검증

CI 외에 없다. 템플릿의 산문 한 덩이를 바꿨을 뿐이고 이것을 읽는 코드 경로가 없다.
`templates/` 는 소스가 아니라 출력이라 이 변경은 새로 만들어지는 볼트에만 닿는다. 기존 볼트는
이미 가진 `SCHEMA.md` 를 그대로 쓴다.

## 마이그레이션 노트

없다. 기존 볼트는 설계상 영향을 받지 않는다.

---

## Changelog

- EN: The shipped `SCHEMA.md` template now defines `updated` as the day content changed (not the day the file was written), and states that nothing enforces it (#288).
- KO: 출하되는 `SCHEMA.md` 템플릿이 `updated` 를 파일을 쓴 날이 아니라 내용이 바뀐 날로 정의하고, 그것을 집행하는 장치가 없다는 사실도 함께 적는다 (#288).

## Checklist

- [ ] `npm test` passes locally
- [ ] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)

Local `npm test` and `npm run lint` were not run for this PR: the working tree is held by
another branch in progress, and this change touches one template prose block with no code
path reading it. CI runs both.
