### PR TITLE
feat(lint): flag a synthesis that has fallen behind its own sources

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -129,6 +129,8 @@ Everything else belongs in `commands/`, which loads the same way.
 npm test           # tests/*.test.mjs, sharded across processes — unit + smoke + contract
 npm run lint       # scripts/lint.mjs — frontmatter + wikilink validation + W8 (design-history stale
                    # vs session-log) + W14 (design-history missing but session-log implies one)
+                   # + W15 (synthesis older than the newest page in its sources_consulted)
+                   # + W16 (sources_consulted names W15 could not resolve)
 npm run fix:verify # Phase 1 of learned_behavior #6 — verifies fix #N status claims in
                    # a wiki spec against `// @fix #N: <test-name>` anchors, read as a
                    # union across every tests/*.mjs. Maintainer dogfood; needs a wiki at

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -13,7 +13,9 @@
  *   --fix               Auto-add missing `updated` field (safe repairs only)
  *   --strict            Promote selected warnings (STRICT_PROMOTE_IDS) to errors
  *                       so they exit 1. Opt-in gate for release-checklist /
- *                       pre-commit; default mode stays byte-identical.
+ *                       pre-commit. Adding the flag did not change what default
+ *                       mode emits; a new warning class still adds warnings
+ *                       there, as every W9..W16 addition has.
  */
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
@@ -30,7 +32,7 @@ import {
 import { findDesignHistoryStale } from './lib/design-history-stale.mjs';
 import { FEEDBACK_SCOPE_RE } from './lib/feedback-scope.mjs';
 import { FAILURE_TYPE_ENUM } from './lib/failure-type.mjs';
-import { collectPagesLint, collectPagesLinkable } from './lib/wikilink.mjs';
+import { collectPagesLint, collectPagesLinkable, slugForms } from './lib/wikilink.mjs';
 import { parseFrontmatter, SEQUENCE_ENTRY_RE } from './lib/frontmatter.mjs';
 import { buildSlugMap } from './lib/slug-resolver.mjs';
 
@@ -303,11 +305,33 @@ const VALID_TYPES = [
 
 const issues = [];
 
+// W15 bookkeeping, filled inside lintPage as it already reads+parses every
+// page once. Reused after the main page loop instead of re-reading every file
+// a second time just to compare `updated` dates.
+//   bySlugForm maps every page's slug form (full/bare/dirRel, the same three
+//   forms buildSlugMap derives) to { updated, count }. `count` is how many
+//   pages claim that form, because a shared bare form is NOT the same
+//   ambiguity the wikilink checker lives with: W4 only asks whether a target
+//   exists, while this rule has to pick one page's date. Picking first-wins
+//   would make the verdict depend on directory walk order. A form claimed
+//   twice is treated as unresolvable instead.
+//   `updated` is null for a page that has none (W3's concern), which is
+//   recorded rather than skipped so the source is known to exist.
+//   synthesisPages holds the type:synthesis pages that declare
+//   sources_consulted, collected for the post-loop comparison below.
+// Dates are compared as strings, which is only the same as comparing time
+// when every value is zero-padded YYYY-MM-DD. `2026-3-1 > 2026-12-15` is true
+// lexically and false in fact, so anything off this shape is excluded from the
+// comparison and reported instead of silently deciding the verdict.
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const bySlugForm = new Map();
+const synthesisPages = [];
+
 // Stable warning class IDs (W1..Wn). `--strict` promotes a frozen subset to
 // errors by ID — never by brittle message-text matching. W8 (design-history
-// stale) predates this scheme; hooks/hypo-personal-check.mjs filters `w.id ===
-// 'W8'`, so it must keep that number — the W5..W7 gap is honest history, not a
-// bug. (spec-v1.3.0 Track E)
+// stale) predates this scheme; the close gate in hooks/hypo-shared.mjs filters
+// `w.id === 'W8'`, so it must keep that number. The W5..W7 gap is honest
+// history, not a bug. (spec-v1.3.0 Track E)
 //
 // STRICT_PROMOTE_IDS (OQ-E1, frozen as a code constant): confirmed content
 // defects only.
@@ -327,6 +351,13 @@ const issues = [];
 //                             PreCompact hook no longer blocks /compact, so
 //                             that set is what --check-session-close and
 //                             --mark-session-closed read, not a compact stop.
+//   W15 synthesis-stale     → excluded, same reason as W8/W14 (a freshness
+//                             signal to triage, not a content defect), and
+//                             its own id for the same reason W14 has one: the
+//                             W8-only close-gate filter must not pick it up.
+//   W16 sources-unresolved  → excluded, same reasons as W15. It reports what
+//                             W15 could not read, so promoting one without the
+//                             other would block on the weaker signal.
 // NOTE: npm run lint / CI / release.yml / crystallize / the close-gate all
 // run plain lint, not --strict, so promotion is forward-looking there: these
 // still surface as warnings on those paths. But --strict is not unused —
@@ -416,6 +447,27 @@ function lintPage({ path, rel }, slugMap, tagVocab, pageDirs, validTypes) {
 
   if (!fm.updated) {
     issue('warn', rel, 'Missing frontmatter field: updated', path, 'W3');
+  }
+
+  // W15 bookkeeping: record this page's slug forms → updated date, and, if it
+  // is itself a synthesis page citing sources, queue it for the post-loop
+  // check. Recorded here (not re-derived after the loop) because content and
+  // fm are already in hand from the reads above.
+  {
+    const noExt = rel.replace(/\.md$/, '').replace(/\\/g, '/');
+    // Deduplicate within one page first. slugForms collapses bare and dirRel
+    // to the same string for a page directly under pages/, so counting raw
+    // values would make every such page look like a two-page collision.
+    for (const form of new Set(Object.values(slugForms(noExt)))) {
+      if (!form) continue;
+      const prior = bySlugForm.get(form);
+      if (prior) prior.count += 1;
+      else bySlugForm.set(form, { updated: fm.updated || null, count: 1 });
+    }
+  }
+  if (fm.type === 'synthesis' && fm.sources_consulted) {
+    const sources = parseTagsField(fm.sources_consulted) || [];
+    if (sources.length > 0) synthesisPages.push({ rel, updated: fm.updated, sources });
   }
 
   // type-conditional required fields
@@ -686,6 +738,81 @@ for (const s of findDesignHistoryStale(args.hypoDir)) {
   );
 }
 
+// W15: synthesis page stale relative to its own sources_consulted. A
+// type:synthesis page absorbs and condenses what other pages already
+// learned; if a listed source has moved on (its `updated` is newer than the
+// synthesis's own `updated`), the synthesis has not caught up. Runs off the
+// bookkeeping lintPage already filled above, so no page is read twice.
+//
+// A source name absent from bySlugForm (a typo, a directory rather than a
+// page, or a path outside the vault) has no date to compare, so W15 cannot
+// judge it either way. W4 does not cover it: that rule reads `[[...]]` out of
+// page bodies and never looks at frontmatter, so an unresolved name here would
+// be reported nowhere. W16 below reports it instead, which is what keeps a
+// page that resolves 4 of its 11 sources from producing a confident-looking
+// W15 built on a third of the evidence.
+// The skip in the loop states that intent; it does not change the outcome. An
+// undefined date loses every comparison it enters, so dropping the guard
+// leaves the same warnings (measured: removing it keeps all four W15 tests
+// green). It stays because the alternative parks undefined in `newest`.
+//
+// Deliberately excluded from STRICT_PROMOTE_IDS, same reasoning as W8/W14: a
+// synthesis lagging its sources is a content-freshness signal for a human to
+// triage, not a defect `--strict` should hard-block a commit on. Given its
+// own id (not W8) so hypo-shared.mjs's `w.id === 'W8'` close-gate filter
+// never mistakes it for a design-history finding.
+for (const { rel, updated, sources } of synthesisPages) {
+  let newest = null;
+  const unresolved = [];
+  for (const source of sources) {
+    const hit = bySlugForm.get(source);
+    // Three ways a source yields no date, kept apart because they tell the
+    // author to do different things. Every one of them lands in W16 below;
+    // removing this branch is what would make W16 stop reporting.
+    if (!hit) {
+      unresolved.push(`${source} (없는 이름)`);
+      continue;
+    }
+    if (hit.count > 1) {
+      unresolved.push(`${source} (${hit.count}개 페이지가 같은 이름)`);
+      continue;
+    }
+    if (!ISO_DATE_RE.test(hit.updated || '')) {
+      unresolved.push(`${source} (updated 없음 또는 YYYY-MM-DD 아님)`);
+      continue;
+    }
+    if (!newest || hit.updated > newest) newest = hit.updated;
+  }
+  const ownDateUsable = ISO_DATE_RE.test(updated || '');
+  if (newest && ownDateUsable && newest > updated) {
+    issue(
+      'warn',
+      rel,
+      `synthesis stale: sources_consulted 최신=${newest} > synthesis updated=${updated}. 새로 쌓인 학습을 반영해 갱신하거나, 반영할 내용이 없으면 updated를 확인하세요`,
+      null,
+      'W15',
+    );
+  }
+  // W16: sources W15 could not compare, reported once per page with the reason
+  // for each. Without this the rule fails open, and silently: a page whose
+  // sources mostly do not resolve still gets a W15 (or no warning at all) with
+  // nothing saying how much of the evidence was actually read. The reasons are
+  // kept apart because the fix differs: a name that resolves to nothing is a
+  // typo or a value this field is not meant to hold, a name claimed by two
+  // pages needs the longer form, and a source with no usable `updated` is W3's
+  // problem on that page. Excluded from STRICT_PROMOTE_IDS and given its own id
+  // for the same reasons as W15.
+  if (unresolved.length > 0) {
+    issue(
+      'warn',
+      rel,
+      `sources_consulted 비교 불가 ${unresolved.length}/${sources.length}: ${unresolved.join(', ')}. 이 소스들은 staleness 비교에서 빠졌습니다`,
+      null,
+      'W16',
+    );
+  }
+}
+
 // W12: project directory missing index.md. SCHEMA.md declares project-index
 // at projects/*/index.md and templates/projects/_template/ ships one, so a
 // project without it is a tooling/vault drift, not a legitimate shape — but
@@ -785,10 +912,12 @@ const errors = issues.filter((i) => i.severity === 'error');
 const warns = issues.filter((i) => i.severity === 'warn');
 
 if (args.json) {
-  // Default mode is byte-identical: only W8 carries an `id` in the JSON payload
-  // (hooks/hypo-personal-check.mjs filters on it). All other IDs stay internal
-  // unless `--strict` is set, where the full ID set is exposed so promoted
-  // findings are traceable to their warning class.
+  // The `id` field, not the warning list, is what default mode holds stable:
+  // only W8 carries one (the close gate in hooks/hypo-shared.mjs filters on
+  // it). Every other id stays internal unless `--strict` is set, where the full
+  // set is exposed so promoted findings are traceable to their warning class.
+  // A new rule does add warnings to default output; that is what a new rule is
+  // for, and W9 through W16 all did it.
   const toOut = ({ severity, file, message, id }) =>
     id && (id === 'W8' || args.strict)
       ? { severity, file, message, id }

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -924,7 +924,7 @@ function applyCommands(commandResults, force) {
     ...existing,
     pkgRoot: PKG_ROOT,
     pkgVersion,
-    schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.1',
+    schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.2',
     commands: newSHAs,
   });
   return applied;
@@ -950,7 +950,7 @@ function writePluginModeMetadata() {
     ...existing,
     pkgRoot: PKG_ROOT,
     pkgVersion,
-    schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.1',
+    schemaVersion: templateSchemaVersion(PKG_ROOT) ?? '2.2',
   });
   return true;
 }

--- a/templates/SCHEMA.md
+++ b/templates/SCHEMA.md
@@ -2,7 +2,7 @@
 title: Wiki Schema
 type: schema
 updated: YYYY-MM-DD
-version: 2.1
+version: 2.2
 ---
 
 # Wiki Schema
@@ -105,7 +105,19 @@ visibility_scope: shared | machine:<device>
 source: <slug or URL>
 verify_by: <question to re-check at next review>
 verify_by_date: YYYY-MM-DD
+sources_consulted: [slug1, slug2]
 ```
+
+`sources_consulted` belongs on a `synthesis` page and names the pages it condenses.
+`lint` reads it: when the newest `updated` among those sources is later than the
+synthesis's own `updated`, the page is reported as stale (W15), so a synthesis that
+has not absorbed what its sources learned since surfaces without anyone diffing dates
+by hand. A bare slug is enough when it is unique. Resolution covers `pages/`,
+`projects/` and `journal/`, which is narrower than what a wikilink target
+accepts, so a name outside those (a directory, a `sources/` file, a path into
+a code repo) does not resolve. An unresolved name is left out of the staleness
+comparison and reported separately (W16), because a name this field cannot
+resolve is either a typo or a value the field is not meant to hold.
 
 `visibility_scope` is a different axis from `scope`: `scope` is memory lifetime,
 `visibility_scope` is where a page may surface. Omitting it means `shared` (the

--- a/tests/lint.test.mjs
+++ b/tests/lint.test.mjs
@@ -2179,6 +2179,315 @@ test('w14-clean: project WITH design-history.md never emits W14, only W8/none', 
   });
 });
 
+// ── W15: synthesis page stale relative to its sources_consulted ─────────────
+// A type:synthesis page absorbs other pages; if a source's `updated` moved
+// past the synthesis's own `updated`, the synthesis has not caught up.
+// `sources_consulted: [name, ...]` uses the same bracket-list shape lint
+// already parses for `tags` (parseTagsField), reused rather than re-invented.
+
+suite('W15/W16: synthesis staleness (sources_consulted)');
+
+test('source newer than synthesis → W15 warn with distinct message and no W8/W14 id', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(
+      join(root, 'pages', 'source-a.md'),
+      '---\ntitle: source-a\ntype: concept\nupdated: 2026-02-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-01-01\nsources_consulted: [source-a]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, `stale synthesis must not fail lint: ${r.stdout}`);
+    assert.equal(parsed.ok, true);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(stale.length, 1, `expected one W15 warn: ${JSON.stringify(parsed.warns)}`);
+    assert.equal(stale[0].file, 'pages/syn.md');
+    assert.ok(!('id' in stale[0]), 'default (non-strict) --json hides ids for anything but W8');
+  });
+});
+
+test('synthesis at least as fresh as every source → no W15 warn', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(
+      join(root, 'pages', 'source-a.md'),
+      '---\ntitle: source-a\ntype: concept\nupdated: 2026-01-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-02-01\nsources_consulted: [source-a]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(
+      stale.length,
+      0,
+      `fresh synthesis must not trip W15: ${JSON.stringify(parsed.warns)}`,
+    );
+  });
+});
+
+test('unresolved sources_consulted entry yields no W15 but a W16 naming it', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-01-01\nsources_consulted: [does-not-exist]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(
+      stale.length,
+      0,
+      `no date to compare means no staleness verdict: ${JSON.stringify(parsed.warns)}`,
+    );
+    const unres = (parsed.warns || []).filter((w) =>
+      w.message.includes('sources_consulted 비교 불가'),
+    );
+    assert.equal(unres.length, 1, `expected one W16 warn: ${JSON.stringify(parsed.warns)}`);
+    assert.equal(unres[0].file, 'pages/syn.md');
+    assert.ok(
+      unres[0].message.includes('does-not-exist'),
+      `W16 must name the unresolved entry: ${unres[0].message}`,
+    );
+    assert.ok(
+      unres[0].message.includes('1/1'),
+      `W16 must report coverage, not just the fact: ${unres[0].message}`,
+    );
+    assert.ok(
+      unres[0].message.includes('없는 이름'),
+      `W16 must say WHY the source could not be compared: ${unres[0].message}`,
+    );
+  });
+});
+
+test('W15 compares against the NEWEST source, not the first or the oldest', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    // Ordered oldest-first on purpose: a rule that keeps the first date, or
+    // that keeps the minimum, produces no warning here. Only picking the
+    // maximum crosses the synthesis's own 2026-02-01.
+    writeFileSync(
+      join(root, 'pages', 'source-old.md'),
+      '---\ntitle: source-old\ntype: concept\nupdated: 2026-01-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'source-new.md'),
+      '---\ntitle: source-new\ntype: concept\nupdated: 2026-03-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-02-01\n' +
+        'sources_consulted: [source-old, source-new]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(stale.length, 1, `newest source must win: ${JSON.stringify(parsed.warns)}`);
+    assert.ok(
+      stale[0].message.includes('최신=2026-03-01'),
+      `W15 must report the maximum source date: ${stale[0].message}`,
+    );
+    const unres = (parsed.warns || []).filter((w) =>
+      w.message.includes('sources_consulted 비교 불가'),
+    );
+    assert.equal(unres.length, 0, 'both sources resolve, so no W16');
+  });
+});
+
+test('a source in a subdirectory resolves by bare name and by dir-relative name', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages', 'learnings'), { recursive: true });
+    // Every fixture above puts source and synthesis side by side in pages/,
+    // where slugForms' full/bare/dirRel collapse to one string and the map
+    // cannot be told apart from a bare-only map. Here they differ:
+    // full=pages/learnings/deep, bare=deep, dirRel=learnings/deep.
+    writeFileSync(
+      join(root, 'pages', 'learnings', 'deep.md'),
+      '---\ntitle: deep\ntype: learning\nupdated: 2026-03-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn-bare.md'),
+      '---\ntitle: syn-bare\ntype: synthesis\nupdated: 2026-01-01\nsources_consulted: [deep]\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn-rel.md'),
+      '---\ntitle: syn-rel\ntype: synthesis\nupdated: 2026-01-01\n' +
+        'sources_consulted: [learnings/deep]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    const staleFiles = (parsed.warns || [])
+      .filter((w) => w.message.includes('synthesis stale'))
+      .map((w) => w.file)
+      .sort();
+    assert.deepEqual(
+      staleFiles,
+      ['pages/syn-bare.md', 'pages/syn-rel.md'],
+      `both slug forms must resolve: ${JSON.stringify(parsed.warns)}`,
+    );
+    const unres = (parsed.warns || []).filter((w) =>
+      w.message.includes('sources_consulted 비교 불가'),
+    );
+    assert.equal(unres.length, 0, `neither form is unresolved: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
+test('a source name claimed by two pages is not compared, and W16 says so', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages', 'a'), { recursive: true });
+    mkdirSync(join(root, 'pages', 'b'), { recursive: true });
+    // Same bare name under two directories. Picking either date would make the
+    // verdict depend on walk order: one of them is newer than the synthesis
+    // and the other is not.
+    writeFileSync(
+      join(root, 'pages', 'a', 'dup.md'),
+      '---\ntitle: dup a\ntype: concept\nupdated: 2026-01-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'b', 'dup.md'),
+      '---\ntitle: dup b\ntype: concept\nupdated: 2026-03-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-02-01\nsources_consulted: [dup]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(stale.length, 0, `an ambiguous name must not decide staleness: ${r.stdout}`);
+    const unres = (parsed.warns || []).filter((w) =>
+      w.message.includes('sources_consulted 비교 불가'),
+    );
+    assert.equal(unres.length, 1, `expected one W16 warn: ${r.stdout}`);
+    assert.ok(
+      unres[0].message.includes('2개 페이지가 같은 이름'),
+      `W16 must name ambiguity as the reason: ${unres[0].message}`,
+    );
+  });
+});
+
+test('a page directly under pages/ is not mistaken for its own collision', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    // slugForms collapses bare and dirRel to the same string here. Counting raw
+    // values instead of distinct ones would report every such page as a
+    // two-page collision and suppress every W15 in the vault.
+    writeFileSync(
+      join(root, 'pages', 'flat.md'),
+      '---\ntitle: flat\ntype: concept\nupdated: 2026-03-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-01-01\nsources_consulted: [flat]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(stale.length, 1, `a flat page must still resolve: ${r.stdout}`);
+    const unres = (parsed.warns || []).filter((w) =>
+      w.message.includes('sources_consulted 비교 불가'),
+    );
+    assert.equal(unres.length, 0, `no ambiguity here: ${r.stdout}`);
+  });
+});
+
+test('a source that exists but has no usable date is reported, not called missing', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    // Present, so calling it a missing name would be wrong. Its date cannot be
+    // compared, so using it would be wrong too.
+    writeFileSync(
+      join(root, 'pages', 'nodate.md'),
+      '---\ntitle: nodate\ntype: concept\n---\n\nbody\n',
+    );
+    // Lexically greater than 2026-02-01, chronologically earlier. A raw string
+    // compare would call the synthesis stale on the strength of this.
+    writeFileSync(
+      join(root, 'pages', 'sloppy.md'),
+      '---\ntitle: sloppy\ntype: concept\nupdated: 2026-3-1\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-02-01\n' +
+        'sources_consulted: [nodate, sloppy]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(stale.length, 0, `an unusable date must not decide staleness: ${r.stdout}`);
+    const unres = (parsed.warns || []).filter((w) =>
+      w.message.includes('sources_consulted 비교 불가'),
+    );
+    assert.equal(unres.length, 1, `expected one W16 warn: ${r.stdout}`);
+    assert.ok(
+      unres[0].message.includes('2/2'),
+      `both sources are uncomparable: ${unres[0].message}`,
+    );
+    assert.ok(
+      !unres[0].message.includes('없는 이름'),
+      `neither source is missing; both exist: ${unres[0].message}`,
+    );
+  });
+});
+
+test('strict: W16 exposes its id but is not promoted to an error', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-01-01\nsources_consulted: [does-not-exist]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json', '--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, 'W16 is excluded from STRICT_PROMOTE_IDS → exit 0');
+    assert.equal(parsed.ok, true);
+    const w16 = (parsed.warns || []).filter((w) => w.id === 'W16');
+    assert.equal(w16.length, 1, `W16 stays a warn under --strict: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
+test('synthesis page without sources_consulted never trips W15', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-01-01\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0);
+    const stale = (parsed.warns || []).filter((w) => w.message.includes('synthesis stale'));
+    assert.equal(stale.length, 0);
+  });
+});
+
+test('strict: W15 exposes its id but is not promoted to an error', () => {
+  withTmpDir((root) => {
+    mkdirSync(join(root, 'pages'), { recursive: true });
+    writeFileSync(
+      join(root, 'pages', 'source-a.md'),
+      '---\ntitle: source-a\ntype: concept\nupdated: 2026-02-01\n---\n\nbody\n',
+    );
+    writeFileSync(
+      join(root, 'pages', 'syn.md'),
+      '---\ntitle: syn\ntype: synthesis\nupdated: 2026-01-01\nsources_consulted: [source-a]\n---\n\nbody\n',
+    );
+    const r = run('lint.mjs', [`--hypo-dir=${root}`, '--json', '--strict']);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(r.status, 0, 'W15 is excluded from STRICT_PROMOTE_IDS → exit 0');
+    assert.equal(parsed.ok, true);
+    const w15 = (parsed.warns || []).filter((w) => w.id === 'W15');
+    assert.equal(w15.length, 1, `W15 stays a warn under --strict: ${JSON.stringify(parsed.warns)}`);
+  });
+});
+
 // ── A-2 (project index lifecycle): W12 missing-index warning ────────────────
 // scripts/lint.mjs: a projects/<slug>/ directory with no index.md warns — never
 // errors, since a hard block would stop /compact for every pre-existing

--- a/tests/upgrade.test.mjs
+++ b/tests/upgrade.test.mjs
@@ -287,24 +287,32 @@ test('--apply generates migration report for major SCHEMA bump', () => {
       );
       const content = readFileSync(out.migrationReport, 'utf-8');
       assert.ok(content.includes('0.9'), 'migration report should reference old version');
+      // Read the version off the shipped template rather than pinning a literal.
+      // The point of this assertion is "the report names the version we are
+      // upgrading TO", and a literal turns every SCHEMA bump into a failing test
+      // that says nothing about the report.
+      const shipped = readFileSync(join(REPO, 'templates', 'SCHEMA.md'), 'utf-8');
+      const shippedVersion = shipped.match(/^version: (.+)$/m)?.[1]?.trim();
+      assert.ok(shippedVersion, 'templates/SCHEMA.md must carry a version stamp');
       assert.ok(
-        content.includes('2.1'),
-        'migration report should reference the new (current) version 2.1',
+        content.includes(shippedVersion),
+        `migration report should reference the new (current) version ${shippedVersion}`,
       );
     });
   });
 });
 
-// FEAT-1 boundary: SCHEMA 2.0 → 2.1 is an additive minor bump (optional
-// failure_type). A minor bump needs no migration report — nothing to backfill.
-test('--apply: SCHEMA 2.0 → 2.1 is a minor bump with no migration report', () => {
+// An additive bump inside the same major is minor, and a minor bump needs no
+// migration report because there is nothing to backfill. The fixture rolls the
+// wiki back to 2.0 and lets the shipped template be whatever it currently is.
+test('--apply: SCHEMA 2.0 to the shipped version is a minor bump with no migration report', () => {
   withTmpHome((home) => {
     withTmpDir((dir) => {
       const hypoDir = join(dir, 'wiki');
       const initR = runWithHome('init.mjs', [`--hypo-dir=${hypoDir}`, '--no-git-init'], home);
       assert.equal(initR.status, 0, `init failed: ${initR.stderr}`);
 
-      // init stamps the current template (2.1); roll the wiki SCHEMA back one minor.
+      // init stamps the current template; roll the wiki SCHEMA back to 2.0.
       const schemaPath = join(hypoDir, 'SCHEMA.md');
       writeFileSync(
         schemaPath,


### PR DESCRIPTION
# English

## What changed

`lint` gains two warning classes for `type: synthesis` pages.

**W15** compares the page's `updated` against the newest `updated` among the pages listed in its `sources_consulted`. If a source has moved on, the synthesis has not caught up.

**W16** reports the sources W15 could not compare, one line per page, with the reason for each:

- a name that resolves to nothing
- a name two pages claim (a bare slug is only enough when it is unique)
- a source whose `updated` is missing or is not `YYYY-MM-DD`

`templates/SCHEMA.md` now documents `sources_consulted`, which it had never named, and its version stamp moves from 2.1 to 2.2.

## Why

Finding a stale synthesis meant diffing dates by hand. Two were found that way and there was no reason to believe they were the only ones. On the maintainer's vault the new rules report 13 stale syntheses and 3 pages whose sources cannot be fully compared.

W16 exists because the rule fails open without it, and silently. One page in that vault resolves 4 of its 11 sources; before W16 it produced a confident-looking W15 built on a third of the evidence, with nothing saying so. An earlier draft claimed the broken-wikilink check would cover these names. It does not: that rule reads `[[...]]` out of page bodies and never looks at frontmatter.

## How

Both rules run off bookkeeping `lintPage` already fills while reading each page once, so no file is read twice.

The slug map records `{ updated, count }` for every page rather than a bare date. `count` matters because a shared bare form is not the same ambiguity the wikilink checker lives with: that check only asks whether a target exists, while this one has to pick a page's date, and picking first-wins would make the verdict depend on directory walk order. Slug forms are deduplicated per page first, since a page directly under `pages/` produces the same string for its bare and directory-relative forms.

Dates compare as strings, which equals comparing time only for the zero-padded shape. `2026-3-1` sorts after `2026-12-15` lexically and before it in fact, so anything off that shape is excluded and reported instead of deciding the verdict.

Neither id is in `STRICT_PROMOTE_IDS`, and neither carries an `id` in default `--json` output. The close gate filters on `w.id === 'W8'`, so it cannot pick either of them up.

## Manual verification

No hook changed, so no live-session run was required. Each new guard was turned off to confirm the tests fail without it, run alone so no concurrent shard could read the disabled state:

```
# pick the oldest source instead of the newest
node tests/runner.mjs --file=lint   → rc=1, "W15 compares against the NEWEST source"

# record only the bare slug form
node tests/runner.mjs --file=lint   → rc=1, "resolves by bare name and by dir-relative name"

# stop emitting W16
node tests/runner.mjs --file=lint   → rc=1, 2 failed

# accept a name claimed by two pages
node tests/runner.mjs --file=lint   → rc=1, "claimed by two pages is not compared"

# drop the date-shape guard
node tests/runner.mjs --file=lint   → rc=1, "exists but has no usable date"

# count raw slug forms again (self-collision)
node tests/runner.mjs --file=lint   → rc=1, 4 failed
```

Each was restored and re-run: `158 passed, 0 failed`, and `grep -c "if (false"` returns 0.

Gates, none piped so the exit code is the command's own:

```
npm test                          rc=0   2245 passed, 0 failed
node tests/parallel.mjs --shards=4 rc=0  2245 passed, 0 failed
npm run lint                      rc=0   0 error(s), 558 warning(s)
npm run format:check              rc=0
npm run check:tracker-ids         rc=0
npm run check:pack-surface        rc=0   136 files, 0 closure violations
```

## Migration notes

The SCHEMA version stamp moves to 2.2, so `upgrade` reports a minor drift on existing vaults. `SCHEMA.md` is user-owned and never overwritten; merge the new optional field when convenient. Nothing breaks if you do not: a vault whose pages carry no `sources_consulted` never trips either rule.

A vault that already uses the field will see new warnings on the first run. They are warnings, not errors, and neither is promoted by `--strict`.

---

# 한국어

## 변경 내용

`lint`에 `type: synthesis` 페이지를 위한 경고 두 종류가 생깁니다.

**W15**는 그 페이지의 `updated`를 `sources_consulted`에 나열된 페이지들 중 가장 최신 `updated`와 비교합니다. 소스가 앞서 나갔으면 합성 페이지가 따라잡지 못한 것입니다.

**W16**은 W15가 비교하지 못한 소스를 페이지당 한 줄로 알리고 사유를 함께 냅니다.

- 아무것도 가리키지 않는 이름
- 두 페이지가 같이 쓰는 이름 (짧은 이름은 그것이 유일할 때만 충분합니다)
- `updated`가 없거나 `YYYY-MM-DD`가 아닌 소스

`templates/SCHEMA.md`가 `sources_consulted`를 이제 문서로 적습니다. 지금까지 이 필드를 한 번도 언급하지 않았습니다. 버전 스탬프도 2.1에서 2.2로 올립니다.

## 이유

낡은 합성 페이지를 찾으려면 날짜를 손으로 대조해야 했습니다. 그렇게 두 건을 찾았는데 그게 전부라고 믿을 근거가 없었습니다. 관리자 볼트에서 새 규칙이 낡은 합성 13건과 소스를 다 비교하지 못하는 페이지 3건을 알립니다.

W16이 있는 이유는 그것이 없으면 규칙이 조용히 통과하기 때문입니다. 그 볼트의 한 페이지는 소스 11개 중 4개만 해석됩니다. W16 이전에는 근거의 3분의 1 위에서 확신에 찬 W15를 냈고 그 사실을 알리는 것이 없었습니다. 초안은 깨진 위키링크 검사가 이 이름들을 받아 준다고 적었는데 사실이 아니었습니다. 그 규칙은 본문의 `[[...]]`만 읽고 프런트매터는 보지 않습니다.

## 방법

두 규칙 모두 `lintPage`가 페이지를 한 번 읽으며 이미 채우는 정보로 돕니다. 어떤 파일도 두 번 읽지 않습니다.

슬러그 맵은 날짜만 담지 않고 페이지마다 `{ updated, count }`를 기록합니다. `count`가 필요한 이유는, 짧은 이름이 겹치는 것이 위키링크 검사가 감당하는 모호함과 다르기 때문입니다. 그쪽은 대상이 존재하는지만 묻지만 이 규칙은 한 페이지의 날짜를 골라야 합니다. 먼저 찾은 쪽을 쓰면 판정이 디렉터리 순회 순서에 좌우됩니다. 슬러그 형태는 페이지 단위로 먼저 중복을 없앱니다. `pages/` 바로 아래 페이지는 짧은 형태와 디렉터리 상대 형태가 같은 문자열이 되기 때문입니다.

날짜는 문자열로 비교하는데, 이것이 시간 비교와 같아지는 것은 자릿수를 채운 형태일 때뿐입니다. `2026-3-1`은 문자열로는 `2026-12-15`보다 뒤에 오고 실제로는 앞섭니다. 그래서 그 형태를 벗어난 값은 판정에 쓰지 않고 알리기만 합니다.

두 id 모두 `STRICT_PROMOTE_IDS`에 없고 기본 `--json` 출력에 `id`를 싣지 않습니다. 마무리 게이트는 `w.id === 'W8'`로 거르므로 둘 중 어느 것도 집어 가지 못합니다.

## 수동 검증

훅을 바꾸지 않아 실세션 실행은 필요 없었습니다. 새 방어마다 그것을 꺼서 시험이 실제로 실패하는지 확인했고, 무력화한 상태를 다른 샤드가 읽지 않도록 단독으로 돌렸습니다.

```
# 최신 대신 가장 오래된 소스를 고르게 함
node tests/runner.mjs --file=lint   → rc=1, "W15 compares against the NEWEST source"

# 짧은 슬러그 형태만 기록
node tests/runner.mjs --file=lint   → rc=1, "resolves by bare name and by dir-relative name"

# W16 발화 중단
node tests/runner.mjs --file=lint   → rc=1, 2 failed

# 두 페이지가 같이 쓰는 이름을 그대로 수용
node tests/runner.mjs --file=lint   → rc=1, "claimed by two pages is not compared"

# 날짜 형태 검사 제거
node tests/runner.mjs --file=lint   → rc=1, "exists but has no usable date"

# 슬러그 형태를 다시 중복 포함해 셈
node tests/runner.mjs --file=lint   → rc=1, 4 failed
```

매번 되돌린 뒤 다시 돌려 `158 passed, 0 failed`를 확인했고 `grep -c "if (false"`가 0입니다.

게이트는 파이프에 물리지 않아 종료 코드가 그 명령 자신의 것입니다.

```
npm test                          rc=0   2245 passed, 0 failed
node tests/parallel.mjs --shards=4 rc=0  2245 passed, 0 failed
npm run lint                      rc=0   0 error(s), 558 warning(s)
npm run format:check              rc=0
npm run check:tracker-ids         rc=0
npm run check:pack-surface        rc=0   136 files, 0 closure violations
```

## 마이그레이션 노트

SCHEMA 버전 스탬프가 2.2로 올라가서 기존 볼트는 `upgrade`에서 minor drift 안내를 받습니다. `SCHEMA.md`는 사용자 소유라 덮어쓰지 않으니 편할 때 새 선택 필드를 병합하시면 됩니다. 안 해도 깨지는 것은 없습니다. 페이지에 `sources_consulted`가 없는 볼트는 두 규칙 어느 것도 발동하지 않습니다.

이미 이 필드를 쓰는 볼트는 첫 실행에서 새 경고를 봅니다. 오류가 아니라 경고이고, `--strict`도 둘을 승격하지 않습니다.

---

## Changelog

- EN: `lint` now flags a `synthesis` page whose `updated` is older than the newest page in its `sources_consulted` (W15), and separately reports the sources it could not compare and why (W16), so a page resolving 4 of its 11 sources no longer produces a confident warning built on a third of the evidence.
- KO: `lint`가 `sources_consulted`의 최신 페이지보다 `updated`가 오래된 `synthesis` 페이지를 알리고(W15), 비교하지 못한 소스와 그 사유를 따로 알립니다(W16). 소스 11개 중 4개만 해석되는 페이지가 근거의 3분의 1 위에서 확신에 찬 경고를 내는 일이 없어집니다.

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
