### PR TITLE
fix(close-gate): read one queued event the same way on every delivery path

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -101,7 +101,7 @@ and nothing on disk, in three cases:
 |---|---|
 | `session-id-required` | No `--session-id` was passed. |
 | `transcript-unresolved` | The id resolves to no transcript under `~/.claude/projects/`. |
-| `no-user-close-signal` | The transcript exists, and the user never asked to close. |
+| `no-user-close-signal` | The transcript exists, but no close authority is in force right now. This one string collapses three different gate outcomes, and only one of them means the user never asked. Read `gateReason` (below) before deciding what to do about it. |
 
 A refusal is not a failure to route around. It means the close should not happen: ask
 the user, and re-run only after they say so.
@@ -130,6 +130,15 @@ no session id.
 | `--apply-session-close --payload=<path>` | **Refused**, exit 1, `reason: 'session-id-required'`. Nothing is written and nothing is committed. |
 | `--apply-session-close --payload=<path> --session-id=<id>` | The only apply path. Verifies close authority against that session's transcript **first**; on a refusal nothing is written. On success: per-field idempotent writes (no-op when bytes match), strict verification, lint gate, commit, and the per-session closed marker. Safe to re-run. |
 | `--apply-session-close --force` | Skips the probe early-exit. It does **not** skip the authority check, and `--payload` plus `--session-id` are still required to apply anything. |
+
+When a refusal carries `reason: 'no-user-close-signal'`, the JSON also carries
+`gateReason`, naming which of the three gate checks refused: `no-open` (the
+transcript holds no user close signal at all), `transcript-rewrite-detected`
+(the transcript changed under the gate), or `no-new-open-since-resolution` (the
+close signal predates a resolution already recorded). The collapsed `reason`
+stays the same string in all three cases, so read `gateReason` rather than
+parsing the `Gate detail:` fragment out of `error`. The field is absent for
+every other refusal.
 
 **Two lint gates run automatically, scoped to the files this close writes:**
 
@@ -171,7 +180,12 @@ If `markerWritten: true`: ask: "Session closed. Would you like to also run knowl
 
 - `session-id-required`: you omitted `--session-id`. Pass the main conversation's id and re-run.
 - `transcript-unresolved`: the id resolved no transcript, so it is almost certainly not the main conversation's (a background-task or Agent-thread uuid, most often). Get the right one and re-run.
-- `no-user-close-signal`: the transcript is this session's, and the user never asked to close in wording the gate recognizes (e.g. "세션 마무리까지 진행해줘" falls outside the close-signal set). Re-running the same id changes nothing, because the transcript is unchanged. Confirm intent once with `AskUserQuestion`, header "세션", a single option labelled **세션 마무리** (설명: "이 세션을 마무리하고 close 마커를 기록"). If the user picks it, that answer lands in the transcript as a recognized close signal, so re-running the exact same command now applies **everything**: the writes, the commit, and the marker. If the user declines, the session stays open and nothing is written. Do NOT touch the close-signal matcher itself, and do not hand-write the files to work around the refusal.
+- `no-user-close-signal`: the transcript is this session's, but no close authority is in force. **Branch on `gateReason` before doing anything.** The three cases need three different responses, and treating them alike is what made this refusal look like it had a new cause every time it appeared.
+  - `no-open`: the user genuinely never asked to close in wording the gate recognizes (e.g. "세션 마무리까지 진행해줘" falls outside the close-signal set). Re-running the same id changes nothing, because the transcript is unchanged. Confirm intent once with `AskUserQuestion`, header "세션", a single option labelled **세션 마무리** (설명: "이 세션을 마무리하고 close 마커를 기록"). If the user picks it, that answer lands in the transcript as a recognized close signal, so re-running the exact same command now applies **everything**: the writes, the commit, and the marker. If the user declines, the session stays open and nothing is written.
+  - `no-new-open-since-resolution`: the user DID ask, and that request was already resolved by an earlier close. Asking again makes them answer a question they have already answered. Report that this session is already closed and stop; do not re-prompt.
+  - `transcript-rewrite-detected`: the transcript changed underneath the gate, so the earlier signal can no longer be attested. This is not a statement about what the user wants. Say what happened rather than asking them to repeat themselves, and let a human decide.
+
+  In all three: do NOT touch the close-signal matcher itself, and do not hand-write the files to work around the refusal.
 
 If the apply succeeded but `markerWritten: false`, do NOT say "session closed." Branch on `markerSkipReason` (`compact-gate-not-ok`, `commit-failed: …`, `marker-did-not-land`): surface the reason verbatim and address it (resolve the compact blocker, fix the git / disk issue) before re-running.
 

--- a/hooks/hypo-shared.mjs
+++ b/hooks/hypo-shared.mjs
@@ -5018,6 +5018,48 @@ export function resolveTranscriptBySessionId(
 // dangerous replay/injection paths carry system|sdk|isMeta|isSidechain and are
 // excluded here anyway.
 const COMMAND_INVOCATION_TAG = /<command-(?:name|message|args)>/;
+
+// Text out of a content-block array, or null when the array carries a command
+// invocation (which is a host artifact, not something the user typed as prose).
+// Extracted so the queued_command attachment branch in walkCloseGate can reuse
+// the exact same rule: a queued prompt arrives as this array shape whenever the
+// user pasted an image alongside their words (measured: 8 such deliveries, all
+// origin.kind "human", host versions 2.1.226 through 2.1.263). Reading only
+// `typeof prompt === 'string'` there dropped those to '' and read a real change
+// of mind as nothing at all.
+function contentBlocksText(content) {
+  const texts = content
+    .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text);
+  const text = texts.length ? texts.join('\n') : null;
+  // A command-invocation tag split across adjacent text blocks (e.g.
+  // '<command-na' + 'me>/hypo:crystallize</command-name>') would survive the
+  // '\n'-joined `text` above with a newline spliced into the middle of the
+  // tag name, so the plain check below can miss it entirely. Today's actual
+  // host format sends the whole invocation as ONE string, so this exact
+  // split is not reproducible against a live session yet — but a check for
+  // "did the host format ever put the tag exactly on a block boundary"
+  // should not depend on where a future host happens to cut the blocks. So
+  // also test each run of CONSECUTIVE text blocks joined with no separator.
+  // This must stay scoped to consecutive text blocks only, never the whole
+  // array: joining across a non-text block in between (an image, say) would
+  // synthesize a tag that never existed in the real content, and that is a
+  // different bug, not a fix — it would throw away a genuine close spoken
+  // next to an unrelated attachment. So a non-text block ends the current
+  // run and starts a new one; it never bridges two runs into one string.
+  let tightRun = '';
+  for (const b of content) {
+    if (b && b.type === 'text' && typeof b.text === 'string') {
+      tightRun += b.text;
+      continue;
+    }
+    if (COMMAND_INVOCATION_TAG.test(tightRun)) return null;
+    tightRun = '';
+  }
+  if (COMMAND_INVOCATION_TAG.test(tightRun)) return null;
+  return text;
+}
+
 function eventUserText(obj) {
   if (obj.isMeta === true) return null;
   if (obj.promptSource === 'system' || obj.promptSource === 'sdk') return null;
@@ -5031,35 +5073,9 @@ function eventUserText(obj) {
   if (typeof content === 'string') {
     text = content.startsWith('Stop hook feedback') ? null : content;
   } else if (Array.isArray(content)) {
-    const texts = content
-      .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
-      .map((b) => b.text);
-    text = texts.length ? texts.join('\n') : null;
-    // A command-invocation tag split across adjacent text blocks (e.g.
-    // '<command-na' + 'me>/hypo:crystallize</command-name>') would survive the
-    // '\n'-joined `text` above with a newline spliced into the middle of the
-    // tag name, so the plain check below can miss it entirely. Today's actual
-    // host format sends the whole invocation as ONE string, so this exact
-    // split is not reproducible against a live session yet — but a check for
-    // "did the host format ever put the tag exactly on a block boundary"
-    // should not depend on where a future host happens to cut the blocks. So
-    // also test each run of CONSECUTIVE text blocks joined with no separator.
-    // This must stay scoped to consecutive text blocks only, never the whole
-    // array: joining across a non-text block in between (an image, say) would
-    // synthesize a tag that never existed in the real content, and that is a
-    // different bug, not a fix — it would throw away a genuine close spoken
-    // next to an unrelated attachment. So a non-text block ends the current
-    // run and starts a new one; it never bridges two runs into one string.
-    let tightRun = '';
-    for (const b of content) {
-      if (b && b.type === 'text' && typeof b.text === 'string') {
-        tightRun += b.text;
-        continue;
-      }
-      if (COMMAND_INVOCATION_TAG.test(tightRun)) return null;
-      tightRun = '';
-    }
-    if (COMMAND_INVOCATION_TAG.test(tightRun)) return null;
+    // null from either cause (no text blocks, or a command invocation) means
+    // "no user prose here", which is exactly what this function returns anyway.
+    text = contentBlocksText(content);
   }
   if (text != null && COMMAND_INVOCATION_TAG.test(text)) return null;
   return text;
@@ -5075,6 +5091,20 @@ function isModelReachableRecord(obj) {
     obj.promptSource === 'sdk' ||
     obj.isSidechain === true
   );
+}
+
+// Queue content that carries no fresh USER decision: empty, or a background-task
+// notification the host injects on the model's behalf. Shared by the enqueue
+// branch and the remove-path (queued_command attachment) branch below so a
+// task notification reads as neutral on BOTH delivery shapes of the same host
+// event. Before this was extracted, only the enqueue branch filtered it — the
+// attachment branch treated any non-close prompt, including a task
+// notification, as a change-of-mind close: a close typed by the user opened
+// the gate, then the notification for an unrelated background task landed
+// via this path and flipped it shut again.
+function isModelCausedQueueContent(text) {
+  const c = typeof text === 'string' ? text.trim() : '';
+  return !c || c.startsWith('<task-notification>');
 }
 
 export function walkCloseGate(transcriptPath) {
@@ -5157,7 +5187,7 @@ export function walkCloseGate(transcriptPath) {
         openedAtIndex = i;
       } else if (/^\/clear(?:\s|$)/.test(c)) {
         open = false; // abandons context → close
-      } else if (!c || c.startsWith('<task-notification>')) {
+      } else if (isModelCausedQueueContent(c)) {
         /* model-caused / empty — neutral */
       } else if (isClosePattern(c)) {
         /* NL close via the queue — the open dequeue gap: the producer cannot be
@@ -5174,16 +5204,80 @@ export function walkCloseGate(transcriptPath) {
     // cannot attest a producer, so it does not open (fail-closed). A NON-close
     // queued command (e.g. "keep working") is a fresh user intent and CLOSES
     // a prior open regardless of origin — that is what closes the re-close hole
-    // where a queued "continue" after a close leaves the stale open live.
+    // where a queued "continue" after a close leaves the stale open live. A
+    // task notification is not that: `modelCaused` below filters it out before
+    // this reaches the change-of-mind close, because the model, not the user,
+    // produced it. This delivery path used to skip that filter and let an
+    // unrelated background-task notification flip a just-opened gate shut.
+    //
+    // Scope of "both shapes classify alike": it holds for task notifications and
+    // for empty content, which is what this fix is about. It does not hold for
+    // slash commands. The enqueue branch reads a queued `/compact` as an opener
+    // and `/clear` as a close, and nothing here mirrors that, so the same
+    // command would close the gate if it ever arrived on this path. Measured
+    // 0 of 1321 attachment deliveries carry a slash prompt, so the divergence
+    // is unreachable today rather than fixed; mirroring it would mean copying
+    // an opener that tests already mark a fail-open defect.
     if (o.type === 'attachment' && o.attachment && o.attachment.type === 'queued_command') {
-      const prompt = typeof o.attachment.prompt === 'string' ? o.attachment.prompt : '';
+      // Same channel guard the typed path applies, for the same reason. This
+      // branch can OPEN the gate, and `origin.kind` alone does not say which
+      // channel the record came in on: a sidechain, injected, sdk or meta
+      // record could carry a human origin and close text and mint an approval
+      // the user never gave in this conversation. eventUserText has refused
+      // those channels all along; the opener next to it did not, so one
+      // classifier trusted a record the other threw away. Measured 0 of 1340
+      // queued_command attachments carry any of these flags, so this closes a
+      // shape the corpus has not produced rather than an observed failure.
+      // `interruptedMessageId` rides along because eventUserText refuses it too.
+      if (isModelReachableRecord(o) || o.interruptedMessageId) continue;
+      // A queued prompt arrives as a content-block array whenever the user
+      // pasted an image alongside their words. Reading only the string shape
+      // dropped those to '' and threw away a real change of mind: the gate
+      // stayed open and the close went through anyway. Measured 8 such
+      // deliveries, every one origin.kind "human", host 2.1.226 to 2.1.263.
+      const rawPrompt = o.attachment.prompt;
+      const prompt =
+        typeof rawPrompt === 'string'
+          ? rawPrompt
+          : Array.isArray(rawPrompt)
+            ? (contentBlocksText(rawPrompt) ?? '')
+            : '';
       const humanOrigin = !!(o.attachment.origin && o.attachment.origin.kind === 'human');
-      if (isClosePattern(prompt)) {
+      // The host labels these deliveries on the record itself, and that label is
+      // the authoritative one: every measured task-notification attachment
+      // (1040 of 1040) carries commandMode 'task-notification'. Keying only on
+      // the '<task-notification>' body prefix would leave the whole filter
+      // resting on a string the host owns and can restyle, and a body that
+      // merely gains a line before the tag would slip past it. The queue-op
+      // branch above has no such field to read, so it keeps the body check
+      // alone; here both are available and both are used.
+      const modelCaused =
+        o.attachment.commandMode === 'task-notification' || isModelCausedQueueContent(prompt);
+      // The filter runs FIRST here, exactly as it does in the enqueue branch
+      // above. Order is load-bearing, not cosmetic: a notification body carries
+      // whatever text the finished task was named after, and isClosePattern
+      // matches on a substring ("wrap up", "오늘 여기까지" inside a <summary>
+      // both measure true). Testing isClosePattern first therefore lets a
+      // model-produced event reach the opener, where a human-origin delivery
+      // would set `open` and push `openedAtIndex` forward. That manufactures a
+      // close signal the user never gave, and moves the index the resolution
+      // comparison reads.
+      //
+      // Reachability, so the next reader does not have to re-measure it: no
+      // recorded delivery hits that path. All 1040 task-notification
+      // attachments in the corpus arrive with no `origin`, so `humanOrigin` is
+      // false and the opener is skipped whichever order the two checks run in.
+      // This is a defensive pin against a host that starts stamping origin on
+      // them, not a repair of an observed failure.
+      if (modelCaused) {
+        /* model-caused / empty: neutral, the same filter the enqueue branch
+           above applies to the same host event on its other delivery shape */
+      } else if (isClosePattern(prompt)) {
         if (humanOrigin) {
           open = true;
           openedAtIndex = i;
         }
-      } else if (prompt) {
+      } else {
         open = false;
       }
       continue;

--- a/scripts/lib/crystallize-close-apply.mjs
+++ b/scripts/lib/crystallize-close-apply.mjs
@@ -630,8 +630,12 @@ const CLOSE_REFUSAL_HELP = [
  * counts (extractUserMessages drops injected, tool, and hook-feedback text).
  *
  *   { ok: true }
- *   { ok: false, reason, error }   reason: session-id-required | transcript-unresolved
- *                                          | no-user-close-signal
+ *   { ok: false, reason, error, gateReason? }   reason: session-id-required |
+ *     transcript-unresolved | no-user-close-signal. `gateReason` is only present
+ *     when `reason` is `no-user-close-signal`, and carries closeGateStatus's own
+ *     reason string (no-open / transcript-rewrite-detected /
+ *     no-new-open-since-resolution) for a caller that wants to tell those three
+ *     apart without parsing `error`.
  */
 function verifyCloseAuthority(sessionId, hypoDir) {
   if (!sessionId) {
@@ -661,6 +665,13 @@ function verifyCloseAuthority(sessionId, hypoDir) {
     return {
       ok: false,
       reason: 'no-user-close-signal',
+      // The user-facing `reason` above stays the single collapsed string
+      // tests and downstream tooling already key on (see this function's own
+      // doc comment). `gateReason` carries closeGateStatus's actual reason
+      // (no-open / transcript-rewrite-detected / no-new-open-since-resolution)
+      // as a separate, machine-readable field, so a caller can tell the three
+      // apart without parsing the "Gate detail: ..." substring out of `error`.
+      gateReason: gateStatus.reason,
       error:
         "session-close apply refused before any wiki write or commit: this session's transcript " +
         'carries no user close signal. The user did not ask to close. ' +
@@ -776,6 +787,11 @@ function refuseUnlessCloseRequested(args) {
       ok: false,
       stage: 'no-user-close-signal',
       reason: closeAuth.reason,
+      // Only set when `reason` is 'no-user-close-signal' (undefined otherwise,
+      // and JSON.stringify drops an undefined-valued key). Lets a caller tell
+      // apart the three closeGateStatus refusals collapsed into that one
+      // `reason` string, without parsing "Gate detail: ..." out of `error`.
+      gateReason: closeAuth.gateReason,
       applied: [],
       // `null`, not `false`: this refusal fires before the commit step is ever
       // reached (see the general result's own `committed` contract below).

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -2508,6 +2508,12 @@ test('IMPR-15: no-user-close-signal → after an AskUserQuestion 세션 마무�
         'no-user-close-signal',
         `expected the no-signal reason (not transcript-unresolved): ${JSON.stringify(o1)}`,
       );
+      // ISSUE-114 axis B: the collapsed `reason` above stays exactly
+      // 'no-user-close-signal' (existing contract, unchanged), but `gateReason`
+      // now carries closeGateStatus's own reason as a separate, machine-readable
+      // field — here it is the "no-open" case, since this transcript has no
+      // close signal in it at all.
+      assert.match(o1.gateReason, /^no-open:/, `expected a structured gate reason: ${r1.stdout}`);
       assert.deepEqual(o1.applied, []);
       // `null`, not `false`: refused before the commit step is ever reached.
       assert.equal(o1.committed, null, 'refused before the commit step ever ran');

--- a/tests/close-signals.test.mjs
+++ b/tests/close-signals.test.mjs
@@ -37,6 +37,11 @@ import {
   withTmpDir,
 } from './helpers.mjs';
 
+// Local, not re-exported through helpers.mjs: this file is the only area that
+// needs the full walk record (helpers hands back isCloseGateOpen, which is just
+// its `.open`). The order tests below assert on `openedAtIndex`.
+const { walkCloseGate } = await import(join(HOOKS, 'hypo-shared.mjs'));
+
 suite('isCompactCommand()');
 
 test('/compact → true', () => {
@@ -1307,6 +1312,271 @@ test('close, then a task-notification replay (origin.kind present) → true (sta
       }),
     ]);
     assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+// A task notification's THIRD delivery shape (ISSUE-114 axis C): the queue
+// records above cover the enqueue and the bare remove, but the corpus's real
+// remove-path delivery lands the prompt again on a `queued_command`
+// attachment (see REMOVE_DELIVERY above), and that attachment branch used to
+// skip the model-caused filter the enqueue branch already applied — a
+// close typed by the user, then this SAME notification arriving through this
+// THIRD shape, flipped the just-opened gate back to closed. All three shapes
+// of the one host event must read neutral, so all three sit in one fixture:
+// an enqueue, its remove, and the remove-path attachment.
+test('close, then a task-notification via enqueue + remove + attachment → true (all three delivery shapes stay neutral)', () => {
+  withTmpDir((dir) => {
+    const notif =
+      '<task-notification>\n<task-id>x</task-id>\n<status>completed</status>\n</task-notification>';
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      QOP('enqueue', notif),
+      QOP('remove', notif),
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: { type: 'queued_command', prompt: notif, commandMode: 'prompt' },
+      },
+    ]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+// The load-bearing twin, on the SAME attachment branch: a human queues a real
+// change of mind ("keep working"), it gets delivered the same way a close
+// would be, and it must still close the gate. Widening the attachment
+// branch's neutral filter to anything non-close would silently kill this
+// contract along with fixing the task-notification case above, so both live
+// in this file and both must pass together.
+test('close, then a human non-close queued via the remove-path attachment → false (still a change of mind)', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      QOP('enqueue', '계속 작업하자'),
+      QOP('remove', '계속 작업하자'),
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: {
+          type: 'queued_command',
+          prompt: '계속 작업하자',
+          commandMode: 'prompt',
+          origin: { kind: 'human' },
+        },
+      },
+    ]);
+    assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+// CHANNEL: this branch can OPEN the gate, so it needs the same channel guard
+// the typed path has always had. `origin.kind` says who produced the text, not
+// which channel the record arrived on, and a sidechain / injected / sdk / meta
+// record can carry both a human origin and close words. eventUserText refuses
+// those channels; the opener beside it did not, so one classifier trusted a
+// record the other threw away. Measured 0 of 1340 queued_command attachments
+// carry any of these flags, so both directions below are composed shapes, not
+// observed ones: a guard against a record the host does not mint today.
+for (const flag of [
+  { isSidechain: true },
+  { isMeta: true },
+  { promptSource: 'system' },
+  { promptSource: 'sdk' },
+  { interruptedMessageId: 'msg_1' },
+]) {
+  const label = Object.keys(flag)[0] + '=' + String(Object.values(flag)[0]);
+  test(`a queued close on a model-reachable channel (${label}) does not open the gate`, () => {
+    withTmpDir((dir) => {
+      const p = writeJsonl(dir, [
+        {
+          type: 'attachment',
+          isSidechain: false,
+          userType: 'external',
+          ...flag,
+          attachment: {
+            type: 'queued_command',
+            prompt: '세션 마무리하자',
+            commandMode: 'prompt',
+            origin: { kind: 'human' },
+          },
+        },
+      ]);
+      assert.equal(isCloseGateOpen(p), false);
+    });
+  });
+
+  test(`a queued non-close on a model-reachable channel (${label}) does not close an open gate`, () => {
+    withTmpDir((dir) => {
+      const p = writeJsonl(dir, [
+        USER(CLOSE),
+        {
+          type: 'attachment',
+          isSidechain: false,
+          userType: 'external',
+          ...flag,
+          attachment: {
+            type: 'queued_command',
+            prompt: '계속 작업하자',
+            commandMode: 'prompt',
+            origin: { kind: 'human' },
+          },
+        },
+      ]);
+      assert.equal(isCloseGateOpen(p), true);
+    });
+  });
+}
+
+// A queued prompt is a content-block array whenever the user pasted an image
+// with their words. Measured 8 such deliveries in the corpus, every one
+// origin.kind "human", host 2.1.226 through 2.1.263. Reading only the string
+// shape dropped them to '' and read a real change of mind as nothing, so a
+// close already granted went through even though the user had since said keep
+// going. Both directions are pinned: the non-close must close the gate, and a
+// close spoken the same way must open it.
+test('a queued human non-close arriving as content blocks still closes the gate', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: {
+          type: 'queued_command',
+          prompt: [
+            { type: 'text', text: '계속 작업하자' },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'x' } },
+          ],
+          commandMode: 'prompt',
+          origin: { kind: 'human' },
+        },
+      },
+    ]);
+    assert.equal(isCloseGateOpen(p), false);
+  });
+});
+
+test('a queued human close arriving as content blocks still opens the gate', () => {
+  withTmpDir((dir) => {
+    const p = writeJsonl(dir, [
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: {
+          type: 'queued_command',
+          prompt: [
+            { type: 'text', text: '세션 마무리하자' },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'x' } },
+          ],
+          commandMode: 'prompt',
+          origin: { kind: 'human' },
+        },
+      },
+    ]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+// The host stamps commandMode on the record itself, and all 1040 measured
+// task-notification attachments carry it. Keying the filter only on the body's
+// '<task-notification>' prefix leaves it resting on a string the host owns: a
+// body that merely gains a line before the tag slips past. This feeds a body
+// that does NOT start with the tag and relies on commandMode alone.
+test('a task-notification identified only by commandMode is still neutral', () => {
+  withTmpDir((dir) => {
+    const body =
+      'Background work finished.\n<task-notification>\n<status>completed</status>\n</task-notification>';
+    // Guard: this body must NOT satisfy the prefix check, or the test measures
+    // the prefix path instead of the commandMode path it exists to cover.
+    assert.equal(body.startsWith('<task-notification>'), false);
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: {
+          type: 'queued_command',
+          prompt: body,
+          commandMode: 'task-notification',
+          origin: { kind: 'human' },
+        },
+      },
+    ]);
+    assert.equal(isCloseGateOpen(p), true);
+  });
+});
+
+// ORDER, on the same attachment branch: a notification body carries whatever
+// text the finished task was named after, and isClosePattern matches on a
+// substring, so a routine `<summary>` can measure true ("wrap up" and "오늘
+// 여기까지" both do). The enqueue branch has always filtered model-caused
+// content BEFORE testing for a close pattern; the attachment branch tested the
+// pattern first. That gap let a model-produced event reach the opener, where a
+// human-origin delivery would set `open` and push `openedAtIndex` forward,
+// manufacturing a close signal the user never gave. This pins the two branches
+// to the same order by feeding the identical body through both shapes and
+// requiring the identical verdict.
+test('a task-notification whose body matches a close pattern opens nothing, on either delivery shape', () => {
+  withTmpDir((dir) => {
+    const notif =
+      '<task-notification>\n<task-id>x</task-id>\n<status>completed</status>\n' +
+      '<summary>Background command "wrap up the docs" completed</summary>\n</task-notification>';
+    // Guard the fixture itself: if isClosePattern stops matching this body the
+    // test would pass while measuring nothing at all.
+    assert.equal(isClosePattern(notif), true);
+
+    const viaEnqueue = writeJsonl(dir, [QOP('enqueue', notif)]);
+    const viaAttachment = writeJsonl(dir, [
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: {
+          type: 'queued_command',
+          prompt: notif,
+          commandMode: 'prompt',
+          origin: { kind: 'human' },
+        },
+      },
+    ]);
+    assert.equal(isCloseGateOpen(viaEnqueue), false);
+    assert.equal(isCloseGateOpen(viaAttachment), false);
+  });
+});
+
+// The other half of the order contract: the same body arriving AFTER a real
+// close must not move `openedAtIndex` either. A gate that reads open for the
+// wrong reason is as wrong as one that reads closed, because the resolution
+// comparison keys on that index.
+test('a close-matching task-notification after a real close does not move openedAtIndex', () => {
+  withTmpDir((dir) => {
+    const notif =
+      '<task-notification>\n<status>completed</status>\n' +
+      '<summary>오늘 여기까지 정리한 결과</summary>\n</task-notification>';
+    assert.equal(isClosePattern(notif), true);
+
+    const p = writeJsonl(dir, [
+      USER(CLOSE),
+      {
+        type: 'attachment',
+        isSidechain: false,
+        userType: 'external',
+        attachment: {
+          type: 'queued_command',
+          prompt: notif,
+          commandMode: 'prompt',
+          origin: { kind: 'human' },
+        },
+      },
+    ]);
+    const walk = walkCloseGate(p);
+    assert.equal(walk.open, true);
+    assert.equal(walk.openedAtIndex, 0); // the user's typed close, not the notification
   });
 });
 


### PR DESCRIPTION
# English

## What changed

`walkCloseGate` now reads one queued host event the same way on every path it can
arrive by. A background-task notification reaches it three ways (a queue enqueue, the
matching remove, and a `queued_command` attachment), and only the queue branch filtered
it. Three siblings on the same branch are closed alongside: the order of the neutral
check, the channel guard the typed path already had, and prompts that arrive as
content-block arrays.

Separately, a refusal carrying `no-user-close-signal` now also carries `gateReason`,
naming which of the three gate checks actually refused.

## Why

A close the user typed opened the gate. Then an unrelated background task finished, its
notification landed on the attachment path, and that path read any non-close prompt as a
change of mind and shut the gate. The refusal came after every file was already written,
and the user had to type the close a second time.

The `gateReason` half is the reason that failure was hard to pin down. Three unrelated
gate outcomes collapsed into one string, so from outside the same refusal looked like it
had a new cause every time someone investigated it. Four separate diagnoses accumulated
before a comparison showed two of them were mutually exclusive.

## How

The two branches share one predicate. The attachment branch also keys on the host's own
`commandMode` label: every measured delivery carries `commandMode: 'task-notification'`,
so resting the whole filter on a body prefix left it one host format change from dying
silently, and the body check stays for deliveries predating the field.

The three siblings, with what is measured and what is a pin:

- **Order.** The neutral filter runs before the close-pattern test, as it does in the
  queue branch. `isClosePattern` matches on a substring, so a notification body naming a
  finished task can measure true and reach the opener. No recorded delivery hits that
  path (all 1040 arrive with no `origin`, so the opener is skipped either way), which
  makes this a pin against a host that starts stamping origin, not a repair.
- **Channel.** This branch can open the gate but was not applying the channel guard
  `eventUserText` has always had. `origin.kind` says who wrote the text, not which
  channel the record came in on, so a sidechain, injected, sdk or meta record carrying a
  human origin could mint an approval. Measured 0 of 1340, so also a pin.
- **Content blocks.** A queued prompt arrives as a block array whenever the user pastes
  an image alongside their words. Reading only the string shape dropped those to empty
  and threw away a real change of mind, letting the close proceed. Measured 8, every one
  human origin, on hosts through 2.1.263. This one is observed. The array extraction
  `eventUserText` already used became a shared helper rather than a second copy.

`gateReason` is a new field beside the existing `reason`, not a replacement: callers and
two CLI tests key on the collapsed string. The command doc branches its recovery guidance
on it, because two of the three causes mean the user *did* ask to close, and the previous
advice (confirm intent again) made them answer a question they had already answered.

The `/compact` divergence between the two branches is deliberately left open. Slash
prompts appear on 0 of 1321 attachment deliveries, and mirroring the queue branch would
copy an opener the tests already mark a fail-open defect. The measurement and the reason
are recorded at the site.

## Manual verification

This changes `hooks/hypo-shared.mjs`, so the deployed copy matters. Note for whoever
upgrades: on the machine this was written on, the plugin cache still runs the bytes of
the `v1.8.1` tag (`hooks/hypo-shared.mjs` sha256 `188dc220a210cb8c…`), four merges behind
`main`. The version string has to move for this to reach a plugin-channel install.

Behavior here is observable only inside a live session, so the real-session check is the
gate that matters and is not covered by the suite. What the suite does pin, with each
defense disabled one at a time and confirmed red before restoring:

```
node tests/runner.mjs --grep='model-reachable channel'        # 10 passed
node tests/runner.mjs --grep='content blocks|commandMode'     # 3 passed
npm test                                                      # 2234 passed, rc=0
npm run lint                                                  # 0 errors, rc=0
npm run check:tracker-ids                                     # rc=0
node tests/parallel.mjs --shards=4                            # 2234 passed, rc=0
```

## Migration notes

None. No stored state, no vault file, and no CLI flag changes shape. `gateReason` is an
added field on a refusal that already existed; `reason` keeps its exact value, so a
caller reading only `reason` sees no difference.

---

# 한국어

## 변경 내용

`walkCloseGate` 가 하나의 queued host 이벤트를 어느 경로로 오든 같게 읽는다. background task
완료 알림은 세 경로(queue enqueue, 짝이 되는 remove, `queued_command` attachment)로 도달하는데
queue 분기만 그것을 걸러냈다. 같은 분기의 형제 셋도 함께 닫는다. 중립 검사의 순서, typed 경로가
이미 갖고 있던 채널 가드, content-block 배열로 오는 prompt다.

별개로, `no-user-close-signal` 거절이 이제 `gateReason` 도 함께 실어 세 게이트 검사 중 무엇이
거절했는지 밝힌다.

## 이유

사용자가 입력한 close 가 게이트를 열었다. 그 뒤 무관한 background task 가 끝나면 그 알림이
attachment 경로로 와서, 그 경로가 아무 non-close prompt 나 마음이 바뀐 것으로 읽고 게이트를
닫았다. 거절은 파일이 전부 쓰인 뒤에 났고, 사용자는 close 를 두 번 입력해야 했다.

`gateReason` 쪽은 그 실패가 왜 잘 안 잡혔는지에 대한 답이다. 서로 무관한 게이트 결과 셋이 한
문자열로 뭉개져, 밖에서는 같은 거절이 조사할 때마다 새 원인을 가진 것처럼 보였다. 진단이 넷까지
쌓인 뒤에야 그중 둘이 서로 배타적이라는 것이 대조로 드러났다.

## 방법

두 분기가 술어 하나를 공유한다. attachment 분기는 host 자신의 `commandMode` 라벨도 함께 본다.
실측된 delivery 가 전부 `commandMode: 'task-notification'` 을 들고 있어서, 필터 전체를 본문 접두
하나에 걸어 두면 host 가 포맷을 한 번 바꾸는 것으로 조용히 죽는다. 본문 검사는 그 필드가 없던
delivery 를 위해 남긴다.

형제 셋을, 실측된 것과 방어적 pin 을 갈라 적는다.

- **순서.** 중립 필터가 close 패턴 검사보다 먼저 돈다. queue 분기가 그렇다. `isClosePattern` 이
  부분 문자열로 매치해서, 끝난 작업의 이름을 담은 알림 본문이 참으로 측정되어 opener 에 닿을 수
  있다. 기록된 delivery 중 그 경로를 타는 것은 없다(1040 건 전부 `origin` 없이 와서 어느 순서든
  opener 를 건너뛴다). 그래서 이것은 host 가 origin 을 붙이기 시작할 때를 대비한 pin 이지 수리가
  아니다.
- **채널.** 이 분기는 게이트를 열 수 있는데 `eventUserText` 가 늘 갖고 있던 채널 가드를 안 걸고
  있었다. `origin.kind` 는 누가 썼는지를 말하지 어느 채널로 들어온 레코드인지를 말하지 않아서,
  human origin 을 단 sidechain · injected · sdk · meta 레코드가 승인을 만들어 낼 수 있었다.
  실측 1340 건 중 0 건이라 이것도 pin 이다.
- **content block.** 사용자가 이미지를 함께 붙여넣으면 queued prompt 가 블록 배열로 온다. 문자열
  형태만 읽으면 그것이 빈 값으로 강등되어 진짜 change of mind 가 버려지고 close 가 그대로
  진행됐다. 실측 8 건이고 전부 human origin, host 2.1.263 까지 나온다. 이것은 관측된 결함이다.
  `eventUserText` 가 이미 쓰던 배열 추출을 두 번째 사본으로 만들지 않고 공유 헬퍼로 들어냈다.

`gateReason` 은 기존 `reason` 옆에 붙는 새 필드이지 대체가 아니다. 호출부와 CLI 테스트 둘이 그
뭉친 문자열을 고정한다. 명령 문서는 복구 지시를 이 필드로 분기한다. 세 원인 중 둘은 사용자가
실제로 close 를 요청한 경우라, 기존 지시(의사를 다시 확인하라)가 이미 답한 질문을 다시 답하게
만들었다.

두 분기의 `/compact` 어긋남은 알고 남겼다. attachment delivery 1321 건 중 slash prompt 는 0 건이고,
queue 분기를 그대로 옮기면 테스트가 이미 fail-open 결함으로 표시한 opener 를 복제하게 된다. 측정값과
사유를 그 자리에 적었다.

## 수동 검증

`hooks/hypo-shared.mjs` 를 바꾸므로 배포된 사본이 중요하다. 업그레이드하는 사람을 위한 메모:
이 변경을 쓴 기계에서 플러그인 캐시는 아직 `v1.8.1` 태그의 바이트를 돌고 있고
(`hooks/hypo-shared.mjs` sha256 `188dc220a210cb8c…`) `main` 보다 네 머지 뒤처져 있었다. 이것이
플러그인 채널 설치에 닿으려면 버전 문자열이 움직여야 한다.

여기 동작은 살아 있는 세션 안에서만 관측되므로, 실세션 확인이 정작 중요한 게이트이고 스위트가
덮지 못한다. 스위트가 고정하는 것은 아래이고, 방어를 하나씩 무력화해 red 를 확인한 뒤 복구했다.

```
node tests/runner.mjs --grep='model-reachable channel'        # 10 passed
node tests/runner.mjs --grep='content blocks|commandMode'     # 3 passed
npm test                                                      # 2234 passed, rc=0
npm run lint                                                  # 0 errors, rc=0
npm run check:tracker-ids                                     # rc=0
node tests/parallel.mjs --shards=4                            # 2234 passed, rc=0
```

## 마이그레이션 노트

없다. 저장된 상태도, 볼트 파일도, CLI 플래그의 모양도 바뀌지 않는다. `gateReason` 은 이미 있던
거절에 더해진 필드이고 `reason` 은 값을 그대로 유지하므로, `reason` 만 읽는 호출부는 차이를
보지 못한다.

---

## Changelog

- EN: The session-close gate now reads a background-task notification the same way on every delivery path, so a task finishing after you asked to close no longer cancels the close (#289). A refusal also reports `gateReason`, naming which gate check refused.
- KO: 세션 close 게이트가 background task 알림을 어느 전달 경로로 오든 같게 읽는다. close 를 요청한 뒤 작업이 끝나도 그 close 가 취소되지 않는다 (#289). 거절은 `gateReason` 으로 어느 게이트 검사가 거절했는지도 함께 알린다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
