### PR TITLE
chore(release): v1.8.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "hypo",
       "source": "./",
       "description": "LLM-native personal wiki — session-aware knowledge base for Claude Code",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "homepage": "https://github.com/sk-lim19f/Hypomnema"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hypo",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "LLM-native personal wiki system — session-aware knowledge base for Claude Code",
   "author": {
     "name": "sk-lim19f",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to Hypomnema are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-09-10
+
+### Bug Fixes
+
+#### English
+
+- Hook notices reach the model again. They were emitted with a top-level `additionalContext`, which Claude Code silently ignores, so the close gate, the resume contract, and lookup results never arrived. Measured after the fix: a canary planted in a project's `hot.md` came back verbatim from a session with every file tool blocked, and the same canary read as absent on the previous build. ([#287](https://github.com/sk-lim19f/Hypomnema/pull/287))
+- The session-close gate reads a background-task notification the same way on every delivery path, so a task finishing after you asked to close no longer cancels the close. A refusal also reports `gateReason`, naming which check refused. ([#289](https://github.com/sk-lim19f/Hypomnema/pull/289))
+- `lint`, `verify`, `graph`, `query` and `crystallize` exit 2 on an unrecognised flag or an empty `--hypo-dir=`, instead of silently dropping it and falling back to the default vault. Their command docs no longer print placeholder syntax as runnable arguments. ([#286](https://github.com/sk-lim19f/Hypomnema/pull/286))
+- The `/compact` and `/clear` notice no longer orders a session close, no longer fires on another project's uncommitted files, and no longer goes silent when the vault is broken enough to be worth reporting (`decisions/0101`). ([#285](https://github.com/sk-lim19f/Hypomnema/pull/285))
+- `/hypo:doctor` no longer accepts a session-closed marker as proof for a project the close gate never evaluated. The marker records the set the gate actually checked, and the audit requires an artifact's project to be in that set as well as in the marker's attribution. ([#284](https://github.com/sk-lim19f/Hypomnema/pull/284))
+
+#### 한국어
+
+- 훅 알림이 다시 모델에 닿습니다. 최상단 `additionalContext`로 나가고 있었는데 Claude Code가 그것을 조용히 무시해서 close 게이트, 세션 재개 계약, lookup 결과가 도착한 적이 없었습니다. 고친 뒤 실측했습니다. 프로젝트 `hot.md`에 심은 난수를 파일 도구를 전부 막은 세션이 그대로 답했고, 같은 난수를 이전 빌드는 못 읽었습니다. ([#287](https://github.com/sk-lim19f/Hypomnema/pull/287))
+- 세션 마무리 게이트가 background task 알림을 어느 전달 경로로 오든 같게 읽습니다. 마무리를 요청한 뒤 작업이 끝나도 그 마무리가 취소되지 않습니다. 거절할 때는 `gateReason`으로 어느 검사가 거절했는지도 함께 알립니다. ([#289](https://github.com/sk-lim19f/Hypomnema/pull/289))
+- `lint`·`verify`·`graph`·`query`·`crystallize`가 못 알아보는 플래그와 빈 `--hypo-dir=`를 조용히 버리고 기본 볼트로 가는 대신 exit 2를 냅니다. 명령 문서도 placeholder 문법을 실행 가능한 인자처럼 찍지 않습니다. ([#286](https://github.com/sk-lim19f/Hypomnema/pull/286))
+- `/compact`·`/clear` 알림이 세션 마무리를 지시하지 않고, 다른 프로젝트의 미커밋 파일로 뜨지 않으며, 보고할 값어치가 있을 만큼 볼트가 망가졌을 때 조용해지지 않습니다 (`decisions/0101`). ([#285](https://github.com/sk-lim19f/Hypomnema/pull/285))
+- `/hypo:doctor`가 close 게이트가 한 번도 평가하지 않은 프로젝트에 대해 session-closed 마커를 증거로 받지 않습니다. 마커가 게이트의 실제 검사 집합을 기록하고, 감사가 산출물의 프로젝트를 귀속뿐 아니라 그 집합에서도 요구합니다. ([#284](https://github.com/sk-lim19f/Hypomnema/pull/284))
+
+### Chores
+
+#### English
+
+- The shipped `SCHEMA.md` template defines `updated` as the day content changed, not the day the file was written, and states plainly that nothing enforces it. ([#288](https://github.com/sk-lim19f/Hypomnema/pull/288))
+
+#### 한국어
+
+- 출하되는 `SCHEMA.md` 템플릿이 `updated`를 파일을 쓴 날이 아니라 내용이 바뀐 날로 정의하고, 그것을 집행하는 장치가 없다는 사실도 함께 적습니다. ([#288](https://github.com/sk-lim19f/Hypomnema/pull/288))
+
 ## [1.8.1] - 2026-09-07
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypomnema",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypomnema",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "MIT",
       "bin": {
         "hypomnema": "scripts/init.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypomnema",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "LLM-native personal wiki system for Claude Code",
   "type": "module",
   "license": "MIT",

--- a/templates/hypo-config.md
+++ b/templates/hypo-config.md
@@ -1,7 +1,7 @@
 ---
 title: Hypomnema Config
 type: config
-version: "1.8.1"
+version: "1.8.2"
 created: YYYY-MM-DD
 ---
 

--- a/tests/close-global.test.mjs
+++ b/tests/close-global.test.mjs
@@ -24,6 +24,9 @@ import { planMarkerDecision, closeResultContradiction } from '../scripts/crystal
 // overwrite step 2 conflict-park check see "this session already read the
 // current bytes" without a live session.
 import { snapshotBase } from '../hooks/base-store.mjs';
+// The gate's own notion of "today", so the fixture below can place a project
+// strictly outside it instead of guessing with local-yesterday.
+import { freshDates } from '../hooks/hypo-shared.mjs';
 import { test, suite } from './harness.mjs';
 import {
   CLOSE_RECONFIRM_MARK,
@@ -3790,19 +3793,29 @@ test('E2E: --mark-session-closed refuses a project that exists on disk but was n
 // attributionScope) from a marker's record of a close that already happened.
 test('a previous day marker does not make its project block an unrelated close today', () => {
   const today = todayLocal();
-  // Local calendar, not toISOString(): the project activity dates this fixture
-  // compares against are local-date (todayLocal), so a UTC slice would put
-  // `stale` on TODAY around the midnight boundary in western timezones and the
-  // fixture would silently stop testing anything.
-  const y = new Date();
-  y.setDate(y.getDate() - 1);
-  const yesterday = `${y.getFullYear()}-${String(y.getMonth() + 1).padStart(2, '0')}-${String(y.getDate()).padStart(2, '0')}`;
-  // `stale` exists and has close files, but its activity is YESTERDAY, so it is
-  // not a today-active candidate. The only thing that can pull it into this
+  // The gate counts BOTH calendar days as today (freshDates / localAndUtcDates in
+  // hooks/hypo-shared.mjs), because some writers stamp local and some stamp UTC.
+  // So local-yesterday is not reliably outside that set. In a UTC+N zone it IS the
+  // UTC day for the first N hours of the local day, which made this fixture's
+  // `stale` a today-active candidate and turned this test red for nine hours every
+  // morning in KST (measured 2026-09-10: red at 08:51 local = 23:51 UTC, green at
+  // 09:06 local = 00:06 UTC). Stepping back from the EARLIEST fresh date keeps
+  // `stale` a genuine non-candidate in every zone, so the marker stays the only
+  // thing that can pull it in, which is what this test is about.
+  const fresh = freshDates();
+  const prev = new Date(`${[...fresh].sort()[0]}T00:00:00Z`);
+  prev.setUTCDate(prev.getUTCDate() - 1);
+  const pastDay = prev.toISOString().slice(0, 10);
+  assert.ok(
+    !fresh.includes(pastDay),
+    `fixture date ${pastDay} must sit outside the gate's today set ${JSON.stringify(fresh)}`,
+  );
+  // `stale` exists and has close files, but its activity is on that past day, so
+  // it is not a today-active candidate. The only thing that can pull it into this
   // close's evaluation is the marker.
   const projects = [
     { slug: 'mine', date: today },
-    { slug: 'stale', date: yesterday, sessionLog: false },
+    { slug: 'stale', date: pastDay, sessionLog: false },
   ];
   withClosePartitionWiki(projects, [], (dir) => {
     const sessionId = 's-crossday-marker';
@@ -3820,11 +3833,30 @@ test('a previous day marker does not make its project block an unrelated close t
     );
     // sessionId is what makes the gate read the marker at all (the PreCompact hook
     // passes one; --mark-session-closed does not).
+    // The marker is written AFTER withClosePartitionWiki's commit, so it stays
+    // untracked and the git axis is dirty here: `gate.ok` is always false in this
+    // test. Take the baseline from gate.close.scope / gate.close.projects, never
+    // from gate.ok, or the assertion goes red for a reason unrelated to close.
     const gate = precompactGateStatus(dir, {
       closeScope: ['mine'],
       sessionId,
       claudeHome: join(dir, '.claude-none'),
     });
+    // Positive baseline first. The absence assertion below only means something
+    // once the marker has actually reached the partition scope; if it has not
+    // (wrong path, session id, TTL, parse failure), `stale` never enters the
+    // picture at all and the absence holds for a reason that has nothing to do
+    // with the defense this test exists to pin. The sibling test further down
+    // carries the same kind of baseline for the same reason.
+    assert.ok(
+      gate.close.scope.includes('stale'),
+      `the marker must reach the partition scope. got ${JSON.stringify(gate.close.scope)}`,
+    );
+    assert.ok(
+      !(gate.close.projects || []).some((p) => p.project === 'stale'),
+      `stale must stay out of the mandatory evaluation set. got ` +
+        `${JSON.stringify(gate.close.projects)}`,
+    );
     assert.equal(
       gate.blockers.some((b) => b.type === 'close'),
       false,

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -524,6 +524,11 @@ function withSyncedWiki(fn) {
 // logEntry?, hotRow? }] — each optional field defaults to `date` (fresh) and can
 // be set to an old date string (or false to omit). Root hot.md rows are built
 // from `hotRow ?? date`; root hot.md frontmatter `updated:` is always today.
+// A `date` meant to be NON-today must be strictly earlier than the smallest of
+// freshDates(): the close gate counts both the local and the UTC calendar day as
+// today, so plain local-yesterday is inside that set for the first N hours of the
+// local day in a UTC+N zone. See tests/close-global.test.mjs, the previous-day
+// marker test, for the fixture that got this wrong.
 function makeMultiProjectWiki(dir, today, projects) {
   mkdirSync(dir, { recursive: true });
   const ym = today.slice(0, 7);


### PR DESCRIPTION
# English

## What changed

Cuts the v1.8.2 patch release. Bumps the version across `package.json`, `package-lock.json`, `.claude-plugin/{plugin,marketplace}.json` and `templates/hypo-config.md`, and adds the `## [1.8.2]` section to `CHANGELOG.md` from the merged PRs' Changelog blocks.

Six fixes ship: #284, #285, #286, #287, #288 and #289. Five are user-visible bug fixes; #288 is a shipped-template wording change and lands under Chores.

A second commit is here that is not part of the version bump. It repairs a test fixture that had started failing on a clock boundary and was blocking the release, since the checklist requires `npm test` green before tagging. It touches `tests/` only.

## Why

A merge to `main` is not a release on either channel. The plugin installer names its cache directory after the manifest version string, so an unchanged version means the copy is skipped and existing installs keep running the old bytes. Every fix above is invisible to an installed user until the version moves.

The test fixture had to move too. The close gate counts both the local and the UTC calendar day as today, because some writers stamp a date in the user's local zone and others stamp UTC. A fixture that wanted a project to be *not* today-active dated it local-yesterday, which is inside that set for the first N hours of the local day in a UTC+N zone. In KST that is a nine hour window every morning during which the test went red with no code changing, and CI never sees it: under UTC the two days never differ.

## How

Followed the "Cutting a release" checklist in `docs/CONTRIBUTING.md`. Step 0 and step 8 (the version spec lifecycle) are exempt for a patch release.

The branch was cut from the last commit before the feature that took the patch option away, so this range carries zero `feat` commits and the patch version is honest. The CI warning added in #292 reports exactly this condition on future releases.

For the fixture: the date is now derived from the earliest value `freshDates()` returns, stepped back one UTC day, so it sits outside the gate's today set in every zone. The test also asserts the gate's own state now (the marker reached the partition scope, and that project stayed out of the mandatory evaluation set) instead of only the absence of a close blocker. The absence alone was holding for reasons unrelated to the defense it was meant to pin. No production code changed.

## Manual verification

No hook, `hypo-shared.mjs`, template or init-flow change is in this PR, so the manual verification requirement does not apply. The release gate set was run locally, each command alone so its exit code is its own:

```
npm test                       rc=0   2234 passed, 0 failed (251.6s)
node tests/parallel.mjs --shards=4  rc=0   2234 passed, 0 failed (207.0s)
npm run lint                   rc=0   0 error(s), 557 warning(s)
npm run check:versions         rc=0   all version-carrying files agree on 1.8.2
npm run check:bilingual        rc=0
npm run smoke:plugin           rc=0
npm run smoke-pack             rc=0
npm run check:tracker-ids      rc=0
npm run check:pack-surface     rc=0   136 files, 0 closure violations
npm run format:check           rc=0
```

The four shard run is included because the fixture change touches `tests/helpers.mjs`, which every area shares, and CI runs four shards rather than the local default.

The fixture repair was also proved red both ways. Turning the defense off (letting a past marker's projects back into the mandatory evaluation set) fails the test inside and outside the clock window, and breaking the marker's session id fails the new baseline with `the marker must reach the partition scope. got ["mine"]`.

## Migration notes

None.

---

# 한국어

## 변경 내용

v1.8.2 패치 릴리스를 자릅니다. `package.json`, `package-lock.json`, `.claude-plugin/{plugin,marketplace}.json`, `templates/hypo-config.md` 의 버전을 올리고, 머지된 PR 들의 Changelog 블록에서 모은 `## [1.8.2]` 절을 `CHANGELOG.md` 에 넣습니다.

수정 여섯이 실립니다. #284, #285, #286, #287, #288, #289 입니다. 다섯은 사용자에게 보이는 버그 수정이고, #288 은 출하되는 템플릿의 문구 변경이라 Chores 로 들어갑니다.

버전 범프에 속하지 않는 커밋이 하나 더 있습니다. 시계 경계에서 깨지기 시작해 릴리스를 막고 있던 테스트 픽스처를 고칩니다. 체크리스트가 태그 전에 `npm test` green 을 요구하기 때문입니다. `tests/` 만 건드립니다.

## 이유

`main` 에 머지하는 것은 두 채널 어느 쪽에서도 릴리스가 아닙니다. 플러그인 설치기가 매니페스트 버전 문자열로 캐시 디렉터리 이름을 짓기 때문에, 버전이 안 움직이면 복사가 건너뛰어지고 기존 설치는 옛 바이트를 계속 돌립니다. 위 수정은 전부 버전이 움직이기 전까지 설치된 사용자에게 보이지 않습니다.

테스트 픽스처도 움직여야 했습니다. close 게이트는 로컬 날짜와 UTC 날짜를 둘 다 오늘로 셉니다. 어떤 작성자는 사용자 로컬 존으로 날짜를 찍고 어떤 작성자는 UTC 로 찍기 때문입니다. 어떤 프로젝트를 오늘 활동이 **아니게** 만들려던 픽스처가 그 날짜를 로컬 어제로 잡았는데, UTC+N 존에서 로컬 하루의 첫 N시간 동안 로컬 어제는 그 집합 안입니다. KST 에서는 매일 아침 아홉 시간이 그 창이고, 그 사이 코드가 하나도 안 바뀌었는데 테스트가 red 가 됐습니다. CI 는 UTC 라 두 날짜가 갈리지 않아 이것을 못 봅니다.

## 방법

`docs/CONTRIBUTING.md` 의 "Cutting a release" 체크리스트를 따랐습니다. 0 단계와 8 단계(버전 스펙 생애주기)는 패치 릴리스에 면제됩니다.

브랜치는 patch 선택지를 없앤 기능 커밋 직전에서 땄습니다. 그래서 이 범위의 `feat` 은 0 이고 패치 버전이 정직합니다. #292 가 붙인 CI 경고가 앞으로의 릴리스에서 바로 이 조건을 알립니다.

픽스처 쪽은 이렇습니다. 날짜를 `freshDates()` 가 돌려주는 값 중 가장 이른 것에서 UTC 로 하루 물러난 값으로 구합니다. 그러면 어느 존에서도 게이트의 오늘 집합 밖입니다. 그리고 테스트가 close 블로커의 부재만 보는 대신 게이트 자신의 상태를 단언합니다. 마커가 파티션 scope 에 도달했다는 것과, 그 프로젝트가 필수 평가 대상에서 빠졌다는 것 둘입니다. 부재 단언만으로는 겨누려던 방어와 무관한 이유로도 통과하고 있었습니다. 프로덕션 코드는 바뀌지 않았습니다.

## 수동 검증

이 PR 에는 훅, `hypo-shared.mjs`, 템플릿, init 흐름 변경이 없어 수동 검증 요구가 걸리지 않습니다. 릴리스 게이트 묶음을 로컬에서 돌렸고, 종료 코드가 각자의 것이 되도록 명령을 하나씩 단독으로 실행했습니다.

```
npm test                       rc=0   2234 passed, 0 failed (251.6s)
node tests/parallel.mjs --shards=4  rc=0   2234 passed, 0 failed (207.0s)
npm run lint                   rc=0   0 error(s), 557 warning(s)
npm run check:versions         rc=0   버전을 담은 파일 전부 1.8.2 일치
npm run check:bilingual        rc=0
npm run smoke:plugin           rc=0
npm run smoke-pack             rc=0
npm run check:tracker-ids      rc=0
npm run check:pack-surface     rc=0   136 files, 0 closure violations
npm run format:check           rc=0
```

4 샤드 실행을 함께 넣은 것은 픽스처 변경이 모든 영역이 공유하는 `tests/helpers.mjs` 를 건드리고, CI 가 로컬 기본값이 아니라 4 샤드로 돌기 때문입니다.

픽스처 수정은 양쪽으로 red 도 증명했습니다. 방어를 끄면(지난 마커의 프로젝트를 필수 평가 대상으로 다시 들이면) 창 안팎 모두 실패하고, 마커의 세션 id 를 어긋나게 하면 새 기준선이 `the marker must reach the partition scope. got ["mine"]` 로 실패합니다.

## 마이그레이션 노트

None.

---

## Changelog

- EN: None
- KO: None

## Checklist

- [x] `npm test` passes locally
- [x] `npm run lint` passes locally
- [x] README / ARCHITECTURE / docs updated if user-facing behavior changed
- [x] Filled the `## Changelog` block above (EN + KO line) if the change is user-visible
- [x] Wrote the body in both `# English` and `# 한국어` blocks
- [x] No tool-attribution footer in the body
- [x] One logical change per PR (rebase / split if necessary)
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, …)
