### PR TITLE
ci: say when a feat has taken the patch option away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # The release-vehicle notice reads tags and the log since the last
+          # one. A shallow clone has neither, and the script reports "cannot
+          # tell" rather than a wrong answer, which would make the step useless.
+          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: 20
       - name: All version-carrying files agree (drift caught pre-release)
         run: npm run check:versions
+      - name: What the next release is allowed to be (notice, never blocks)
+        run: node scripts/check-release-vehicle.mjs --github
       - name: Plugin surfaces load-valid (manifest, hooks, commands/skills)
         run: npm run smoke:plugin
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "fix:verify": "node scripts/fix-status-verify.mjs",
     "graph": "node scripts/graph.mjs",
     "smoke-pack": "node scripts/smoke-pack.mjs",
+    "check:release-vehicle": "node scripts/check-release-vehicle.mjs",
     "check:versions": "node scripts/check-versions.mjs",
     "smoke:plugin": "node scripts/smoke-plugin.mjs",
     "check:bilingual": "node scripts/check-bilingual.mjs --changelog",

--- a/scripts/check-release-vehicle.mjs
+++ b/scripts/check-release-vehicle.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// check-release-vehicle.mjs — report what the next release is allowed to be.
+//
+// Semver decides the version from the change kind, but nothing in this repo was
+// watching for the moment that decision gets taken away. A `feat` merged onto
+// main means the next release cannot be a patch. Twice that happened and the
+// patch shipped anyway (v1.7.1 carried 5 feat commits, v1.7.4 carried 1), and
+// once the patch line just stalled, which is what lanes.md predicted.
+//
+// This is a NOTICE, not a gate. It exits 0 either way. The point is that the
+// moment is visible while a PR is still open, so the maintainer can cut the
+// pending patch first if that is what they want. Making it a hard failure would
+// block every feat PR until a release happened, which is a worse trade than
+// letting a human read one line.
+//
+// Usage:
+//   node scripts/check-release-vehicle.mjs           # human-readable notice
+//   node scripts/check-release-vehicle.mjs --json    # machine-readable
+//   node scripts/check-release-vehicle.mjs --github  # also emit ::warning::
+//
+// Exit 0 always, including when it cannot tell (no tags, shallow clone). A
+// checker that cannot see the history says so rather than reporting "patch is
+// fine", because that answer is indistinguishable from the real one and would
+// be wrong exactly when it matters.
+
+import { spawnSync } from 'child_process';
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const forGithub = args.includes('--github');
+
+function git(...a) {
+  const r = spawnSync('git', a, { encoding: 'utf-8' });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+// A shallow clone has no tags and a truncated log, so both lookups below fail
+// the same way. Report that as 'unknown' rather than guessing.
+const lastTag = git('describe', '--tags', '--abbrev=0', '--match', 'v*');
+const shallow = git('rev-parse', '--is-shallow-repository') === 'true';
+
+let result;
+if (shallow || !lastTag) {
+  result = {
+    determined: false,
+    reason: shallow ? 'shallow-clone' : 'no-release-tag',
+    lastTag,
+    minimumBump: null,
+    feats: [],
+    commitCount: 0,
+  };
+} else {
+  const log = git('log', '--format=%s', `${lastTag}..HEAD`) || '';
+  const subjects = log.split('\n').filter((s) => s.trim());
+  // Conventional Commits: `feat:` and `feat(scope):` both mean a new user
+  // surface. `feat!:` / `BREAKING CHANGE` would mean major, but this repo has
+  // never cut one, so it is not special-cased; a human reads the notice anyway.
+  const feats = subjects.filter((s) => /^feat(\([^)]*\))?!?:/.test(s));
+  result = {
+    determined: true,
+    reason: null,
+    lastTag,
+    minimumBump: feats.length > 0 ? 'minor' : 'patch',
+    feats,
+    commitCount: subjects.length,
+  };
+}
+
+if (asJson) {
+  console.log(JSON.stringify(result, null, 2));
+} else if (!result.determined) {
+  console.log(
+    `[check-release-vehicle] cannot tell (${result.reason}). ` +
+      `Run in a full clone with tags to get an answer.`,
+  );
+} else if (result.minimumBump === 'minor') {
+  const lines = [
+    `[check-release-vehicle] the next release must be at least a MINOR.`,
+    `  ${result.feats.length} feat commit(s) since ${result.lastTag}, out of ${result.commitCount}:`,
+    ...result.feats.map((s) => `    ${s}`),
+    `  A patch release cannot carry these. If a patch line is pending, cut it`,
+    `  before merging more feat work, or accept that the pending fixes ship`,
+    `  in the minor.`,
+  ];
+  console.log(lines.join('\n'));
+} else {
+  console.log(
+    `[check-release-vehicle] OK: ${result.commitCount} commit(s) since ${result.lastTag}, ` +
+      `no feat. A patch release is still available.`,
+  );
+}
+
+if (forGithub && result.determined && result.minimumBump === 'minor') {
+  const names = result.feats.join('; ').replace(/[\r\n]+/g, ' ');
+  console.log(
+    `::warning title=Next release must be minor::` +
+      `${result.feats.length} feat commit(s) since ${result.lastTag}: ${names}`,
+  );
+}

--- a/tests/release-checks.test.mjs
+++ b/tests/release-checks.test.mjs
@@ -4,6 +4,7 @@
 // build on each other; suites may not — that is what lets the runner shard.
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -16,7 +17,7 @@ import {
   parseSemver,
 } from '../scripts/lib/check-bilingual.mjs';
 import { test, suite } from './harness.mjs';
-import { run, withTmpDir } from './helpers.mjs';
+import { SCRIPTS, SESSION_TMP_HOME, gitRepo, run, withTmpDir } from './helpers.mjs';
 
 // ── check-bilingual: release-doc bilingual rule enforcement ─────────────────
 
@@ -692,4 +693,105 @@ test('this repo ships no name shared by commands/ and skills/', () => {
     !/name collision/.test(r.stdout + r.stderr),
     `repo must ship one surface per name: ${r.stdout}`,
   );
+});
+
+// ── check-release-vehicle.mjs ───────────────────────────────────────────────
+// Semver picks the version from the change kind, but nothing watched for the
+// moment a `feat` on main takes the patch option away. It happened three times:
+// v1.7.1 shipped with 5 feat commits, v1.7.4 with 1, and once the patch line
+// simply stalled. This reports the state; it never blocks.
+
+suite('check-release-vehicle.mjs');
+
+// The script reads the git history of its own cwd, so these drive it against a
+// throwaway repo rather than this checkout. HOME is pinned like every other
+// spawn in this suite: git writes config under it.
+function vehicle(dir, args = []) {
+  return spawnSync(process.execPath, [join(SCRIPTS, 'check-release-vehicle.mjs'), ...args], {
+    cwd: dir,
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: SESSION_TMP_HOME },
+  });
+}
+
+function commit(dir, subject) {
+  writeFileSync(join(dir, 'f.txt'), subject);
+  spawnSync('git', ['add', '-A'], { cwd: dir, encoding: 'utf-8' });
+  spawnSync('git', ['commit', '-q', '-m', subject], { cwd: dir, encoding: 'utf-8' });
+}
+
+test('a feat since the last tag forces the next release to be a minor', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    commit(dir, 'chore: base');
+    spawnSync('git', ['tag', 'v1.0.0'], { cwd: dir, encoding: 'utf-8' });
+    commit(dir, 'fix(x): a bug');
+    commit(dir, 'feat(lint): a new rule');
+    const r = vehicle(dir, ['--json']);
+    assert.equal(r.status, 0, 'the notice never blocks');
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.determined, true);
+    assert.equal(out.minimumBump, 'minor');
+    assert.equal(out.lastTag, 'v1.0.0');
+    assert.equal(out.commitCount, 2);
+    assert.deepEqual(out.feats, ['feat(lint): a new rule']);
+  });
+});
+
+test('only fixes and chores since the last tag leaves patch available', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    commit(dir, 'chore: base');
+    spawnSync('git', ['tag', 'v1.0.0'], { cwd: dir, encoding: 'utf-8' });
+    commit(dir, 'fix(x): a bug');
+    commit(dir, 'docs: a word');
+    // Neither of these is a feat, and neither may be mistaken for one: the
+    // prefix has to be the whole type token, not a substring of a word.
+    commit(dir, 'refactor: rename feature flags');
+    commit(dir, 'fix: feature parity with the docs');
+    const out = JSON.parse(vehicle(dir, ['--json']).stdout);
+    assert.equal(out.minimumBump, 'patch');
+    assert.deepEqual(out.feats, [], `no commit here is a feat: ${JSON.stringify(out.feats)}`);
+  });
+});
+
+test('a bare `feat:` with no scope counts', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    commit(dir, 'chore: base');
+    spawnSync('git', ['tag', 'v2.0.0'], { cwd: dir, encoding: 'utf-8' });
+    commit(dir, 'feat: something new');
+    const out = JSON.parse(vehicle(dir, ['--json']).stdout);
+    assert.equal(out.minimumBump, 'minor');
+  });
+});
+
+test('a repo with no release tag reports that it cannot tell, not that patch is fine', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    commit(dir, 'feat: the very first thing');
+    const r = vehicle(dir, ['--json']);
+    assert.equal(r.status, 0);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.determined, false, 'no tag means no answer');
+    assert.equal(out.reason, 'no-release-tag');
+    assert.equal(out.minimumBump, null, 'an unknown answer must not read as patch');
+  });
+});
+
+test('--github emits an Actions warning only when the answer is minor', () => {
+  withTmpDir((dir) => {
+    gitRepo(dir);
+    commit(dir, 'chore: base');
+    spawnSync('git', ['tag', 'v1.0.0'], { cwd: dir, encoding: 'utf-8' });
+    commit(dir, 'fix: only a fix');
+    assert.ok(
+      !vehicle(dir, ['--github']).stdout.includes('::warning'),
+      'a patch-eligible line must not warn',
+    );
+    commit(dir, 'feat: now a feature');
+    const withFeat = vehicle(dir, ['--github']).stdout;
+    assert.ok(withFeat.includes('::warning title=Next release must be minor::'), withFeat);
+    assert.ok(withFeat.includes('feat: now a feature'), withFeat);
+  });
 });


### PR DESCRIPTION
# English

## What changed

A new maintainer check, `scripts/check-release-vehicle.mjs`, reports what the next release is allowed to be. The `plugin-channel` CI job runs it and prints an Actions warning when the answer is no longer "patch".

It never fails the build. That job now checks out full history, because the check reads tags and the log since the last one.

## Why

Semver decides the version from the change kind, and nothing was watching for the moment that decision gets made for us. A `feat` merged to `main` means the next release cannot be a patch. By the time anyone looks, the pending fixes are already in the same bucket as the feature.

Measured on this repo's own history:

| Range | Release | Commits | feat |
|---|---|---|---|
| v1.7.0 → v1.7.1 | patch | 17 | 5 |
| v1.7.3 → v1.7.4 | patch | 9 | 1 |
| v1.8.1 → HEAD | not yet cut | 8 | 1 |

The first two shipped as patches anyway, so the version number understated what changed. The third is the state `main` is in right now: a patch line that cannot be cut as a patch.

Splitting the work into separate PRs does not prevent this, which is worth stating because it looks like it should. Both branches land on the same `main`, so the vehicle is decided by release timing, not by branch topology. Timing is what nobody was watching, and it lived only in a maintainer note that no gate reads.

## How

The check asks git two questions: what is the last `v*` tag, and what are the commit subjects since it. A subject matching `feat:` or `feat(scope):` means the next release is at least a minor.

Two decisions are worth naming.

**It warns rather than blocks.** Failing every feat PR until someone cuts a release is a worse trade than one line a human reads while the PR is still open. The point is that the moment is visible, not that it is forbidden.

**It refuses to guess.** A shallow clone or a repo with no tags reports `determined: false` rather than falling back to "patch is fine". Those two answers are indistinguishable to a reader, and the wrong one is wrong exactly when it matters. That is also why the CI job now uses `fetch-depth: 0`; without it the step would have run and said nothing useful.

The script is maintainer tooling and is not in `package.json`'s `files`, so it does not ship to npm. `check:pack-surface` confirms the tarball is unchanged.

## Manual verification

Run against this repo, it identifies the current state:

```
$ node scripts/check-release-vehicle.mjs
[check-release-vehicle] the next release must be at least a MINOR.
  1 feat commit(s) since v1.8.1, out of 8:
    feat(lint): flag a synthesis that has fallen behind its own sources (#290)
```

Five tests drive it against throwaway repos rather than this checkout. Each behavior was turned off to confirm the tests fail without it, run alone:

```
# match `feat` as a substring instead of a type token
node tests/runner.mjs --file=release-checks  → rc=1, "only fixes and chores ... leaves patch available"

# let an undetermined answer fall back to patch
node tests/runner.mjs --file=release-checks  → rc=1, "reports that it cannot tell, not that patch is fine"

# stop emitting the Actions warning
node tests/runner.mjs --file=release-checks  → rc=1, "--github emits an Actions warning only when ..."
```

Restored and re-run: `50 passed, 0 failed`.

Gates, none piped so the exit code is the command's own:

```
npm test                    rc=0   2250 passed, 0 failed
npm run check:pack-surface  rc=0   136 files, 0 closure violations
npm run format:check        rc=0
npm run check:tracker-ids   rc=0
```

## Migration notes

None. Maintainer tooling only; nothing ships and no existing behavior changes.

---

# 한국어

## 변경 내용

메인테이너용 검사 `scripts/check-release-vehicle.mjs`를 추가합니다. 다음 릴리스가 무엇이 될 수 있는지 알려 주고, `plugin-channel` CI 잡이 이것을 돌려 답이 더는 patch가 아닐 때 Actions 경고를 냅니다.

빌드를 막지는 않습니다. 이 검사가 태그와 그 이후 로그를 읽으므로 해당 잡이 전체 히스토리를 받아 오도록 바꿨습니다.

## 이유

semver는 변경의 종류로 버전을 정하는데, 그 결정이 우리 대신 내려지는 순간을 아무도 보고 있지 않았습니다. `feat`이 `main`에 들어오면 다음 릴리스는 patch가 될 수 없습니다. 알아차렸을 때는 밀려 있던 fix들이 이미 그 기능과 같은 통에 들어가 있습니다.

이 레포의 실제 이력입니다.

| 구간 | 릴리스 | 커밋 | feat |
|---|---|---|---|
| v1.7.0 → v1.7.1 | patch | 17 | 5 |
| v1.7.3 → v1.7.4 | patch | 9 | 1 |
| v1.8.1 → HEAD | 미출하 | 8 | 1 |

앞의 둘은 그대로 patch로 나갔고, 그래서 버전 번호가 실제 변경보다 작게 말했습니다. 세 번째가 지금 `main`의 상태입니다. patch로 낼 수 없게 된 patch 라인입니다.

작업을 PR로 갈라도 이것이 막히지 않습니다. 막힐 것처럼 보이니 적어 둡니다. 두 브랜치가 결국 같은 `main`에 얹히므로, vehicle을 정하는 것은 브랜치 구조가 아니라 릴리스 타이밍입니다. 그 타이밍이 아무도 안 보던 자리이고, 메인테이너 노트에만 있어서 어떤 게이트도 읽지 않았습니다.

## 방법

git에 두 가지를 묻습니다. 마지막 `v*` 태그가 무엇인지, 그 뒤 커밋 제목이 무엇인지. `feat:`이나 `feat(scope):`에 걸리는 제목이 있으면 다음 릴리스는 최소 minor입니다.

짚어 둘 결정이 둘입니다.

**막지 않고 알립니다.** 누군가 릴리스를 낼 때까지 모든 feat PR을 떨어뜨리는 것은, PR이 열려 있는 동안 사람이 한 줄 읽는 것보다 나쁜 거래입니다. 금지하자는 것이 아니라 그 순간이 보이게 하자는 것입니다.

**모를 때는 짐작하지 않습니다.** 얕은 클론이거나 태그가 없으면 "patch면 된다"로 떨어지지 않고 `determined: false`를 냅니다. 읽는 사람에게 두 답은 구별되지 않고, 틀린 쪽은 하필 중요한 순간에 틀립니다. CI 잡이 `fetch-depth: 0`을 쓰는 이유도 같습니다. 그게 없으면 이 단계가 돌긴 해도 쓸모 있는 말을 못 합니다.

이 스크립트는 메인테이너 도구라 `package.json`의 `files`에 없고 npm으로 나가지 않습니다. `check:pack-surface`가 tarball이 그대로임을 확인합니다.

## 수동 검증

이 레포에 돌리면 지금 상태를 그대로 짚습니다.

```
$ node scripts/check-release-vehicle.mjs
[check-release-vehicle] the next release must be at least a MINOR.
  1 feat commit(s) since v1.8.1, out of 8:
    feat(lint): flag a synthesis that has fallen behind its own sources (#290)
```

시험 다섯은 이 체크아웃이 아니라 일회용 레포를 상대로 돕니다. 각 동작을 꺼서 시험이 실제로 실패하는지 단독으로 확인했습니다.

```
# feat 을 타입 토큰이 아니라 부분 문자열로 매칭
node tests/runner.mjs --file=release-checks  → rc=1, "only fixes and chores ... leaves patch available"

# 판정 불가를 patch 로 떨어뜨림
node tests/runner.mjs --file=release-checks  → rc=1, "reports that it cannot tell, not that patch is fine"

# Actions 경고 발화 중단
node tests/runner.mjs --file=release-checks  → rc=1, "--github emits an Actions warning only when ..."
```

되돌린 뒤 다시 돌려 `50 passed, 0 failed`를 확인했습니다.

게이트는 파이프에 물리지 않아 종료 코드가 그 명령 자신의 것입니다.

```
npm test                    rc=0   2250 passed, 0 failed
npm run check:pack-surface  rc=0   136 files, 0 closure violations
npm run format:check        rc=0
npm run check:tracker-ids   rc=0
```

## 마이그레이션 노트

없습니다. 메인테이너 도구뿐이고 출하되는 것도, 기존 동작이 바뀌는 것도 없습니다.

---

## Changelog

- EN: None (maintainer tooling; nothing ships).
- KO: 없음 (메인테이너 도구이고 출하되지 않습니다).

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
